### PR TITLE
🐛 fix bug by adding missing required parameters for anthropic claude

### DIFF
--- a/models/bedrock/models/llm/anthropic.claude-3-5-haiku-v1.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-3-5-haiku-v1.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/anthropic.claude-3-haiku-v1.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-3-haiku-v1.yaml
@@ -34,6 +34,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -43,6 +44,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/anthropic.claude-3-opus-v1.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-3-opus-v1.yaml
@@ -34,6 +34,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -43,6 +44,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/anthropic.claude-3-sonnet-v1.5.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-3-sonnet-v1.5.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/anthropic.claude-3-sonnet-v1.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-3-sonnet-v1.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/anthropic.claude-3-sonnet-v2.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-3-sonnet-v2.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/anthropic.claude-instant-v1.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-instant-v1.yaml
@@ -27,6 +27,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -36,6 +37,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/anthropic.claude-v1.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-v1.yaml
@@ -27,6 +27,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -36,6 +37,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/anthropic.claude-v2.1.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-v2.1.yaml
@@ -27,6 +27,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -36,6 +37,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/anthropic.claude-v2.yaml
+++ b/models/bedrock/models/llm/anthropic.claude-v2.yaml
@@ -27,6 +27,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -36,6 +37,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/eu.anthropic.claude-3-haiku-v1.yaml
+++ b/models/bedrock/models/llm/eu.anthropic.claude-3-haiku-v1.yaml
@@ -34,6 +34,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -43,6 +44,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/eu.anthropic.claude-3-sonnet-v1.5.yaml
+++ b/models/bedrock/models/llm/eu.anthropic.claude-3-sonnet-v1.5.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/eu.anthropic.claude-3-sonnet-v1.yaml
+++ b/models/bedrock/models/llm/eu.anthropic.claude-3-sonnet-v1.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/eu.anthropic.claude-3-sonnet-v2.yaml
+++ b/models/bedrock/models/llm/eu.anthropic.claude-3-sonnet-v2.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/us.anthropic.claude-3-5-haiku-v1.yaml
+++ b/models/bedrock/models/llm/us.anthropic.claude-3-5-haiku-v1.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/us.anthropic.claude-3-haiku-v1.yaml
+++ b/models/bedrock/models/llm/us.anthropic.claude-3-haiku-v1.yaml
@@ -34,6 +34,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -43,6 +44,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/us.anthropic.claude-3-opus-v1.yaml
+++ b/models/bedrock/models/llm/us.anthropic.claude-3-opus-v1.yaml
@@ -34,6 +34,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -43,6 +44,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/us.anthropic.claude-3-sonnet-v1.5.yaml
+++ b/models/bedrock/models/llm/us.anthropic.claude-3-sonnet-v1.5.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/us.anthropic.claude-3-sonnet-v1.yaml
+++ b/models/bedrock/models/llm/us.anthropic.claude-3-sonnet-v1.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0

--- a/models/bedrock/models/llm/us.anthropic.claude-3-sonnet-v2.yaml
+++ b/models/bedrock/models/llm/us.anthropic.claude-3-sonnet-v2.yaml
@@ -33,6 +33,7 @@ parameter_rules:
       zh_Hans: 生成内容的随机性。
       en_US: The amount of randomness injected into the response.
   - name: top_p
+    use_template: top_p
     required: false
     type: float
     default: 0.999
@@ -42,6 +43,9 @@ parameter_rules:
       zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
       en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
     required: false
     type: int
     default: 0


### PR DESCRIPTION
## Summary
The Bedrock Official Plugin was in an uninstallable state. I found that the cause of the error was missing parameters, so this Pull Request fixes the parameters.

## Related Issue
- https://github.com/langgenius/dify-official-plugins/issues/141
- https://github.com/langgenius/dify/issues/12625