### PR TITLE
fix(slidespeak): miscorrect apikey checking logic

### DIFF
--- a/tools/slidespeak/manifest.yaml
+++ b/tools/slidespeak/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 0.0.1
+version: 0.0.2

--- a/tools/slidespeak/provider/slidespeak.py
+++ b/tools/slidespeak/provider/slidespeak.py
@@ -17,5 +17,5 @@ class SlideSpeakProvider(ToolProvider):
         test_task_id = "xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
         url = f"{base_url or 'https://api.slidespeak.co/api/v1'}/task_status/{test_task_id}"
         response = requests.get(url, headers=headers)
-        if response.status_code != 200:
+        if response.status_code not in [200, 404]:
             raise ToolProviderCredentialValidationError("Invalid SlideSpeak API key")


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/1dc630dc-ee97-4f74-8961-c350261c3dba)

after:

![image](https://github.com/user-attachments/assets/0801e4b3-4c68-4071-b52e-ab0506d3816d)
