### PR TITLE
feat(gemini): add Gemini 2.0 models

### DIFF
--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.2
+version: 0.0.3

--- a/models/gemini/models/llm/_position.yaml
+++ b/models/gemini/models/llm/_position.yaml
@@ -1,3 +1,9 @@
+- gemini-2.0-flash-001
+- gemini-2.0-flash-exp
+- gemini-2.0-flash-lite-preview-02-05
+- gemini-2.0-pro-exp-02-05
+- gemini-2.0-flash-thinking-exp-1219
+- gemini-2.0-flash-thinking-exp-01-21
 - gemini-1.5-pro
 - gemini-1.5-pro-latest
 - gemini-1.5-pro-001

--- a/models/gemini/models/llm/gemini-2.0-flash-001.yaml
+++ b/models/gemini/models/llm/gemini-2.0-flash-001.yaml
@@ -1,0 +1,41 @@
+model: gemini-2.0-flash-001
+label:
+  en_US: Gemini 2.0 Flash 001
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+  - video
+  - audio
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: max_output_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.00'
+  output: '0.00'
+  unit: '0.000001'
+  currency: USD

--- a/models/gemini/models/llm/gemini-2.0-flash-exp.yaml
+++ b/models/gemini/models/llm/gemini-2.0-flash-exp.yaml
@@ -1,0 +1,41 @@
+model: gemini-2.0-flash-exp
+label:
+  en_US: Gemini 2.0 Flash Exp
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+  - video
+  - audio
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: max_output_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.00'
+  output: '0.00'
+  unit: '0.000001'
+  currency: USD

--- a/models/gemini/models/llm/gemini-2.0-flash-lite-preview-02-05.yaml
+++ b/models/gemini/models/llm/gemini-2.0-flash-lite-preview-02-05.yaml
@@ -1,0 +1,42 @@
+model: gemini-2.0-flash-lite-preview-02-05
+label:
+  en_US: Gemini 2.0 Flash Lite Preview 0205
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+  - video
+  - audio
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: max_output_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.00'
+  output: '0.00'
+  unit: '0.000001'
+  currency: USD
+

--- a/models/gemini/models/llm/gemini-2.0-flash-thinking-exp-01-21.yaml
+++ b/models/gemini/models/llm/gemini-2.0-flash-thinking-exp-01-21.yaml
@@ -1,0 +1,39 @@
+model: gemini-2.0-flash-thinking-exp-01-21
+label:
+  en_US: Gemini 2.0 Flash Thinking Exp 01-21
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - document
+  - video
+  - audio
+model_properties:
+  mode: chat
+  context_size: 32767
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: max_output_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.00'
+  output: '0.00'
+  unit: '0.000001'
+  currency: USD

--- a/models/gemini/models/llm/gemini-2.0-flash-thinking-exp-1219.yaml
+++ b/models/gemini/models/llm/gemini-2.0-flash-thinking-exp-1219.yaml
@@ -1,0 +1,39 @@
+model: gemini-2.0-flash-thinking-exp-1219
+label:
+  en_US: Gemini 2.0 Flash Thinking Exp 1219
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - document
+  - video
+  - audio
+model_properties:
+  mode: chat
+  context_size: 32767
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: max_output_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.00'
+  output: '0.00'
+  unit: '0.000001'
+  currency: USD

--- a/models/gemini/models/llm/gemini-2.0-pro-exp-02-05.yaml
+++ b/models/gemini/models/llm/gemini-2.0-pro-exp-02-05.yaml
@@ -1,0 +1,41 @@
+model: gemini-2.0-pro-exp-02-05
+label:
+  en_US: Gemini 2.0 pro exp 02-05
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+  - video
+  - audio
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: max_output_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.00'
+  output: '0.00'
+  unit: '0.000001'
+  currency: USD

--- a/models/gemini/requirements.txt
+++ b/models/gemini/requirements.txt
@@ -1,4 +1,4 @@
-dify_plugin~=0.0.1b61
+dify_plugin~=0.0.1b64
 google-ai-generativelanguage~=0.6.9
 google-api-python-client~=2.90.0
 google-api-core~=2.18.0


### PR DESCRIPTION
## Summary

This PR adds support for new Gemini 2.0 model variants including Flash, Pro, and experimental versions.

### Added Models
- gemini-2.0-flash-001
- gemini-2.0-flash-exp
- gemini-2.0-flash-lite-preview-02-05
- gemini-2.0-pro-exp-02-05
- gemini-2.0-flash-thinking-exp-1219
- gemini-2.0-flash-thinking-exp-01-21

## Screenshots

| Model name | Screenshots |
|--------|--------|
| gemini-2.0-flash-001  | <img width="300" alt="flash-001" src="https://github.com/user-attachments/assets/e8a6aad3-506b-4b90-bfce-ba89085584f7" /> |
| gemini-2.0-flash-exp | <img width="300" alt="image" src="https://github.com/user-attachments/assets/2d6b010f-0e0a-4edb-a36c-fbd1bc7a2bd5" /> |
| gemini-2.0-flash-lite-preview-02-05 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/afe39789-afa3-4e14-94c6-821b9bcec60f" /> |
| gemini-2.0-pro-exp-02-05 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/436dac54-e1e7-4b3a-8dcf-399896bbadd5" /> |
| gemini-2.0-flash-thinking-exp-1219 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/20b72878-0479-4ce3-a2c6-227f0046c0c5" /> | 
| gemini-2.0-flash-thinking-exp-01-21| <img width="300" alt="image" src="https://github.com/user-attachments/assets/88847225-bcbd-4577-b74e-01aef16094fe" /> | 
