### PR TITLE
fix: Update deepseek-chat.yaml to include the latest api call prices

### DIFF
--- a/models/deepseek/models/llm/deepseek-chat.yaml
+++ b/models/deepseek/models/llm/deepseek-chat.yaml
@@ -77,7 +77,7 @@ parameter_rules:
       - text
       - json_object
 pricing:
-  input: "1"
-  output: "2"
+  input: "2"
+  output: "8"
   unit: "0.000001"
   currency: RMB


### PR DESCRIPTION
I have updated the pricing of deepseek-chat API as found [here](https://api-docs.deepseek.com/quick_start/pricing)

Fixes #198 