### PR TITLE
feat: add the Janus Pro Model in Siliconflow tool

### DIFF
--- a/tools/siliconflow/tools/janus.py
+++ b/tools/siliconflow/tools/janus.py
@@ -1,0 +1,74 @@
+from typing import Any, Union, List
+import requests
+from requests.exceptions import RequestException
+from core.tools.entities.tool_entities import ToolInvokeMessage
+from core.tools.tool.builtin_tool import BuiltinTool
+SILICONFLOW_API_URL = "https://api.siliconflow.cn/v1/image/generations"
+MODEL_NAME = "deepseek-ai/Janus-Pro-7B"
+class JanusTool(BuiltinTool):
+    """Tool for generating images using the Janus Pro 7B model via SiliconFlow API.
+    
+    This model generates 384x384 resolution images. The generated image URLs are valid for 1 hour.
+    """
+    def _invoke(
+        self, user_id: str, tool_parameters: dict[str, Any]
+    ) -> Union[ToolInvokeMessage, List[ToolInvokeMessage]]:
+        """Invoke the Janus Pro 7B model to generate images.
+        Args:
+            user_id: The ID of the user making the request
+            tool_parameters: Dictionary containing:
+                - prompt: Text description of the image to generate
+                - seed (optional): Random seed for reproducible generation
+        Returns:
+            List of messages containing the API response and generated image URLs
+        Raises:
+            RequestException: If there is an error communicating with the API
+        """
+        if not tool_parameters.get("prompt"):
+            return self.create_text_message("Error: prompt is required")
+        headers = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "authorization": f"Bearer {self.runtime.credentials['siliconFlow_api_key']}",
+        }
+        # Prepare the payload with required parameters
+        payload = {
+            "model": MODEL_NAME,
+            "prompt": tool_parameters["prompt"],  # 已验证存在
+        }
+        # Add optional seed if provided
+        if "seed" in tool_parameters and tool_parameters["seed"] is not None:
+            try:
+                seed = int(tool_parameters["seed"])
+                if 1 <= seed <= 9999999999:
+                    payload["seed"] = seed
+            except (ValueError, TypeError):
+                pass  # 忽略无效的 seed 值
+        try:
+            # Make the API request
+            response = requests.post(SILICONFLOW_API_URL, json=payload, headers=headers, timeout=30)
+            response.raise_for_status()
+            
+            # Process the response
+            res = response.json()
+            result = [self.create_json_message(res)]
+            
+            # Extract and save image URLs (valid for 1 hour)
+            images = res.get("images", [])
+            if not images:
+                return self.create_text_message("No images were generated")
+                
+            for image in images:
+                if image_url := image.get("url"):
+                    result.append(
+                        self.create_image_message(
+                            image=image_url,
+                            save_as=self.VariableKey.IMAGE.value
+                        )
+                    )
+            
+            return result
+        except RequestException as e:
+            return self.create_text_message(f"Error generating image: {str(e)}")
+        except Exception as e:
+            return self.create_text_message(f"Unexpected error: {str(e)}") 

--- a/tools/siliconflow/tools/janus.yaml
+++ b/tools/siliconflow/tools/janus.yaml
@@ -1,0 +1,43 @@
+identity:
+  name: janus
+  author: hjlarry
+  label:
+    en_US: Janus Pro
+    zh_Hans: Janus Pro
+    zh_CN: Janus Pro
+  icon: icon.svg
+description:
+  human:
+    en_US: Generate image via SiliconFlow's Janus Pro 7B model. 
+    zh_Hans: 使用 SiliconFlow 的 Janus Pro 7B 模型生成图片。
+    zh_CN: 使用 SiliconFlow 的 Janus Pro 7B 模型生成图片。
+  llm: This tool uses the Janus Pro 7B model to generate 384x384 resolution images from text prompts. The generated image URLs are valid for 1 hour.
+parameters:
+  - name: prompt
+    type: string
+    required: true
+    default: an island near sea, with seagulls, moon shining over the sea, light house, boats in the background
+    label:
+      en_US: Prompt
+      zh_Hans: 提示词
+      zh_CN: 提示词
+    human_description:
+      en_US: The text prompt used to generate the image. English prompts are recommended for better results.
+      zh_Hans: 用于生成图片的文字提示词。建议使用英文提示词以获得更好的生成效果。
+      zh_CN: 用于生成图片的文字提示词。建议使用英文提示词以获得更好的生成效果。
+    llm_description: The text description that will be used to generate the image. The model works best with detailed English prompts.
+    form: llm
+  - name: seed
+    type: number
+    required: false
+    min: 1
+    max: 9999999999
+    label:
+      en_US: Seed
+      zh_Hans: 种子
+      zh_CN: 种子
+    human_description:
+      en_US: Random seed for image generation (1-9999999999). Using the same seed and prompt will produce similar images.
+      zh_Hans: 图片生成的随机种子(1-9999999999)。使用相同的种子和提示词可以生成相似的图片。
+      zh_CN: 图片生成的随机种子(1-9999999999)。使用相同的种子和提示词可以生成相似的图片。
+    form: form 


### PR DESCRIPTION
# Summary

This PR adds support for the Janus Pro 7B model to the SiliconFlow tool. Users can now generate 384x384 resolution images based on text prompts using this model. This model is currently available for free in SiliconFlow.

# Screenshots

| Before | After |
|--------|-------|
|  ![image](https://github.com/user-attachments/assets/0895fd75-3f71-47da-b367-9352f17c7f2c)      | ![image](https://github.com/user-attachments/assets/be7fccfc-a80d-4669-8b3b-fec37138f7f7) |
|  None  | ![image](https://github.com/user-attachments/assets/8f961819-6abb-4897-992b-13bb0fe3d003) |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

