### PR TITLE
set service_account_info as None when vertex_service_account_key param is not set

### DIFF
--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -98,7 +98,13 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
         :param stream: is stream response
         :return: full response or stream response chunk generator result
         """
-        service_account_info = json.loads(base64.b64decode(credentials["vertex_service_account_key"]))
+        service_account_info = (
+            json.loads(base64.b64decode(service_account_key))
+            if (
+                service_account_key := credentials.get("vertex_service_account_key", "")
+            )
+            else None
+        )
         project_id = credentials["vertex_project_id"]
         SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
         token = ""
@@ -436,7 +442,13 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
         dynamic_threshold = config_kwargs.pop("grounding", None)
         if stop:
             config_kwargs["stop_sequences"] = stop
-        service_account_info = json.loads(base64.b64decode(credentials["vertex_service_account_key"]))
+        service_account_info = (
+            json.loads(base64.b64decode(service_account_key))
+            if (
+                service_account_key := credentials.get("vertex_service_account_key", "")
+            )
+            else None
+        )
         project_id = credentials["vertex_project_id"]
         location = credentials["vertex_location"]
         if service_account_info:

--- a/models/vertex_ai/models/text_embedding/text_embedding.py
+++ b/models/vertex_ai/models/text_embedding/text_embedding.py
@@ -48,7 +48,13 @@ class VertexAiTextEmbeddingModel(CommonVertexAi, TextEmbeddingModel):
         :param input_type: input type
         :return: embeddings result
         """
-        service_account_info = json.loads(base64.b64decode(credentials["vertex_service_account_key"]))
+        service_account_info = (
+            json.loads(base64.b64decode(service_account_key))
+            if (
+                service_account_key := credentials.get("vertex_service_account_key", "")
+            )
+            else None
+        )
         project_id = credentials["vertex_project_id"]
         location = credentials["vertex_location"]
         if service_account_info:
@@ -91,7 +97,13 @@ class VertexAiTextEmbeddingModel(CommonVertexAi, TextEmbeddingModel):
         :return:
         """
         try:
-            service_account_info = json.loads(base64.b64decode(credentials["vertex_service_account_key"]))
+            service_account_info = (
+                json.loads(base64.b64decode(service_account_key))
+                if (
+                    service_account_key := credentials.get("vertex_service_account_key", "")
+                )
+                else None
+            )
             project_id = credentials["vertex_project_id"]
             location = credentials["vertex_location"]
             if service_account_info:


### PR DESCRIPTION
When I leave blank `Service Account Key` field to use ADC(Application Default Credential), got error "vertex_service_account_key"
<img width="375" alt="image" src="https://github.com/user-attachments/assets/b51e9d95-a69d-466f-8964-305bbf8a577a" />

To fix this issue, set service_account_info as None when vertex_service_account_key param is not set.
