### PR TITLE
fix: change zhipuai validate model name from glm-4 to glm-4-flash

### DIFF
--- a/models/zhipuai/provider/zhipuai.py
+++ b/models/zhipuai/provider/zhipuai.py
@@ -17,7 +17,7 @@ class ZhipuaiProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="glm-4", credentials=credentials)
+            model_instance.validate_credentials(model="glm-4-flash", credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:


### PR DESCRIPTION
fix #281 