### PR TITLE
fix: gemini models can't auth

### DIFF
--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -1,5 +1,5 @@
 author: langgenius
-created_at: '2024-09-20T00:13:50.29298939-04:00'
+created_at: "2024-09-20T00:13:50.29298939-04:00"
 description:
   en_US: Google's Gemini model.
   zh_Hans: 谷歌提供的 Gemini 模型.
@@ -8,17 +8,17 @@ label:
   en_US: Gemini
 meta:
   arch:
-  - amd64
-  - arm64
+    - amd64
+    - arm64
   runner:
     entrypoint: main
     language: python
-    version: '3.12'
+    version: "3.12"
   version: 0.0.1
 name: gemini
 plugins:
   models:
-  - provider/google.yaml
+    - provider/google.yaml
 resource:
   memory: 268435456
   permission:
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/gemini/provider/google.py
+++ b/models/gemini/provider/google.py
@@ -1,7 +1,8 @@
 import logging
+
+from dify_plugin import ModelProvider
 from dify_plugin.entities.model import ModelType
 from dify_plugin.errors.model import CredentialsValidateFailedError
-from dify_plugin import ModelProvider
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +18,13 @@ class GoogleProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="gemini-pro", credentials=credentials)
+            model_instance.validate_credentials(
+                model="gemini-2.0-flash-lite", credentials=credentials
+            )
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:
-            logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
+            logger.exception(
+                f"{self.get_provider_schema().provider} credentials validate failed"
+            )
             raise ex


### PR DESCRIPTION
Fixed the issue where authorization failed due to the non-existence of the gemini-pro model.

| Before | After |
|--------|-------|
| <img width="1069" alt="image" src="https://github.com/user-attachments/assets/3177454a-9f43-4196-b624-7072a503f1a2" /> | <img width="841" alt="image" src="https://github.com/user-attachments/assets/1608477e-cbcd-4e09-9bfe-8bde918ace19" /> |

