### PR TITLE
chore: bump version of models/openai_api_compatible to 0.0.5

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"


### PR DESCRIPTION
for the mistake in #252 