### PR TITLE
upgrade oci models [Fix:#288]

### DIFF
--- a/models/oci/manifest.yaml
+++ b/models/oci/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.2
+version: 0.0.3

--- a/models/oci/models/llm/_position.yaml
+++ b/models/oci/models/llm/_position.yaml
@@ -1,3 +1,5 @@
-- cohere.command-r-16k
-- cohere.command-r-plus
-- meta.llama-3-70b-instruct
+- cohere.command-r-08-2024
+- cohere.command-r-plus-08-2024
+- meta.llama-3.1-405b-instruct
+- meta.llama-3.2-90b-vision-instruct
+- meta.llama-3.3-70b-instruct

--- a/models/oci/models/llm/cohere.command-r-08-2024.yaml
+++ b/models/oci/models/llm/cohere.command-r-08-2024.yaml
@@ -1,18 +1,19 @@
-model: meta.llama-3-70b-instruct
+model: cohere.command-r-08-2024
 label:
-  zh_Hans: meta.llama-3-70b-instruct
-  en_US: meta.llama-3-70b-instruct
+  en_US: cohere.command-r-08-2024 v1.7
 model_type: llm
 features:
+  - multi-tool-call
   - agent-thought
+  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 131072
+  context_size: 128000
 parameter_rules:
   - name: temperature
     use_template: temperature
     default: 1
-    max: 2.0
+    max: 1.0
   - name: topP
     use_template: top_p
     default: 0.75
@@ -32,21 +33,20 @@ parameter_rules:
     max: 500
   - name: presencePenalty
     use_template: presence_penalty
-    min: -2
-    max: 2
+    min: 0
+    max: 1
     default: 0
   - name: frequencyPenalty
     use_template: frequency_penalty
-    min: -2
-    max: 2
+    min: 0
+    max: 1
     default: 0
   - name: maxTokens
     use_template: max_tokens
     default: 600
-    max: 8000
+    max: 4000
 pricing:
-  input: '0.015'
-  output: '0.015'
+  input: '0.0009'
+  output: '0.0009'
   unit: '0.0001'
   currency: USD
-deprecated: true

--- a/models/oci/models/llm/cohere.command-r-16k.yaml
+++ b/models/oci/models/llm/cohere.command-r-16k.yaml
@@ -50,3 +50,4 @@ pricing:
   output: '0.004'
   unit: '0.0001'
   currency: USD
+deprecated: true

--- a/models/oci/models/llm/cohere.command-r-plus-08-2024.yaml
+++ b/models/oci/models/llm/cohere.command-r-plus-08-2024.yaml
@@ -1,18 +1,19 @@
-model: meta.llama-3-70b-instruct
+model: cohere.command-r-plus-08-2024
 label:
-  zh_Hans: meta.llama-3-70b-instruct
-  en_US: meta.llama-3-70b-instruct
+  en_US: cohere.command-r-plus v1.6
 model_type: llm
 features:
+  - multi-tool-call
   - agent-thought
+  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 131072
+  context_size: 128000
 parameter_rules:
   - name: temperature
     use_template: temperature
     default: 1
-    max: 2.0
+    max: 1.0
   - name: topP
     use_template: top_p
     default: 0.75
@@ -32,21 +33,20 @@ parameter_rules:
     max: 500
   - name: presencePenalty
     use_template: presence_penalty
-    min: -2
-    max: 2
+    min: 0
+    max: 1
     default: 0
   - name: frequencyPenalty
     use_template: frequency_penalty
-    min: -2
-    max: 2
+    min: 0
+    max: 1
     default: 0
   - name: maxTokens
     use_template: max_tokens
     default: 600
-    max: 8000
+    max: 4000
 pricing:
-  input: '0.015'
-  output: '0.015'
+  input: '0.0156'
+  output: '0.0156'
   unit: '0.0001'
   currency: USD
-deprecated: true

--- a/models/oci/models/llm/cohere.command-r-plus.yaml
+++ b/models/oci/models/llm/cohere.command-r-plus.yaml
@@ -50,3 +50,4 @@ pricing:
   output: '0.0219'
   unit: '0.0001'
   currency: USD
+deprecated: true

--- a/models/oci/models/llm/llm.py
+++ b/models/oci/models/llm/llm.py
@@ -30,7 +30,7 @@ from oci.generative_ai_inference.models.base_chat_response import BaseChatRespon
 logger = logging.getLogger(__name__)
 request_template = {
     "compartmentId": "",
-    "servingMode": {"modelId": "cohere.command-r-plus", "servingType": "ON_DEMAND"},
+    "servingMode": {"modelId": "cohere.command-r-plus-08-2024", "servingType": "ON_DEMAND"},
     "chatRequest": {
         "apiFormat": "COHERE",
         "maxTokens": 600,
@@ -53,14 +53,36 @@ oci_config_template = {
 
 class OCILargeLanguageModel(LargeLanguageModel):
     _supported_models = {
-        "meta.llama-3-70b-instruct": {
+        "meta.llama-3.1-405b-instruct": {
             "system": True,
             "multimodal": False,
             "tool_call": False,
             "stream_tool_call": False,
         },
-        "cohere.command-r-16k": {"system": True, "multimodal": False, "tool_call": True, "stream_tool_call": False},
-        "cohere.command-r-plus": {"system": True, "multimodal": False, "tool_call": True, "stream_tool_call": False},
+        "meta.llama-3.2-90b-vision-instruct": {
+            "system": True,
+            "multimodal": False,
+            "tool_call": False,
+            "stream_tool_call": False,
+        },
+        "meta.llama-3.3-70b-instruct": {
+            "system": True,
+            "multimodal": False,
+            "tool_call": False,
+            "stream_tool_call": False,
+        },
+        "cohere.command-r-08-2024": {
+            "system": True,
+            "multimodal": False,
+            "tool_call": True,
+            "stream_tool_call": False,
+        },
+        "cohere.command-r-plus-08-2024": {
+            "system": True,
+            "multimodal": False,
+            "tool_call": True,
+            "stream_tool_call": False,
+        },
     }
 
     def _is_tool_call_supported(self, model_id: str, stream: bool = False) -> bool:

--- a/models/oci/models/llm/meta.llama-3.1-405b-instruct.yaml
+++ b/models/oci/models/llm/meta.llama-3.1-405b-instruct.yaml
@@ -1,7 +1,7 @@
-model: meta.llama-3-70b-instruct
+model: meta.llama-3.1-405b-instruct
 label:
-  zh_Hans: meta.llama-3-70b-instruct
-  en_US: meta.llama-3-70b-instruct
+  zh_Hans: meta.llama-3.1-405b-instruct
+  en_US: meta.llama-3.1-405b-instruct
 model_type: llm
 features:
   - agent-thought
@@ -43,10 +43,9 @@ parameter_rules:
   - name: maxTokens
     use_template: max_tokens
     default: 600
-    max: 8000
+    max: 4000
 pricing:
-  input: '0.015'
-  output: '0.015'
+  input: '0.0267'
+  output: '0.0267'
   unit: '0.0001'
   currency: USD
-deprecated: true

--- a/models/oci/models/llm/meta.llama-3.2-90b-vision-instruct.yaml
+++ b/models/oci/models/llm/meta.llama-3.2-90b-vision-instruct.yaml
@@ -1,7 +1,7 @@
-model: meta.llama-3-70b-instruct
+model: meta.llama-3.2-90b-vision-instruct
 label:
-  zh_Hans: meta.llama-3-70b-instruct
-  en_US: meta.llama-3-70b-instruct
+  zh_Hans: meta.llama-3.2-90b-vision-instruct
+  en_US: meta.llama-3.2-90b-vision-instruct
 model_type: llm
 features:
   - agent-thought
@@ -43,10 +43,9 @@ parameter_rules:
   - name: maxTokens
     use_template: max_tokens
     default: 600
-    max: 8000
+    max: 4000
 pricing:
-  input: '0.015'
-  output: '0.015'
+  input: '0.005'
+  output: '0.005'
   unit: '0.0001'
   currency: USD
-deprecated: true

--- a/models/oci/models/llm/meta.llama-3.3-70b-instruct.yaml
+++ b/models/oci/models/llm/meta.llama-3.3-70b-instruct.yaml
@@ -1,7 +1,7 @@
-model: meta.llama-3-70b-instruct
+model: meta.llama-3.3-70b-instruct
 label:
-  zh_Hans: meta.llama-3-70b-instruct
-  en_US: meta.llama-3-70b-instruct
+  zh_Hans: meta.llama-3.3-70b-instruct
+  en_US: meta.llama-3.3-70b-instruct
 model_type: llm
 features:
   - agent-thought
@@ -43,10 +43,9 @@ parameter_rules:
   - name: maxTokens
     use_template: max_tokens
     default: 600
-    max: 8000
+    max: 4000
 pricing:
-  input: '0.015'
-  output: '0.015'
+  input: '0.0018'
+  output: '0.0018'
   unit: '0.0001'
   currency: USD
-deprecated: true

--- a/models/oci/provider/oci.py
+++ b/models/oci/provider/oci.py
@@ -17,7 +17,7 @@ class OCIGENAIProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="cohere.command-r-plus", credentials=credentials)
+            model_instance.validate_credentials(model="cohere.command-r-plus-08-2024", credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:


### PR DESCRIPTION
Upgrade oci models, some are depreated and some are added according to latest oracle oci document [About the Chat Models in Generative AI](https://docs.oracle.com/en-us/iaas/Content/generative-ai/chat-models.htm#chat-models).

Deprecated:
- Command R (cohere.command-r-16k) ([Deprecated]
- Command R+ (cohere.command-r-plus) ([Deprecated]
- meta.llama-3-70b-instruct

Added:
- Command R 08-2024 (cohere.command-r-08-2024) (New)
- Command R+ 08-2024 (cohere.command-r-plus-08-2024) (New)
- [Meta Llama 3.3 70B (New)] meta.llama-3.3-70b-instruct
- [Meta Llama 3.2 Family (New)] meta.llama-3.2-90b-vision-instruct
- [Meta Llama 3.1 Family] meta.llama-3.1-405b-instruct


By the way, I've pull a request to original dify repository before (https://github.com/langgenius/dify/pull/13174), but it was merged here.