### PR TITLE
remove license section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,3 @@ In the future, all new official plugins developed by Dify will be updated and ma
 ### Security disclosure
 
 To protect your privacy, please avoid posting security issues on GitHub. Instead, send your questions to [security@dify.ai](mailto:security@dify.ai) and we will provide you with a more detailed answer.
-
-### License
-
-This repository is available under the [Dify Open Source License](https://github.com/langgenius/dify/blob/main/LICENSE), which is essentially Apache 2.0 with a few additional restrictions.


### PR DESCRIPTION
I removed the part of the License cause this repository uses the original Apache 2.0 License.