### PR TITLE
Add minimax-text-01 model to supported LLM configurations

### DIFF
--- a/models/minimax/manifest.yaml
+++ b/models/minimax/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/models/minimax/models/llm/llm.py
+++ b/models/minimax/models/llm/llm.py
@@ -33,6 +33,7 @@ from models.llm.types import MinimaxMessage
 
 class MinimaxLargeLanguageModel(LargeLanguageModel):
     model_apis = {
+        "minimax-text-01": MinimaxChatCompletionPro,
         "abab7-chat-preview": MinimaxChatCompletionPro,
         "abab6.5s-chat": MinimaxChatCompletionPro,
         "abab6.5-chat": MinimaxChatCompletionPro,

--- a/models/minimax/models/llm/minimax-text-01.yaml
+++ b/models/minimax/models/llm/minimax-text-01.yaml
@@ -1,0 +1,46 @@
+model: minimax-text-01
+label:
+  en_US: Minimax-Text-01
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000192
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    min: 0.01
+    max: 1
+    default: 0.1
+  - name: top_p
+    use_template: top_p
+    min: 0.01
+    max: 1
+    default: 0.95
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    default: 2048
+    min: 1
+    max: 1000192
+  - name: mask_sensitive_info
+    type: boolean
+    default: true
+    label:
+      zh_Hans: 隐私保护
+      en_US: Moderate
+    help:
+      zh_Hans: 对输出中易涉及隐私问题的文本信息进行打码，目前包括但不限于邮箱、域名、链接、证件号、家庭住址等，默认true，即开启打码
+      en_US: Mask the sensitive info of the generated content, such as email/domain/link/address/phone/id..
+  - name: presence_penalty
+    use_template: presence_penalty
+  - name: frequency_penalty
+    use_template: frequency_penalty
+pricing:
+  input: "0.001"
+  output: "0.008"
+  unit: "0.001"
+  currency: RMB


### PR DESCRIPTION
* Add new Minimax model "minimax-text-01" to the model_apis dictionary
* Consistent with previous model configuration updates

sync: https://github.com/langgenius/dify/pull/12763