### PR TITLE
fix(ark): remove tool call feature for deepseek v3

### DIFF
--- a/models/volcengine_maas/manifest.yaml
+++ b/models/volcengine_maas/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/models/volcengine_maas/models/llm/models.py
+++ b/models/volcengine_maas/models/llm/models.py
@@ -29,7 +29,7 @@ configs: dict[str, ModelConfig] = {
     ),
     "DeepSeek-V3": ModelConfig(
         properties=ModelProperties(context_size=64000, max_tokens=8192, mode=LLMMode.CHAT),
-        features=[ModelFeature.AGENT_THOUGHT, ModelFeature.TOOL_CALL, ModelFeature.STREAM_TOOL_CALL],
+        features=[ModelFeature.AGENT_THOUGHT],
     ),
     "Doubao-1.5-vision-pro-32k": ModelConfig(
         properties=ModelProperties(context_size=32768, max_tokens=12288, mode=LLMMode.CHAT),


### PR DESCRIPTION
tool call feature for deepseek v3 is not provided by volcengine ark service