### PR TITLE
fix: ReAct Agent instruction param is not used

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/strategies/ReAct.py
+++ b/agent-strategies/cot_agent/strategies/ReAct.py
@@ -110,7 +110,7 @@ class ReActAgentStrategy(AgentStrategy):
             stop.append("Observation")
         # init instruction
         inputs = react_params.inputs
-        instruction = ""
+        instruction = react_params.instruction or ""
         self._instruction = self._fill_in_inputs_from_external_data_tools(
             instruction, inputs
         )


### PR DESCRIPTION
ReAct Agent instruction param is not used in code
https://github.com/langgenius/dify/issues/14630