### PR TITLE
Fix failed to create rerank model when use vllm rerank

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/rerank/rerank.py
+++ b/models/openai_api_compatible/models/rerank/rerank.py
@@ -4,4 +4,27 @@ from dify_plugin.interfaces.model.openai_compatible.rerank import (
 
 
 class OpenAIRerankModel(OAICompatRerankModel):
-    pass
+    def validate_credentials(self, model: str, credentials: dict) -> None:
+        """
+        Validate model credentials
+
+        :param model: model name
+        :param credentials: model credentials
+        :return:
+        """
+        try:
+            self._invoke(
+                model=model,
+                credentials=credentials,
+                query="What is the capital of the United States?",
+                docs=[
+                    "Carson City is the capital city of the American state of Nevada. At the 2010 United States "
+                    "Census, Carson City had a population of 55,274.",
+                    "The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean that "
+                    "are a political division controlled by the United States. Its capital is Saipan.",
+                ],
+                score_threshold=0.8,
+                top_n=3,
+            )
+        except Exception as ex:
+            raise CredentialsValidateFailedError(str(ex)) from ex


### PR DESCRIPTION
[#14140](https://github.com/langgenius/dify/issues/14140)
rewrite the validate_credentials method of the parent class and add the parameter top_n when calling the _invoke method