### PR TITLE
chore: gpustack tools api path

### DIFF
--- a/tools/gpustack/manifest.yaml
+++ b/tools/gpustack/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 type: plugin
 author: langgenius
 name: gpustack_tools

--- a/tools/gpustack/provider/gpustack.py
+++ b/tools/gpustack/provider/gpustack.py
@@ -6,9 +6,9 @@ from dify_plugin import ToolProvider
 
 class GPUStackProvider(ToolProvider):
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
-        base_url = credentials.get("base_url", "").removesuffix("/").removesuffix("/v1-openai")
+        base_url = credentials.get("base_url", "").removesuffix("/").removesuffix("/v1")
         api_key = credentials.get("api_key", "")
-        tls_verify = credentials.get("tls_verify", True)
+        tls_verify = bool(credentials.get("tls_verify", True))
 
         if not base_url:
             raise ToolProviderCredentialValidationError("GPUStack base_url is required")

--- a/tools/gpustack/tools/image_edit.py
+++ b/tools/gpustack/tools/image_edit.py
@@ -27,11 +27,12 @@ class ImageEditTool(Tool):
 
             base_url = get_base_url(self.runtime.credentials["base_url"])
             response = requests.post(
-                f"{base_url}/v1-openai/images/edits",
+                f"{base_url}/v1/images/edits",
                 headers={"Authorization": f"Bearer {self.runtime.credentials['api_key']}"},
                 data=params,
                 files=files,
-                verify=self.runtime.credentials.get("tls_verify", True),
+                verify=bool(self.runtime.credentials.get("tls_verify", True)),
+                timeout=float(tool_parameters.get("timeout")),
             )
 
             if not response.ok:

--- a/tools/gpustack/tools/image_edit.yaml
+++ b/tools/gpustack/tools/image_edit.yaml
@@ -188,3 +188,14 @@ parameters:
     human_description:
       en_US: Random seed for image generation. Using the same seed will produce similar results.
       zh_Hans: 图像生成的随机种子。使用相同的种子会产生相似的结果。
+  - name: timeout
+    type: number
+    required: false
+    default: 600
+    label:
+      en_US: Timeout(seconds)
+      zh_Hans: 超时时间(秒)
+    human_description:
+      en_US: The maximum time to wait for the image generation to complete(seconds).
+      zh_Hans: 等待图像生成完成的最大时间(秒)。
+    form: form

--- a/tools/gpustack/tools/text2image.py
+++ b/tools/gpustack/tools/text2image.py
@@ -17,10 +17,11 @@ class TextToImageTool(Tool):
             params = get_common_params(tool_parameters)
             base_url = get_base_url(self.runtime.credentials["base_url"])
             response = requests.post(
-                f"{base_url}/v1-openai/images/generations",
+                f"{base_url}/v1/images/generations",
                 headers={"Authorization": f"Bearer {self.runtime.credentials['api_key']}"},
                 json=params,
-                verify=self.runtime.credentials.get("tls_verify", True),
+                verify=bool(self.runtime.credentials.get("tls_verify", True)),
+                timeout=float(tool_parameters.get("timeout")),
             )
 
             if not response.ok:

--- a/tools/gpustack/tools/text2image.yaml
+++ b/tools/gpustack/tools/text2image.yaml
@@ -176,3 +176,14 @@ parameters:
       en_US: Random seed for image generation. Using the same seed will produce similar results.
       zh_Hans: 图像生成的随机种子。使用相同的种子会产生相似的结果。
     form: form
+  - name: timeout
+    type: number
+    required: false
+    default: 600
+    label:
+      en_US: Timeout(seconds)
+      zh_Hans: 超时时间(秒)
+    human_description:
+      en_US: The maximum time to wait for the image generation to complete(seconds).
+      zh_Hans: 等待图像生成完成的最大时间(秒)。
+    form: form


### PR DESCRIPTION
This PR is going to:
1. Change GPUStack tools API path from `v1-openai` to `v1`
2. Add timeouts for image generation tools, as some LLM-based image generators can take a long time to process requests, potentially causing excessive wait times for users.