### PR TITLE
fix: missing import `time` module

### DIFF
--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -1,6 +1,7 @@
 import base64
 import tempfile
 import json
+import time
 import os
 from collections.abc import Generator
 from typing import Optional, Union


### PR DESCRIPTION
Line 326 use time.sleep, but it was never been imported.

It should be well tested before it came to v1.0.0