### PR TITLE
Update llm.py of tongyi

### DIFF
--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -169,7 +169,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             response = MultiModalConversation.call(**params, stream=stream)
         else:
             params["messages"] = self._convert_prompt_messages_to_tongyi_messages(prompt_messages)
-            response = Generation.call(**params, result_format="message", stream=stream, incremental_output=True)
+            response = Generation.call(**params, result_format="message", stream=stream, incremental_output=stream)
         if stream:
             return self._handle_generate_stream_response(model, credentials, response, prompt_messages)
         return self._handle_generate_response(model, credentials, response, prompt_messages)


### PR DESCRIPTION
try to fix "incremental_output Only Supports Stream Call" error when configure tongyi provider.

See also https://github.com/langgenius/dify/discussions/13605, https://github.com/langgenius/dify/pull/13620/files.