### PR TITLE
add agent though config to OpenAI-API-compatible

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -1,7 +1,20 @@
+from typing import Mapping
+
+from dify_plugin.entities.model import AIModelEntity, ModelFeature
 from dify_plugin.interfaces.model.openai_compatible.llm import (
     OAICompatLargeLanguageModel,
 )
 
 
 class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
-    pass
+    def get_customizable_model_schema(self, model: str, credentials: Mapping) -> AIModelEntity:
+        entity = super().get_customizable_model_schema(model, credentials)
+
+        agent_though_support = credentials.get("agent_though_support", "not_supported")
+        if agent_though_support == "supported":
+            try:
+                entity.features.index(ModelFeature.AGENT_THOUGHT)
+            except ValueError:
+                entity.features.append(ModelFeature.AGENT_THOUGHT)
+
+        return entity

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -118,6 +118,24 @@ model_credential_schema:
           value: llm
       default: "4096"
       type: text-input
+    - variable: agent_though_support
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        en_US: Agent Thought
+      type: select
+      required: false
+      default: not_supported
+      options:
+        - value: supported
+          label:
+            en_US: Support
+            zh_Hans: 支持
+        - value: not_supported
+          label:
+            en_US: Not Support
+            zh_Hans: 不支持
     - variable: function_calling_type
       show_on:
         - variable: __model_type


### PR DESCRIPTION
[https://github.com/langgenius/dify/pull/13263](https://github.com/langgenius/dify/pull/13263)

Add an Agent Though configuration item to the OpenAI-API-compatible model provider, corresponding to ModelFeature.AGENT_THOUGH