### PR TITLE
Update GPUStack model API path

### DIFF
--- a/models/gpustack/README.md
+++ b/models/gpustack/README.md
@@ -1,0 +1,28 @@
+## Overview
+
+GPUStack is an open-source GPU cluster manager for running AI models.
+
+## Key Features
+- Broad Hardware Compatibility: Run with different brands of GPUs in Apple Macs, Windows PCs, and Linux servers.
+Broad Model Support: From LLMs to diffusion models, audio, embedding, and reranker models.
+- Scales with Your GPU Inventory: Easily add more GPUs or nodes to scale up your operations.
+- Distributed Inference: Supports both single-node multi-GPU and multi-node inference and serving.
+- Multiple Inference Backends: Supports llama-box (llama.cpp & stable-diffusion.cpp), vox-box and vLLM as the inference backends.
+- Lightweight Python Package: Minimal dependencies and operational overhead.
+- OpenAI-compatible APIs: Serve APIs that are compatible with OpenAI standards.
+- User and API key management: Simplified management of users and API keys.
+- GPU metrics monitoring: Monitor GPU performance and utilization in real-time.
+- Token usage and rate metrics: Track token usage and manage rate limits effectively.
+
+## Quickstart
+
+You need setup your own GPUStack server. Please refer to GPUStack official docs [quickstart](https://docs.gpustack.ai/latest/quickstart/)
+
+## Configure
+
+After setting up your GPUStack server, you will need the following to configure this plugin:
+
+- GPUStack Server URL (e.g., http://yourserveraddress:port)
+- GPUStack API Key
+
+Obtain these from your GPUStack server, then enter them into the settings. Click "Save" to activate the plugin.

--- a/models/gpustack/manifest.yaml
+++ b/models/gpustack/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.2
+version: 0.0.3

--- a/models/gpustack/manifest.yaml
+++ b/models/gpustack/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.3
+version: 0.0.2

--- a/models/gpustack/manifest.yaml
+++ b/models/gpustack/manifest.yaml
@@ -1,7 +1,8 @@
 author: langgenius
 created_at: "2024-09-20T00:13:50.29298939-04:00"
 description:
-  en_US: GPUStack
+  en_US: GPUStack is an open-source GPU cluster manager for running AI models.
+  zh_Hans: GPUStack 是一个专为运行 AI 模型而设计的开源 GPU 集群管理器，致力于支持基于任何品牌的异构 GPU 构建统一管理的算力集群
 icon: icon_s_en.png
 label:
   en_US: GPUStack
@@ -32,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.2
+version: 0.0.3

--- a/models/gpustack/models/llm/llm.py
+++ b/models/gpustack/models/llm/llm.py
@@ -37,6 +37,6 @@ class GPUStackLanguageModel(OAICompatLargeLanguageModel):
 
     def _get_compatible_credentials(self, credentials: dict) -> dict:
         credentials = credentials.copy()
-        base_url = credentials["endpoint_url"].rstrip("/").removesuffix("/v1-openai")
-        credentials["endpoint_url"] = f"{base_url}/v1-openai"
+        base_url = credentials["endpoint_url"].rstrip("/").removesuffix("/v1")
+        credentials["endpoint_url"] = f"{base_url}/v1"
         return credentials

--- a/models/gpustack/models/rerank/rerank.py
+++ b/models/gpustack/models/rerank/rerank.py
@@ -59,11 +59,12 @@ class GPUStackRerankModel(RerankModel):
         }
         data = {"model": model, "query": query, "documents": docs, "top_n": top_n}
         try:
+            timeout = float(credentials.get("timeout", 10))
             response = post(
                 str(URL(endpoint_url) / "v1" / "rerank"),
                 headers=headers,
                 data=dumps(data),
-                timeout=10,
+                timeout=timeout,
             )
             response.raise_for_status()
             results = response.json()

--- a/models/gpustack/models/speech2text/speech2text.py
+++ b/models/gpustack/models/speech2text/speech2text.py
@@ -31,6 +31,6 @@ class GPUStackSpeechToTextModel(OAICompatSpeechToTextModel):
 
     def _get_compatible_credentials(self, credentials: dict) -> dict:
         credentials = credentials.copy()
-        base_url = credentials["endpoint_url"].rstrip("/").removesuffix("/v1-openai")
-        credentials["endpoint_url"] = f"{base_url}/v1-openai"
+        base_url = credentials["endpoint_url"].rstrip("/").removesuffix("/v1")
+        credentials["endpoint_url"] = f"{base_url}/v1"
         return credentials

--- a/models/gpustack/models/text_embedding/text_embedding.py
+++ b/models/gpustack/models/text_embedding/text_embedding.py
@@ -27,6 +27,6 @@ class GPUStackTextEmbeddingModel(OAICompatEmbeddingModel):
 
     def _get_compatible_credentials(self, credentials: dict) -> dict:
         credentials = credentials.copy()
-        base_url = credentials["endpoint_url"].rstrip("/").removesuffix("/v1-openai")
-        credentials["endpoint_url"] = f"{base_url}/v1-openai"
+        base_url = credentials["endpoint_url"].rstrip("/").removesuffix("/v1")
+        credentials["endpoint_url"] = f"{base_url}/v1"
         return credentials

--- a/models/gpustack/models/tts/tts.py
+++ b/models/gpustack/models/tts/tts.py
@@ -37,7 +37,7 @@ class GPUStackTextToSpeechModel(OAICompatTextToSpeechModel):
         :return: compatible credentials
         """
         compatible_credentials = credentials.copy()
-        base_url = credentials["endpoint_url"].rstrip("/").removesuffix("/v1-openai")
-        compatible_credentials["endpoint_url"] = f"{base_url}/v1-openai"
+        base_url = credentials["endpoint_url"].rstrip("/").removesuffix("/v1")
+        compatible_credentials["endpoint_url"] = f"{base_url}/v1"
 
         return compatible_credentials

--- a/models/gpustack/provider/gpustack.yaml
+++ b/models/gpustack/provider/gpustack.yaml
@@ -124,11 +124,27 @@ model_credential_schema:
       required: false
       default: "Chinese Female"
       placeholder:
-        en_US: "Chinese Female, Chinese Male, Japanese Male, Cantonese Female, English Female, English Male, Korean Female"
-        zh_Hans: "Chinese Female, Chinese Male, Japanese Male, Cantonese Female, English Female, English Male, Korean Female"
+        en_US: "Chinese Female,Chinese Male, Japanese Male, Cantonese Female, English Female, English Male, Korean Female"
+        zh_Hans: "Chinese Female,Chinese Male, Japanese Male, Cantonese Female, English Female, English Male, Korean Female"
       help:
         en_US: "List voice names separated by commas. First voice will be used as default."
         zh_Hans: "用英文逗号分隔的声音列表。第一个声音将作为默认值。"
+    - variable: timeout
+      label:
+        en_US: Timeout(s)
+        zh_Hans: 超时时间(秒)
+      type: text-input
+      required: false
+      default: "600"
+      placeholder:
+        en_US: "600"
+        zh_Hans: "600"
+      help:
+        en_US: "The maximum time to wait for the model to complete the task(seconds)."
+        zh_Hans: "等待模型完成任务的最大时间(秒)。"
+      show_on:
+        - value: rerank
+          variable: __model_type
   model:
     label:
       en_US: Model Name


### PR DESCRIPTION
This PR is going to:
 - change model API path from `v1-openai` to `v1`
 - Add timeout configuration for `rerank` model
 - update model plugin docs.