### PR TITLE
feat(azure_openai): add o1 base model, support reasoning_effort, and fix minor issues

### DIFF
--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/models/azure_openai/models/constants.py
+++ b/models/azure_openai/models/constants.py
@@ -1288,6 +1288,8 @@ LLM_BASE_MODELS = [
             model_type=ModelType.LLM,
             features=[
                 ModelFeature.AGENT_THOUGHT,
+                ModelFeature.MULTI_TOOL_CALL,
+                ModelFeature.STREAM_TOOL_CALL,
             ],
             fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
             model_properties={

--- a/models/azure_openai/models/constants.py
+++ b/models/azure_openai/models/constants.py
@@ -1271,8 +1271,8 @@ LLM_BASE_MODELS = [
                 _get_o1_max_tokens(default=512, min_val=1, max_val=65536),
             ],
             pricing=PriceConfig(
-                input=3.00,
-                output=12.00,
+                input=1.10,
+                output=4.40,
                 unit=0.000001,
                 currency="USD",
             ),

--- a/models/azure_openai/models/constants.py
+++ b/models/azure_openai/models/constants.py
@@ -1279,6 +1279,57 @@ LLM_BASE_MODELS = [
         ),
     ),
     AzureBaseModel(
+        base_model_name="o1",
+        entity=AIModelEntity(
+            model="fake-deployment-name",
+            label=I18nObject(
+                en_US="fake-deployment-name-label",
+            ),
+            model_type=ModelType.LLM,
+            features=[
+                ModelFeature.AGENT_THOUGHT,
+                ModelFeature.VISION,
+                ModelFeature.MULTI_TOOL_CALL,
+                ModelFeature.STREAM_TOOL_CALL,
+            ],
+            fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
+            model_properties={
+                ModelPropertyKey.MODE: LLMMode.CHAT.value,
+                ModelPropertyKey.CONTEXT_SIZE: 200000,
+            },
+            parameter_rules=[
+                ParameterRule(
+                    name="response_format",
+                    label=I18nObject(zh_Hans="回复格式", en_US="response_format"),
+                    type="string",
+                    help=I18nObject(
+                        zh_Hans="指定模型必须输出的格式",
+                        en_US="specifying the format that the model must output",
+                    ),
+                    required=False,
+                    options=["text", "json_object", "json_schema"],
+                ),
+                ParameterRule(
+                    name="json_schema",
+                    label=I18nObject(en_US="JSON Schema"),
+                    type="text",
+                    help=I18nObject(
+                        zh_Hans="设置返回的json schema，llm将按照它返回",
+                        en_US="Set a response json schema will ensure LLM to adhere it.",
+                    ),
+                    required=False,
+                ),
+                _get_o1_max_tokens(default=512, min_val=1, max_val=100000),
+            ],
+            pricing=PriceConfig(
+                input=15.00,
+                output=60.00,
+                unit=0.000001,
+                currency="USD",
+            ),
+        ),
+    ),
+    AzureBaseModel(
         base_model_name="o3-mini",
         entity=AIModelEntity(
             model="fake-deployment-name",

--- a/models/azure_openai/models/constants.py
+++ b/models/azure_openai/models/constants.py
@@ -1319,6 +1319,17 @@ LLM_BASE_MODELS = [
                     ),
                     required=False,
                 ),
+                ParameterRule(
+                    name="reasoning_effort",
+                    label=I18nObject(zh_Hans="推理工作", en_US="reasoning_effort"),
+                    type="string",
+                    help=I18nObject(
+                        zh_Hans="限制推理模型的推理工作",
+                        en_US="constrains effort on reasoning for reasoning models",
+                    ),
+                    required=False,
+                    options=["low", "medium", "high"],
+                ),
                 _get_o1_max_tokens(default=512, min_val=1, max_val=100000),
             ],
             pricing=PriceConfig(
@@ -1368,6 +1379,17 @@ LLM_BASE_MODELS = [
                         en_US="Set a response json schema will ensure LLM to adhere it.",
                     ),
                     required=False,
+                ),
+                ParameterRule(
+                    name="reasoning_effort",
+                    label=I18nObject(zh_Hans="推理工作", en_US="reasoning_effort"),
+                    type="string",
+                    help=I18nObject(
+                        zh_Hans="限制推理模型的推理工作",
+                        en_US="constrains effort on reasoning for reasoning models",
+                    ),
+                    required=False,
+                    options=["low", "medium", "high"],
                 ),
                 _get_o1_max_tokens(default=512, min_val=1, max_val=100000),
             ],

--- a/models/azure_openai/models/constants.py
+++ b/models/azure_openai/models/constants.py
@@ -1292,7 +1292,7 @@ LLM_BASE_MODELS = [
             fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
             model_properties={
                 ModelPropertyKey.MODE: LLMMode.CHAT.value,
-                ModelPropertyKey.CONTEXT_SIZE: 128000,
+                ModelPropertyKey.CONTEXT_SIZE: 200000,
             },
             parameter_rules=[
                 ParameterRule(
@@ -1316,7 +1316,7 @@ LLM_BASE_MODELS = [
                     ),
                     required=False,
                 ),
-                _get_o1_max_tokens(default=512, min_val=1, max_val=65536),
+                _get_o1_max_tokens(default=512, min_val=1, max_val=100000),
             ],
             pricing=PriceConfig(
                 input=1.10,

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -661,7 +661,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb"""
         model = credentials["base_model_name"]
         try:
-            if "o3" in model:
+            if "o1" in model or "o3" in model:
                 model = "gpt-4o"
             encoding = tiktoken.encoding_for_model(model)
         except KeyError:

--- a/models/azure_openai/provider/azure_openai.yaml
+++ b/models/azure_openai/provider/azure_openai.yaml
@@ -46,6 +46,9 @@ model_credential_schema:
         zh_Hans: API 版本
       options:
         - label:
+            en_US: 2025-02-01-preview
+          value: 2025-02-01-preview
+        - label:
             en_US: 2025-01-01-preview
           value: 2025-01-01-preview
         - label:

--- a/models/azure_openai/provider/azure_openai.yaml
+++ b/models/azure_openai/provider/azure_openai.yaml
@@ -146,6 +146,12 @@ model_credential_schema:
               variable: __model_type
           value: o1-preview
         - label:
+            en_US: o1
+          show_on:
+            - value: llm
+              variable: __model_type
+          value: o1
+        - label:
             en_US: gpt-4o-mini
           show_on:
             - value: llm

--- a/models/azure_openai/requirements.txt
+++ b/models/azure_openai/requirements.txt
@@ -1,4 +1,4 @@
-dify_plugin==0.0.1b65
-openai~=1.57.2
+dify_plugin==0.0.1b72
+openai~=1.65.4
 tiktoken~=0.8.0
-numpy~=2.2.0
+numpy~=2.2.3


### PR DESCRIPTION
This PR changes following:

- ✅ Add the latest API version; `2025-01-01-preview`
- ✅ Correct price table for `o1-mini`
  - https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
  - $1.10 for Input and $4.40 for Output, instead of $3.00 for Input and $12.00 for Outpu
- ✅ Correct context window for `o3-mini`
  - https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/reasoning
  - 200,000 for Input and 100,000 for Output, instead of 128,000 for Input and 65,535 for Output
- ✅ Add support of Function Calling for `o3-mini`
- ✅ Add new base model; `o1`
- ✅ Add parameter `reasoning_effort` for `o3-mini`

Closes #404, closes #408

I understand that multiple topics should not be mixed in a single PR, sorry for this, but since these were many small fixes, I have consolidated them.
If everything should really be in separate PRs, I can split them as the commits are already separated. Please let me know.
