### PR TITLE
docs: Update top_p descriptions for Amazon Nova models

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/amazon.nova-lite-v1.yaml
+++ b/models/bedrock/models/llm/amazon.nova-lite-v1.yaml
@@ -35,8 +35,8 @@ parameter_rules:
     min: 0.000
     max: 1.000
     label:
-      zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
-      en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
+      zh_Hans: 在核采样中，Amazon Nova 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
+      en_US: In nucleus sampling, Amazon Nova computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
     required: false
     type: int

--- a/models/bedrock/models/llm/amazon.nova-micro-v1.yaml
+++ b/models/bedrock/models/llm/amazon.nova-micro-v1.yaml
@@ -34,8 +34,8 @@ parameter_rules:
     min: 0.000
     max: 1.000
     label:
-      zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
-      en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
+      zh_Hans: 在核采样中，Amazon Nova 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
+      en_US: In nucleus sampling, Amazon Nova computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
     required: false
     type: int

--- a/models/bedrock/models/llm/amazon.nova-pro-v1.yaml
+++ b/models/bedrock/models/llm/amazon.nova-pro-v1.yaml
@@ -35,8 +35,8 @@ parameter_rules:
     min: 0.000
     max: 1.000
     label:
-      zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
-      en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
+      zh_Hans: 在核采样中，Amazon Nova 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
+      en_US: In nucleus sampling, Amazon Nova computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
     required: false
     type: int

--- a/models/bedrock/models/llm/us.amazon.nova-lite-v1.yaml
+++ b/models/bedrock/models/llm/us.amazon.nova-lite-v1.yaml
@@ -35,8 +35,8 @@ parameter_rules:
     min: 0.000
     max: 1.000
     label:
-      zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
-      en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
+      zh_Hans: 在核采样中，Amazon Nova 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
+      en_US: In nucleus sampling, Amazon Nova computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
     required: false
     type: int

--- a/models/bedrock/models/llm/us.amazon.nova-micro-v1.yaml
+++ b/models/bedrock/models/llm/us.amazon.nova-micro-v1.yaml
@@ -34,8 +34,8 @@ parameter_rules:
     min: 0.000
     max: 1.000
     label:
-      zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
-      en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
+      zh_Hans: 在核采样中，Amazon Nova 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
+      en_US: In nucleus sampling, Amazon Nova computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
     required: false
     type: int

--- a/models/bedrock/models/llm/us.amazon.nova-pro-v1.yaml
+++ b/models/bedrock/models/llm/us.amazon.nova-pro-v1.yaml
@@ -35,8 +35,8 @@ parameter_rules:
     min: 0.000
     max: 1.000
     label:
-      zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
-      en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
+      zh_Hans: 在核采样中，Amazon Nova 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
+      en_US: In nucleus sampling, Amazon Nova computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
   - name: top_k
     required: false
     type: int


### PR DESCRIPTION
In `top_p` descriptions, fixed `Anthropic Claude` to `Amazon Nova`.