### PR TITLE
fix(Jina): Mark `base_url` as not required because handled with default in code

### DIFF
--- a/models/jina/manifest.yaml
+++ b/models/jina/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: "langgenius"
 name: "jina"

--- a/models/jina/models/rerank/rerank.py
+++ b/models/jina/models/rerank/rerank.py
@@ -24,6 +24,8 @@ class JinaRerankModel(RerankModel):
     Model class for Jina rerank model.
     """
 
+    api_base: str = "https://api.jina.ai/v1"
+
     def _invoke(
         self,
         model: str,
@@ -49,7 +51,7 @@ class JinaRerankModel(RerankModel):
         if len(docs) == 0:
             return RerankResult(model=model, docs=[])
 
-        base_url = credentials.get("base_url", "https://api.jina.ai/v1")
+        base_url = credentials.get("base_url", self.api_base)
         if base_url.endswith("/"):
             base_url = base_url[:-1]
 

--- a/models/jina/provider/jina.yaml
+++ b/models/jina/provider/jina.yaml
@@ -52,11 +52,10 @@ model_credential_schema:
         zh_Hans: 服务器 URL
         en_US: Base URL
       type: text-input
-      required: true
+      required: false
       placeholder:
         zh_Hans: Base URL, e.g. https://api.jina.ai/v1
         en_US: Base URL, e.g. https://api.jina.ai/v1
-      default: 'https://api.jina.ai/v1'
     - variable: context_size
       label:
         zh_Hans: 上下文大小


### PR DESCRIPTION
Adding the model in load balancing mode would fail because the base_url is not specified in provider form_manifest, but required by model form_manifest
The url is handled with a default value both in `text_embedding.py` and `rerank.py`

Closes #441