### PR TITLE
feat(jina_reader): add options to remove images and control caching behavior

### DIFF
--- a/tools/jina/manifest.yaml
+++ b/tools/jina/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - search
 - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/jina/manifest.yaml
+++ b/tools/jina/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - search
 - productivity
 type: plugin
-version: 0.0.4
+version: 0.0.7

--- a/tools/jina/tools/jina_reader.py
+++ b/tools/jina/tools/jina_reader.py
@@ -33,6 +33,8 @@ class JinaReaderTool(Tool):
         wait_for_selector = tool_parameters.get("wait_for_selector")
         if wait_for_selector is not None and wait_for_selector != "":
             headers["X-Wait-For-Selector"] = wait_for_selector
+        if tool_parameters.get("remove_images", False):
+            headers["X-Retain-Images"] = "none"
         if tool_parameters.get("image_caption", False):
             headers["X-With-Generated-Alt"] = "true"
         if tool_parameters.get("gather_all_links_at_the_end", False):
@@ -44,6 +46,8 @@ class JinaReaderTool(Tool):
             headers["X-Proxy-Url"] = proxy_server
         if tool_parameters.get("no_cache", False):
             headers["X-No-Cache"] = "true"
+        if tool_parameters.get("no_cache_track", False):
+            headers["DNT"] = "1"
         # max_retries = tool_parameters.get("max_retries", 3)
         response = requests.get(
             str(URL(self._jina_reader_endpoint + url)),

--- a/tools/jina/tools/jina_reader.yaml
+++ b/tools/jina/tools/jina_reader.yaml
@@ -75,6 +75,17 @@ parameters:
   name: wait_for_selector
   required: false
   type: string
+- form: form
+  human_description:
+    en_US: Remove all images from the response.
+    zh_Hans: 从响应中删除所有图片。
+  label:
+    en_US: Remove images
+    zh_Hans: 删除图片
+  llm_description: Remove all images from the response
+  name: remove_images
+  required: false
+  type: boolean
 - default: false
   form: form
   human_description:
@@ -151,6 +162,18 @@ parameters:
     zh_Hans: 绕过缓存
   llm_description: bypass the cache
   name: no_cache
+  required: false
+  type: boolean
+- default: false
+  form: form
+  human_description:
+    en_US: When enabled, request results won't be cached on jina servers.
+    zh_Hans: 启用后，请求结果将不会被缓存在 jina 服务器上。
+  label:
+    en_US: Do Not Cache/Track
+    zh_Hans: 请勿缓存/追踪
+  llm_description: Do Not Cache/Track
+  name: no_cache_track
   required: false
   type: boolean
 - default: false


### PR DESCRIPTION
Now when we use the jina_reader tool, we can choose whether to remove the images in the parsing results and whether to allow the Jina server to cache the web pages we parse.