### PR TITLE
fix(novita model): revised version number to 0.0.3 and remove duplicate description

### DIFF
--- a/models/novita/manifest.yaml
+++ b/models/novita/manifest.yaml
@@ -1,5 +1,5 @@
 author: langgenius
-created_at: 2024-10-08 16:58:21.101264-04:00
+created_at: 2024-10-08T16:58:21.101264-04:00
 description:
   en_US: Novita AI provides an LLM API that matches various application scenarios with high cost-effectiveness.
   zh_Hans: 适配多种海外应用场景的高性价比 LLM API

--- a/models/novita/manifest.yaml
+++ b/models/novita/manifest.yaml
@@ -6,8 +6,6 @@ description:
 icon: icon_s_en.svg
 label:
   en_US: Novita
-description:
-  en_US: Novita
 meta:
   arch:
   - amd64
@@ -35,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.2
+version: 0.0.3


### PR DESCRIPTION
Reason: The plugin version number was updated to 0.0.3 because the previous contributor made changes to the plugin but forgot to upgrade its version. This oversight caused installations to still use the outdated content.