### PR TITLE
Fix missing import in rerank.py for openai-compatible plugin

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/rerank/rerank.py
+++ b/models/openai_api_compatible/models/rerank/rerank.py
@@ -1,7 +1,9 @@
 from dify_plugin.interfaces.model.openai_compatible.rerank import (
     OAICompatRerankModel,
 )
-
+from dify_plugin.errors.model import (
+    CredentialsValidateFailedError,
+)
 
 class OpenAIRerankModel(OAICompatRerankModel):
     def validate_credentials(self, model: str, credentials: dict) -> None:


### PR DESCRIPTION
add missing import of CredentialsValidateFailedError for openai-compatible plugin