### PR TITLE
fix：LLMModelConfig() got multiple values for keyword argument 'comple

### DIFF
--- a/extensions/oaicompat_dify_model/endpoints/llm.py
+++ b/extensions/oaicompat_dify_model/endpoints/llm.py
@@ -33,7 +33,10 @@ class OaicompatDifyModelEndpoint(Endpoint, BaseAuth):
 
         llm: Optional[dict] = settings.get("llm")
         if not llm:
-            raise ValueError("LLM is not set")
+            raise ValueError("LLM is not set")        
+
+        if "completion_params" not in llm:
+            llm["completion_params"] = {}
 
         data = r.get_json(force=True)
         if not data:
@@ -72,9 +75,7 @@ class OaicompatDifyModelEndpoint(Endpoint, BaseAuth):
         def generator():
             if not stream:
                 llm_invoke_response = self.session.model.llm.invoke(
-                    model_config=LLMModelConfig(
-                        completion_params=llm.get("completion_params", {}), **llm
-                    ),
+                    model_config=LLMModelConfig(**llm),
                     prompt_messages=prompt_messages,
                     tools=tools,
                     stream=False,
@@ -105,9 +106,7 @@ class OaicompatDifyModelEndpoint(Endpoint, BaseAuth):
                 )
             else:
                 llm_invoke_response = self.session.model.llm.invoke(
-                    model_config=LLMModelConfig(
-                        completion_params=llm.get("completion_params", {}), **llm
-                    ),
+                    model_config=LLMModelConfig(**llm),
                     prompt_messages=prompt_messages,
                     tools=tools,
                     stream=True,

--- a/extensions/oaicompat_dify_model/manifest.yaml
+++ b/extensions/oaicompat_dify_model/manifest.yaml
@@ -30,7 +30,7 @@ plugins:
   endpoints:
     - group/oaicompat_dify_model.yaml
 meta:
-  version: 0.0.1
+  version: 0.0.5
   arch:
     - amd64
     - arm64

--- a/extensions/oaicompat_dify_model/manifest.yaml
+++ b/extensions/oaicompat_dify_model/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.5
 type: plugin
 author: langgenius
 name: oaicompat_dify_model
@@ -30,7 +30,7 @@ plugins:
   endpoints:
     - group/oaicompat_dify_model.yaml
 meta:
-  version: 0.0.5
+  version: 0.0.1
   arch:
     - amd64
     - arm64

--- a/extensions/oaicompat_dify_model/manifest.yaml
+++ b/extensions/oaicompat_dify_model/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.1
 type: plugin
 author: langgenius
 name: oaicompat_dify_model


### PR DESCRIPTION
now, the request error message
```
{
"code": -500,
"message": "{"message":"{\"args\":{},\"error_type\":\"TypeError\",\"message\":\"dify_plugin.entities.model.llm.LLMModelConfig() got multiple values for keyword argument 'completion_params'\"}","error_type":"PluginDaemonInternalServerError","args":null}",
"data": null
}
``


close #452 