### PR TITLE
Fix anthropic thinking mode with tool use chat history arrangement

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -776,7 +776,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                                     "input": json.loads(tool_call.function.arguments),
                                 }
                             )
-                    if message.content:
+                    elif message.content:
                         content.append({"type": "text", "text": message.content})
                     if prompt_message_dicts and prompt_message_dicts[-1]["role"] == "assistant":
                         prompt_message_dicts[-1]["content"].extend(content)


### PR DESCRIPTION
Fixes: https://github.com/langgenius/dify/issues/16082

The message history should maintain:
Assistant message with tool_use
User message with tool_result

But instead it's creating:
Assistant message with thinking + tool_use + text (duplicating the content)
User message with tool_result

<img width="784" alt="image" src="https://github.com/user-attachments/assets/38b53b70-5dd2-474a-bb13-ae88cd40eadb" />
<img width="770" alt="image" src="https://github.com/user-attachments/assets/3e8baa0f-ff8d-45a7-b627-be2a2e441634" />
