### PR TITLE
VertexAI Models: replace vertexai library into google-cloud-aiplatform

### DIFF
--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 from typing import Optional, Union, cast
 import google.auth.transport.requests
 import requests
-import vertexai.generative_models as glm
+import google.cloud.aiplatform_v1 as glm
 from anthropic import AnthropicVertex, Stream
 from anthropic.types import (
     ContentBlockDeltaEvent,

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -506,8 +506,9 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
             return self._handle_generate_stream_response(model, credentials, response, prompt_messages)
         return self._handle_generate_response(model, credentials, response, prompt_messages)
 
+
     def _handle_generate_response(
-        self, model: str, credentials: dict, response: glm.GenerationResponse, prompt_messages: list[PromptMessage]
+        self, model: str, credentials: dict, response: glm.GenerateContentResponse, prompt_messages: list[PromptMessage]
     ) -> LLMResult:
         """
         Handle llm response
@@ -518,6 +519,7 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
         :param prompt_messages: prompt messages
         :return: llm response
         """
+
         assistant_prompt_message = AssistantPromptMessage(content=response.candidates[0].content.parts[0].text)
         prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
         completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
@@ -526,7 +528,7 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
         return result
 
     def _handle_generate_stream_response(
-        self, model: str, credentials: dict, response: glm.GenerationResponse, prompt_messages: list[PromptMessage]
+        self, model: str, credentials: dict, response: glm.GenerateContentResponse, prompt_messages: list[PromptMessage]
     ) -> Generator:
         """
         Handle llm stream response

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -493,7 +493,7 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
             generation_config_params["response_mime_type"] = "application/json"
         elif mime_type:
             generation_config_params["response_mime_type"] = mime_type
-        
+
         generation_config = glm.GenerationConfig(**generation_config_params)
         
         response = google_model.generate_content(
@@ -736,6 +736,7 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
                 exceptions.Cancelled,
             ],
         }
+
 
     def _convert_schema_for_vertex(self, schema):
         """

--- a/models/vertex_ai/requirements.txt
+++ b/models/vertex_ai/requirements.txt
@@ -1,4 +1,4 @@
-dify_plugin==0.0.1b65
+dify_plugin==0.0.1b73
 anthropic==0.42.0
 google-cloud-aiplatform==1.85.0
 Pillow==11.0.0

--- a/models/vertex_ai/requirements.txt
+++ b/models/vertex_ai/requirements.txt
@@ -1,4 +1,4 @@
 dify_plugin==0.0.1b65
 anthropic==0.42.0
-vertexai==1.71.1
+google-cloud-aiplatform==1.85.0
 Pillow==11.0.0


### PR DESCRIPTION
# What
When running with the Grounding option enabled in the Vertex AI plugin for Gemini 1.5 and other models, it fails because the DynamicRetrievalConfig object does not exist.
![CleanShot 2025-03-19 at 11 48 38@2x](https://github.com/user-attachments/assets/3e9d22a3-7d2d-4dbc-aed4-12488c51f021)

# Why
The library installed in [requirements.txt](https://github.com/langgenius/dify-official-plugins/blob/main/models/vertex_ai/requirements.txt) is version 1.71.1, but the latest Google SDK is 1.85.0.
- The latest version of [vertexai](https://pypi.org/project/vertexai/) is 1.71.1 and has stopped being updated.
- [Google SDK](https://pypi.org/project/google-cloud-aiplatform/) supports up to version 1.85.0.

DynamicRetrievalConfig is not implemented in version 1.71.1, causing the failure, but updating to version 1.85.0 will resolve this issue.

# Env
- Selfhost
- Dify v1.0
- Plugin(Vertex AI | Google Cloud Platform) v0.0.7 