### PR TITLE
fix:Failed to transform agent message using tongyi function calling

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.12
+version: 0.0.13
 created_at: "2024-09-20T00:13:50.29298939-04:00"

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -200,7 +200,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 **params,
                 result_format="message",
                 stream=stream,
-                incremental_output=stream,
+                incremental_output=False if tools else stream,
             )
         if stream:
             return self._handle_generate_stream_response(

--- a/models/tongyi/requirements.txt
+++ b/models/tongyi/requirements.txt
@@ -1,4 +1,4 @@
-dify_plugin==0.0.1b72
+dify_plugin==0.0.1b73
 numpy~=2.2.3
 dashscope~=1.22.2
 openai~=1.65.4


### PR DESCRIPTION
Fix #424 
When stream = true and incremental_output = true, the tool call will report an error, when stream-tool-call incremental_output must be false