### PR TITLE
fix(azure_openai): support streaming for o3 based models

### DIFF
--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -373,7 +373,11 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             system_fingerprint=block_result.system_fingerprint,
             delta=LLMResultChunkDelta(
                 index=0,
-                message=AssistantPromptMessage(content=text),
+                message=AssistantPromptMessage(
+                    content=text or "",
+                    name=block_result.message.name,
+                    tool_calls=block_result.message.tool_calls,
+                ),
                 finish_reason="stop",
                 usage=block_result.usage,
             ),

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -319,11 +319,14 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         prompt_messages = self._clear_illegal_prompt_messages(base_model_name, prompt_messages)
         block_as_stream = False
         if base_model_name.startswith(("o1", "o3")):
-            if stream:
-                block_as_stream = True
-                stream = False
-                if "stream_options" in extra_model_kwargs:
-                    del extra_model_kwargs["stream_options"]
+            # o1 and o1-* do not support streaming
+            # https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/reasoning#api--feature-support
+            if base_model_name.startswith("o1"):
+                if stream:
+                    block_as_stream = True
+                    stream = False
+                    if "stream_options" in extra_model_kwargs:
+                        del extra_model_kwargs["stream_options"]
             if "stop" in extra_model_kwargs:
                 del extra_model_kwargs["stop"]
         response = client.chat.completions.create(

--- a/models/azure_openai/requirements.txt
+++ b/models/azure_openai/requirements.txt
@@ -1,4 +1,4 @@
-dify_plugin==0.0.1b72
-openai~=1.65.4
+dify_plugin==0.0.1b74
+openai~=1.67.0
 tiktoken~=0.8.0
-numpy~=2.2.3
+numpy~=2.2.4


### PR DESCRIPTION
This PR changes following implementations:

- ✅ Changed the conditional `if` statement based on the model name to a judgment using `base_model_name`
  - In AOAI, the model name can be changed arbitrarily by the user, making it impossible to predict precisely; however, base_model_name can be predicted.
- ✅ If the model supports tool calls, but doesn't support straming, there are cases where an empty array `[]` is returned as the  content from LLM in models, which was causing errors on the API side. To resolve this, This PR changed it to return `""` when the result is `[]`.
- ✅ The model o3-mini supports streaming, but it was forced to `stream: false` Corrected conditionals for this.

closes #487 