### PR TITLE
feat: add GitHub repository README tool for github plugin

### DIFF
--- a/tools/github/manifest.yaml
+++ b/tools/github/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.0.2
+version: 0.0.3

--- a/tools/github/provider/github.yaml
+++ b/tools/github/provider/github.yaml
@@ -52,3 +52,4 @@ identity:
   - utilities
 tools:
 - tools/github_repositories.yaml
+- tools/github_repository_readme.yaml

--- a/tools/github/requirements.txt
+++ b/tools/github/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin==0.0.1b65
+dify_plugin==0.0.1b74

--- a/tools/github/tools/github_repository_readme.py
+++ b/tools/github/tools/github_repository_readme.py
@@ -6,7 +6,7 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 
-class GithubRepositoriesTool(Tool):
+class GithubRepositoryReadmeTool(Tool):
     def _invoke(
             self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/github/tools/github_repository_readme.py
+++ b/tools/github/tools/github_repository_readme.py
@@ -1,0 +1,70 @@
+import base64
+from typing import Any, Generator
+
+import requests
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+class GithubRepositoriesTool(Tool):
+    def _invoke(
+            self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        invoke tools
+        """
+        owner = tool_parameters.get("owner", "")
+        repo = tool_parameters.get("repo", "")
+        ref = tool_parameters.get("ref", "")
+        dir_path = tool_parameters.get("dir", "")
+        if not owner:
+            yield self.create_text_message("Please input owner")
+        if not repo:
+            yield self.create_text_message("Please input repo")
+        if "access_tokens" not in self.runtime.credentials or not self.runtime.credentials.get("access_tokens"):
+            yield self.create_text_message("Github API Access Tokens is required.")
+        if "api_version" not in self.runtime.credentials or not self.runtime.credentials.get("api_version"):
+            api_version = "2022-11-28"
+        else:
+            api_version = self.runtime.credentials.get("api_version")
+        try:
+            headers = {
+                "Content-Type": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.runtime.credentials.get('access_tokens')}",
+                "X-GitHub-Api-Version": api_version,
+            }
+            s = requests.session()
+            api_domain = "https://api.github.com"
+            url = f"{api_domain}/repos/{owner}/{repo}/readme"
+            if dir_path:
+                url = f"{url}/{dir_path}"
+            if ref:
+                url = f"{url}?ref={ref}"
+            response = s.request(
+                method="GET",
+                headers=headers,
+                url=url,
+            )
+            response_data = response.json()
+            if response.status_code == 200:
+                if "base64" != response_data.get("encoding"):
+                    yield self.create_json_message({
+                        "status": False,
+                        "content": None,
+                        "message": f"Can not get base64 encoded readme, response encoding is {response_data.get('encoding')}"
+                    })
+                    return
+                content = response_data.get("content")
+                decoded_bytes = base64.b64decode(content)
+                decoded_str = decoded_bytes.decode('utf-8')
+                yield self.create_json_message({"status": True, "message": "success", "content": decoded_str})
+            else:
+                yield self.create_json_message({"status": False,
+                                                "message": f"Request failed: {response.status_code} {response_data.get("message")}",
+                                                "content": None})
+        except Exception as e:
+            yield self.create_json_message({
+                "status": False,
+                "message": f"Request failed: {e}",
+                "content": None
+            })

--- a/tools/github/tools/github_repository_readme.yaml
+++ b/tools/github/tools/github_repository_readme.yaml
@@ -1,0 +1,70 @@
+description:
+  human:
+    en_US: Gets the README from a repository directory.
+    pt_BR: Obter o README de um diretório do repositório.
+    zh_Hans: 从存储库某个目录中获取README
+  llm: A tool when you wants to gets the README content from a repository directory.
+extra:
+  python:
+    source: tools/github_repository_readme.py
+identity:
+  author: itning
+  icon: icon.svg
+  label:
+    en_US: Get README content
+    pt_BR: Obter conteúdo do README
+    zh_Hans: 获取README内容
+  name: github_repository_readme
+parameters:
+- form: llm
+  human_description:
+    en_US: The account owner of the repository. The name is not case sensitive.
+    pt_BR: Proprietário da conta do repositório. O nome não diferencia maiúsculas de minúsculas.
+    zh_Hans: 仓库的账户所有者。名称不区分大小写。
+  label:
+    en_US: owner
+    pt_BR: owner
+    zh_Hans: owner
+  llm_description: The account owner of the repository. The name is not case sensitive.
+  name: owner
+  required: true
+  type: string
+- form: llm
+  human_description:
+    en_US: The name of the repository without the .git extension. The name is not case sensitive.
+    pt_BR: O nome do repositório sem a extensão .git. O nome não diferencia maiúsculas de minúsculas.
+    zh_Hans: 仓库名称不带.git扩展名。名称不区分大小写。
+  label:
+    en_US: repo
+    pt_BR: repo
+    zh_Hans: repo
+  llm_description: The name of the repository without the .git extension. The name is not case sensitive.
+  name: repo
+  required: true
+  type: string
+- form: llm
+  human_description:
+    en_US: "The name of the commit/branch/tag. Default: the repository’s default branch."
+    pt_BR: "O nome do commit/branch/tag. Valor padrão: a branch padrão do repositório."
+    zh_Hans: commit/branch/tag的名称。默认值：仓库的默认分支。
+  label:
+    en_US: ref
+    pt_BR: ref
+    zh_Hans: ref
+  llm_description: "The name of the commit/branch/tag. Default: the repository’s default branch."
+  name: ref
+  required: false
+  type: string
+- form: llm
+  human_description:
+    en_US: The alternate path to look for a README file
+    pt_BR: O caminho alternativo para encontrar o arquivo README
+    zh_Hans: 查找README文件的备用路径。
+  label:
+    en_US: dir
+    pt_BR: dir
+    zh_Hans: dir
+  llm_description: The alternate path to look for a README file
+  name: dir
+  required: false
+  type: string


### PR DESCRIPTION
New feature: Retrieve the content of a README file from a GitHub repository.

github api: https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-a-repository-readme

![image](https://github.com/user-attachments/assets/730f5513-2d1a-4953-a6de-8e332a976f4f)

![image](https://github.com/user-attachments/assets/6d74f144-c6c7-45a3-a7d7-2130602cd540)

![image](https://github.com/user-attachments/assets/5b2cb833-8525-4a9c-8003-8e3de32dab3c)
