### PR TITLE
fix(azure_openai): add workaround to json_schema mode before fundamental fix will be merged

### DIFF
--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/models/azure_openai/models/constants.py
+++ b/models/azure_openai/models/constants.py
@@ -531,7 +531,17 @@ LLM_BASE_MODELS = [
                         en_US="specifying the format that the model must output",
                     ),
                     required=False,
-                    options=["text", "json_object"],
+                    options=["text", "json_object", "json_schema"],
+                ),
+                ParameterRule(
+                    name="json_schema",
+                    label=I18nObject(en_US="JSON Schema"),
+                    type="text",
+                    help=I18nObject(
+                        zh_Hans="设置返回的json schema，llm将按照它返回",
+                        en_US="Set a response json schema will ensure LLM to adhere it.",
+                    ),
+                    required=False,
                 ),
             ],
             pricing=PriceConfig(
@@ -675,7 +685,17 @@ LLM_BASE_MODELS = [
                         en_US="specifying the format that the model must output",
                     ),
                     required=False,
-                    options=["text", "json_object"],
+                    options=["text", "json_object", "json_schema"],
+                ),
+                ParameterRule(
+                    name="json_schema",
+                    label=I18nObject(en_US="JSON Schema"),
+                    type="text",
+                    help=I18nObject(
+                        zh_Hans="设置返回的json schema，llm将按照它返回",
+                        en_US="Set a response json schema will ensure LLM to adhere it.",
+                    ),
+                    required=False,
                 ),
             ],
             pricing=PriceConfig(
@@ -1199,27 +1219,6 @@ LLM_BASE_MODELS = [
                 ModelPropertyKey.CONTEXT_SIZE: 128000,
             },
             parameter_rules=[
-                ParameterRule(
-                    name="response_format",
-                    label=I18nObject(zh_Hans="回复格式", en_US="response_format"),
-                    type="string",
-                    help=I18nObject(
-                        zh_Hans="指定模型必须输出的格式",
-                        en_US="specifying the format that the model must output",
-                    ),
-                    required=False,
-                    options=["text", "json_object", "json_schema"],
-                ),
-                ParameterRule(
-                    name="json_schema",
-                    label=I18nObject(en_US="JSON Schema"),
-                    type="text",
-                    help=I18nObject(
-                        zh_Hans="设置返回的json schema，llm将按照它返回",
-                        en_US="Set a response json schema will ensure LLM to adhere it.",
-                    ),
-                    required=False,
-                ),
                 _get_o1_max_tokens(default=512, min_val=1, max_val=32768),
             ],
             pricing=PriceConfig(
@@ -1247,27 +1246,6 @@ LLM_BASE_MODELS = [
                 ModelPropertyKey.CONTEXT_SIZE: 128000,
             },
             parameter_rules=[
-                ParameterRule(
-                    name="response_format",
-                    label=I18nObject(zh_Hans="回复格式", en_US="response_format"),
-                    type="string",
-                    help=I18nObject(
-                        zh_Hans="指定模型必须输出的格式",
-                        en_US="specifying the format that the model must output",
-                    ),
-                    required=False,
-                    options=["text", "json_object", "json_schema"],
-                ),
-                ParameterRule(
-                    name="json_schema",
-                    label=I18nObject(en_US="JSON Schema"),
-                    type="text",
-                    help=I18nObject(
-                        zh_Hans="设置返回的json schema，llm将按照它返回",
-                        en_US="Set a response json schema will ensure LLM to adhere it.",
-                    ),
-                    required=False,
-                ),
                 _get_o1_max_tokens(default=512, min_val=1, max_val=65536),
             ],
             pricing=PriceConfig(

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -306,6 +306,8 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                 }
             else:
                 model_parameters["response_format"] = {"type": response_format}
+        elif "json_schema" in model_parameters:
+            del model_parameters["json_schema"]
         extra_model_kwargs = {}
         if tools:
             extra_model_kwargs["tools"] = [
@@ -776,3 +778,40 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         if not base_model_name:
             raise ValueError("Base Model Name is required")
         return base_model_name
+
+    # TODO: remove this method once https://github.com/langgenius/dify-plugin-sdks/pull/57 is merged
+    #       and the version of dify-plugin-sdks is updated
+    def _code_block_mode_wrapper(
+        self,
+        model: str,
+        credentials: dict,
+        prompt_messages: list[PromptMessage],
+        model_parameters: dict,
+        tools: Optional[list[PromptMessageTool]] = None,
+        stop: Optional[list[str]] = None,
+        stream: bool = True,
+        user: Optional[str] = None,
+    ) -> Union[LLMResult, Generator[LLMResultChunk, None, None]]:
+
+        if "response_format" in model_parameters and model_parameters["response_format"] in ["JSON", "XML"]:
+            return super()._code_block_mode_wrapper(
+                model=model,
+                credentials=credentials,
+                prompt_messages=prompt_messages,
+                model_parameters=model_parameters,
+                tools=tools,
+                stop=stop,
+                stream=stream,
+                user=user,
+            )
+        else:
+            return self._invoke(
+                model=model,
+                credentials=credentials,
+                prompt_messages=prompt_messages,
+                model_parameters=model_parameters,
+                tools=tools,
+                stop=stop,
+                stream=stream,
+                user=user,
+            )


### PR DESCRIPTION
This PR makes `response_format: "json_schema"` work correctly through the following changes:

- ✅ Override `_code_block_mode_wrapper` to skip it if `response_format` is NOT `JSON` or `XML`
  - The fundamental fix is here: https://github.com/langgenius/dify-plugin-sdks/pull/57
  - This is a temporary workaround before merging langgenius/dify-plugin-sdks#57
- ✅ Update parameter rules for each models
  - The latest `gpt-4o` and `gpt-4o-mini` supports `json_schema`, so I added it
  - `o1-mini` and `o1-preview` do not support `response_format` and `json_schema`, so I removed it ([refer to the official doc](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/reasoning#api--feature-support))
- ✅ Bump plugin version from 0.0.8 to **0.0.10**
  - I've already bump its version to **0.0.9** in another PR https://github.com/langgenius/dify-official-plugins/pull/505, so this PR bump it to **0.0.10**
  - I think it would be better to change the version with each PR, but please let me know if it should be set to 0.0.9 in this PR. Alternatively, feel free to edit my branch directly.

Closes https://github.com/langgenius/dify-official-plugins/issues/477, closes https://github.com/langgenius/dify-official-plugins/issues/425, closes https://github.com/langgenius/dify/issues/14475