### PR TITLE
fix: improve error handling in GitHub README tool

### DIFF
--- a/tools/github/manifest.yaml
+++ b/tools/github/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.0.3
+version: 0.0.4


### PR DESCRIPTION
Why modify the error handling logic of this tool? 

When retrying on failure is enabled, the retry will not be executed because the system does not capture the error.

![image](https://github.com/user-attachments/assets/6240ca52-39cd-4aa6-b0cc-f725946916d9)

![image](https://github.com/user-attachments/assets/ccdce029-f089-4b28-8609-d6a4e4048c43)

After modification, retry is allowed.

![image](https://github.com/user-attachments/assets/df7c465f-a7b4-43b7-a8a4-061c84376459)
