### PR TITLE
feat(dingtalk): 支持 Markdown 消息类型并优化工具配置

### DIFF
--- a/tools/dingtalk/manifest.yaml
+++ b/tools/dingtalk/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.2
+version: 0.0.3

--- a/tools/dingtalk/provider/dingtalk.yaml
+++ b/tools/dingtalk/provider/dingtalk.yaml
@@ -2,7 +2,7 @@ extra:
   python:
     source: provider/dingtalk.py
 identity:
-  author: Bowen Liang
+  author: Bowen Liang & LiuHao
   description:
     en_US: DingTalk group robot
     pt_BR: DingTalk group robot

--- a/tools/dingtalk/tools/dingtalk_group_bot.py
+++ b/tools/dingtalk/tools/dingtalk_group_bot.py
@@ -32,12 +32,15 @@ class DingTalkGroupBotTool(Tool):
             yield self.create_text_message(
                 "Invalid parameter sign_secret. Regarding information about security details,please refer to the DingTalk docs:https://open.dingtalk.com/document/robots/customize-robot-security-settings"
             )
-        msgtype = "text"
+        message_type = tool_parameters.get("message_type", "text")
         api_url = "https://oapi.dingtalk.com/robot/send"
         headers = {"Content-Type": "application/json"}
         params = {"access_token": access_token}
         self._apply_security_mechanism(params, sign_secret)
-        payload = {"msgtype": msgtype, "text": {"content": content}}
+        if message_type == "markdown":
+            payload = {"msgtype": "markdown", "markdown": {"content": content}}
+        else:
+            payload = {"msgtype": "text", "text": {"content": content}}
         try:
             res = httpx.post(api_url, headers=headers, params=params, json=payload)
             if res.is_success:

--- a/tools/dingtalk/tools/dingtalk_group_bot.yaml
+++ b/tools/dingtalk/tools/dingtalk_group_bot.yaml
@@ -16,40 +16,64 @@ identity:
     zh_Hans: 发送群消息
   name: dingtalk_group_bot
 parameters:
-- form: form
-  human_description:
-    en_US: access_token in the group robot webhook
-    pt_BR: access_token in the group robot webhook
-    zh_Hans: 群自定义机器人webhook中access_token字段的值
-  label:
-    en_US: access token
-    pt_BR: access token
-    zh_Hans: access token
-  name: access_token
-  required: true
-  type: secret-input
-- form: form
-  human_description:
-    en_US: secret key for signing
-    pt_BR: secret key for signing
-    zh_Hans: 加签秘钥
-  label:
-    en_US: secret key for signing
-    pt_BR: secret key for signing
-    zh_Hans: 加签秘钥
-  name: sign_secret
-  required: true
-  type: secret-input
-- form: llm
-  human_description:
-    en_US: Content to sent to the group.
-    pt_BR: Content to sent to the group.
-    zh_Hans: 群消息文本
-  label:
-    en_US: content
-    pt_BR: content
-    zh_Hans: 消息内容
-  llm_description: Content of the message
-  name: content
-  required: true
-  type: string
+  - form: form
+    human_description:
+      en_US: access_token in the group robot webhook
+      pt_BR: access_token in the group robot webhook
+      zh_Hans: 群自定义机器人webhook中access_token字段的值
+    label:
+      en_US: access token
+      pt_BR: access token
+      zh_Hans: access token
+    name: access_token
+    required: true
+    type: secret-input
+  - form: form
+    human_description:
+      en_US: secret key for signing
+      pt_BR: secret key for signing
+      zh_Hans: 加签秘钥
+    label:
+      en_US: secret key for signing
+      pt_BR: secret key for signing
+      zh_Hans: 加签秘钥
+    name: sign_secret
+    required: true
+    type: secret-input
+  - form: llm
+    human_description:
+      en_US: Content to sent to the group.
+      pt_BR: Content to sent to the group.
+      zh_Hans: 群消息文本
+    label:
+      en_US: content
+      pt_BR: content
+      zh_Hans: 消息内容
+    llm_description: Content of the message
+    name: content
+    required: true
+    type: string
+  - default: text
+    form: form
+    human_description:
+      en_US: dingtalk Group bot message type
+      pt_BR: dingtalk Group bot message type
+      zh_Hans: 群机器人webhook的消息类型
+    label:
+      en_US: dingtalk Group bot message type
+      pt_BR: dingtalk Group bot message type
+      zh_Hans: 群机器人webhook的消息类型
+    name: message_type
+    options:
+      - label:
+          en_US: Text
+          pt_BR: Text
+          zh_Hans: 文本
+        value: text
+      - label:
+          en_US: Markdown
+          pt_BR: Markdown
+          zh_Hans: Markdown
+        value: markdown
+    required: true
+    type: select


### PR DESCRIPTION
- 在钉钉群机器人工具中添加了对 Markdown 消息类型的支持
- 更新了工具配置，增加了消息类型选择参数- 调整了 payload构造逻辑，根据消息类型选择合适的格式
- 更新了工具和插件的版本号