### PR TITLE
fix: BingSearch credential validations

### DIFF
--- a/tools/bing/manifest.yaml
+++ b/tools/bing/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: "langgenius"
 name: "bing"

--- a/tools/bing/provider/bing.py
+++ b/tools/bing/provider/bing.py
@@ -11,11 +11,11 @@ class BingProvider(ToolProvider):
             for _ in BingWebSearchTool.from_credentials(credentials).invoke(
                 tool_parameters={
                     "query": "test",
-                    "enable_computation": True,
-                    "enable_entities": True,
-                    "enable_news": True,
-                    "enable_related_search": True,
-                    "enable_webpages": True,
+                    "enable_computation": credentials.get("allow_computation", False),
+                    "enable_entities": credentials.get("allow_entities", False),
+                    "enable_news": credentials.get("allow_news", False),
+                    "enable_related_search": credentials.get("allow_related_searches", False),
+                    "enable_webpages": credentials.get("allow_web_pages", False),
                     "limit": 10,
                     "result_type": "link",
                     "market": "US",


### PR DESCRIPTION
Fixes #553 

BingSearch uses user-selected fields([Bing Search FEATURES](https://www.microsoft.com/en-us/bing/apis/pricing)) for authorization.