### PR TITLE
fix: typo Maximum Iterations

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/strategies/ReAct.yaml
+++ b/agent-strategies/cot_agent/strategies/ReAct.yaml
@@ -47,9 +47,9 @@ parameters:
     type: number
     required: true
     label:
-      en_US: Maxium Iterations
+      en_US: Maximum Iterations
       zh_Hans: 最大迭代次数
-      pt_BR: Maxium Iterations
+      pt_BR: Maximum Iterations
     default: 3
     min: 1
     max: 30

--- a/agent-strategies/cot_agent/strategies/function_calling.yaml
+++ b/agent-strategies/cot_agent/strategies/function_calling.yaml
@@ -47,9 +47,9 @@ parameters:
     type: number
     required: true
     label:
-      en_US: Maxium Iterations
+      en_US: Maximum Iterations
       zh_Hans: 最大迭代次数
-      pt_BR: Maxium Iterations
+      pt_BR: Maximum Iterations
     default: 3
     max: 30
     min: 1


### PR DESCRIPTION
Fix https://github.com/langgenius/dify/issues/14998

Typo fix: `Maxium Iterations` => `Maximum Iterations`.