### PR TITLE
fix(azure_openai): temporarily pin sdk version

### DIFF
--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.10
+version: 0.0.11

--- a/models/azure_openai/requirements.txt
+++ b/models/azure_openai/requirements.txt
@@ -1,4 +1,4 @@
-dify_plugin==0.0.1b74
+dify_plugin~=0.0.1b73,<0.0.1b74
 openai~=1.67.0
 tiktoken~=0.8.0
 numpy~=2.2.4


### PR DESCRIPTION
The SDK version 0.0.1b74 causes following issues:

- https://github.com/langgenius/dify/issues/16353
- https://github.com/langgenius/dify/issues/16726
- https://github.com/langgenius/dify/issues/16816

This PR pins the SDK version to 0.0.1b73 as a temporary workaround.

- For openai: https://github.com/langgenius/dify-official-plugins/pull/569
- For azure_openai: https://github.com/langgenius/dify-official-plugins/pull/568
- For openrouter: https://github.com/langgenius/dify-official-plugins/pull/572
