### PR TITLE
fix(openai): temporarily pin sdk version

### DIFF
--- a/models/openai/manifest.yaml
+++ b/models/openai/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.13
+version: 0.0.14
 type: plugin
 author: "langgenius"
 name: "openai"

--- a/models/openai/requirements.txt
+++ b/models/openai/requirements.txt
@@ -1,4 +1,4 @@
-dify_plugin~=0.0.1b66
+dify_plugin~=0.0.1b66,<0.0.1b74
 tiktoken~=0.8.0
 openai~=1.64.0
 numpy~=1.26.4


### PR DESCRIPTION
The SDK version 0.0.1b74 causes following issues:

- https://github.com/langgenius/dify/issues/16353
- https://github.com/langgenius/dify/issues/16726
- https://github.com/langgenius/dify/issues/16816

This PR pins the SDK version to 0.0.1b73 as a temporary workaround.

- For openai: https://github.com/langgenius/dify-official-plugins/pull/569
- For azure_openai: https://github.com/langgenius/dify-official-plugins/pull/568
- For openrouter: https://github.com/langgenius/dify-official-plugins/pull/572
