### PR TITLE
fix(openrouter): temporarily pin sdk version

### DIFF
--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -24,5 +24,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.0.5
+version: 0.0.6
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/openrouter/requirements.txt
+++ b/models/openrouter/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin==0.0.1b74
+dify_plugin~=0.0.1b73,<0.0.1b74


### PR DESCRIPTION
The SDK version 0.0.1b74 causes following issues:

- https://github.com/langgenius/dify/issues/16353
- https://github.com/langgenius/dify/issues/16726
- https://github.com/langgenius/dify/issues/16816

This PR pins the SDK version to 0.0.1b73 as a temporary workaround.

- For openai: https://github.com/langgenius/dify-official-plugins/pull/569
- For azure_openai: https://github.com/langgenius/dify-official-plugins/pull/568
- For openrouter: https://github.com/langgenius/dify-official-plugins/pull/572
