### PR TITLE
fix: Redundant insertion of system/user prompts in the function-calling agent

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.13
+version: 0.0.14
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/strategies/function_calling.py
+++ b/agent-strategies/cot_agent/strategies/function_calling.py
@@ -59,6 +59,8 @@ class FunctionCallingAgentStrategy(AgentStrategy):
         self.query = query
         self.instruction = fc_params.instruction
         history_prompt_messages = fc_params.model.history_prompt_messages
+        history_prompt_messages.insert(0, self._system_prompt_message)
+        history_prompt_messages.append(self._user_prompt_message)
 
         # convert tool messages
         tools = fc_params.tools
@@ -458,8 +460,6 @@ class FunctionCallingAgentStrategy(AgentStrategy):
         current_thoughts: list[PromptMessage],
         history_prompt_messages: list[PromptMessage],
     ) -> list[PromptMessage]:
-        history_prompt_messages.insert(0, self._system_prompt_message)
-        history_prompt_messages.append(self._user_prompt_message)
         prompt_messages = [
             *history_prompt_messages,
             *current_thoughts,


### PR DESCRIPTION
## Related Issue or Context
The function-calling agent redundantly inserts system and user prompts into message history every iteration.

## Type of Change
<!-- Put an `x` in all the boxes that apply -->
- [x] Bug Fix (non-breaking change which fixes an Issue)
- [ ] New Feature (non-breaking change which adds Functionality)
- [ ] Breaking Change (fix or feature that may cause existing Functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other

## Version Control (if applicable)
- [x] Version bumped in Manifest.yaml (top-level `Version` field, not in Meta section)
<!-- Version format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Major Releases with widespread Breaking Changes
- MINOR (x.0.x): For New Features or limited Breaking Changes
- PATCH (x.x.0): For backwards-compatible Bug Fixes and minor Improvements
- Note: Each version component (MAJOR, MINOR, PATCH) can be 2 digits, e.g., 10.11.22
-->

## Test Evidence (if applicable)

#### Before: System/User prompts have been inserted into `prompt_messages` several times when `iteration_step` > 1
![微信截图_20250411163153](https://github.com/user-attachments/assets/b0165b7b-2842-4858-beb1-29e2a185c70b)

#### After: System/User prompts have been inserted into `prompt_messages` only once when `iteration_step` > 1
![微信截图_20250411163426](https://github.com/user-attachments/assets/d8e34e36-4ef3-4cac-8f80-a1bf280de9f1)


### Environment Verification
> [!IMPORTANT]
> At least one environment must be tested.

#### Local Deployment Environment
Local Deployment Dify Version: 1.1.3
- [x] Changes tested in a Clean Environment that matches Production Configuration
<!--
- Python virtual env matching Manifest.yaml & requirements.txt
- No breaking changes in Dify that may affect the testing result
-->

#### SaaS Environment
- [ ] Testing performed on cloud.dify.ai
- [ ] Changes tested in a Clean Environment that matches Production Configuration
<!--
- Python virtual env matching Manifest.yaml & requirements.txt
-->