### PR TITLE
fix: PluginInvokeError with Hugging Face in Dify: Pydantic Validation Error (EmbeddingUsage expects integer instead of list)

### DIFF
--- a/models/huggingface_hub/manifest.yaml
+++ b/models/huggingface_hub/manifest.yaml
@@ -26,4 +26,4 @@ resource:
     tool:
       enabled: false
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/models/huggingface_hub/models/text_embedding/text_embedding.py
+++ b/models/huggingface_hub/models/text_embedding/text_embedding.py
@@ -162,8 +162,8 @@ class HuggingfaceHubTextEmbeddingModel(_CommonHuggingfaceHub, TextEmbeddingModel
             tokens=tokens,
         )
         usage = EmbeddingUsage(
-            tokens=tokens,
-            total_tokens=tokens,
+            tokens=tokens[0],
+            total_tokens=tokens[0],
             unit_price=input_price_info.unit_price,
             price_unit=input_price_info.unit,
             total_price=input_price_info.total_amount,


### PR DESCRIPTION
This addresses the issue #660.
### Error
`dify_plugin.errors.model.InvokeError: [models] Error: 2 validation errors for EmbeddingUsage
tokens
  Input should be a valid integer [type=int_type, input_value=[82], input_type=list]
    For further information visit https://errors.pydantic.dev/2.8/v/int_type
total_tokens
  Input should be a valid integer [type=int_type, input_value=[82], input_type=list]`


### Changes
used `tokens[0]` instead of `tokens`