### PR TITLE
feat: add structured output support to openai_api_compatible

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.13
+version: 0.0.14
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -2,8 +2,11 @@ from typing import Mapping
 
 from dify_plugin.entities.model import (
     AIModelEntity,
+    DefaultParameterName,
     I18nObject,
-    ModelFeature
+    ModelFeature,
+    ParameterRule,
+    ParameterType
 )
 
 from dify_plugin.interfaces.model.openai_compatible.llm import (
@@ -21,6 +24,35 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                 entity.features.index(ModelFeature.AGENT_THOUGHT)
             except ValueError:
                 entity.features.append(ModelFeature.AGENT_THOUGHT)
+
+        structured_output_support = credentials.get("structured_output_support", "not_supported")
+        if structured_output_support == "supported":
+            # ----
+            # The following section should be added after the new version of `dify-plugin-sdks`
+            # is released.
+            # Related Commit:
+            # https://github.com/langgenius/dify-plugin-sdks/commit/0690573a879caf43f92494bf411f45a1835d96f6
+            # ----
+            # try:
+            #     entity.features.index(ModelFeature.STRUCTURED_OUTPUT)
+            # except ValueError:
+            #     entity.features.append(ModelFeature.STRUCTURED_OUTPUT)
+
+            entity.parameter_rules.append(ParameterRule(
+                name=DefaultParameterName.RESPONSE_FORMAT.value,
+                label=I18nObject(en_US="Response Format", zh_Hans="回复格式"),
+                help=I18nObject(
+                    en_US="Specifying the format that the model must output.",
+                    zh_Hans="指定模型必须输出的格式。",
+                ),
+                type=ParameterType.STRING,
+                options=["text", "json_object", "json_schema"],
+                required=False,
+            ))
+            entity.parameter_rules.append(ParameterRule(
+                name="json_schema",
+                use_template="json_schema"
+            ))
 
         if "display_name" in credentials and credentials["display_name"] != "":
             entity.label= I18nObject(

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -204,6 +204,24 @@ model_credential_schema:
           label:
             en_US: Not Support
             zh_Hans: 不支持
+    - variable: structured_output_support
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        en_US: Structured Output
+      type: select
+      required: false
+      default: not_supported
+      options:
+        - value: supported
+          label:
+            en_US: Support
+            zh_Hans: 支持
+        - value: not_supported
+          label:
+            en_US: Not Support
+            zh_Hans: 不支持
     - variable: stream_mode_delimiter
       label:
         zh_Hans: 流模式返回结果的分隔符


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

Added structured output support to OpenAI-compatible LLMs.
The parameter rule settings were based on [gpt-4o.yaml](https://github.com/langgenius/dify-official-plugins/blob/2ea9dba5de751566865b8f99c8fbcc9ae2f03c77/models/openai/models/llm/gpt-4o.yaml#L28-L42).

### Related Issue and PR

- [[Feature Request] Structuring Outputs using OpenAi-API-compatible #15831](https://github.com/langgenius/dify/issues/15831)
- [feat(openai_compatible): Add structured output support #95](https://github.com/langgenius/dify-plugin-sdks/pull/95)

### Test Result

If "Structured Output" was set to "Support" in model settings:
<img src="https://github.com/user-attachments/assets/535309c9-0938-44ed-8ed0-9806ed73c61f" width="300">

Then `json_schema` can be configured in PARAMETERS:
<img src="https://github.com/user-attachments/assets/56700fc3-9782-419c-99f8-9e62bd2538a4" width="600">

Here is an output example:
<img src="https://github.com/user-attachments/assets/b6222393-e994-45fe-989b-37e134d9e0cd" width="300">

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run All Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. Dify Version is: 1.2.0<!-- Specify Your Version (e.g., 1.2.0) -->
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
