### PR TITLE
Update volcengine deepseek v3 r1 max_token & context_size

### DIFF
--- a/models/volcengine_maas/manifest.yaml
+++ b/models/volcengine_maas/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.11
+version: 0.0.12

--- a/models/volcengine_maas/models/llm/models.py
+++ b/models/volcengine_maas/models/llm/models.py
@@ -40,11 +40,11 @@ configs: dict[str, ModelConfig] = {
         features=[ModelFeature.AGENT_THOUGHT],
     ),
     "DeepSeek-R1": ModelConfig(
-        properties=ModelProperties(context_size=65536, max_tokens=8192, mode=LLMMode.CHAT),
+        properties=ModelProperties(context_size=65536, max_tokens=16384, mode=LLMMode.CHAT),
         features=[ModelFeature.AGENT_THOUGHT, ModelFeature.TOOL_CALL, ModelFeature.STREAM_TOOL_CALL],
     ),
     "DeepSeek-V3": ModelConfig(
-        properties=ModelProperties(context_size=65536, max_tokens=8192, mode=LLMMode.CHAT),
+        properties=ModelProperties(context_size=128000, max_tokens=16384, mode=LLMMode.CHAT),
         features=[ModelFeature.AGENT_THOUGHT, ModelFeature.TOOL_CALL, ModelFeature.STREAM_TOOL_CALL],
     ),
     "Doubao-1.5-vision-pro-32k": ModelConfig(


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

volcengine deepseek-v3-250324 support 128k context and 16k max token output
deepseek-r1 support 16k max token output

[volcengine doc](https://www.volcengine.com/docs/82379/1330310#deepseek)

## This PR contains Changes to *LLM Models Plugin*

- [x] Other Changes (Add New Models, etc.)

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
