### PR TITLE
[gitee ai] refactor(models):adapting to the [Prompt Generator]

### DIFF
--- a/models/gitee_ai/manifest.yaml
+++ b/models/gitee_ai/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/models/gitee_ai/models/llm/Align-DS-V.yaml
+++ b/models/gitee_ai/models/llm/Align-DS-V.yaml
@@ -32,7 +32,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/DeepSeek-R1-Distill-Qwen-1.5B.yaml
+++ b/models/gitee_ai/models/llm/DeepSeek-R1-Distill-Qwen-1.5B.yaml
@@ -44,7 +44,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/DeepSeek-R1-Distill-Qwen-14B.yaml
+++ b/models/gitee_ai/models/llm/DeepSeek-R1-Distill-Qwen-14B.yaml
@@ -44,7 +44,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/DeepSeek-R1-Distill-Qwen-32B.yaml
+++ b/models/gitee_ai/models/llm/DeepSeek-R1-Distill-Qwen-32B.yaml
@@ -44,7 +44,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/DeepSeek-R1-Distill-Qwen-7B.yaml
+++ b/models/gitee_ai/models/llm/DeepSeek-R1-Distill-Qwen-7B.yaml
@@ -44,7 +44,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/DeepSeek-R1.yaml
+++ b/models/gitee_ai/models/llm/DeepSeek-R1.yaml
@@ -44,7 +44,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/DeepSeek-V3.yaml
+++ b/models/gitee_ai/models/llm/DeepSeek-V3.yaml
@@ -44,7 +44,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/InternVL2-8B.yaml
+++ b/models/gitee_ai/models/llm/InternVL2-8B.yaml
@@ -32,7 +32,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/InternVL2.5-26B.yaml
+++ b/models/gitee_ai/models/llm/InternVL2.5-26B.yaml
@@ -32,7 +32,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/InternVL2.5-78B.yaml
+++ b/models/gitee_ai/models/llm/InternVL2.5-78B.yaml
@@ -32,7 +32,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/QwQ-32B.yaml
+++ b/models/gitee_ai/models/llm/QwQ-32B.yaml
@@ -32,7 +32,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/Qwen2-72B-Instruct.yaml
+++ b/models/gitee_ai/models/llm/Qwen2-72B-Instruct.yaml
@@ -44,7 +44,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/Qwen2-7B-Instruct.yaml
+++ b/models/gitee_ai/models/llm/Qwen2-7B-Instruct.yaml
@@ -44,7 +44,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/Qwen2-VL-72B.yaml
+++ b/models/gitee_ai/models/llm/Qwen2-VL-72B.yaml
@@ -32,7 +32,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/Qwen2.5-14B-Instruct.yaml
+++ b/models/gitee_ai/models/llm/Qwen2.5-14B-Instruct.yaml
@@ -33,7 +33,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/Qwen2.5-32B-Instruct.yaml
+++ b/models/gitee_ai/models/llm/Qwen2.5-32B-Instruct.yaml
@@ -33,7 +33,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/Qwen2.5-72B-Instruct.yaml
+++ b/models/gitee_ai/models/llm/Qwen2.5-72B-Instruct.yaml
@@ -33,7 +33,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/Qwen2.5-VL-32B-Instruct.yaml
+++ b/models/gitee_ai/models/llm/Qwen2.5-VL-32B-Instruct.yaml
@@ -32,7 +32,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/Yi-34B-Chat.yaml
+++ b/models/gitee_ai/models/llm/Yi-34B-Chat.yaml
@@ -43,7 +43,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/codegeex4-all-9b.yaml
+++ b/models/gitee_ai/models/llm/codegeex4-all-9b.yaml
@@ -43,7 +43,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/deepseek-coder-33B-instruct.yaml
+++ b/models/gitee_ai/models/llm/deepseek-coder-33B-instruct.yaml
@@ -43,7 +43,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/gemma-3-27b-it.yaml
+++ b/models/gitee_ai/models/llm/gemma-3-27b-it.yaml
@@ -44,7 +44,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/glm-4-9b-chat.yaml
+++ b/models/gitee_ai/models/llm/glm-4-9b-chat.yaml
@@ -43,7 +43,6 @@ parameter_rules:
     default: 0.7
     min: 0.0
     max: 1.0
-    precision: 1
     required: true
     help:
       en_US: "The randomness of the sampling temperature control output. The temperature value is within the range of [0.0, 1.0]. The higher the value, the more random and creative the output; the lower the value, the more stable it is. It is recommended to adjust either top_p or temperature parameters according to your needs to avoid adjusting both at the same time."

--- a/models/gitee_ai/models/llm/llm.py
+++ b/models/gitee_ai/models/llm/llm.py
@@ -20,16 +20,18 @@ class GiteeAILargeLanguageModel(OAICompatLargeLanguageModel):
         stream: bool = True,
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator]:
-        self._add_custom_parameters(credentials, model, model_parameters)
+        self._add_custom_parameters(credentials, model, model_parameters, stream)
         return super()._invoke(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
-        self._add_custom_parameters(credentials, model, None)
+        self._add_custom_parameters(credentials, model, None, True)
         super().validate_credentials(model, credentials)
 
-    def _add_custom_parameters(self, credentials: dict, model: str, model_parameters: dict) -> None:
+    def _add_custom_parameters(self, credentials: dict, model: str, model_parameters: dict, stream: bool) -> None:
         credentials["endpoint_url"] = "https://ai.gitee.com/v1"
         credentials["mode"] = LLMMode.CHAT.value
+        if model_parameters is not None:
+            model_parameters["stream"] = stream
 
         schema = self.get_model_schema(model, credentials)
         assert schema is not None, f"Model schema not found for model {model}"

--- a/models/gitee_ai/requirements.txt
+++ b/models/gitee_ai/requirements.txt
@@ -1,2 +1,2 @@
-dify_plugin==0.0.1b65
+dify_plugin>=0.1.0,<0.2.0
 dashscope==1.20.14


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [X] Other Changes (Add New Models, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [X] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [X] I'm Using `dify_plugin>=0.1.0,<0.2.0` in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [X] Dify Version is: 1.2.0, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->