### PR TITLE
fix bedrock converse

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -1444,33 +1444,17 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 })
         
         return formatted_messages
-    def _convert_messages_to_prompt(self, prompt_messages: list[PromptMessage], prefix: str, model_name: str) -> str:
-        """
-        Convert a list of PromptMessage objects to a single string prompt
+    def _convert_messages_to_prompt(
+            self, messages: list[PromptMessage], model_prefix: str, model_name: Optional[str] = None
+    ) -> str:
+        if not messages:
+            return ""
 
-        :param prompt_messages: List of PromptMessage objects
-        :param prefix: Model prefix (from model.split(".")[0])
-        :param model_name: Model name (from model.split(".")[1])
-        :return: A string representation of the messages
-        """
-        prompt_str = ""
+        messages = messages.copy()  # don't mutate the original list
+        if not isinstance(messages[-1], AssistantPromptMessage):
+            messages.append(AssistantPromptMessage(content=""))
 
-        for message in prompt_messages:
-            role = message.role
-            content = message.content
+        text = "".join(self._convert_one_message_to_text(message, model_prefix, model_name) for message in messages)
 
-            # Add role prefix based on message type
-            if role == "system":
-                prompt_str += f"System: {content}\n\n"
-            elif role == "user":
-                prompt_str += f"User: {content}\n\n"
-            elif role == "assistant":
-                prompt_str += f"Assistant: {content}\n\n"
-            elif role == "function":
-                # Handle function messages if needed
-                prompt_str += f"Function ({message.name}): {content}\n\n"
-            else:
-                # Handle any other role types
-                prompt_str += f"{role.capitalize()}: {content}\n\n"
-
-        return prompt_str.strip()
+        # trim off the trailing ' ' that might come from the "Assistant: "
+        return text.rstrip()

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -1444,3 +1444,33 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 })
         
         return formatted_messages
+    def _convert_messages_to_prompt(self, prompt_messages: list[PromptMessage], prefix: str, model_name: str) -> str:
+        """
+        Convert a list of PromptMessage objects to a single string prompt
+
+        :param prompt_messages: List of PromptMessage objects
+        :param prefix: Model prefix (from model.split(".")[0])
+        :param model_name: Model name (from model.split(".")[1])
+        :return: A string representation of the messages
+        """
+        prompt_str = ""
+
+        for message in prompt_messages:
+            role = message.role
+            content = message.content
+
+            # Add role prefix based on message type
+            if role == "system":
+                prompt_str += f"System: {content}\n\n"
+            elif role == "user":
+                prompt_str += f"User: {content}\n\n"
+            elif role == "assistant":
+                prompt_str += f"Assistant: {content}\n\n"
+            elif role == "function":
+                # Handle function messages if needed
+                prompt_str += f"Function ({message.name}): {content}\n\n"
+            else:
+                # Handle any other role types
+                prompt_str += f"{role.capitalize()}: {content}\n\n"
+
+        return prompt_str.strip()


### PR DESCRIPTION
to fix:
<img width="413" alt="image" src="https://github.com/user-attachments/assets/2e5bd9da-518f-4afe-983a-97dfffe9b05f" />


## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [ ] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I'm Using `dify_plugin>=0.1.0,<0.2.0` in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->