### PR TITLE
gemini: adapted to OpenAI's json schema

### DIFF
--- a/tools/gitlab/manifest.yaml
+++ b/tools/gitlab/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/gitlab/tools/gitlab_files.py
+++ b/tools/gitlab/tools/gitlab_files.py
@@ -43,36 +43,67 @@ class GitlabFilesTool(Tool):
     ) -> list[dict[str, Any]]:
         domain = site_url
         headers = {"PRIVATE-TOKEN": access_token}
-        results = []
-        tree_url = None
+        results: list[dict[str, Any]] = []
+
         try:
+            encoded_identifier = urllib.parse.quote(identifier, safe="") if is_repository else None
+            project_id: Union[str, None]
             if is_repository:
-                encoded_identifier = urllib.parse.quote(identifier, safe="")
-                tree_url = f"{domain}/api/v4/projects/{encoded_identifier}/repository/tree?path={path}&ref={branch}"
+                project_id = None
             else:
                 project_id = self.get_project_id(site_url, access_token, identifier)
-                if project_id:
-                    tree_url = f"{domain}/api/v4/projects/{project_id}/repository/tree?path={path}&ref={branch}"
-            if tree_url:
+                if not project_id:
+                    return results
+
+            project_reference = encoded_identifier if is_repository else str(project_id)
+
+            def build_tree_url(target_path: str) -> str:
+                encoded_path = urllib.parse.quote(target_path, safe="/") if target_path else ""
+                query_path = f"&path={encoded_path}" if target_path else ""
+                return f"{domain}/api/v4/projects/{project_reference}/repository/tree?ref={branch}{query_path}"
+
+            def build_file_url(target_path: str) -> str:
+                encoded_path = urllib.parse.quote(target_path, safe="")
+                return (
+                    f"{domain}/api/v4/projects/{project_reference}/repository/files/{encoded_path}/raw?ref={branch}"
+                )
+
+            def fetch_directory(target_path: str) -> Union[list[dict[str, Any]], None]:
+                tree_url = build_tree_url(target_path)
                 response = requests.get(tree_url, headers=headers, verify=ssl_verify)
+                if response.status_code == 404:
+                    return None
                 response.raise_for_status()
-                items = response.json()
-                for item in items:
+                return response.json()
+
+            def fetch_file(target_path: str) -> Union[dict[str, Any], None]:
+                if not target_path:
+                    return None
+                file_url = build_file_url(target_path)
+                response = requests.get(file_url, headers=headers, verify=ssl_verify)
+                if response.status_code == 404:
+                    return None
+                response.raise_for_status()
+                return {"path": target_path, "branch": branch, "content": response.text}
+
+            def walk_path(target_path: str) -> list[dict[str, Any]]:
+                directory_items = fetch_directory(target_path)
+                if directory_items is None:
+                    file_result = fetch_file(target_path)
+                    return [file_result] if file_result else []
+
+                collected: list[dict[str, Any]] = []
+                for item in directory_items:
                     item_path = item["path"]
                     if item["type"] == "tree":
-                        results.extend(
-                            self.fetch_files(site_url, access_token, identifier, branch, item_path, is_repository, ssl_verify)
-                        )
+                        collected.extend(walk_path(item_path))
                     else:
-                        encoded_item_path = urllib.parse.quote(item_path, safe="")
-                        if is_repository:
-                            file_url = f"{domain}/api/v4/projects/{encoded_identifier}/repository/files/{encoded_item_path}/raw?ref={branch}"
-                        else:
-                            file_url = f"{domain}/api/v4/projects/{project_id}/repository/files{encoded_item_path}/raw?ref={branch}"
-                        file_response = requests.get(file_url, headers=headers, verify=ssl_verify)
-                        file_response.raise_for_status()
-                        file_content = file_response.text
-                        results.append({"path": item_path, "branch": branch, "content": file_content})
+                        file_result = fetch_file(item_path)
+                        if file_result:
+                            collected.append(file_result)
+                return collected
+
+            results = walk_path(path)
         except requests.RequestException as e:
             print(f"Error fetching data from GitLab: {e}")
         return results


### PR DESCRIPTION
When using the structure output feature, the input structures of Gemini and OpenAI are significantly different. 
This PR makes Gemini adapt to the input of OpenAI's json schema without affecting its original usage method.

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [X] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [ ] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I'm Using `dify_plugin>=0.1.0,<0.2.0` in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [X] Dify Version is: 1.0.0, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->