### PR TITLE
Remove transformers dependencies on Llama API plugin

### DIFF
--- a/models/llama_api/manifest.yaml
+++ b/models/llama_api/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 type: plugin
 author: langgenius
 name: llama-api
@@ -28,7 +28,7 @@ plugins:
   models:
     - provider/llama-api.yaml
 meta:
-  version: 0.0.1
+  version: 0.0.2
   arch:
     - amd64
     - arm64

--- a/models/llama_api/models/llm/llm.py
+++ b/models/llama_api/models/llm/llm.py
@@ -1,7 +1,6 @@
 import logging
 from collections.abc import Generator
 from typing import cast, Optional, Union
-from transformers import AutoTokenizer
 
 import openai
 
@@ -534,11 +533,10 @@ class LlamaApiLargeLanguageModel(LargeLanguageModel):
         messages: list[PromptMessage],
         tools: Optional[list[PromptMessageTool]] = None,
     ) -> int:
-        tokenizer = AutoTokenizer.from_pretrained("unsloth/Llama-4-Scout-17B-16E-Instruct-unsloth-bnb-4bit")
         num_tokens = 0
         messages_dict = [self._convert_prompt_message_to_dict(m) for m in messages]
         for message in messages_dict:
-            num_tokens += len(tokenizer.encode(str(message), add_special_tokens=False))
+            num_tokens += self._get_num_tokens_by_gpt2(str(message))
         return num_tokens
 
     def _extract_response_tool_calls(

--- a/models/llama_api/requirements.txt
+++ b/models/llama_api/requirements.txt
@@ -1,3 +1,2 @@
 dify_plugin>=0.2.0,<0.3.0
-transformers~=4.51.3
 openai~=1.77.0


### PR DESCRIPTION
https://github.com/langgenius/dify-official-plugins/pull/845 introduced Llama API plugin.

Initially we are using transformers package to count tokens, but somehow the production version of dify has this weird error

```
[llama-api] Error: PluginInvokeError: {"args":{},"error_type":"KeyError","message":"\u003cclass 'transformers.models.bit.configuration_bit.BitConfig'\u003e"}
```

I suspect it's related to some transformers package dependencies version incompatibility or something.
Upon digging futher, looks like dify provide a util function to count an approximate tokens using _get_num_tokens_by_gpt2()
I saw many model providers are using that too, and hence migrating to that and removing transformers as a package dependencies.

I tested this by building the dify plugin manually, and upload it into dify cloud (prod) and test it out, and how the error no longer appears. 

<img width="1226" alt="Screenshot 2025-05-06 at 8 37 06 PM" src="https://github.com/user-attachments/assets/db8dab0b-06b1-4645-a901-4a0086fb6e29" />

<img width="1219" alt="Screenshot 2025-05-06 at 8 41 51 PM" src="https://github.com/user-attachments/assets/b9dc4f7a-4f78-4db1-a7f8-7ee7f419ecac" />

