### PR TITLE
fix(vertex-ai): switch to REST transport to fix concurrency hang

### DIFF
--- a/models/vertex_ai/main.py
+++ b/models/vertex_ai/main.py
@@ -1,7 +1,4 @@
-import grpc.experimental.gevent
 from dify_plugin import Plugin, DifyPluginEnv
-
-grpc.experimental.gevent.init_gevent()
 
 plugin = Plugin(DifyPluginEnv(MAX_REQUEST_TIMEOUT=120))
 

--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.21
+version: 0.0.22

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -490,9 +490,9 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
             location = credentials["vertex_location"]
         if service_account_info:
             service_accountSA = service_account.Credentials.from_service_account_info(service_account_info)
-            aiplatform.init(credentials=service_accountSA, project=project_id, location=location)
+            aiplatform.init(credentials=service_accountSA, project=project_id, location=location, api_transport="rest")
         else:
-            aiplatform.init(project=project_id, location=location)
+            aiplatform.init(project=project_id, location=location, api_transport="rest")
             
         history = []
         system_instruction = ""

--- a/models/vertex_ai/models/text_embedding/text_embedding.py
+++ b/models/vertex_ai/models/text_embedding/text_embedding.py
@@ -59,9 +59,9 @@ class VertexAiTextEmbeddingModel(CommonVertexAi, TextEmbeddingModel):
         location = credentials["vertex_location"]
         if service_account_info:
             service_accountSA = service_account.Credentials.from_service_account_info(service_account_info)
-            aiplatform.init(credentials=service_accountSA, project=project_id, location=location)
+            aiplatform.init(credentials=service_accountSA, project=project_id, location=location, api_transport="rest")
         else:
-            aiplatform.init(project=project_id, location=location)
+            aiplatform.init(project=project_id, location=location, api_transport="rest")
         client = VertexTextEmbeddingModel.from_pretrained(model)
         (embeddings_batch, embedding_used_tokens) = self._embedding_invoke(client=client, texts=texts)
         usage = self._calc_response_usage(model=model, credentials=credentials, tokens=embedding_used_tokens)
@@ -108,9 +108,9 @@ class VertexAiTextEmbeddingModel(CommonVertexAi, TextEmbeddingModel):
             location = credentials["vertex_location"]
             if service_account_info:
                 service_accountSA = service_account.Credentials.from_service_account_info(service_account_info)
-                aiplatform.init(credentials=service_accountSA, project=project_id, location=location)
+                aiplatform.init(credentials=service_accountSA, project=project_id, location=location, api_transport="rest")
             else:
-                aiplatform.init(project=project_id, location=location)
+                aiplatform.init(project=project_id, location=location, api_transport="rest")
             client = VertexTextEmbeddingModel.from_pretrained(model)
             self._embedding_invoke(model=model, client=client, texts=["ping"])
         except Exception as ex:


### PR DESCRIPTION
## Related Issues or Context

This PR fixes an issue where the Vertex AI plugin hangs during document ingestion when handling multiple tasks. The problem was caused by gRPC transport not working well with the Gevent-based runtime. Switching to REST transport solves the issue.

Root Cause: gRPC transport hangs under concurrency due to incompatibility with Gevent.
Fix: Use REST transport in the Vertex AI SDK.

###  Root Cause (5 Whys)
- Why did the Dify plugin daemon get stuck?
It was waiting for responses from the Python plugin runtime, which never completed the embedding tasks.
- Why were the tasks never completed?
The Python plugin runtime got stuck during the first call to Vertex AI SDK’s embedding method.
- Why did it get stuck on that call?
The SDK used gRPC, which isn’t compatible with the Gevent/greenlets concurrency model.
- Why was gRPC incompatible?
The runtime used `grpc.experimental.gevent.init_gevent()` which causes silent hangs under load.
- Why wasn’t this caught earlier?
Heartbeat ran in a separate thread and continued normally, masking the deadlock.

### Ingestion Process
[![](https://mermaid.ink/img/pako:eNp1VO1q2zAUfZWLfmWQdGmyZq0ZhZKUtrSspS0bjMCQ7RtbRJY8SU7jlf7cv8H-jw32GHuevsBeYddW4rgNDZjo456je-490j2LdIwsYBa_FKginAieGJ5NFdAv58aJSORcOZiIWflRmzma7b0rWSRCTThmWvndUC9Xq3BdKCcyhM5V6VKtXvmALYryeIkRcEujNaIHt9zOodoonDbQuU0N8hh2X-ZYIP0_I_GLF8I6VLhhGbzIcoo0DZFvMW02blDFLa7hiotWt6vzAY3D5dFZxebHQJObyTl0kuurMUE9ZlPh3uFhu6RBfRzEOiqySgpmIcaxUAk4qo8Ht-MruC9FQKQ25y5K61BYCA5nl5CLHFcwH-cRVGc6Kud36tkRkBhEJdE1IAolzFpZAGMuZQuUIbU6Jn3oPjertlH6XjsEI5LUgZ7BhqUqBxQWLSjuxALB1eUl7LvQvD7sKO0g0hkJEqFEuBMuhROsBDTUa7JeS9Lj7-9wyikBsEJSsCyBqMCgzbWy-EJaa_TJSjuEUkdzjOGOC1eJnJElq4zr3MZcVdmVAmVMOSpntISQR_M1ectWW-19_PXNtzhtDNaxTlBJdY6G1GrFZZPmk1b3lhvbENHPP__-_iAhjThw2rewU3nYgi7cU716QT5uU3bbqQYtz_tm1OKEKtB2a-EZn1fFsCVdrwx4nlN8pUO6tNw-6EhK34_J8dHk4nJ8DvRC1PlhfctJKWgly5r6xnMK668TWawELskXXQgLB8ors7UlqEFkadZliRExC5wpsMsyNBmvpuy-SmTKXIoZTllAw5ib-ZRN1QNh6Jp-0jpbw4wukpQFMy4tzYo85m79Ljarpn4AxpreBhaMBjUHC-7ZkgW7w_7O3mAwHPRHw93RcLhPuyUF7e2MBm8ORgej_gF9_dFDl32tT-3v7L_de_gPkx7mOA?type=png)](https://mermaid.live/edit#pako:eNp1VO1q2zAUfZWLfmWQdGmyZq0ZhZKUtrSspS0bjMCQ7RtbRJY8SU7jlf7cv8H-jw32GHuevsBeYddW4rgNDZjo456je-490j2LdIwsYBa_FKginAieGJ5NFdAv58aJSORcOZiIWflRmzma7b0rWSRCTThmWvndUC9Xq3BdKCcyhM5V6VKtXvmALYryeIkRcEujNaIHt9zOodoonDbQuU0N8hh2X-ZYIP0_I_GLF8I6VLhhGbzIcoo0DZFvMW02blDFLa7hiotWt6vzAY3D5dFZxebHQJObyTl0kuurMUE9ZlPh3uFhu6RBfRzEOiqySgpmIcaxUAk4qo8Ht-MruC9FQKQ25y5K61BYCA5nl5CLHFcwH-cRVGc6Kud36tkRkBhEJdE1IAolzFpZAGMuZQuUIbU6Jn3oPjertlH6XjsEI5LUgZ7BhqUqBxQWLSjuxALB1eUl7LvQvD7sKO0g0hkJEqFEuBMuhROsBDTUa7JeS9Lj7-9wyikBsEJSsCyBqMCgzbWy-EJaa_TJSjuEUkdzjOGOC1eJnJElq4zr3MZcVdmVAmVMOSpntISQR_M1ectWW-19_PXNtzhtDNaxTlBJdY6G1GrFZZPmk1b3lhvbENHPP__-_iAhjThw2rewU3nYgi7cU716QT5uU3bbqQYtz_tm1OKEKtB2a-EZn1fFsCVdrwx4nlN8pUO6tNw-6EhK34_J8dHk4nJ8DvRC1PlhfctJKWgly5r6xnMK668TWawELskXXQgLB8ors7UlqEFkadZliRExC5wpsMsyNBmvpuy-SmTKXIoZTllAw5ib-ZRN1QNh6Jp-0jpbw4wukpQFMy4tzYo85m79Ljarpn4AxpreBhaMBjUHC-7ZkgW7w_7O3mAwHPRHw93RcLhPuyUF7e2MBm8ORgej_gF9_dFDl32tT-3v7L_de_gPkx7mOA)

### Task Execution Details
[![](https://mermaid.ink/img/pako:eNqdlE1u2zAQha8yYDcJYCcmKau2Fi38UxRBm6RIigKt7AUtjWTBEimQVBLH8Fm6bI_XI5SSLCfedFFtRBLvm5n3KGhHIhUjCUiSq8doLbSFz3cLCe65t253Fjav5Tn0--9gQsOvwmzA1GcGMgmpRpQ52mXLTGirY-FM5Dl8Q23xCSZXcD__1ElYK-GhO4NCbNBAevdlBpEjOg1vNV54reQGt_1S2GiNcSu0OktT1AZm_UhpPAG9BpzT3dWrqiCV7K9yFW0ymb7fL2QrntfDwo1qkCkNG32JOlG6MNDp4ery9lB92rqbsvDjwTbEyo0vlYVthnnc6VqLUx5-eEBpIVeqhESrZ5TQd2owtZkqd9U7ojU8Z7u56vKQ6AzX469EtAGl4eoWrIIkk5lZ1y4aD3Ur-O6YpqMX3jjKdA1Q14SuZNfmEA-KuHYXhn9-_vp93LrZokxHVS40PIrMLpfHpNjrpIbum8hcqrWmDkhJkMJmDwjGVUF7adfalex6Dk96nobfDT4Ztuk3KRqIlLRa5VBq5e4j33a325aa-C_5azRV4YqIxDqzblcqabDT-43-g4zP2u82UkXpKDTL824OY7c51jeWOEvBm2S16hnXe4Nuzflh3X_MYrsOWPl0AvH_gbwOiuMXyPf_CR1v6IAK8YIOBqcoP0VdBi0UJdER4mO-kKRHUp3FJLC6wh4pUBei3pJdzS-IXWOBCxK4ZSz0ZkEWcu-YUsgfShUdplWVrkmQiNy4XVXGwuI8E6kWxfFUo4xRz1QlLQmG1GuKkGBHnkhAR-yCUuZTn9MhZW8p75EtCZh3wdmI-t5gwOlgPOJ83yPPTd_Bxcij3PPY2B9zxthg2CMYZ1bp6_ZX1vzR9n8BaCCFqQ?type=png)](https://mermaid.live/edit#pako:eNqdlE1u2zAQha8yYDcJYCcmKau2Fi38UxRBm6RIigKt7AUtjWTBEimQVBLH8Fm6bI_XI5SSLCfedFFtRBLvm5n3KGhHIhUjCUiSq8doLbSFz3cLCe65t253Fjav5Tn0--9gQsOvwmzA1GcGMgmpRpQ52mXLTGirY-FM5Dl8Q23xCSZXcD__1ElYK-GhO4NCbNBAevdlBpEjOg1vNV54reQGt_1S2GiNcSu0OktT1AZm_UhpPAG9BpzT3dWrqiCV7K9yFW0ymb7fL2QrntfDwo1qkCkNG32JOlG6MNDp4ery9lB92rqbsvDjwTbEyo0vlYVthnnc6VqLUx5-eEBpIVeqhESrZ5TQd2owtZkqd9U7ojU8Z7u56vKQ6AzX469EtAGl4eoWrIIkk5lZ1y4aD3Ur-O6YpqMX3jjKdA1Q14SuZNfmEA-KuHYXhn9-_vp93LrZokxHVS40PIrMLpfHpNjrpIbum8hcqrWmDkhJkMJmDwjGVUF7adfalex6Dk96nobfDT4Ztuk3KRqIlLRa5VBq5e4j33a325aa-C_5azRV4YqIxDqzblcqabDT-43-g4zP2u82UkXpKDTL824OY7c51jeWOEvBm2S16hnXe4Nuzflh3X_MYrsOWPl0AvH_gbwOiuMXyPf_CR1v6IAK8YIOBqcoP0VdBi0UJdER4mO-kKRHUp3FJLC6wh4pUBei3pJdzS-IXWOBCxK4ZSz0ZkEWcu-YUsgfShUdplWVrkmQiNy4XVXGwuI8E6kWxfFUo4xRz1QlLQmG1GuKkGBHnkhAR-yCUuZTn9MhZW8p75EtCZh3wdmI-t5gwOlgPOJ83yPPTd_Bxcij3PPY2B9zxthg2CMYZ1bp6_ZX1vzR9n8BaCCFqQ)

Start → Task starts in greenlet → Call Vertex AI SDK → SDK makes gRPC call → Monkey-patched gRPC triggers C-core call →
[Decision] Is gRPC call non-blocking? → ❌ No → gRPC performs blocking I/O → Greenlet does not yield → Event loop frozen
[Decision] Does gRPC need callback or IO to finish? → ✅ Yes → Needs scheduler to run → 🧨 Deadlock - circular wait

### Fixing Approach: Use Vertex AI REST Transport
<img width="347" alt="image" src="https://github.com/user-attachments/assets/7b77ad75-8031-46de-98a1-d66093380d6b" />

Result: With REST transport, concurrent embedding tasks complete successfully.

###  Related GitHub Issues

Closes #1132 

---

## This PR contains Changes to *Non-Plugin*

* [ ] Documentation
* [x] Other

---

## This PR contains Changes to *Non-LLM Models Plugin*

* [x] I have Run Comprehensive Tests Relevant to My Changes
  📷 *Tested locally under concurrent embedding load. Plugin no longer hangs.*

---

## This PR contains Changes to *LLM Models Plugin*

* [x] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling)
  📷 *Before: plugin hangs after first request. After: runs normally with multiple concurrent tasks.*
* [ ] My Changes Affect Message Flow Handling
* [ ] My Changes Affect Multimodal Input Handling
* [ ] My Changes Affect Multimodal Output Generation
* [ ] My Changes Affect Structured Output Format
* [ ] My Changes Affect Token Consumption Metrics
* [ ] My Changes Affect Other LLM Functionalities
* [x] Other Changes (Changed Vertex AI SDK transport from gRPC to REST)

---

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)

* [x] I have Bumped Up the Version in `manifest.yaml` to `0.0.22`

---

## Dify Plugin SDK Version

* [x] I have Ensured `dify_plugin>=0.3.0,<0.4.0` is in requirements.txt

---

## Environment Verification (If Any Code Changes)

### Local Deployment Environment

* [x] Dify Version is: 1.3.1
  Tested locally with clean setup. Plugin runs with REST transport and handles concurrent tasks correctly.

### SaaS Environment

* [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration