### PR TITLE
feat: add jina-reranker-m0 and jina-embeddings-v4 models

### DIFF
--- a/models/jina/manifest.yaml
+++ b/models/jina/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: "langgenius"
 name: "jina"

--- a/models/jina/models/rerank/_position.yaml
+++ b/models/jina/models/rerank/_position.yaml
@@ -1,3 +1,4 @@
+- jina-reranker-m0
 - jina-reranker-v2-base-multilingual
 - jina-reranker-v1-turbo-en
 - jina-reranker-v1-tiny-en

--- a/models/jina/models/rerank/jina-reranker-m0.yaml
+++ b/models/jina/models/rerank/jina-reranker-m0.yaml
@@ -1,0 +1,4 @@
+model: jina-reranker-m0
+model_type: rerank
+model_properties:
+  context_size: 8192

--- a/models/jina/models/rerank/rerank.py
+++ b/models/jina/models/rerank/rerank.py
@@ -23,6 +23,7 @@ from dify_plugin.entities.model.rerank import (
     RerankDocument,
     RerankResult,
 )
+from models.shared.input import transform_jina_input_text
 
 
 class JinaRerankModel(RerankModel):
@@ -73,7 +74,7 @@ class JinaRerankModel(RerankModel):
         data = {
             "model": model,
             "query": query,
-            "documents": docs,
+            "documents": [transform_jina_input_text(model, doc) for doc in docs],
             "top_n": top_n,
         }
 

--- a/models/jina/models/shared/input.py
+++ b/models/jina/models/shared/input.py
@@ -1,0 +1,14 @@
+def transform_jina_input_text(model: str, text: str) -> dict:
+    """
+    Transform text input for Jina model
+
+    :param model: model name
+    :param text: input text
+    :return: transformed input
+    """
+    specific_models = ["jina-clip-v1", "jina-clip-v2", "jina-embeddings-v4", "jina-reranker-m0"]
+
+    if model in specific_models:
+        # For specific models, wrap text in a dictionary
+        return {"text": text}
+    return text

--- a/models/jina/models/text_embedding/jina-embeddings-v4.yaml
+++ b/models/jina/models/text_embedding/jina-embeddings-v4.yaml
@@ -1,0 +1,9 @@
+model: jina-embeddings-v4
+model_type: text-embedding
+model_properties:
+  context_size: 8192
+  max_chunks: 2048
+pricing:
+  input: '0.001'
+  unit: '0.001'
+  currency: USD

--- a/models/jina/models/text_embedding/text_embedding.py
+++ b/models/jina/models/text_embedding/text_embedding.py
@@ -27,6 +27,7 @@ from dify_plugin.errors.model import (
     InvokeRateLimitError,
     InvokeServerUnavailableError,
 )
+from models.shared.input import transform_jina_input_text
 from models.text_embedding.jina_tokenizer import JinaTokenizer
 
 
@@ -68,18 +69,13 @@ class JinaTextEmbeddingModel(TextEmbeddingModel):
             "Content-Type": "application/json",
         }
 
-        def transform_jina_input_text(model, text):
-            if model == "jina-clip-v1" or model == "jina-clip-v2":
-                return {"text": text}
-            return text
-
         data = {
             "model": model,
             "input": [transform_jina_input_text(model, text) for text in texts],
         }
 
         # model specific parameters
-        if model == "jina-embeddings-v3" or model == "jina-clip-v2":
+        if model == "jina-embeddings-v3" or model == "jina-embeddings-v4":
             # set `task` type according to input type for the best performance
             data["task"] = (
                 "retrieval.query"

--- a/models/jina/requirements.txt
+++ b/models/jina/requirements.txt
@@ -1,2 +1,2 @@
-dify_plugin>=0.2.0,<0.3.0
+dify_plugin>=0.3.0,<0.5.0
 transformers~=4.42.4


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
<img width="773" height="543" alt="Screenshot 2025-07-11 at 18 08 46" src="https://github.com/user-attachments/assets/83eb5490-1e3d-49c0-9ee6-7b228bfefd07" />
<img width="421" height="502" alt="Screenshot 2025-07-11 at 18 01 54" src="https://github.com/user-attachments/assets/208cda2f-7731-4fda-9e3c-b6e8c139c912" />
