### PR TITLE
refract: anthropic claude prompt caching

### DIFF
--- a/models/anthropic/README.md
+++ b/models/anthropic/README.md
@@ -5,3 +5,25 @@ Anthropic offers a suite of AI models designed for safety and helpfulness, excel
 You'll need your Anthropic API Key to configure this plugin. After obtaining it from Anthropic, enter it along with your API URL in the settings below. Save to activate.
 
 ![](./_assets/anthropic-01.png)
+
+## Prompt-Caching Options
+Claude’s API allows you to mark specific parts of a request as *ephemeral*. The blocks are then cached on Anthropic’s side so future requests are cheaper and faster.  
+This plugin exposes fine-grained switches so you control exactly **what** is cached.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `prompt_caching_system_message` | `true` | Cache content wrapped in `<cache>…</cache>` inside the system prompt. |
+| `prompt_caching_tool_definitions` | `true` | Adds `cache_control` to every tool definition sent in the `tools` array. |
+| `prompt_caching_images` | `true` | Caches image blocks. |
+| `prompt_caching_documents` | `true` | Caches PDF document blocks. |
+| `prompt_caching_tool_results` | `true` | Caches `tool_use` / `tool_result` blocks. |
+| `prompt_caching_message_flow` | `0` | If set to a positive integer *N*, any user or assistant text message longer than *N* words gets cached automatically. `0` disables this auto-caching. |
+
+**Anthropic limit:** At most **4** blocks may include `cache_control` in a single request.  
+The plugin enforces this by prioritising blocks in the following order:
+1. Images / Documents  
+2. System-message `<cache></cache>` blocks  
+3. Large text messages (message-flow threshold)  
+4. Tool definitions & tool results
+
+If more than four candidates exist, lower-priority blocks have their `cache_control` removed automatically before the request is sent.

--- a/models/anthropic/main.py
+++ b/models/anthropic/main.py
@@ -1,4 +1,7 @@
 from dify_plugin import Plugin, DifyPluginEnv
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 plugin = Plugin(DifyPluginEnv())
 

--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.15
+version: 0.1.0

--- a/models/anthropic/models/llm/claude-3-5-haiku-20241022.yaml
+++ b/models/anthropic/models/llm/claude-3-5-haiku-20241022.yaml
@@ -31,6 +31,66 @@ parameter_rules:
     max: 8192
   - name: response_format
     use_template: response_format
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
 pricing:
   input: '1.00'
   output: '5.00'

--- a/models/anthropic/models/llm/claude-3-5-sonnet-20240620.yaml
+++ b/models/anthropic/models/llm/claude-3-5-sonnet-20240620.yaml
@@ -33,6 +33,66 @@ parameter_rules:
     max: 8192
   - name: response_format
     use_template: response_format
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
 pricing:
   input: '3.00'
   output: '15.00'

--- a/models/anthropic/models/llm/claude-3-5-sonnet-20241022.yaml
+++ b/models/anthropic/models/llm/claude-3-5-sonnet-20241022.yaml
@@ -33,6 +33,66 @@ parameter_rules:
     max: 8192
   - name: response_format
     use_template: response_format
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
 pricing:
   input: '3.00'
   output: '15.00'

--- a/models/anthropic/models/llm/claude-3-7-sonnet-20250219.yaml
+++ b/models/anthropic/models/llm/claude-3-7-sonnet-20250219.yaml
@@ -64,6 +64,66 @@ parameter_rules:
     help:
       zh_Hans: 启用长达128K标记的输出能力。
       en_US: Enable capability for up to 128K output tokens.
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
 pricing:
   input: '3.00'
   output: '15.00'

--- a/models/anthropic/models/llm/claude-opus-4-20250514.yaml
+++ b/models/anthropic/models/llm/claude-opus-4-20250514.yaml
@@ -55,6 +55,66 @@ parameter_rules:
     max: 32000
   - name: response_format
     use_template: response_format
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
 pricing:
   input: '15.00'
   output: '75.00'

--- a/models/anthropic/models/llm/claude-sonnet-4-20250514.yaml
+++ b/models/anthropic/models/llm/claude-sonnet-4-20250514.yaml
@@ -55,6 +55,66 @@ parameter_rules:
     max: 64000
   - name: response_format
     use_template: response_format
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
 pricing:
   input: '3.00'
   output: '15.00'

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -1,8 +1,11 @@
 import base64
 import io
 import json
+import re
 from collections.abc import Generator, Sequence
 from typing import Any, Mapping, Optional, Union, cast
+import logging
+
 import anthropic
 import requests
 from anthropic import Anthropic, Stream
@@ -48,29 +51,105 @@ from PIL import Image
 ANTHROPIC_BLOCK_MODE_PROMPT = 'You should always follow the instructions and output a valid {{block}} object.\nThe structure of the {{block}} object you can found in the instructions, use {"answer": "$your_answer"} as the default structure\nif you are not sure about the structure.\n\n<instructions>\n{{instructions}}\n</instructions>\n'
 
 
+class PromptCachingHandler:
+    def __init__(self, prompt_messages: Sequence[PromptMessage], enable_system_cache: bool = False):
+        self.prompt_messages = prompt_messages
+        self.enable_system_cache = enable_system_cache
+
+    def get_system_prompt(self) -> Union[str, list[dict]]:
+        system_components = []
+        raw_system_content_parts = []
+        for message in self.prompt_messages:
+            if isinstance(message, SystemPromptMessage):
+                if isinstance(message.content, str):
+                    raw_system_content_parts.append(message.content.strip())
+                elif isinstance(message.content, list):
+                    for c in message.content:
+                        if isinstance(c, TextPromptMessageContent):
+                            raw_system_content_parts.append(c.data.strip())
+                else:
+                    raise ValueError(
+                        f"Unknown system prompt message content type {type(message.content)}"
+                    )
+
+        system_content_str = "\n".join(raw_system_content_parts)
+
+        if self.enable_system_cache and "<cache>" in system_content_str:
+            parts = re.split(r'(<cache>.*?</cache>)', system_content_str, flags=re.DOTALL)
+            for part in parts:
+                if not part:
+                    continue
+                if part.startswith('<cache>') and part.endswith('</cache>'):
+                    cached_content = part[len('<cache>'):-len('</cache>')]
+                    if cached_content:
+                        system_components.append({
+                "type": "text",
+                            "text": cached_content,
+                "cache_control": {"type": "ephemeral"}
+                        })
+                elif part:
+                    system_components.append({
+                        "type": "text",
+                        "text": part
+                    })
+        elif system_content_str:
+            system_components.append({"type": "text", "text": system_content_str})
+
+        system: Union[str, list[dict]] = ""
+        if system_components:
+            if any("cache_control" in comp for comp in system_components):
+                system = system_components
+            else:
+                system = "\n".join(comp["text"] for comp in system_components if comp.get("text"))
+        
+        return system
+
+    # --- Pricing Helpers -------------------------------------------------
+    # Cache write incurs a 25% premium (1.25×) on the written tokens
+    # Cache read receives a 90% discount (0.1×) on the read tokens
+
+    CACHE_WRITE_MULTIPLIER: float = 1.25
+    CACHE_READ_MULTIPLIER: float = 0.1
+
+    @classmethod
+    def calc_adjusted_prompt_tokens(
+        cls,
+        base_prompt_tokens: int,
+        cache_creation_input_tokens: int = 0,
+        cache_read_input_tokens: int = 0,
+    ) -> int:
+        """Return billing-adjusted prompt tokens.
+
+        Args:
+            base_prompt_tokens: The raw prompt tokens counted by the API.
+            cache_creation_input_tokens: Tokens written to cache in this request.
+            cache_read_input_tokens: Tokens read from cache in this request.
+        Returns:
+            int: Adjusted prompt tokens to be billed.
+        """
+        adjusted = base_prompt_tokens
+
+        if cache_creation_input_tokens > 0:
+            adjusted += int(cache_creation_input_tokens * cls.CACHE_WRITE_MULTIPLIER)
+
+        if cache_read_input_tokens > 0:
+            adjusted += int(cache_read_input_tokens * cls.CACHE_READ_MULTIPLIER)
+
+        return adjusted
+
+
 class AnthropicLargeLanguageModel(LargeLanguageModel):
     def __init__(self, model_schemas=None):
         super().__init__(model_schemas or [])
         self.previous_thinking_blocks = []
         self.previous_redacted_thinking_blocks = []
-
-    def _process_text_for_cache(self, text):
-        """
-        Process text content to detect <cache> tags and return the appropriate 
-        content format with cache_control if needed.
-        
-        :param text: Text content to process
-        :return: Processed content, either as string or dict with cache_control
-        """
-        if "<cache>" in text:
-            return {
-                "type": "text",
-                "text": text.replace("<cache>", ""),
-                "cache_control": {"type": "ephemeral"}
-            }
-        return {"type": "text", "text": text}
-
-
+        # Flag to indicate whether tool definitions should include cache_control
+        self._tool_cache_enabled = False
+        self._system_cache_enabled = False
+        self._image_cache_enabled = False
+        self._document_cache_enabled = False
+        self._tool_results_cache_enabled = False
+        self._message_flow_cache_threshold: int = 0
 
     def _invoke(
         self,
@@ -148,9 +227,73 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             extra_model_kwargs["metadata"] = completion_create_params.Metadata(
                 user_id=user
             )
+        # Extract caching flags early so _convert_prompt_messages can use them
+        self._tool_cache_enabled = model_parameters.pop("prompt_caching_tool_definitions", False)
+        self._system_cache_enabled = model_parameters.pop("prompt_caching_system_message", False)
+        self._image_cache_enabled = model_parameters.pop("prompt_caching_images", False)
+        self._document_cache_enabled = model_parameters.pop("prompt_caching_documents", False)
+        self._tool_results_cache_enabled = model_parameters.pop("prompt_caching_tool_results", False)
+        self._message_flow_cache_threshold = int(model_parameters.pop("prompt_caching_message_flow", 0) or 0)
+
         (system, prompt_message_dicts) = self._convert_prompt_messages(prompt_messages)
         if system:
             extra_model_kwargs["system"] = system
+
+        # Helper to prune cache_control blocks to max 4 by priority
+        def _prune_cache_blocks(payload: dict):
+            blocks: list[tuple[int, dict]] = []  # (priority, block_dict)
+
+            # Helper to record
+            def _record_block(d: dict, priority: int):
+                if "cache_control" in d:
+                    blocks.append((priority, d))
+
+            # 1. system blocks
+            if isinstance(payload.get("system"), list):
+                for block in payload["system"]:
+                    if isinstance(block, dict):
+                        _record_block(block, 2)  # system priority 2
+
+            # 2. message content blocks
+            for msg in payload.get("messages", []):
+                content = msg.get("content")
+                if isinstance(content, list):
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        btype = block.get("type")
+                        if btype in {"image", "document"}:
+                            pr = 1
+                        elif btype in {"tool_use", "tool_result"}:
+                            pr = 4
+                        else:
+                            pr = 3  # text or others
+                        _record_block(block, pr)
+
+            # 3. tools definitions
+            for tool_def in payload.get("tools", []):
+                if isinstance(tool_def, dict):
+                    _record_block(tool_def, 4)
+
+            # Sort by priority (lower number = higher priority)
+            blocks.sort(key=lambda x: x[0])
+
+            # Keep first 4
+            for idx, (_, block_dict) in enumerate(blocks):
+                if idx >= 4:
+                    block_dict.pop("cache_control", None)
+
+        # Build preliminary request payload (without tools yet)
+        request_payload = {
+            "model": model,
+            "messages": prompt_message_dicts,
+            "stream": stream,
+            "extra_headers": extra_headers,
+            **model_parameters,
+            **extra_model_kwargs,
+        }
+
+        # We will insert tools later; prune cache blocks after that just before send
 
         if model == "claude-3-5-sonnet-20240620":
             if model_parameters.get("max_tokens", 0) > 4096:
@@ -176,6 +319,16 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             extra_model_kwargs["tools"] = [
                 self._transform_tool_prompt(tool) for tool in tools
             ]
+            
+            # Log the transformed tools to verify cache_control is added
+            logging.info(f"Anthropic API Tools: {json.dumps(extra_model_kwargs['tools'], indent=2)}")
+            
+            request_payload["tools"] = extra_model_kwargs["tools"]
+
+            # Now prune cache blocks to respect Anthropic limit
+            _prune_cache_blocks(request_payload)
+
+            logging.info(f"Anthropic API Request: {json.dumps(request_payload, indent=2)}")
             response = client.messages.create(
                 model=model,
                 messages=prompt_message_dicts,
@@ -186,6 +339,8 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 **{k: v for k, v in extra_model_kwargs.items() if k != "tools"},
             )
         else:
+            logging.info(f"Anthropic API Request: {json.dumps(request_payload, indent=2)}")
+            _prune_cache_blocks(request_payload)
             response = client.messages.create(
                 model=model,
                 messages=prompt_message_dicts,
@@ -199,6 +354,8 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             return self._handle_chat_generate_stream_response(
                 model, credentials, response, prompt_messages
             )
+        
+        logging.info(f"Anthropic API Response: {response.model_dump_json(indent=2)}")
         return self._handle_chat_generate_response(
             model, credentials, response, prompt_messages
         )
@@ -287,6 +444,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             "name": tool.name,
             "description": tool.description,
             "input_schema": input_schema,
+            **({"cache_control": {"type": "ephemeral"}} if getattr(self, "_tool_cache_enabled", False) else {}),
         }
 
     def _transform_chat_json_prompts(
@@ -447,16 +605,6 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     ),
                 )
                 assistant_prompt_message.tool_calls.append(tool_call)
-                
-        # Extract cache metrics if available
-        cache_creation_input_tokens = 0
-        cache_read_input_tokens = 0
-        if response.usage:
-            if hasattr(response.usage, "cache_creation_input_tokens"):
-                cache_creation_input_tokens = response.usage.cache_creation_input_tokens
-            
-            if hasattr(response.usage, "cache_read_input_tokens"):
-                cache_read_input_tokens = response.usage.cache_read_input_tokens
         
         prompt_tokens = (
             response.usage
@@ -475,19 +623,21 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             )
         )
         
-        # UPDATED: Token accounting for billing with cache adjustments
-        adjusted_prompt_tokens = prompt_tokens
-        
-        # Cache write premium: add full cache tokens plus 25% premium
-        if cache_creation_input_tokens > 0:
-            cache_write_premium = int(cache_creation_input_tokens * 0.25)
-            adjusted_prompt_tokens += cache_creation_input_tokens + cache_write_premium
-        
-        # Cache read discount: only charge 10% of cached tokens (90% discount)
-        if cache_read_input_tokens > 0:
-            adjusted_prompt_tokens += int(cache_read_input_tokens * 0.1)
-        
-        # Get usage with adjusted token count for billing
+        # Adjust prompt tokens for cache operations
+        cache_creation_input_tokens = 0
+        cache_read_input_tokens = 0
+        if response.usage:
+            if hasattr(response.usage, "cache_creation_input_tokens") and response.usage.cache_creation_input_tokens:
+                cache_creation_input_tokens = response.usage.cache_creation_input_tokens
+            if hasattr(response.usage, "cache_read_input_tokens") and response.usage.cache_read_input_tokens:
+                cache_read_input_tokens = response.usage.cache_read_input_tokens
+
+        adjusted_prompt_tokens = PromptCachingHandler.calc_adjusted_prompt_tokens(
+            prompt_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+        )
+
         usage = super()._calc_response_usage(
             model=model,
             credentials=credentials,
@@ -536,19 +686,19 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         current_thinking_blocks = []
         current_redacted_thinking_blocks = []
         
-        # Add cache token tracking
+        # Cache token tracking
         cache_creation_input_tokens = 0
         cache_read_input_tokens = 0
         
         for chunk in response:
+            logging.info(f"Anthropic API Stream Response Chunk: {chunk.model_dump_json()}")
             if isinstance(chunk, MessageStartEvent):
                 if chunk.message:
                     return_model = chunk.message.model
                     input_tokens = chunk.message.usage.input_tokens
-                    # Check for cache metrics in the start event
-                    if hasattr(chunk.message.usage, "cache_creation_input_tokens"):
+                    if hasattr(chunk.message.usage, "cache_creation_input_tokens") and chunk.message.usage.cache_creation_input_tokens:
                         cache_creation_input_tokens = chunk.message.usage.cache_creation_input_tokens
-                    if hasattr(chunk.message.usage, "cache_read_input_tokens"):
+                    if hasattr(chunk.message.usage, "cache_read_input_tokens") and chunk.message.usage.cache_read_input_tokens:
                         cache_read_input_tokens = chunk.message.usage.cache_read_input_tokens
             elif hasattr(chunk, "type") and chunk.type == "content_block_start":
                 if hasattr(chunk, "content_block"):
@@ -671,10 +821,9 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             elif isinstance(chunk, MessageDeltaEvent):
                 output_tokens = chunk.usage.output_tokens
                 finish_reason = chunk.delta.stop_reason
-                # Check for updated cache metrics
-                if hasattr(chunk.usage, "cache_creation_input_tokens"):
+                if hasattr(chunk.usage, "cache_creation_input_tokens") and chunk.usage.cache_creation_input_tokens:
                     cache_creation_input_tokens = chunk.usage.cache_creation_input_tokens
-                if hasattr(chunk.usage, "cache_read_input_tokens"):
+                if hasattr(chunk.usage, "cache_read_input_tokens") and chunk.usage.cache_read_input_tokens:
                     cache_read_input_tokens = chunk.usage.cache_read_input_tokens
             elif isinstance(chunk, MessageStopEvent):
                 if current_block_type == "thinking" and current_block_index is not None:
@@ -702,19 +851,13 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 if tool_calls and current_redacted_thinking_blocks:
                     self.previous_redacted_thinking_blocks = current_redacted_thinking_blocks
                 
-                # UPDATED: Token accounting for billing with cache adjustments
-                adjusted_prompt_tokens = input_tokens
-
-                # Cache write premium: add full cache tokens plus 25% premium
-                if cache_creation_input_tokens > 0:
-                    cache_write_premium = int(cache_creation_input_tokens * 0.25)
-                    adjusted_prompt_tokens += cache_creation_input_tokens + cache_write_premium
-
-                # Cache read discount: only charge 10% of cached tokens (90% discount)
-                if cache_read_input_tokens > 0:
-                    adjusted_prompt_tokens += int(cache_read_input_tokens * 0.1)
+                # Adjust prompt tokens for cache operations
+                adjusted_prompt_tokens = PromptCachingHandler.calc_adjusted_prompt_tokens(
+                    input_tokens,
+                    cache_creation_input_tokens,
+                    cache_read_input_tokens,
+                )
                 
-                # Get usage with adjusted token count for billing
                 usage = super()._calc_response_usage(
                     model, 
                     credentials, 
@@ -759,62 +902,12 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
 
     def _convert_prompt_messages(
         self, prompt_messages: Sequence[PromptMessage]
-    ) -> tuple[str, list[dict]]:
+    ) -> tuple[Union[str, list[dict]], list[dict]]:
         """
         Convert prompt messages to dict list and system
         """
-        system = ""
-        system_components = []
-        first_loop = True
-        for message in prompt_messages:
-            if isinstance(message, SystemPromptMessage):
-                if isinstance(message.content, str):
-                    content = message.content.strip()
-                    if "<cache>" in content:
-                        system_components.append({
-                            "type": "text",
-                            "text": content.replace("<cache>", ""),
-                            "cache_control": {"type": "ephemeral"}
-                        })
-                    else:
-                        system_components.append({"type": "text", "text": content})
-                    
-                    if first_loop:
-                        system = content
-                        first_loop = False
-                    else:
-                        system += "\n"
-                        system += content
-                elif isinstance(message.content, list):
-                    combined_content = ""
-                    for c in message.content:
-                        if isinstance(c, TextPromptMessageContent):
-                            text_content = c.data.strip()
-                            combined_content += text_content
-                    
-                    if "<cache>" in combined_content:
-                        system_components.append({
-                            "type": "text",
-                            "text": combined_content.replace("<cache>", ""),
-                            "cache_control": {"type": "ephemeral"}
-                        })
-                    else:
-                        system_components.append({"type": "text", "text": combined_content})
-                    
-                    if first_loop:
-                        system = combined_content
-                        first_loop = False
-                    else:
-                        system += "\n"
-                        system += combined_content
-                else:
-                    raise ValueError(
-                        f"Unknown system prompt message content type {type(message.content)}"
-                    )
-        
-        # If we have structured system components with cache controls, use them instead of a single string
-        if len(system_components) > 0 and any(comp.get("cache_control") for comp in system_components):
-            system = system_components
+        caching_handler = PromptCachingHandler(prompt_messages, enable_system_cache=getattr(self, "_system_cache_enabled", False))
+        system = caching_handler.get_system_prompt()
         
         prompt_message_dicts = []
         for message in prompt_messages:
@@ -822,12 +915,12 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 if isinstance(message, UserPromptMessage):
                     message = cast(UserPromptMessage, message)
                     if isinstance(message.content, str):
-                        if "<cache>" in message.content:
+                        if self._message_flow_cache_threshold and len(message.content.split()) >= self._message_flow_cache_threshold:
                             message_dict = {
-                                "role": "user", 
+                                "role": "user",
                                 "content": [{
                                     "type": "text",
-                                    "text": message.content.replace("<cache>", ""),
+                                    "text": message.content,
                                     "cache_control": {"type": "ephemeral"}
                                 }]
                             }
@@ -835,41 +928,28 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                             message_dict = {"role": "user", "content": message.content}
                         prompt_message_dicts.append(message_dict)
                     else:
-                        sub_messages = []
+                        # message.content is a list
+                        document_parts: list[dict] = []
+                        image_parts: list[dict] = []
+                        text_parts: list[dict] = []
                         for message_content in message.content or []:
                             if message_content.type == PromptMessageContentType.TEXT:
-                                message_content = cast(
-                                    TextPromptMessageContent, message_content
-                                )
-                                text_content = message_content.data
-                                if "<cache>" in text_content:
-                                    sub_message_dict = {
-                                        "type": "text",
-                                        "text": text_content.replace("<cache>", ""),
-                                        "cache_control": {"type": "ephemeral"}
-                                    }
-                                else:
-                                    sub_message_dict = {
-                                        "type": "text",
-                                        "text": text_content,
-                                    }
-                                sub_messages.append(sub_message_dict)
+                                text_content = cast(TextPromptMessageContent, message_content).data
+                                sub_message_dict = {
+                                    "type": "text",
+                                    "text": text_content,
+                                }
+                                if self._message_flow_cache_threshold and len(text_content.split()) >= self._message_flow_cache_threshold:
+                                    sub_message_dict["cache_control"] = {"type": "ephemeral"}
+                                text_parts.append(sub_message_dict)
                             elif message_content.type == PromptMessageContentType.IMAGE:
-                                message_content = cast(
-                                    ImagePromptMessageContent, message_content
-                                )
+                                message_content = cast(ImagePromptMessageContent, message_content)
                                 if not message_content.data.startswith("data:"):
                                     try:
-                                        image_content = requests.get(
-                                            message_content.data
-                                        ).content
-                                        with Image.open(
-                                            io.BytesIO(image_content)
-                                        ) as img:
+                                        image_content = requests.get(message_content.data).content
+                                        with Image.open(io.BytesIO(image_content)) as img:
                                             mime_type = f"image/{img.format.lower()}"
-                                        base64_data = base64.b64encode(
-                                            image_content
-                                        ).decode("utf-8")
+                                        base64_data = base64.b64encode(image_content).decode("utf-8")
                                     except Exception as ex:
                                         raise ValueError(
                                             f"Failed to fetch image data from url {message_content.data}, {ex}"
@@ -878,12 +958,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                                     data_split = message_content.data.split(";base64,")
                                     mime_type = data_split[0].replace("data:", "")
                                     base64_data = data_split[1]
-                                if mime_type not in {
-                                    "image/jpeg",
-                                    "image/png",
-                                    "image/gif",
-                                    "image/webp",
-                                }:
+                                if mime_type not in {"image/jpeg", "image/png", "image/gif", "image/webp"}:
                                     raise ValueError(
                                         f"Unsupported image type {mime_type}, only support image/jpeg, image/png, image/gif, and image/webp"
                                     )
@@ -895,10 +970,10 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                                         "data": base64_data,
                                     },
                                 }
-                                sub_messages.append(sub_message_dict)
-                            elif isinstance(
-                                message_content, DocumentPromptMessageContent
-                            ):
+                                if getattr(self, "_image_cache_enabled", False):
+                                    sub_message_dict["cache_control"] = {"type": "ephemeral"}
+                                image_parts.append(sub_message_dict)
+                            elif isinstance(message_content, DocumentPromptMessageContent):
                                 if message_content.mime_type != "application/pdf":
                                     raise ValueError(
                                         f"Unsupported document type {message_content.mime_type}, only support application/pdf"
@@ -911,10 +986,11 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                                         "data": message_content.base64_data,
                                     },
                                 }
-                                sub_messages.append(sub_message_dict)
-                        prompt_message_dicts.append(
-                            {"role": "user", "content": sub_messages}
-                        )
+                                if getattr(self, "_document_cache_enabled", False):
+                                    sub_message_dict["cache_control"] = {"type": "ephemeral"}
+                                document_parts.append(sub_message_dict)
+                        sub_messages = document_parts + image_parts + text_parts
+                        prompt_message_dicts.append({"role": "user", "content": sub_messages})
                 elif isinstance(message, AssistantPromptMessage):
                     message = cast(AssistantPromptMessage, message)
                     content = []
@@ -927,17 +1003,20 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     
                     if message.tool_calls:
                         for tool_call in message.tool_calls:
-                            content.append({
+                            tool_use_dict = {
                                 "type": "tool_use",
                                 "id": tool_call.id,
                                 "name": tool_call.function.name,
                                 "input": json.loads(tool_call.function.arguments),
-                            })
+                            }
+                            if getattr(self, "_tool_results_cache_enabled", False):
+                                tool_use_dict['cache_control'] = {'type': 'ephemeral'}
+                            content.append(tool_use_dict)
                     elif message.content:
-                        if "<cache>" in message.content:
+                        if self._message_flow_cache_threshold and len(message.content.split()) >= self._message_flow_cache_threshold:
                             content.append({
-                                "type": "text", 
-                                "text": message.content.replace("<cache>", ""),
+                                "type": "text",
+                                "text": message.content,
                                 "cache_control": {"type": "ephemeral"}
                             })
                         else:
@@ -951,29 +1030,18 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 elif isinstance(message, ToolPromptMessage):
                     message = cast(ToolPromptMessage, message)
                     content = message.content
-                    if "<cache>" in content:
-                        message_dict = {
-                            "role": "user",
-                            "content": [
-                                {
-                                    "type": "tool_result",
-                                    "tool_use_id": message.tool_call_id,
-                                    "content": content.replace("<cache>", ""),
-                                    "cache_control": {"type": "ephemeral"}
-                                }
-                            ],
-                        }
-                    else:
-                        message_dict = {
-                            "role": "user",
-                            "content": [
-                                {
-                                    "type": "tool_result",
-                                    "tool_use_id": message.tool_call_id,
-                                    "content": content,
-                                }
-                            ],
-                        }
+                    tool_result_content = {
+                        "type": "tool_result",
+                        "tool_use_id": message.tool_call_id,
+                        "content": content,
+                    }
+                    if getattr(self, "_tool_results_cache_enabled", False):
+                        tool_result_content["cache_control"] = {"type": "ephemeral"}
+                    
+                    message_dict = {
+                        "role": "user",
+                        "content": [tool_result_content],
+                    }
                     prompt_message_dicts.append(message_dict)
                 else:
                     raise ValueError(f"Got unknown type {message}")

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -269,6 +269,8 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                         text_len = 0
                         if btype in {"image", "document"}:
                             pr = 1
+                            if block.get("source", {}).get("type") == "base64":
+                                text_len = len(block.get("source", {}).get("data", ""))
                         elif btype in {"tool_use", "tool_result"}:
                             pr = 4
                         else:

--- a/models/anthropic/requirements.txt
+++ b/models/anthropic/requirements.txt
@@ -1,3 +1,3 @@
 dify_plugin>=0.3.0,<0.5.0
-anthropic~=0.48.0
+anthropic~=0.57.1
 pillow~=11.0.0


### PR DESCRIPTION
## Related Issues or Context

Also handle multi-modal contents in best practice.
<img width="1182" height="182" alt="CleanShot 2025-07-12 at 12 41 31@2x" src="https://github.com/user-attachments/assets/25d8a085-ca5b-419f-9981-dfc582c6ce16" />
https://docs.anthropic.com/en/docs/build-with-claude/pdf-support#:~:text=Send%20your%20first%20PDF%20request

<img width="2158" height="1364" alt="CleanShot 2025-07-12 at 10 52 13@2x" src="https://github.com/user-attachments/assets/34fde67d-8a9c-4354-9cc7-dce0a6b3bbd1" />

https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [x] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->
<img width="2778" height="1524" alt="CleanShot 2025-07-12 at 10 14 48@2x" src="https://github.com/user-attachments/assets/8d111ad5-f940-4143-8d12-0c0220dc0158" />

- [x] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->
<img width="2642" height="1524" alt="CleanShot 2025-07-12 at 10 17 15@2x" src="https://github.com/user-attachments/assets/150a67d0-898a-4420-9ddc-8b81d6755c1d" />


- [x] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->
<img width="1442" height="974" alt="CleanShot 2025-07-12 at 10 17 52@2x" src="https://github.com/user-attachments/assets/bd213d7a-a6f9-4a43-b219-a3e936e3ff24" />

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->
### Before Caching
<img width="630" height="122" alt="CleanShot 2025-07-12 at 10 44 31@2x" src="https://github.com/user-attachments/assets/7d3fed4e-413c-4d3c-b382-48c30c0cdd3e" />
<img width="568" height="560" alt="CleanShot 2025-07-12 at 10 44 37@2x" src="https://github.com/user-attachments/assets/0efec974-03e6-4faa-91dc-9e1c14e8a41a" />

### After Caching
<img width="570" height="222" alt="CleanShot 2025-07-12 at 10 45 18@2x" src="https://github.com/user-attachments/assets/e77a4f9f-a121-4efe-b461-6751582293f4" />
<img width="476" height="562" alt="CleanShot 2025-07-12 at 10 45 38@2x" src="https://github.com/user-attachments/assets/b6a3a5b9-c2f8-42f2-ab4d-62dffbfbbfaa" />

- [x] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->
### Tool Definitions Caching
<img width="2090" height="662" alt="CleanShot 2025-07-12 at 10 25 18@2x" src="https://github.com/user-attachments/assets/1f6e681b-b426-4363-8e32-da27f534c4ca" />

### Images and Documents Caching
<img width="1334" height="748" alt="CleanShot 2025-07-12 at 10 28 57@2x" src="https://github.com/user-attachments/assets/341777e8-9ddd-4642-b2eb-fff16537dd93" />

### System Message Caching
<img width="1326" height="408" alt="CleanShot 2025-07-12 at 10 29 27@2x" src="https://github.com/user-attachments/assets/11b785b0-c58c-4006-83f1-68bcca2ed371" />

### Tool Use Results Caching
<img width="2078" height="736" alt="CleanShot 2025-07-12 at 10 30 03@2x" src="https://github.com/user-attachments/assets/3f5e072c-0da8-4dff-994b-ded6f4287808" />

### Assistant and User Message Flow Caching
<img width="2102" height="364" alt="CleanShot 2025-07-12 at 10 42 05@2x" src="https://github.com/user-attachments/assets/e42b3c22-caf3-4cc7-b167-44d1b13847ea" />


- [x] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->
<img width="780" height="712" alt="CleanShot 2025-07-12 at 10 20 13@2x" src="https://github.com/user-attachments/assets/c55d651d-59bd-4da5-8582-b1a36a576de5" />

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
