### PR TITLE
fix(openai_api_compatible): Ensure JSON schema compatibility

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.16
+version: 0.0.17
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -9,8 +9,7 @@ from dify_plugin.entities.model import (
     ParameterType,
 )
 from dify_plugin.entities.model.llm import LLMResult
-from dify_plugin.entities.model.message import PromptMessage, PromptMessageTool
-
+from dify_plugin.entities.model.message import PromptMessage, PromptMessageTool, SystemPromptMessage
 from dify_plugin.interfaces.model.openai_compatible.llm import (
     OAICompatLargeLanguageModel,
 )
@@ -88,6 +87,30 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         stream: bool = True,
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator]:
+        # Compatibility adapter for Dify's 'json_schema' structured output mode.
+        # The base class does not natively handle the 'json_schema' parameter. This block
+        # translates it into a standard OpenAI-compatible request by:
+        # 1. Forcing the response format to 'json_object'.
+        # 2. Injecting the JSON schema directly into the system prompt to guide the model.
+        # This ensures models like gpt-4o produce the correct structured output.
+        # The original 'json_schema' parameter is intentionally not removed to support
+        # other potential OpenAI-compatible models that might handle it differently.
+        if model_parameters.get("response_format") == "json_schema":
+            model_parameters["response_format"] = "json_object"
+            json_schema_str = model_parameters.get("json_schema")  # Use .get() instead of .pop() for safety
+
+            if json_schema_str:
+                structured_output_prompt = (
+                    "Your response must be a JSON object that validates against the following JSON schema, and nothing else.\n"
+                    f"JSON Schema: ```json\n{json_schema_str}\n```"
+                )
+
+                existing_system_prompt = next((p for p in prompt_messages if p.role == 'system'), None)
+                if existing_system_prompt:
+                    existing_system_prompt.content = structured_output_prompt + "\n\n" + existing_system_prompt.content
+                else:
+                    prompt_messages.insert(0, SystemPromptMessage(content=structured_output_prompt))
+
         enable_thinking = model_parameters.pop("enable_thinking", None)
         if enable_thinking is not None:
             model_parameters["chat_template_kwargs"] = {"enable_thinking": bool(enable_thinking)}


### PR DESCRIPTION
#### **Title:** `fix(openai_api_compatible): Ensure structured output for 'json_schema' mode`

**Problem**:
OpenAI-compatible models (e.g., GPT-4o) were failing to produce correct structured output when Dify's `response_format: 'json_schema'` mode was used. The root cause was twofold:
1.  The plugin's base class (`OAICompatLargeLanguageModel`) does not natively support the `'json_schema'` parameter and only recognizes `'json_object'`.
2.  There was no mechanism to inject the specific schema rules into the system prompt, leaving the model without explicit instructions on what structure to follow.

**Solution**:
This commit introduces a compatibility adapter within the `_invoke` method to intercept and translate these requests correctly.
- It translates the `response_format` from the internal `'json_schema'` to the standard `'json_object'`, enabling the model's JSON mode.
- It injects the full JSON schema from the `json_schema` parameter directly into the system prompt, providing explicit, actionable instructions to the model.
- Crucially, the original `json_schema` parameter is preserved (not popped) to ensure forward compatibility with other potential models that might have their own way of handling it.

**Result**:
This fix ensures reliable structured output for all OpenAI-compatible models using this feature. It is fully backward-compatible, as the logic only activates when `'json_schema'` is explicitly requested, leaving all other operations unaffected.

## Related Issues or Context
This change is needed to correctly support Dify's native structured output feature (`response_format: 'json_schema'`) with modern OpenAI-compatible models like GPT-4o, which were previously failing to adhere to the provided schema.

Dify Issue：[#21767](https://github.com/langgenius/dify/issues/21767)

## This PR contains Changes to *Non-Plugin*
- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- []I have Run Comprehensive Tests Relevant to My Changes

<img width="1030" height="769" alt="image" src="https://github.com/user-attachments/assets/e3308e35-1997-41fa-a73c-b635e9f35e02" />

<img width="1067" height="577" alt="image" src="https://github.com/user-attachments/assets/8cfe42ee-cbe3-488d-b81c-b4940918b82e" />


## This PR contains Changes to *LLM Models Plugin*

- [x] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
- [x] My Changes Affect Structured Output Format (JSON, XML, etc.)
- [x] My Changes Affect Token Consumption Metrics
  > **Note:** Injecting the schema into the prompt slightly increases input token consumption, which is an expected and necessary trade-off for ensuring correct output.
- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
  > **提醒:** 请在提交前，务必将 `manifest.yaml` 中的版本号升级 (例如，从 `0.0.16` 到 `0.0.17`)。

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)

### Local Deployment Environment
- [x] Dify Version is: `1.6.0` I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration.

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
