### PR TITLE
fix: gpustack image tool compatible url path

### DIFF
--- a/tools/gpustack/manifest.yaml
+++ b/tools/gpustack/manifest.yaml
@@ -1,10 +1,10 @@
-version: 0.0.2
+version: 0.0.3
 type: plugin
 author: langgenius
 name: gpustack_tools
 label:
-  en_US: gpustack
-  zh_Hans: gpustack
+  en_US: GPUStack AI Tools
+  zh_Hans: GPUStack AI 工具集
 description:
   en_US: The GPUStack tools enables seamless interaction with local large models for rapid development of personalized AI applications.
   zh_Hans: GPUStack 工具集与本地大模型的无缝交互，用于快速构建个性化 AI 应用。

--- a/tools/gpustack/provider/gpustack.py
+++ b/tools/gpustack/provider/gpustack.py
@@ -6,7 +6,7 @@ from dify_plugin import ToolProvider
 
 class GPUStackProvider(ToolProvider):
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
-        base_url = credentials.get("base_url", "").removesuffix("/").removesuffix("/v1")
+        base_url = credentials.get("base_url", "").removesuffix("/").removesuffix("/v1").removesuffix("/v1-openai")
         api_key = credentials.get("api_key", "")
         tls_verify = bool(credentials.get("tls_verify", True))
 
@@ -19,7 +19,7 @@ class GPUStackProvider(ToolProvider):
             "authorization": f"Bearer {api_key}",
         }
 
-        response = requests.get(f"{base_url}/v1-openai/models", headers=headers, verify=tls_verify)
+        response = requests.get(f"{base_url}/v1/models", headers=headers, verify=tls_verify)
         if response.status_code != 200:
             raise ToolProviderCredentialValidationError(
                 f"Failed to validate GPUStack API key, status code: {response.status_code}-{response.text}"

--- a/tools/gpustack/tools/utils.py
+++ b/tools/gpustack/tools/utils.py
@@ -1,11 +1,8 @@
-from base64 import b64decode
 from typing import Any
 import requests
 
-from dify_plugin.entities.tool import ToolInvokeMessage
-
 def get_base_url(base_url: str) -> str:
-    return base_url.rstrip("/").removesuffix("/v1-openai")
+    return base_url.rstrip("/").removesuffix("/v1").removesuffix("/v1-openai")
 
 def get_common_params(tool_parameters: dict[str, Any]) -> dict[str, Any]:
     return {


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

When user configure GPUStack image tool, it will very easily add path `/v1` or `/v1-openai` to the server url, which will cause 404 not found, as the image tool in 0.2 will append v1. We want fix it by removing additional /v1 or /v1-openai. 
<img width="1920" height="836" alt="Snipaste_2025-07-24_23-08-13" src="https://github.com/user-attachments/assets/ef920bf1-a784-4dae-87d2-e5c23c02d1aa" />
<img width="1912" height="925" alt="Snipaste_2025-07-24_23-38-44" src="https://github.com/user-attachments/assets/cf499b08-a8b8-487d-8042-8c74c70dc072" />
<img width="1910" height="920" alt="Snipaste_2025-07-24_23-39-08" src="https://github.com/user-attachments/assets/49edfa2a-cd2e-4e05-9e72-0824524207f8" />

As the screenshots shows, the tool plugins could config /v1 or /v1-openai path.

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
