### PR TITLE
feat(models): fix token counting in gemini and add pricing details fo…

### DIFF
--- a/models/bedrock/models/llm/anthropic-claude.yaml
+++ b/models/bedrock/models/llm/anthropic-claude.yaml
@@ -146,3 +146,8 @@ parameter_rules:
       en_US: Only sample from the top K options for each subsequent token. Use top_k to remove long tail low probability responses.
   - name: response_format
     use_template: response_format
+pricing:
+  input: '0.003'
+  output: '0.015'
+  unit: '0.001'
+  currency: USD

--- a/models/bedrock/models/llm/deepseek.yaml
+++ b/models/bedrock/models/llm/deepseek.yaml
@@ -78,3 +78,8 @@ parameter_rules:
       en_US: The probability threshold in nucleus sampling. When reasoning is enabled, this parameter will be disabled.
   - name: response_format
     use_template: response_format
+pricing:
+  input: '0.00135'
+  output: '0.0054'
+  unit: '0.001'
+  currency: USD

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -490,11 +490,6 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 thinking_started = hasThought
                 index += len(candidate.content.parts)
 
-                if chunk.usage_metadata:
-                    completion_tokens += (
-                        chunk.usage_metadata.candidates_token_count or 0
-                    )
-
                 # if the stream is not finished, yield the chunk
                 if not candidate.finish_reason:
                     yield LLMResultChunk(
@@ -509,6 +504,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 else:
                     if chunk.usage_metadata:
                         prompt_tokens = chunk.usage_metadata.prompt_token_count or 0
+                        completion_tokens = chunk.usage_metadata.candidates_token_count or 0
                         if chunk.usage_metadata.thoughts_token_count:
                             completion_tokens = completion_tokens + chunk.usage_metadata.thoughts_token_count
                     if prompt_tokens == 0 or completion_tokens == 0:


### PR DESCRIPTION

## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->
- Incorrect Token Counting for Gemini

 The code accumulates completion_tokens for every chunk when processing Gemini's candidates_token_count:
 ```ptyhon
 if chunk.usage_metadata:
    completion_tokens += (
        chunk.usage_metadata.candidates_token_count or 0
    )
   ```
 However, Gemini's candidates token count is already incrementally increasing with each chunk. The current implementation causes duplicate counting, leading to an explosion of token counts.
<img width="1405" height="573" alt="image" src="https://github.com/user-attachments/assets/ad13b368-43bb-4d3a-a00f-f5a1dd6ff28c" />
- add bead rock price for deepseek and claude

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [ ] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
