### PR TITLE
Bugfix - Gitlab Plugin -Fix incorrect arg passsed to get_project_id in Gitlab file tool

### DIFF
--- a/tools/gitlab/tools/gitlab_files.py
+++ b/tools/gitlab/tools/gitlab_files.py
@@ -1,8 +1,9 @@
 import urllib.parse
-from typing import Any, Union, Generator
+from typing import Any, Generator, Union
+
 import requests
-from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
 
 
 class GitlabFilesTool(Tool):
@@ -30,7 +31,7 @@ class GitlabFilesTool(Tool):
         if repository:
             result = self.fetch_files(site_url, access_token, repository, branch, path, True, ssl_verify)
         else:
-            project_id = self.get_project_id(site_url, access_token, repository)
+            project_id = self.get_project_id(site_url, access_token, project)
             if project_id:
                 result = self.fetch_files(site_url, access_token, project, branch, path, False, ssl_verify)
 


### PR DESCRIPTION
An incorrect variable was passed to the helper method `get_project_id` on line 34 in `./tools/gitlab/tools/gitlab_files.py`.

Two paths are taken:
1) If `repository` is a non-empty string, then retrieve the Gitlab file via request using repository name.
2) If 'repository' is an empty string, then retrieve the Gitlab file using the Gitlab Projects API using project name.

Path 2) incorrectly passed the `repository` variable as an argument to the `get_project_id` helper method.

This PR simply swaps the incorrect argument `repository` to the `project` variable defined in the `GitlabFilesTool` `_invoke` method.

## Related Issues or Context
[Related Issue](https://github.com/langgenius/dify-official-plugins/issues/1401)

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [X] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
  - Patch - bumped from 0.0.4 ==> 0.0.5

## Dify Plugin SDK Version
- [X] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))