### PR TITLE
Support international endpoints for Tongyi embedding, rerank, speech2text and tts

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.36
+version: 0.0.37
 created_at: "2024-09-20T00:13:50.29298939-04:00"

--- a/models/tongyi/models/rerank/rerank.py
+++ b/models/tongyi/models/rerank/rerank.py
@@ -50,6 +50,8 @@ class GTERerankModel(RerankModel):
         """
         if len(docs) == 0:
             return RerankResult(model=model, docs=docs)
+        if credentials.get("use_international_endpoint", "false") == "true":
+            dashscope.base_http_api_url = "https://dashscope-intl.aliyuncs.com/api/v1"
         dashscope.api_key = credentials["dashscope_api_key"]
         response = dashscope.TextReRank.call(
             query=query, documents=docs, model=model, top_n=top_n, return_documents=True

--- a/models/tongyi/models/speech2text/speech2text.py
+++ b/models/tongyi/models/speech2text/speech2text.py
@@ -23,6 +23,8 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
         :return: text for given audio file
         """
         try:
+            if credentials.get("use_international_endpoint", "false") == "true":
+                dashscope.base_http_api_url = "https://dashscope-intl.aliyuncs.com/api/v1"
             dashscope.api_key = credentials["dashscope_api_key"]
             file.seek(0)
             audio = AudioSegment.from_file(file)

--- a/models/tongyi/models/text_embedding/text_embedding.py
+++ b/models/tongyi/models/text_embedding/text_embedding.py
@@ -32,6 +32,8 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         :param input_type: input type
         :return: embeddings result
         """
+        if credentials.get("use_international_endpoint", "false") == "true":
+            dashscope.base_http_api_url = "https://dashscope-intl.aliyuncs.com/api/v1"
         credentials_kwargs = self._to_credential_kwargs(credentials)
         context_size = self._get_context_size(model, credentials)
         max_chunks = self._get_max_chunks(model, credentials)

--- a/models/tongyi/models/tts/tts.py
+++ b/models/tongyi/models/tts/tts.py
@@ -110,6 +110,8 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
         :param audio_type: audio file type
         :return: text translated to audio file
         """
+        if credentials.get("use_international_endpoint", "false") == "true":
+            dashscope.base_http_api_url = "https://dashscope-intl.aliyuncs.com/api/v1"
         response = dashscope.audio.tts.SpeechSynthesizer.call(
             model=voice,
             sample_rate=48000,


### PR DESCRIPTION
…txt, and tts

## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
