### PR TITLE
Fix(openai): tool use issue with latest openai SDK, gpt 5 chat latest might contains incorrect context window size

### DIFF
--- a/models/openai/manifest.yaml
+++ b/models/openai/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.1
+version: 0.2.2
 type: plugin
 author: "langgenius"
 name: "openai"

--- a/models/openai/models/llm/gpt-5-chat-latest.yaml
+++ b/models/openai/models/llm/gpt-5-chat-latest.yaml
@@ -9,7 +9,7 @@ features:
   - vision
 model_properties:
   mode: chat
-  context_size: 
+  context_size: 128000
   # 2025-08-08: Need to be confirmed. 
   # Documentation shows 400,000 but since max tokens is 16,384, 
   # the context size should be 128,000, like gpt-4o.

--- a/models/openai/models/llm/gpt-5-chat-latest.yaml
+++ b/models/openai/models/llm/gpt-5-chat-latest.yaml
@@ -9,7 +9,10 @@ features:
   - vision
 model_properties:
   mode: chat
-  context_size: 400000
+  context_size: 
+  # 2025-08-08: Need to be confirmed. 
+  # Documentation shows 400,000 but since max tokens is 16,384, 
+  # the context size should be 128,000, like gpt-4o.
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -23,7 +26,7 @@ parameter_rules:
     use_template: max_tokens
     default: 8192
     min: 1
-    max: 16384
+    max: 16384 # 2025-08-08: Documentation shows 128,000 but API testing confirms 16,384 limit
 pricing:
   input: '1.25'
   output: '10.00'

--- a/models/openai/models/llm/llm.py
+++ b/models/openai/models/llm/llm.py
@@ -1140,10 +1140,9 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         tool_calls = []
         if response_tool_calls:
             for response_tool_call in response_tool_calls:
-                assert isinstance(
-                    response_tool_call,
-                    (ChatCompletionMessageToolCall, ChoiceDeltaToolCall),
-                )
+                # Avoid isinstance with possibly generic typing classes; use duck-typing instead
+                if not hasattr(response_tool_call, "function"):
+                    continue
                 if response_tool_call.function:
                     function = AssistantPromptMessage.ToolCall.ToolCallFunction(
                         name=response_tool_call.function.name or "",
@@ -1170,9 +1169,11 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         """
         tool_call = None
         if response_function_call:
-            assert isinstance(
-                response_function_call, (FunctionCall, ChoiceDeltaFunctionCall)
-            )
+            # Avoid isinstance with possibly generic typing classes; use duck-typing instead
+            if not hasattr(response_function_call, "name") or not hasattr(
+                response_function_call, "arguments"
+            ):
+                return None
 
             function = AssistantPromptMessage.ToolCall.ToolCallFunction(
                 name=response_function_call.name or "",

--- a/models/openai/models/llm/llm.py
+++ b/models/openai/models/llm/llm.py
@@ -1140,9 +1140,6 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         tool_calls = []
         if response_tool_calls:
             for response_tool_call in response_tool_calls:
-                # Avoid isinstance with possibly generic typing classes; use duck-typing instead
-                if not hasattr(response_tool_call, "function"):
-                    continue
                 if response_tool_call.function:
                     function = AssistantPromptMessage.ToolCall.ToolCallFunction(
                         name=response_tool_call.function.name or "",

--- a/models/openai/models/llm/llm.py
+++ b/models/openai/models/llm/llm.py
@@ -1170,9 +1170,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         tool_call = None
         if response_function_call:
             # Avoid isinstance with possibly generic typing classes; use duck-typing instead
-            if not hasattr(response_function_call, "name") or not hasattr(
-                response_function_call, "arguments"
-            ):
+            if not hasattr(response_function_call, "name"):
                 return None
 
             function = AssistantPromptMessage.ToolCall.ToolCallFunction(


### PR DESCRIPTION
## Related Issues or Context
Adjusted context_size and max_tokens in gpt-5-chat-latest.yaml based on API testing and documentation. Added comments to clarify discrepancies between documentation and actual API limits.

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<img width="1492" height="1250" alt="CleanShot 2025-08-08 at 06 02 04@2x" src="https://github.com/user-attachments/assets/4e73f5d0-65f0-4d85-83ec-991a3f56f9f0" />


- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] Other Changes (Add New Models, Fix Model Parameters etc.)
<img width="2034" height="890" alt="CleanShot 2025-08-08 at 05 11 04@2x" src="https://github.com/user-attachments/assets/a9d7ea3e-94c3-4c78-aca4-3fa41a62e047" />


## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
