### PR TITLE
feat(gemini_cf): add Gemini via Cloudflare Worker provider

### DIFF
--- a/models/gemini_cf/README.md
+++ b/models/gemini_cf/README.md
@@ -1,0 +1,14 @@
+# Gemini（Cloudflare 代理）模型插件
+
+本供应商通过 Cloudflare Worker 反向代理访问 Gemini v1beta API。安装后在 Dify 的“模型供应商”中配置以下两项：
+
+- Base URL（必填）：形如 `https://<your-worker>.workers.dev`
+- API Key（必填）：与你的 Worker 通信的密钥
+
+请求约定：
+- 路由与官方 Gemini 基本一致，例如：`{base_url}/v1beta/models/{model}:generateContent`
+- 认证头：`x-api-key: <你的密钥>`
+
+注意：
+- 若你需要兼容 Dify 官方 `google_gemini` 供应商的认证（例如 `x-goog-api-key` 或 `?key=` 查询参数），请在 Worker 中做一层映射（例如将 `x-goog-api-key` 或 URL 的 `key` 参数转为 `x-api-key`）。
+- 本插件内置了多款 2.5/2.0 的 LLM 型号。TTS 预览版如需支持，请另行补充 `tts` 类型的模型 YAML（或改造 Worker 与调用链）。

--- a/models/gemini_cf/manifest.yaml
+++ b/models/gemini_cf/manifest.yaml
@@ -1,0 +1,31 @@
+version: 0.0.1
+type: model
+provider: gemini_cf
+name:
+  en_US: Gemini (Cloudflare Proxy)
+  zh_Hans: Gemini（Cloudflare 代理）
+author: local
+description:
+  en_US: Use Google Gemini via your Cloudflare Worker reverse proxy.
+  zh_Hans: 通过 Cloudflare Worker 反向代理使用 Google Gemini。
+
+# 供应商级别凭证（安装后在“设置-模型供应商”中填写）
+credentials:
+  - name: base_url
+    label:
+      en_US: Base URL
+      zh_Hans: 代理基地址
+    type: text-input
+    required: true
+    placeholder: https://your-worker.example.workers.dev
+  - name: api_key
+    label:
+      en_US: API Key
+      zh_Hans: 通信密钥
+    type: secret-input
+    required: true
+    placeholder: cf_xxx
+
+# 该插件提供的模型类型
+supported_model_types:
+  - llm

--- a/models/gemini_cf/models/llm/gemini-2.0-flash.yaml
+++ b/models/gemini_cf/models/llm/gemini-2.0-flash.yaml
@@ -1,0 +1,26 @@
+model: gemini-2.0-flash
+label:
+  en_US: Gemini 2.0 Flash (CF Proxy)
+  zh_Hans: Gemini 2.0 Flash（CF 代理）
+model_type: llm
+features:
+  - chat
+  - completion
+  - vision
+model_properties:
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+pricing:
+  input: 0
+  output: 0
+  unit: 0.000001
+  currency: USD

--- a/models/gemini_cf/models/llm/gemini-2.5-flash-lite.yaml
+++ b/models/gemini_cf/models/llm/gemini-2.5-flash-lite.yaml
@@ -1,0 +1,26 @@
+model: gemini-2.5-flash-lite
+label:
+  en_US: Gemini 2.5 Flash-Lite (CF Proxy)
+  zh_Hans: Gemini 2.5 Flash-Lite（CF 代理）
+model_type: llm
+features:
+  - chat
+  - completion
+  - vision
+model_properties:
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+pricing:
+  input: 0
+  output: 0
+  unit: 0.000001
+  currency: USD

--- a/models/gemini_cf/models/llm/gemini-2.5-flash.yaml
+++ b/models/gemini_cf/models/llm/gemini-2.5-flash.yaml
@@ -1,0 +1,26 @@
+model: gemini-2.5-flash
+label:
+  en_US: Gemini 2.5 Flash (CF Proxy)
+  zh_Hans: Gemini 2.5 Flash（CF 代理）
+model_type: llm
+features:
+  - chat
+  - completion
+  - vision
+model_properties:
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+pricing:
+  input: 0
+  output: 0
+  unit: 0.000001
+  currency: USD

--- a/models/gemini_cf/models/llm/gemini-2.5-pro.yaml
+++ b/models/gemini_cf/models/llm/gemini-2.5-pro.yaml
@@ -1,0 +1,26 @@
+model: gemini-2.5-pro
+label:
+  en_US: Gemini 2.5 Pro (CF Proxy)
+  zh_Hans: Gemini 2.5 Pro（CF 代理）
+model_type: llm
+features:
+  - chat
+  - completion
+  - vision
+model_properties:
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 8192
+pricing:
+  input: 0
+  output: 0
+  unit: 0.000001
+  currency: USD


### PR DESCRIPTION
This PR adds a new provider 'gemini_cf' to access Google Gemini via Cloudflare Worker reverse proxy.\n\n- Provider manifest with credentials: base_url, api_key (sent as x-api-key)\n- LLM models: gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.0-flash\n- README for configuration guidance\n\nIf maintainers prefer reusing existing google_gemini or openai_compatible providers instead of a new provider folder, I can migrate these YAMLs accordingly.\n