### PR TITLE
add claude & deepseek models

### DIFF
--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -26,5 +26,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.0.15
+version: 0.0.16
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/openrouter/models/llm/_position.yaml
+++ b/models/openrouter/models/llm/_position.yaml
@@ -14,6 +14,8 @@
 - openai/gpt-4
 - openai/gpt-4-32k
 - openai/gpt-3.5-turbo
+- anthropic/claude-opus-4
+- anthropic/claude-opus-4.1
 - anthropic/claude-sonnet-4
 - anthropic/claude-3.7-sonnet:thinking
 - anthropic/claude-3.7-sonnet
@@ -45,6 +47,18 @@
 - qwen/qwen-2.5-72b-instruct
 - qwen/qwen-2-72b-instruct
 - deepseek/deepseek-chat
+- deepseek/deepseek-chat-v3-0324
 - deepseek/deepseek-coder
+- deepseek/deepseek-prover-v2
+- deepseek/deepseek-r1
+- deepseek/deepseek-r1-0528
+- deepseek/deepseek-r1-0528-qwen3-8b
+- deepseek/deepseek-r1-distill-llama-70b
+- deepseek/deepseek-r1-distill-qwen-32b
+- deepseek/deepseek-r1-distill-qwen-14b
+- deepseek/deepseek-r1-distill-llama-8b
+- deepseek/deepseek-r1-distill-qwen-7b
+- deepseek/deepseek-r1-distill-qwen-1.5b
+- deepseek/deepseek-v3-base
 - x-ai/grok-3-beta
 - x-ai/grok-3-mini-beta

--- a/models/openrouter/models/llm/claude-opus-4.1.yaml
+++ b/models/openrouter/models/llm/claude-opus-4.1.yaml
@@ -1,0 +1,62 @@
+model: anthropic/claude-opus-4.1
+label:
+  en_US: claude-opus-4.1
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 200000
+parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。启用时，temperature、top_p和top_k将被禁用。
+      en_US: Controls the model's thinking capability. When enabled, temperature, top_p and top_k will be disabled.
+  - name: thinking_budget
+    label:
+      zh_Hans: 推理预算
+      en_US: Thinking Budget
+    type: int
+    default: 1024
+    min: 0
+    max: 64000
+    required: false
+    help:
+      zh_Hans: 推理的预算限制（最小1024），必须小于max_tokens。仅在推理模式启用时可用。
+      en_US: Budget limit for thinking (minimum 1024), must be less than max_tokens. Only available when thinking mode is enabled.
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    default: 32000
+    min: 1
+    max: 32000
+  - name: response_format
+    use_template: response_format
+pricing:
+  input: "15.00"
+  output: "75.00"
+  unit: "0.000001"
+  currency: USD

--- a/models/openrouter/models/llm/claude-opus-4.yaml
+++ b/models/openrouter/models/llm/claude-opus-4.yaml
@@ -1,21 +1,23 @@
-model: deepseek/deepseek-chat
+model: anthropic/claude-opus-4
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: claude-opus-4
 model_type: llm
 features:
-  - agent-thought
   - multi-tool-call
+  - agent-thought
   - stream-tool-call
+  - vision
+  - document
 model_properties:
   mode: chat
-  context_size: 163840
+  context_size: 200000
 parameter_rules:
   - name: temperature
     use_template: temperature
     type: float
     default: 1
     min: 0.0
-    max: 2.0
+    max: 1.0
     help:
       zh_Hans: 控制生成结果的多样性和随机性。数值越小，越严谨；数值越大，越发散。
       en_US: Control the diversity and randomness of generated results. The smaller the value, the more rigorous it is; the larger the value, the more divergent it is.
@@ -24,7 +26,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -32,8 +34,8 @@ parameter_rules:
     use_template: top_p
     type: float
     default: 1
-    min: 0.01
-    max: 1.00
+    min: 0.0
+    max: 1.0
     help:
       zh_Hans: 控制生成结果的随机性。数值越小，随机性越弱；数值越大，随机性越强。一般而言，top_p 和 temperature 两个参数选择一个进行调整即可。
       en_US: Control the randomness of generated results. The smaller the value, the weaker the randomness; the larger the value, the stronger the randomness. Generally speaking, you can adjust one of the two parameters top_p and temperature.
@@ -46,16 +48,8 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
-    help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "15"
+  output: "75"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-chat-v3-0324.yaml
+++ b/models/openrouter/models/llm/deepseek-chat-v3-0324.yaml
@@ -1,6 +1,6 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-chat-v3-0324
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-chat-v3-0324
 model_type: llm
 features:
   - agent-thought
@@ -24,7 +24,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.

--- a/models/openrouter/models/llm/deepseek-prover-v2.yaml
+++ b/models/openrouter/models/llm/deepseek-prover-v2.yaml
@@ -1,11 +1,9 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-prover-v2
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-prover-v2
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 163840
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,18 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "0.50"
+  output: "2.18"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-r1-0528-qwen3-8b.yaml
+++ b/models/openrouter/models/llm/deepseek-r1-0528-qwen3-8b.yaml
@@ -1,14 +1,12 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-r1-0528-qwen3-8b
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-r1-0528-qwen3-8b
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 163840
+  context_size: 32000
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,18 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "0.01"
+  output: "0.02"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-r1-0528.yaml
+++ b/models/openrouter/models/llm/deepseek-r1-0528.yaml
@@ -1,11 +1,9 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-r1-0528
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-r1-0528
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 163840
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,20 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
   input: "0.18"
   output: "0.72"
   unit: "0.000001"
   currency: USD
+ 
+

--- a/models/openrouter/models/llm/deepseek-r1-distill-llama-70b.yaml
+++ b/models/openrouter/models/llm/deepseek-r1-distill-llama-70b.yaml
@@ -1,14 +1,12 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-r1-distill-llama-70b
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-r1-distill-llama-70b
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 163840
+  context_size: 131072
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,18 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "0.033"
+  output: "0.133"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-r1-distill-llama-8b.yaml
+++ b/models/openrouter/models/llm/deepseek-r1-distill-llama-8b.yaml
@@ -1,14 +1,12 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-r1-distill-llama-8b
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-r1-distill-llama-8b
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 163840
+  context_size: 32000
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,18 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "0.04"
+  output: "0.04"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-r1-distill-qwen-1.5b.yaml
+++ b/models/openrouter/models/llm/deepseek-r1-distill-qwen-1.5b.yaml
@@ -1,14 +1,12 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-r1-distill-qwen-1.5b
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-r1-distill-qwen-1.5b
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 163840
+  context_size: 131072
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,18 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
   input: "0.18"
-  output: "0.72"
+  output: "0.18"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-r1-distill-qwen-14b.yaml
+++ b/models/openrouter/models/llm/deepseek-r1-distill-qwen-14b.yaml
@@ -1,14 +1,12 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-r1-distill-qwen-14b
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-r1-distill-qwen-14b
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 163840
+  context_size: 64000
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,18 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "0.15"
+  output: "0.15"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-r1-distill-qwen-32b.yaml
+++ b/models/openrouter/models/llm/deepseek-r1-distill-qwen-32b.yaml
@@ -1,14 +1,12 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-r1-distill-qwen-32b
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-r1-distill-qwen-32b
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 163840
+  context_size: 131072
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,18 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "0.075"
+  output: "0.15"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-r1-distill-qwen-7b.yaml
+++ b/models/openrouter/models/llm/deepseek-r1-distill-qwen-7b.yaml
@@ -1,14 +1,12 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-r1-distill-qwen-7b
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-r1-distill-qwen-7b
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 163840
+  context_size: 131072
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,18 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "0.10"
+  output: "0.20"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-r1.yaml
+++ b/models/openrouter/models/llm/deepseek-r1.yaml
@@ -1,11 +1,9 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-r1
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-r1
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 163840
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -46,16 +44,18 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-    default: 0
-    min: -2.0
-    max: 2.0
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: false
     help:
-      zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
-      en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "0.40"
+  output: "2.00"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/deepseek-v3-base.yaml
+++ b/models/openrouter/models/llm/deepseek-v3-base.yaml
@@ -1,11 +1,9 @@
-model: deepseek/deepseek-chat
+model: deepseek/deepseek-v3-base
 label:
-  en_US: deepseek-chat (DeepSeek V3)
+  en_US: deepseek-v3-base
 model_type: llm
 features:
   - agent-thought
-  - multi-tool-call
-  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 163840
@@ -24,7 +22,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 4096
+    max: 8192
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -55,7 +53,7 @@ parameter_rules:
       zh_Hans: 介于 -2.0 和 2.0 之间的数字。如果该值为正，那么新 token 会根据其在已有文本中的出现频率受到相应的惩罚，降低模型重复相同内容的可能性。
       en_US: A number between -2.0 and 2.0. If the value is positive, new tokens are penalized based on their frequency of occurrence in existing text, reducing the likelihood that the model will repeat the same content.
 pricing:
-  input: "0.18"
-  output: "0.72"
+  input: "0.20"
+  output: "0.80"
   unit: "0.000001"
   currency: USD


### PR DESCRIPTION
## Related Issues or Context

Adding multiple new DeepSeek and Claude Opus 4 models to OpenRouter provider to support the latest AI models available on OpenRouter platform.

### Context:
- DeepSeek has released multiple new R1 series reasoning models and distilled variants
- Anthropic released Claude Opus 4, benchmarked as world's best coding model
- OpenRouter now supports these models but they were missing from Dify's OpenRouter plugin
- Updated existing DeepSeek V3 model configuration to match current OpenRouter specifications

## This PR contains Changes to *Non-Plugin* 
- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes

## This PR contains Changes to *LLM Models Plugin*

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)

- [ ] My Changes Affect Token Consumption Metrics

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)

- [x] Other Changes (Add New Models, Fix Model Parameters etc.)

### Models Added/Updated:

#### New DeepSeek Models:
1. **deepseek-r1** - Original R1 reasoning model (671B params, $0.40/$2.00)
2. **deepseek-r1-distill-qwen-32b** - 32B distilled model ($0.075/$0.15)
3. **deepseek-r1-distill-qwen-14b** - 14B distilled model ($0.15/$0.15)
4. **deepseek-r1-distill-llama-70b** - 70B Llama-based distilled model ($0.033/$0.133)
5. **deepseek-r1-distill-llama-8b** - 8B Llama-based distilled model ($0.04/$0.04)
6. **deepseek-r1-distill-qwen-1.5b** - 1.5B ultra-efficient model ($0.18/$0.18)

<img width="830" height="331" alt="image" src="https://github.com/user-attachments/assets/76cdea29-a63b-48ed-96a4-52974a90843a" />
<img width="334" height="354" alt="image" src="https://github.com/user-attachments/assets/5f4a0ec4-8610-4f86-b447-485604607843" />


#### New Anthropic Model:
8. **claude-opus-4** - World's best coding model (200K context, $15/$75)

<img width="782" height="310" alt="image" src="https://github.com/user-attachments/assets/570853af-4b2c-424c-908c-99ac8c82c0f0" />


#### Updated Existing Model:
- **deepseek-chat** - Updated to reflect DeepSeek V3 specifications (163K context, $0.18/$0.72, added tool calling features)

### Features Added:
- All new models support reasoning capabilities (`agent-thought`)
- DeepSeek R1 models support reasoning token hiding (`exclude_reasoning_tokens`)
- Claude Opus 4 supports vision, document processing, and advanced tool calling
- Updated context sizes and pricing to match current OpenRouter specifications

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)

**Version changed from 0.0.15 to 0.0.16** (incremented through multiple model additions)

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt

## Environment Verification (If Any Code Changes)

### Local Deployment Environment
- [ ] Dify Version is: <!-- 1.4.0+ -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration.

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration

---

**Summary**: This PR adds 7 new cutting-edge AI models to the OpenRouter provider and updates 1 existing model configuration, ensuring Dify users have access to the latest DeepSeek R1 reasoning models and Claude Opus 4 coding capabilities. All models are configured with appropriate pricing, context sizes, and feature flags according to OpenRouter's current specifications.