### PR TITLE
feat: add simple pptx_extractor

### DIFF
--- a/tools/dify_extractor/README.md
+++ b/tools/dify_extractor/README.md
@@ -1,10 +1,7 @@
 ## dify_extractor
 
 **Author:** langgenius
-**Version:** 0.0.1
+**Version:** 0.0.2
 **Type:** tool
 
 ### Description
-
-
-

--- a/tools/dify_extractor/manifest.yaml
+++ b/tools/dify_extractor/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 type: plugin
 author: langgenius
 name: dify_extractor

--- a/tools/dify_extractor/requirements.txt
+++ b/tools/dify_extractor/requirements.txt
@@ -2,6 +2,7 @@ dify_plugin==0.5.0b8
 pandas[excel,output-formatting,performance]~=2.2.2
 chardet~=5.1.0
 python-docx~=1.1.0
+python-pptx~=1.0.2
 openpyxl~=3.1.5
 bs4~=0.0.1
 xlrd~=2.0.1

--- a/tools/dify_extractor/tools/dify_extractor.py
+++ b/tools/dify_extractor/tools/dify_extractor.py
@@ -12,6 +12,7 @@ from tools.markdown_extractor import MarkdownExtractor
 from tools.pdf_extractor import PdfExtractor
 from tools.text_extractor import TextExtractor
 from tools.word_extractor import WordExtractor
+from tools.pptx_extractor import PPTXExtractor
 
 
 class DifyExtractorTool(Tool):
@@ -32,6 +33,8 @@ class DifyExtractorTool(Tool):
             extractor = HtmlExtractor(file_bytes, file_name)
         elif file_extension == ".docx":
             extractor = WordExtractor(self, file_bytes, file_name)
+        elif file_extension == ".pptx":
+            extractor = PPTXExtractor(self, file_bytes, file_name)
         elif file_extension == ".csv":
             extractor = CSVExtractor(file_bytes, file_name, autodetect_encoding=True)
         else:

--- a/tools/dify_extractor/tools/dify_extractor.yaml
+++ b/tools/dify_extractor/tools/dify_extractor.yaml
@@ -20,10 +20,10 @@ parameters:
       zh_Hans: file
       pt_BR: file
     human_description:
-      en_US:  the file to be parsed(support pdf, ppt, pptx, doc, docx, png, jpg, jpeg)
-      zh_Hans: 用于解析的文件(支持 pdf, ppt, pptx, doc, docx, png, jpg, jpeg)
-      pt_BR:  o arquivo a ser analisado (suporta pdf, ppt, pptx, doc, docx, png, jpg, jpeg)
-    llm_description: the file to be parsed (support pdf, ppt, pptx, doc, docx, png, jpg, jpeg)
+      en_US:  the file to be parsed (support pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv)
+      zh_Hans: 用于解析的文件 (支持 pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv)
+      pt_BR:  o arquivo a ser analisado (suporta pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv)
+    llm_description: the file to be parsed (support pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv)
     form: llm
 output_schema:
     type: object

--- a/tools/dify_extractor/tools/pptx_extractor.py
+++ b/tools/dify_extractor/tools/pptx_extractor.py
@@ -1,0 +1,131 @@
+"""Abstract interface for pptx document loader implementations."""
+
+import logging
+import mimetypes
+import re
+import uuid
+from io import BytesIO
+from urllib.parse import urlparse
+
+import requests
+from dify_plugin import Tool
+from pptx import Presentation
+
+from tools.extractor_base import BaseExtractor
+from tools.document import Document, ExtractorResult
+
+logger = logging.getLogger(__name__)
+
+
+class PPTXExtractor(BaseExtractor):
+    """Load pptx files.
+
+    Args:
+        tool: Tool instance
+        file_bytes: file bytes
+        file_name: file name
+    """
+
+    def __init__(self, tool: Tool, file_bytes: bytes, file_name: str):
+        """Initialize with file path."""
+        self._file_bytes = file_bytes
+        self._file_name = file_name
+        self._tool = tool
+
+    def extract(self) -> ExtractorResult:
+        """Load given path as single page."""
+        content, img_list = self.parse_pptx(self._file_bytes)
+        return ExtractorResult(
+            md_content=content,
+            documents=[
+                Document(page_content=content, metadata={"source": self._file_name})
+            ],
+            img_list=img_list,
+            origin_result=None
+        )
+
+    @staticmethod
+    def _is_valid_url(url: str) -> bool:
+        """Check if the url is valid."""
+        parsed = urlparse(url)
+        return bool(parsed.netloc) and bool(parsed.scheme)
+
+    def _extract_images_from_pptx(self, prs):
+        image_map = {}
+        img_list = []
+        for slide_idx, slide in enumerate(prs.slides):
+            for shape in slide.shapes:
+                if hasattr(shape, "image"):
+                    image_ext = shape.image.ext
+                    if image_ext is None:
+                        continue
+                    file_uuid = str(uuid.uuid4())
+                    file_name = file_uuid + "." + image_ext
+                    mime_type, _ = mimetypes.guess_type(file_name)
+
+                    file_res = self._tool.session.file.upload(
+                        file_name, shape.image.blob, mime_type
+                    )
+
+                    image_map[(slide_idx, shape.shape_id)] = f"![image]({file_res.preview_url})"
+                    img_list.append(file_res)
+
+        return image_map, img_list
+
+    def _table_to_markdown(self, table):
+        markdown = ""
+        rows = table.rows
+        cols = table.columns
+        total_cols = len(cols)
+
+        # Header
+        header_cells = [cell.text.strip() for cell in rows[0].cells]
+        markdown += "| " + " | ".join(header_cells) + " |\n"
+        markdown += "| " + " | ".join(["---"] * total_cols) + " |\n"
+
+        # Rows
+        for row in list(rows)[1:]:
+            row_cells = [cell.text.strip() for cell in row.cells]
+            markdown += "| " + " | ".join(row_cells) + " |\n"
+
+        return markdown
+
+    def parse_pptx(self, file_bytes):
+        prs = Presentation(BytesIO(file_bytes))
+
+        content = []
+
+        image_map, img_list = self._extract_images_from_pptx(prs)
+
+        url_pattern = re.compile(r"http://[^\s+]+//|https://[^\s+]+")
+        for slide_idx, slide in enumerate(prs.slides):
+            slide_content = []
+            for shape in slide.shapes:
+                # Extract text (including hyperlinks)
+                if shape.has_text_frame:
+                    for paragraph in shape.text_frame.paragraphs:
+                        para_text = ""
+                        for run in paragraph.runs:
+                            run_text = run.text or ""
+                            # Check for hyperlink
+                            if run.hyperlink and run.hyperlink.address:
+                                if url_pattern.match(run.hyperlink.address):
+                                    para_text += f"[{run_text}]({run.hyperlink.address})"
+                                else:
+                                    para_text += run_text
+                            else:
+                                para_text += run_text
+                        if para_text.strip():
+                            slide_content.append(para_text.strip())
+                # Extract images
+                if hasattr(shape, "image"):
+                    image_md = image_map.get((slide_idx, shape.shape_id))
+                    if image_md:
+                        slide_content.append(image_md)
+                # Extract tables
+                if shape.has_table:
+                    table_md = self._table_to_markdown(shape.table)
+                    slide_content.append(table_md)
+            if slide_content:
+                content.append(f"# Slide {slide_idx + 1}\n" + "\n".join(slide_content))
+        return "\n\n".join(content), img_list


### PR DESCRIPTION
## Related Issues or Context

**NOTE:  This is intended for the `feat/datasource` branch, not for `main`.**

Add simple extractor for PPTX to the dify_extractor plugin. This is a port of https://github.com/langgenius/dify/pull/24184.

- Using [python-pptx](https://pypi.org/project/python-pptx/) by the same maintainer of python-docx.
- Based on the WordExtractor with minimal modification.
- Support extracting images, tables, and hyperlinks (with http or https) in the slides.

## Screenshots

- Example PPTX file (includes some images and tables)
  - https://create.microsoft.com/en-us/template/business-plan-presentation-96423eb0-8e02-4a99-b83b-bc60d19202d5
- Example: Slide 9 and 10
  - <img width="430" height="478" alt="image" src="https://github.com/user-attachments/assets/ad99ed3d-5194-4878-9f9f-b38e68ab590e" />
- Result:
  - <img width="1820" height="697" alt="image" src="https://github.com/user-attachments/assets/4c2da655-007e-43bd-9f57-79c96cebedf6" />
  - <img width="1359" height="861" alt="image" src="https://github.com/user-attachments/assets/5ee49a66-68e7-4b1c-9c86-1dd910a6eeaa" />