### PR TITLE
fix(gemini-config): deprecate multiple gemini models and refine thinking/response modality config

### DIFF
--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.4.1
+version: 0.4.2

--- a/models/gemini/models/llm/gemini-1.5-flash-001.yaml
+++ b/models/gemini/models/llm/gemini-1.5-flash-001.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-1.5-flash-8b-exp-0827.yaml
+++ b/models/gemini/models/llm/gemini-1.5-flash-8b-exp-0827.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-1.5-flash-8b-exp-0924.yaml
+++ b/models/gemini/models/llm/gemini-1.5-flash-8b-exp-0924.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-1.5-flash-exp-0827.yaml
+++ b/models/gemini/models/llm/gemini-1.5-flash-exp-0827.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-1.5-flash-latest.yaml
+++ b/models/gemini/models/llm/gemini-1.5-flash-latest.yaml
@@ -42,3 +42,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-1.5-pro-001.yaml
+++ b/models/gemini/models/llm/gemini-1.5-pro-001.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-1.5-pro-exp-0801.yaml
+++ b/models/gemini/models/llm/gemini-1.5-pro-exp-0801.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-1.5-pro-exp-0827.yaml
+++ b/models/gemini/models/llm/gemini-1.5-pro-exp-0827.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-2.0-pro-exp-02-05.yaml
+++ b/models/gemini/models/llm/gemini-2.0-pro-exp-02-05.yaml
@@ -42,3 +42,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-2.0-pro-exp.yaml
+++ b/models/gemini/models/llm/gemini-2.0-pro-exp.yaml
@@ -42,3 +42,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-2.5-flash-preview-04-17.yaml
+++ b/models/gemini/models/llm/gemini-2.5-flash-preview-04-17.yaml
@@ -88,3 +88,4 @@ pricing:
   output: '0.60'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-2.5-pro-exp-03-25.yaml
+++ b/models/gemini/models/llm/gemini-2.5-pro-exp-03-25.yaml
@@ -78,3 +78,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-exp-1114.yaml
+++ b/models/gemini/models/llm/gemini-exp-1114.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-exp-1121.yaml
+++ b/models/gemini/models/llm/gemini-exp-1121.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/gemini-exp-1206.yaml
+++ b/models/gemini/models/llm/gemini-exp-1206.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/learnlm-1.5-pro-experimental.yaml
+++ b/models/gemini/models/llm/learnlm-1.5-pro-experimental.yaml
@@ -39,3 +39,4 @@ pricing:
   output: '0.00'
   unit: '0.000001'
   currency: USD
+deprecated: true

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -321,17 +321,14 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
     @staticmethod
     def _set_response_modalities(*, config: types.GenerateContentConfig, model_name: str) -> None:
         if model_name in ["gemini-2.0-flash-preview-image-generation", "nano-banana"]:
-            config.response_modalities = [
-                types.MediaModality.TEXT.value,
-                types.MediaModality.IMAGE.value,
-            ]
+            config.response_modalities = [types.Modality.TEXT.value, types.Modality.IMAGE.value]
         elif model_name in [
             "models/gemini-2.5-flash-preview-native-audio-dialog",
             "models/gemini-2.5-flash-exp-native-audio-thinking-dialog",
             "models/gemini-2.5-flash-live-preview",
             "models/gemini-2.0-flash-live-001",
         ]:
-            config.response_modalities = [types.MediaModality.AUDIO.value]
+            config.response_modalities = [types.Modality.AUDIO.value]
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
         """

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -377,14 +377,8 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         :return:
         """
         try:
-            ping_message = UserPromptMessage(content="ping")
-            self._generate(
-                model=model,
-                credentials=credentials,
-                prompt_messages=[ping_message],
-                stream=False,
-                model_parameters={"max_output_tokens": 5},
-            )
+            genai_client = genai.Client(api_key=credentials["google_api_key"])
+            genai_client.models.count_tokens(model=model, contents="ping")
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 

--- a/models/gemini/provider/google.py
+++ b/models/gemini/provider/google.py
@@ -18,9 +18,7 @@ class GoogleProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(
-                model="gemini-2.0-flash-lite", credentials=credentials
-            )
+            model_instance.validate_credentials(model="gemini-2.5-flash", credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:

--- a/models/gemini/pyproject.toml
+++ b/models/gemini/pyproject.toml
@@ -13,8 +13,7 @@ dependencies = [
     "numpy>=2.3.2",
 ]
 
-# uv run black . -C -l 100
-# uv run ruff check --fix
+# uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
 dev = [
     "black>=25.1.0",


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

This PR improves the handling of Gemini model configurations and cleans up the model list.

**Key Changes:**

*   **Deprecations:**
    *   Added `deprecated: true` to several experimental and legacy Gemini models in their YAML configs.

*   **Refactoring ( `GoogleLargeLanguageModel` ):**
    *   Fix: Introduced a temporary blacklist to prevent errors when setting `thinking_config` on incompatible models (e.g., `gemini-2.0-flash-preview-image-generation`, `nano-banana`). This is a short-term fix.
    *   Feature: Configured correct response modalities for models with mixed-mode outputs (image, audio).
    *   Refactoring: Extracted chat parameter and tool calling logic into dedicated methods (`_set_chat_parameters`, `_set_tool_calling`) to improve code organization.
    *   Goal: The overall refactor makes handling different model types more robust and centralized.

*   **Configuration & Validation:**
    *   Improvement: Replaced the legacy credentials validation method with a direct API call using `genai.Client` for more reliable validation at no cost.
    *   Update: Changed the default model used for validation from `gemini-2.0-flash-lite` to `gemini-2.5-flash`.

*   **Bug Fixes:**
    *   Fix: Correctly set the mime type to `text/markdown` for Markdown (`.md`) document uploads, ensuring proper handling by the Gemini API.

This work addresses the following issues:
- Fixed #1500 
- Fixed #1456 
- Fixed #1403 

<img width="974" height="1641" alt="image" src="https://github.com/user-attachments/assets/892029d3-da71-4689-b597-f408606a843e" />


## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [x] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
