### PR TITLE
feat: add response format support for structured output in volcengine models (doubao-seed-1.6)

### DIFF
--- a/models/volcengine_maas/manifest.yaml
+++ b/models/volcengine_maas/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.29
+version: 0.0.30

--- a/models/volcengine_maas/models/client.py
+++ b/models/volcengine_maas/models/client.py
@@ -185,6 +185,7 @@ class ArkClientV3:
         temperature: Optional[float] = None,
         skip_moderation: Optional[bool] = None,
         thinking: Thinking | None = None,
+        response_format: Optional[dict] = None,
     ) -> ChatCompletion:
         """Block chat"""
         return self.ark.chat.completions.create(
@@ -198,6 +199,7 @@ class ArkClientV3:
             top_p=top_p,
             temperature=temperature,
             thinking=thinking,
+            response_format=response_format,
             extra_headers={"x-ark-moderation-scene": "skip-ark-moderation"} if skip_moderation else None,
         )
 
@@ -213,6 +215,7 @@ class ArkClientV3:
         temperature: Optional[float] = None,
         skip_moderation: Optional[bool] = None,
         thinking: Thinking | None = None,
+        response_format: Optional[dict] = None,
     ) -> Generator[ChatCompletionChunk]:
         """Stream chat"""
         chunks = self.ark.chat.completions.create(
@@ -228,6 +231,7 @@ class ArkClientV3:
             temperature=temperature,
             stream_options={"include_usage": True},
             thinking=thinking,
+            response_format=response_format,
             extra_headers={"x-ark-moderation-scene": "skip-ark-moderation"} if skip_moderation else None,
         )
         yield from chunks

--- a/models/volcengine_maas/models/llm/models.py
+++ b/models/volcengine_maas/models/llm/models.py
@@ -26,7 +26,7 @@ configs: dict[str, ModelConfig] = {
     "Doubao-Seed-1.6-vision": ModelConfig(
         properties=ModelProperties(context_size=262144, max_tokens=32768, mode=LLMMode.CHAT),
         features=[ModelFeature.AGENT_THOUGHT, ModelFeature.VISION, ModelFeature.VIDEO,
-                  ModelFeature.TOOL_CALL, ModelFeature.STREAM_TOOL_CALL],
+                  ModelFeature.TOOL_CALL, ModelFeature.STREAM_TOOL_CALL, ModelFeature.STRUCTURED_OUTPUT],
         pricing=PriceConfig(input=Decimal("0.0008"), output=Decimal("0.0080"), unit=Decimal("0.001"), currency="RMB"),
     ),
     "DeepSeek-V3.1": ModelConfig(
@@ -42,13 +42,13 @@ configs: dict[str, ModelConfig] = {
     "Doubao-Seed-1.6": ModelConfig(
         properties=ModelProperties(context_size=262144, max_tokens=16384, mode=LLMMode.CHAT),
         features=[ModelFeature.AGENT_THOUGHT, ModelFeature.VISION, ModelFeature.VIDEO,
-                  ModelFeature.TOOL_CALL, ModelFeature.STREAM_TOOL_CALL],
+                  ModelFeature.TOOL_CALL, ModelFeature.STREAM_TOOL_CALL, ModelFeature.STRUCTURED_OUTPUT],
         pricing=PriceConfig(input=Decimal("0.0024"), output=Decimal("0.0240"), unit=Decimal("0.001"), currency="RMB"),
     ),
     "Doubao-Seed-1.6-flash": ModelConfig(
         properties=ModelProperties(context_size=262144, max_tokens=16384, mode=LLMMode.CHAT),
         features=[ModelFeature.AGENT_THOUGHT, ModelFeature.VISION, ModelFeature.VIDEO,
-                  ModelFeature.TOOL_CALL, ModelFeature.STREAM_TOOL_CALL],
+                  ModelFeature.TOOL_CALL, ModelFeature.STREAM_TOOL_CALL, ModelFeature.STRUCTURED_OUTPUT],
         pricing=PriceConfig(input=Decimal("0.0006"), output=Decimal("0.0060"), unit=Decimal("0.001"), currency="RMB"),
     ),
     "Doubao-Seed-1.6-thinking": ModelConfig(
@@ -279,4 +279,6 @@ def get_v3_req_params(credentials: dict, model_parameters: dict, stop: list[str]
     if model_parameters.get("thinking"):
         thinking: Thinking = {"type": model_parameters["thinking"]}
         req_params["thinking"] = thinking
+    if model_parameters.get("response_format"):
+        req_params["response_format"] = model_parameters.get("response_format")
     return req_params


### PR DESCRIPTION
## Related Issues or Context

<img width="721" height="343" alt="image" src="https://github.com/user-attachments/assets/71c023a1-7512-4b01-b36b-2110447b2510" />


<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x ] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
