### PR TITLE
fix(plugin): add required context_size to OpenAITextEmbeddingModel (fix #1591)

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.21
+version: 0.0.22
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/text_embedding/text_embedding.py
+++ b/models/openai_api_compatible/models/text_embedding/text_embedding.py
@@ -10,10 +10,8 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
     def get_customizable_model_schema(
         self, model: str, credentials: Mapping | dict
     ) -> AIModelEntity:
+        credentials = credentials or {}
         entity = super().get_customizable_model_schema(model, credentials)
-
-        # add this line
-        entity.context_size = credentials.get("context_size")  # required integer
 
         if "display_name" in credentials and credentials["display_name"] != "":
             entity.label = I18nObject(
@@ -21,4 +19,3 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
             )
 
         return entity
-


### PR DESCRIPTION
Fixes #1591
Fixes https://github.com/langgenius/dify-official-plugins/issues/1595 – Prevents the PluginInvokeError when credentials is None in text_embedding.py.

- Added `context_size` field to OpenAITextEmbeddingModel.
- Pulls the value from plugin credentials to fix "Variable context_size is required" error.
