### PR TITLE
fix(text_embedding): guard against NoneType iterables (fixes #1595)

### DIFF
--- a/models/openai_api_compatible/models/text_embedding/text_embedding.py
+++ b/models/openai_api_compatible/models/text_embedding/text_embedding.py
@@ -10,6 +10,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
     def get_customizable_model_schema(
         self, model: str, credentials: Mapping | dict
     ) -> AIModelEntity:
+        credentials = credentials or {}
         entity = super().get_customizable_model_schema(model, credentials)
 
         if "display_name" in credentials and credentials["display_name"] != "":


### PR DESCRIPTION
## Related Issues or Context
Fixes #1595 – Prevents the PluginInvokeError when `credentials` is None in text_embedding.py.
Fixes https://github.com/langgenius/dify-official-plugins/issues/1595 – Prevents the PluginInvokeError when credentials is None in text_embedding.py.

## This PR contains Changes to *Non-Plugin* 
- [ ] Documentation
- [x] Other (Bug Fix)

## Changes Made
- Added a defensive guard in text_embedding.py: `credentials = credentials or {}`.
- Ensures iteration over `credentials` never fails if it's None.
- No functional change; only prevents the TypeError crash.

## Version Control
- [ ] I have Bumped Up the Version in Manifest.yaml (not needed for this bug fix)

## Environment Verification
- [x] Tested locally in a clean environment matching production configuration
- [ ] Tested on SaaS environment
