### PR TITLE
fix(feat/datasource): bump sdk version to support new ref format for output schema

### DIFF
--- a/tools/general_chunk/manifest.yaml
+++ b/tools/general_chunk/manifest.yaml
@@ -33,4 +33,4 @@ resource:
       enabled: true
 tags:
 type: plugin
-version: 0.0.2
+version: 0.0.3

--- a/tools/general_chunk/requirements.txt
+++ b/tools/general_chunk/requirements.txt
@@ -1,3 +1,3 @@
-dify_plugin==0.5.0b11
+dify_plugin==0.5.0b14
 yfinance==0.2.51
 pandas==2.2.3

--- a/tools/parent_child_chunk/manifest.yaml
+++ b/tools/parent_child_chunk/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: parentchild_chunker

--- a/tools/parent_child_chunk/requirements.txt
+++ b/tools/parent_child_chunk/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin==0.5.0b11
+dify_plugin==0.5.0b14

--- a/tools/qa_chunk/manifest.yaml
+++ b/tools/qa_chunk/manifest.yaml
@@ -33,4 +33,4 @@ resource:
       enabled: true
 tags:
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/qa_chunk/requirements.txt
+++ b/tools/qa_chunk/requirements.txt
@@ -1,3 +1,3 @@
-dify_plugin==0.5.0b10
+dify_plugin==0.5.0b14
 yfinance==0.2.51
 pandas==2.2.3


### PR DESCRIPTION
## Related Issues or Context

NOTE: This is intended for the ✨ **feat/datasource** branch, not for **main**.

New `$ref: "https://..."` format does not work with old SDK version.
This PR bumps SDK version for the plugin which has new ref format and uses old SDK version.

Follow-up for: https://github.com/langgenius/dify-official-plugins/commit/4a3f0478c8c224114e9f2937fd048bed2bacffb9

```bash
2025/08/28 13:44:59 run.go:135: [ERROR]plugin langgenius/general_chunker:0.0.2 exited with error: exit status 1

luginRegistration(config)

                        ^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/app/cwd/langgenius/general_chunker-0.0.2@8c2f309e9d67a472dad1e9d1e8d1de89249859551b60682f545c7c5ba6bb344a/.venv/lib/python3.12/site-packages/dify_plugin/core/plugin_registration.py", line 127, in __init__

    self._load_plugin_configuration()


  File "/app/cwd/langgenius/general_chunker-0.0.2@8c2f309e9d67a472dad1e9d1e8d1de89249859551b60682f545c7c5ba6bb344a/.venv/lib/python3.12/site-packages/dify_plugin/core/plugin_registration.py", line 174, in _load_plugin_configuration


    raise ValueError(f"Error loading plugin configuration: {e!s}") from e

ValueError: Error loading plugin configuration: 1 validation error for ToolProviderConfiguration

tools

  Value error, Error loading tool configuration: Unsupported reference format: [https://dify.ai/schemas/v1/general_structure.json⁠](https://dify.ai/schemas/v1/general_structure.json) [type=value_error, input_value=['tools/general.yaml'], input_type=list]

    For further information visit [https://errors.pydantic.dev/2.11/v/value_error⁠](https://errors.pydantic.dev/2.11/v/value_error)
```