### PR TITLE
Fix/bedrock inference profile cache support

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.33
+version: 0.0.34
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -57,12 +57,9 @@ from . import model_ids
 from utils.inference_profile import (
     get_inference_profile_info,
     validate_inference_profile,
-    extract_model_info_from_profile,
+    extract_model_info_from_profile
 )
-
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 logger = logging.getLogger(__name__)
 ANTHROPIC_BLOCK_MODE_PROMPT = """You should always follow the instructions and output a valid {{block}} object.
@@ -79,106 +76,26 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
     # please refer to the documentation: https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
     # TODO There is invoke issue: context limit on Cohere Model, will add them after fixed.
     CONVERSE_API_ENABLED_MODEL_INFO = [
-        {
-            "prefix": "us.deepseek",
-            "support_system_prompts": True,
-            "support_tool_use": False,
-        },
-        {
-            "prefix": "us.anthropic.claude",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "eu.anthropic.claude",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "apac.anthropic.claude",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "anthropic.claude",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "amazon.nova",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "us.amazon.nova",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "eu.amazon.nova",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "apac.amazon.nova",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "us.meta.llama",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "eu.meta.llama",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "apac.meta.llama",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "meta.llama",
-            "support_system_prompts": True,
-            "support_tool_use": False,
-        },
-        {
-            "prefix": "mistral.mistral-7b-instruct",
-            "support_system_prompts": False,
-            "support_tool_use": False,
-        },
-        {
-            "prefix": "mistral.mixtral-8x7b-instruct",
-            "support_system_prompts": False,
-            "support_tool_use": False,
-        },
-        {
-            "prefix": "mistral.mistral-large",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "mistral.mistral-small",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "cohere.command-r",
-            "support_system_prompts": True,
-            "support_tool_use": True,
-        },
-        {
-            "prefix": "amazon.titan",
-            "support_system_prompts": False,
-            "support_tool_use": False,
-        },
-        {
-            "prefix": "ai21.jamba-1-5",
-            "support_system_prompts": True,
-            "support_tool_use": False,
-        },
+        {"prefix": "us.deepseek", "support_system_prompts": True, "support_tool_use": False},
+        {"prefix": "us.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "eu.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "apac.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "amazon.nova", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "us.amazon.nova", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "eu.amazon.nova", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "apac.amazon.nova", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "us.meta.llama", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "eu.meta.llama", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "apac.meta.llama", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "meta.llama", "support_system_prompts": True, "support_tool_use": False},
+        {"prefix": "mistral.mistral-7b-instruct", "support_system_prompts": False, "support_tool_use": False},
+        {"prefix": "mistral.mixtral-8x7b-instruct", "support_system_prompts": False, "support_tool_use": False},
+        {"prefix": "mistral.mistral-large", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "mistral.mistral-small", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "cohere.command-r", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "amazon.titan", "support_system_prompts": False, "support_tool_use": False},
+        {"prefix": "ai21.jamba-1-5", "support_system_prompts": True, "support_tool_use": False},
     ]
 
     @staticmethod
@@ -190,15 +107,15 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         return None
 
     def _code_block_mode_wrapper(
-        self,
-        model: str,
-        credentials: dict,
-        prompt_messages: list[PromptMessage],
-        model_parameters: dict,
-        tools: Optional[list[PromptMessageTool]] = None,
-        stop: Optional[list[str]] = None,
-        stream: bool = True,
-        user: Optional[str] = None,
+            self,
+            model: str,
+            credentials: dict,
+            prompt_messages: list[PromptMessage],
+            model_parameters: dict,
+            tools: Optional[list[PromptMessageTool]] = None,
+            stop: Optional[list[str]] = None,
+            stream: bool = True,
+            user: Optional[str] = None,
     ) -> Union[LLMResult, Generator]:
         """
         Code block mode wrapper for invoking large language model
@@ -211,29 +128,16 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 stop.append("\n```")
             response_format = model_parameters.pop("response_format")
             format_prompt = SystemPromptMessage(
-                content=ANTHROPIC_BLOCK_MODE_PROMPT.replace(
-                    "{{instructions}}", prompt_messages[0].content
-                ).replace("{{block}}", response_format)
+                content=ANTHROPIC_BLOCK_MODE_PROMPT.replace("{{instructions}}", prompt_messages[0].content).replace(
+                    "{{block}}", response_format
+                )
             )
-            if len(prompt_messages) > 0 and isinstance(
-                prompt_messages[0], SystemPromptMessage
-            ):
+            if len(prompt_messages) > 0 and isinstance(prompt_messages[0], SystemPromptMessage):
                 prompt_messages[0] = format_prompt
             else:
                 prompt_messages.insert(0, format_prompt)
-            prompt_messages.append(
-                AssistantPromptMessage(content=f"\n```{response_format}")
-            )
-        return self._invoke(
-            model,
-            credentials,
-            prompt_messages,
-            model_parameters,
-            tools,
-            stop,
-            stream,
-            user,
-        )
+            prompt_messages.append(AssistantPromptMessage(content=f"\n```{response_format}"))
+        return self._invoke(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
 
     def _invoke(
         self,
@@ -269,20 +173,16 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     # Handle response_format for inference profiles only if underlying model is Anthropic
                     if model_parameters.get("response_format"):
                         # Check if the underlying model is Anthropic based
-                        profile_info = get_inference_profile_info(
-                            inference_profile_id, credentials
-                        )
+                        profile_info = get_inference_profile_info(inference_profile_id, credentials)
                         underlying_models = profile_info.get("models", [])
                         is_anthropic = False
-
+                        
                         if underlying_models:
                             first_model_arn = underlying_models[0].get("modelArn", "")
                             if "foundation-model/" in first_model_arn:
-                                underlying_model_id = first_model_arn.split(
-                                    "foundation-model/"
-                                )[1]
+                                underlying_model_id = first_model_arn.split("foundation-model/")[1]
                                 is_anthropic = "anthropic.claude" in underlying_model_id
-
+                        
                         if is_anthropic:
                             stop = stop or []
                             if "```\n" not in stop:
@@ -291,89 +191,53 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                                 stop.append("\n```")
                             response_format = model_parameters.pop("response_format")
                             format_prompt = SystemPromptMessage(
-                                content=ANTHROPIC_BLOCK_MODE_PROMPT.replace(
-                                    "{{instructions}}", prompt_messages[0].content
-                                ).replace("{{block}}", response_format)
+                                content=ANTHROPIC_BLOCK_MODE_PROMPT.replace("{{instructions}}", prompt_messages[0].content).replace(
+                                    "{{block}}", response_format
+                                )
                             )
-                            if len(prompt_messages) > 0 and isinstance(
-                                prompt_messages[0], SystemPromptMessage
-                            ):
+                            if len(prompt_messages) > 0 and isinstance(prompt_messages[0], SystemPromptMessage):
                                 prompt_messages[0] = format_prompt
                             else:
                                 prompt_messages.insert(0, format_prompt)
-                            prompt_messages.append(
-                                AssistantPromptMessage(
-                                    content=f"\n```{response_format}"
-                                )
-                            )
+                            prompt_messages.append(AssistantPromptMessage(content=f"\n```{response_format}"))
                         else:
                             # For non-Anthropic models, just remove response_format parameter
                             model_parameters.pop("response_format", None)
-
+                    
                     return self._generate_with_converse(
-                        model_info,
-                        credentials,
-                        prompt_messages,
-                        model_parameters,
-                        stop,
-                        stream,
-                        user,
-                        tools,
-                        model,
+                        model_info, credentials, prompt_messages, model_parameters, stop, stream, user, tools, model
                     )
                 else:
-                    raise InvokeError(
-                        f"Could not get model information for inference profile {inference_profile_id}"
-                    )
+                    raise InvokeError(f"Could not get model information for inference profile {inference_profile_id}")
             except Exception as e:
                 logger.error(f"Failed to invoke inference profile: {str(e)}")
-                raise InvokeError(
-                    f"Failed to invoke inference profile {inference_profile_id}: {str(e)}"
-                )
+                raise InvokeError(f"Failed to invoke inference profile {inference_profile_id}: {str(e)}")
         else:
             # Traditional model - try converse API first, then fall back if needed
             try:
                 model_info = self._get_model_info(model, credentials, model_parameters)
                 if model_info:
                     return self._generate_with_converse(
-                        model_info,
-                        credentials,
-                        prompt_messages,
-                        model_parameters,
-                        stop,
-                        stream,
-                        user,
-                        tools,
-                        model,
+                        model_info, credentials, prompt_messages, model_parameters, stop, stream, user, tools, model
                     )
             except Exception as e:
                 logger.error(f"Failed to get model info: {str(e)}")
-
+            
             # Fallback to traditional model ID for non-converse API models
-            model_name = model_parameters.get("model_name")
+            model_name = model_parameters.get('model_name')
             if not model_name:
                 raise InvokeError("Model name is required for non-converse API models")
 
         model_id = model_ids.get_model_id(model, model_name)
         # Store model_name in credentials for pricing calculation
         credentials_with_model = credentials.copy()
-        credentials_with_model["model_parameters"] = {"model_name": model_name}
-        return self._generate(
-            model_id,
-            credentials_with_model,
-            prompt_messages,
-            model_parameters,
-            stop,
-            stream,
-            user,
-        )
+        credentials_with_model['model_parameters'] = {'model_name': model_name}
+        return self._generate(model_id, credentials_with_model, prompt_messages, model_parameters, stop, stream, user)
 
-    def _get_model_info(
-        self, model: str, credentials: dict, model_parameters: dict
-    ) -> dict:
+    def _get_model_info(self, model: str, credentials: dict, model_parameters: dict) -> dict:
         """
         Get model information for converse API
-
+        
         :param model: model name
         :param credentials: model credentials
         :param model_parameters: model parameters
@@ -386,9 +250,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             profile_arn = profile_info.get("inferenceProfileArn")
 
             if not profile_arn:
-                raise InvokeError(
-                    f"Could not get ARN for inference profile {inference_profile_id}"
-                )
+                raise InvokeError(f"Could not get ARN for inference profile {inference_profile_id}")
 
             # Use inference profile ARN as model ID
             model_id = profile_arn
@@ -403,55 +265,43 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 # Extract model ID from ARN
                 if "foundation-model/" in first_model_arn:
                     underlying_model_id = first_model_arn.split("foundation-model/")[1]
-                    model_info = BedrockLargeLanguageModel._find_model_info(
-                        underlying_model_id
-                    )
+                    model_info = BedrockLargeLanguageModel._find_model_info(underlying_model_id)
                     if model_info:
                         # Use the inference profile ARN but with underlying model capabilities
                         model_info = model_info.copy()
-                        model_info["model"] = (
-                            model_id  # Use inference profile ARN for actual API call
-                        )
-                        model_info["underlying_model_id"] = (
-                            underlying_model_id  # Store underlying model ID for cache support
-                        )
-                        logger.info(
-                            f"Using inference profile {model_id} with capabilities from {underlying_model_id}"
-                        )
+                        model_info["model"] = model_id  # Use inference profile ARN for actual API call
+                        model_info["underlying_model_id"] = underlying_model_id  # Store underlying model ID for cache support
+                        logger.info(f"Using inference profile {model_id} with capabilities from {underlying_model_id}")
                         return model_info
             if not model_info:
-                logger.info(
-                    f"Using inference profile {model_id} with default capabilities"
-                )
+                logger.info(f"Using inference profile {model_id} with default capabilities")
                 return {
                     "model": model_id,
                     "support_system_prompts": True,
-                    "support_tool_use": True,
+                    "support_tool_use": True
                 }
         else:
             # Use traditional model ID resolution
-            model_name = model_parameters.pop("model_name")
+            model_name = model_parameters.pop('model_name')
             model_id = model_ids.get_model_id(model, model_name)
-
+            
             # Store model_name in credentials for pricing calculation
-            if "model_parameters" not in credentials:
-                credentials["model_parameters"] = {}
-            credentials["model_parameters"]["model_name"] = model_name
-
-            if model_parameters.pop("cross-region", False):
-                region_name = credentials["aws_region"]
+            if 'model_parameters' not in credentials:
+                credentials['model_parameters'] = {}
+            credentials['model_parameters']['model_name'] = model_name
+            
+            if model_parameters.pop('cross-region', False):
+                region_name = credentials['aws_region']
                 region_prefix = model_ids.get_region_area(region_name)
                 if not region_prefix:
-                    raise InvokeError(
-                        f"Region {region_name} Unsupport cross-region Inference"
-                    )
+                    raise InvokeError(f'Region {region_name} Unsupport cross-region Inference')
                 model_id = "{}.{}".format(region_prefix, model_id)
 
             model_info = BedrockLargeLanguageModel._find_model_info(model_id)
             if model_info:
                 model_info["model"] = model_id
                 return model_info
-
+            
             return None
 
     def _generate_with_converse(
@@ -483,30 +333,18 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         # Log the incoming parameters for debugging
         logger.info(f"[CACHE PARAMS] Received model_parameters: {model_parameters}")
         system_cache_checkpoint = model_parameters.pop("system_cache_checkpoint", False)  # Default to False
-        latest_two_messages_cache_checkpoint = model_parameters.pop(
-            "latest_two_messages_cache_checkpoint", False
-        )
-        logger.info(
-            f"---cache_checkpoints--- system: {system_cache_checkpoint}, penultimate: {latest_two_messages_cache_checkpoint}"
-        )
+        latest_two_messages_cache_checkpoint = model_parameters.pop("latest_two_messages_cache_checkpoint", False)
+        logger.info(f"---cache_checkpoints--- system: {system_cache_checkpoint}, penultimate: {latest_two_messages_cache_checkpoint}")
         model_id = model_info["model"]
-        print(
-            f"[CACHE DEBUG] Model: {model_id}, Cache checkpoints - System: {system_cache_checkpoint}, Penultimate: {latest_two_messages_cache_checkpoint}"
-        )
-        logger.info(
-            f"[CACHE DEBUG] Model: {model_id}, Cache checkpoints - System: {system_cache_checkpoint}, Penultimate: {latest_two_messages_cache_checkpoint}"
-        )
+        print(f"[CACHE DEBUG] Model: {model_id}, Cache checkpoints - System: {system_cache_checkpoint}, Penultimate: {latest_two_messages_cache_checkpoint}")
+        logger.info(f"[CACHE DEBUG] Model: {model_id}, Cache checkpoints - System: {system_cache_checkpoint}, Penultimate: {latest_two_messages_cache_checkpoint}")
 
         # Enable cache if either checkpoint is enabled
         # For inference profiles, use underlying model ID for cache support check
         cache_check_model_id = model_info.get("underlying_model_id", model_id)
         cache_supported = is_cache_supported(cache_check_model_id)
-        print(
-            f"[CACHE DEBUG] Model: {model_id}, Underlying: {cache_check_model_id}, Cache supported: {cache_supported}"
-        )
-        logger.info(
-            f"[CACHE DEBUG] Model: {model_id}, Underlying: {cache_check_model_id}, Cache supported: {cache_supported}"
-        )
+        print(f"[CACHE DEBUG] Model: {model_id}, Underlying: {cache_check_model_id}, Cache supported: {cache_supported}")
+        logger.info(f"[CACHE DEBUG] Model: {model_id}, Underlying: {cache_check_model_id}, Cache supported: {cache_supported}")
         if cache_supported == False:
             system_cache_checkpoint = False
             latest_two_messages_cache_checkpoint = False
@@ -518,11 +356,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             prompt_messages,
             model_id=cache_config_model_id,
             system_cache_checkpoint=system_cache_checkpoint,
-            latest_two_messages_cache_checkpoint=latest_two_messages_cache_checkpoint,
+            latest_two_messages_cache_checkpoint=latest_two_messages_cache_checkpoint
         )
-        inference_config, additional_model_fields = (
-            self._convert_converse_api_model_parameters(model_parameters, stop)
-        )
+        inference_config, additional_model_fields = self._convert_converse_api_model_parameters(model_parameters, stop)
 
         parameters = {
             "modelId": model_info["model"],
@@ -542,9 +378,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             # if two consecutive user messages found, combine them into one message
             for i in range(len(conversations_list) - 2, -1, -1):
                 if conversations_list[i]["role"] == conversations_list[i + 1]["role"]:
-                    conversations_list[i]["content"].extend(
-                        conversations_list.pop(i + 1)["content"]
-                    )
+                    conversations_list[i]["content"].extend(conversations_list.pop(i + 1)["content"])
 
             if stream:
                 response = bedrock_client.converse_stream(**parameters)
@@ -563,51 +397,31 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
                     # Extract cache metrics if available
                     cache_read_tokens = response["usage"].get("cacheReadInputTokens", 0)
-                    cache_write_tokens = response["usage"].get(
-                        "cacheWriteInputTokens", 0
-                    )
+                    cache_write_tokens = response["usage"].get("cacheWriteInputTokens", 0)
 
                     # Always log the metrics for debugging
-                    print(
-                        f"[CACHE METRICS] Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
-                    )
-                    logger.info(
-                        f"[CACHE METRICS] Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
-                    )
+                    print(f"[CACHE METRICS] Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
+                    logger.info(f"[CACHE METRICS] Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
 
                     # Print the full response usage for debugging
-                    print(
-                        f"[CACHE DEBUG] Response usage: {json.dumps(response['usage'], default=str)}"
-                    )
+                    print(f"[CACHE DEBUG] Response usage: {json.dumps(response['usage'], default=str)}")
 
                     # Log cache usage if any tokens were read or written
                     if cache_read_tokens > 0 or cache_write_tokens > 0:
-                        logger.info(
-                            f"Cache metrics - Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
-                        )
+                        logger.info(f"Cache metrics - Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
                         # If tokens were read from cache, log the savings
                         if cache_read_tokens > 0:
-                            print(
-                                f"[CACHE HIT] {cache_read_tokens} tokens read from cache"
-                            )
-                            logger.info(
-                                f"Cache hit detected - {cache_read_tokens} tokens read from cache"
-                            )
+                            print(f"[CACHE HIT] {cache_read_tokens} tokens read from cache")
+                            logger.info(f"Cache hit detected - {cache_read_tokens} tokens read from cache")
                         elif cache_write_tokens > 0:
-                            print(
-                                f"[CACHE WRITE] {cache_write_tokens} tokens written to cache"
-                            )
-                            logger.info(
-                                f"Cache write detected - {cache_write_tokens} tokens written to cache"
-                            )
+                            print(f"[CACHE WRITE] {cache_write_tokens} tokens written to cache")
+                            logger.info(f"Cache write detected - {cache_write_tokens} tokens written to cache")
                 else:
                     # Log if usage data is missing
                     print(f"[WARNING] No usage data in response")
                     logger.warning(f"No usage data in response")
 
-                return self._handle_converse_response(
-                    model_info["model"], credentials, response, prompt_messages
-                )
+                return self._handle_converse_response(model_info["model"], credentials, response, prompt_messages)
         except ClientError as ex:
             error_code = ex.response["Error"]["Code"]
             full_error_msg = f"{error_code}: {ex.response['Error']['Message']}"
@@ -622,11 +436,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             raise InvokeError(str(ex))
 
     def _handle_converse_response(
-        self,
-        model: str,
-        credentials: dict,
-        response: dict,
-        prompt_messages: list[PromptMessage],
+        self, model: str, credentials: dict, response: dict, prompt_messages: list[PromptMessage]
     ) -> LLMResult:
         """
         Handle llm chat response
@@ -652,13 +462,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             )
             tool_calls.append(tool_call)
 
-            assistant_prompt_message = AssistantPromptMessage(
-                content=text, tool_calls=tool_calls
-            )
+            assistant_prompt_message = AssistantPromptMessage(content=text, tool_calls=tool_calls)
         else:
-            assistant_prompt_message = AssistantPromptMessage(
-                content=response_content[0]["text"]
-            )
+            assistant_prompt_message = AssistantPromptMessage(content=response_content[0]["text"])
 
         # calculate num tokens
         if response["usage"]:
@@ -667,29 +473,21 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             completion_tokens = response["usage"]["outputTokens"]
 
             # Log cache metrics if available
-            cache_read_tokens = response["usage"].get("cacheReadInputTokensCount", 0)
-            cache_write_tokens = response["usage"].get("cacheWriteInputTokensCount", 0)
+            cache_read_tokens = response["usage"].get("cacheReadInputTokens", 0)
+            cache_write_tokens = response["usage"].get("cacheWriteInputTokens", 0)
 
             if cache_read_tokens > 0 or cache_write_tokens > 0:
-                logger.info(
-                    f"Cache metrics - Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
-                )
+                logger.info(f"Cache metrics - Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
                 # If tokens were read from cache, log the savings
                 if cache_read_tokens > 0:
-                    logger.info(
-                        f"Cache hit detected - {cache_read_tokens} tokens read from cache"
-                    )
+                    logger.info(f"Cache hit detected - {cache_read_tokens} tokens read from cache")
         else:
             # calculate num tokens
             prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
-            completion_tokens = self.get_num_tokens(
-                model, credentials, [assistant_prompt_message]
-            )
+            completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
 
         # transform usage
-        usage = self._calc_response_usage(
-            model, credentials, prompt_tokens, completion_tokens
-        )
+        usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
 
         result = LLMResult(
             model=model,
@@ -753,71 +551,41 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     # Safely extract usage data with proper error handling
                     if "usage" in chunk["metadata"]:
                         input_tokens = chunk["metadata"]["usage"].get("inputTokens", 0)
-                        output_tokens = chunk["metadata"]["usage"].get(
-                            "outputTokens", 0
-                        )
+                        output_tokens = chunk["metadata"]["usage"].get("outputTokens", 0)
 
                         # Extract cache metrics if available
-                        cache_read_tokens = chunk["metadata"]["usage"].get(
-                            "cacheReadInputTokens", 0
-                        )
-                        cache_write_tokens = chunk["metadata"]["usage"].get(
-                            "cacheWriteInputTokens", 0
-                        )
+                        cache_read_tokens = chunk["metadata"]["usage"].get("cacheReadInputTokens", 0)
+                        cache_write_tokens = chunk["metadata"]["usage"].get("cacheWriteInputTokens", 0)
 
                         # Always log the metrics for debugging
-                        print(
-                            f"[STREAM CACHE METRICS] Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
-                        )
-                        logger.info(
-                            f"[STREAM CACHE METRICS] Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
-                        )
+                        print(f"[STREAM CACHE METRICS] Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
+                        logger.info(f"[STREAM CACHE METRICS] Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
 
                         # Print the full usage data for debugging
-                        print(
-                            f"[STREAM USAGE DATA] {json.dumps(chunk['metadata']['usage'], default=str)}"
-                        )
+                        print(f"[STREAM USAGE DATA] {json.dumps(chunk['metadata']['usage'], default=str)}")
 
                         # Log cache usage if any tokens were read or written
                         if cache_read_tokens > 0 or cache_write_tokens > 0:
-                            logger.info(
-                                f"Cache metrics - Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
-                            )
+                            logger.info(f"Cache metrics - Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
                             # If tokens were read from cache, log the savings
                             if cache_read_tokens > 0:
-                                print(
-                                    f"[STREAM CACHE HIT] {cache_read_tokens} tokens read from cache"
-                                )
-                                logger.info(
-                                    f"Cache hit detected - {cache_read_tokens} tokens read from cache"
-                                )
+                                print(f"[STREAM CACHE HIT] {cache_read_tokens} tokens read from cache")
+                                logger.info(f"Cache hit detected - {cache_read_tokens} tokens read from cache")
                             elif cache_write_tokens > 0:
-                                print(
-                                    f"[STREAM CACHE WRITE] {cache_write_tokens} tokens written to cache"
-                                )
-                                logger.info(
-                                    f"Cache write detected - {cache_write_tokens} tokens written to cache"
-                                )
+                                print(f"[STREAM CACHE WRITE] {cache_write_tokens} tokens written to cache")
+                                logger.info(f"Cache write detected - {cache_write_tokens} tokens written to cache")
                     else:
                         # Log if usage data is missing
-                        print(
-                            f"[STREAM WARNING] No usage data in metadata: {json.dumps(chunk['metadata'], default=str)}"
-                        )
-                        logger.warning(
-                            f"No usage data in metadata chunk: {json.dumps(chunk['metadata'], default=str)}"
-                        )
+                        print(f"[STREAM WARNING] No usage data in metadata: {json.dumps(chunk['metadata'], default=str)}")
+                        logger.warning(f"No usage data in metadata chunk: {json.dumps(chunk['metadata'], default=str)}")
 
-                    usage = self._calc_response_usage(
-                        model, credentials, input_tokens, output_tokens
-                    )
+                    usage = self._calc_response_usage(model, credentials, input_tokens, output_tokens)
                     yield LLMResultChunk(
                         model=return_model,
                         prompt_messages=prompt_messages,
                         delta=LLMResultChunkDelta(
                             index=index,
-                            message=AssistantPromptMessage(
-                                content="", tool_calls=tool_calls
-                            ),
+                            message=AssistantPromptMessage(content="", tool_calls=tool_calls),
                             finish_reason=finish_reason,
                             usage=usage,
                         ),
@@ -825,7 +593,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 elif "contentBlockDelta" in chunk:
                     delta = chunk["contentBlockDelta"]["delta"]
                     if "reasoningContent" in delta:
-                        formatted_reasoning = ""
+                        formatted_reasoning = ''
                         if "text" in delta["reasoningContent"]:
                             # Get reasoning content text
                             reasoning_text = delta["reasoningContent"]["text"] or ""
@@ -876,10 +644,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 elif "contentBlockStop" in chunk:
                     # If reasoning was started but never completed (no text content followed)
                     # we need to close the thinking tag
-                    if (
-                        reasoning_tailer_added is False
-                        and full_assistant_content.startswith("<think>")
-                    ):
+                    if reasoning_tailer_added is False and full_assistant_content.startswith("<think>"):
                         assistant_prompt_message = AssistantPromptMessage(
                             content="\n</think>"
                         )
@@ -932,27 +697,22 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             additional_model_fields["top_k"] = model_parameters["top_k"]
 
         if "anthropic_beta" in model_parameters:
-            additional_model_fields["anthropic_beta"] = list(
-                map(
-                    lambda v: v.strip(),
-                    model_parameters["anthropic_beta"].strip().split(","),
-                )
-            )
+            additional_model_fields["anthropic_beta"] = list(map(lambda v:v.strip(), model_parameters["anthropic_beta"].strip().split(",")))
 
         # process reasoning related parameters, construct nested reasoning_config structure
         if "reasoning_type" in model_parameters:
             reasoning_type = model_parameters["reasoning_type"]
             if reasoning_type:
-                reasoning_config = {"type": "enabled"}
+                reasoning_config = {
+                    "type": "enabled"
+                }
                 # set budget_tokens, ensure at least 1024
                 budget_tokens = 1024
                 if "reasoning_budget" in model_parameters:
                     budget_tokens = max(1024, model_parameters["reasoning_budget"])
                 # make sure budget_tokens is less than max_tokens
                 if "max_tokens" in model_parameters:
-                    budget_tokens = min(
-                        budget_tokens, model_parameters["max_tokens"] - 1
-                    )
+                    budget_tokens = min(budget_tokens, model_parameters["max_tokens"] - 1)
                     reasoning_config["budget_tokens"] = budget_tokens
                 additional_model_fields["reasoning_config"] = reasoning_config
                 inference_config["temperature"] = 1
@@ -961,13 +721,8 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
         return inference_config, additional_model_fields
 
-    def _convert_converse_prompt_messages(
-        self,
-        prompt_messages: list[PromptMessage],
-        model_id: str = None,
-        system_cache_checkpoint: bool = True,
-        latest_two_messages_cache_checkpoint: bool = False,
-    ) -> tuple[list, list[dict]]:
+    def _convert_converse_prompt_messages(self, prompt_messages: list[PromptMessage], model_id: str = None,
+        system_cache_checkpoint: bool = True, latest_two_messages_cache_checkpoint: bool = False) -> tuple[list, list[dict]]:
         """
         Convert prompt messages to dict list and system
         Add cache points for supported models when enable_cache is True
@@ -985,12 +740,8 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         cache_config = get_cache_config(model_id)
 
         # Process system messages first
-        system_messages = [
-            msg for msg in prompt_messages if isinstance(msg, SystemPromptMessage)
-        ]
-        other_messages = [
-            msg for msg in prompt_messages if not isinstance(msg, SystemPromptMessage)
-        ]
+        system_messages = [msg for msg in prompt_messages if isinstance(msg, SystemPromptMessage)]
+        other_messages = [msg for msg in prompt_messages if not isinstance(msg, SystemPromptMessage)]
 
         # Add system messages
         for message in system_messages:
@@ -999,16 +750,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
             # Add cache point to system if it's not empty and caching is supported for system field
         # and system_cache_checkpoint is enabled
-        if (
-            system
-            and cache_config
-            and "system" in cache_config["supported_fields"]
-            and system_cache_checkpoint
-        ):
+        if system and cache_config and "system" in cache_config["supported_fields"] and system_cache_checkpoint:
             system.append({"cachePoint": {"type": "default"}})
-            print(
-                f"[CACHE DEBUG] Added cache point to system messages for model: {model_id}"
-            )
+            print(f"[CACHE DEBUG] Added cache point to system messages for model: {model_id}")
 
             # Process other messages
         for message in other_messages:
@@ -1016,24 +760,14 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             prompt_message_dicts.append(message_dict)
 
             # Only add cache point to messages if supported and latest_two_messages_cache_checkpoint is enabled
-        if (
-            cache_config
-            and "messages" in cache_config["supported_fields"]
-            and latest_two_messages_cache_checkpoint
-        ):
+        if cache_config and "messages" in cache_config["supported_fields"] and latest_two_messages_cache_checkpoint:
             # Find all user messages
-            user_message_indices = [
-                i
-                for i, msg in enumerate(prompt_message_dicts)
-                if msg["role"] in ["user"]
-            ]
+            user_message_indices = [i for i, msg in enumerate(prompt_message_dicts) if msg["role"] in ["user"]]
 
             # Add cache point to available user messages (up to the latest two)
             if len(user_message_indices) > 0:
                 # Get indices for the latest messages (either one or two depending on availability)
-                indices_to_cache = user_message_indices[
-                    -min(2, len(user_message_indices)) :
-                ]
+                indices_to_cache = user_message_indices[-min(2, len(user_message_indices)):]
                 print(f"[CACHE DEBUG] indices_to_cacheis {indices_to_cache}")
                 for idx in indices_to_cache:
                     message = prompt_message_dicts[idx]
@@ -1043,32 +777,21 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     if isinstance(message["content"], list):
                         # Add cache point to the content array
                         message["content"].append({"cachePoint": {"type": "default"}})
-                        print(
-                            f"[CACHE DEBUG] Added cache point to user message content list at index {idx} for model: {model_id}"
-                        )
+                        print(f"[CACHE DEBUG] Added cache point to user message content list at index {idx} for model: {model_id}")
                     else:
                         # If content is not a list, convert it to a list with the original content and add cache point
                         original_content = message["content"]
-                        message["content"] = [
-                            {"text": original_content},
-                            {"cachePoint": {"type": "default"}},
-                        ]
-                        print(
-                            f"[CACHE DEBUG] Converted user message content to list and added cache point at index {idx} for model: {model_id}"
-                        )
+                        message["content"] = [{"text": original_content}, {"cachePoint": {"type": "default"}}]
+                        print(f"[CACHE DEBUG] Converted user message content to list and added cache point at index {idx} for model: {model_id}")
 
                     prompt_message_dicts[idx] = message
         # Print the final system and messages for debugging
         # print(f"[CACHE DEBUG] System messages: {json.dumps(system, default=str)}")
-        print(
-            f"[CACHE DEBUG] Prompt messages: {json.dumps(prompt_message_dicts, default=str)}"
-        )
+        print(f"[CACHE DEBUG] Prompt messages: {json.dumps(prompt_message_dicts, default=str)}")
 
         return system, prompt_message_dicts
 
-    def _convert_converse_tool_config(
-        self, tools: Optional[list[PromptMessageTool]] = None
-    ) -> dict:
+    def _convert_converse_tool_config(self, tools: Optional[list[PromptMessageTool]] = None) -> dict:
         tool_config = {}
         configs = []
         if tools:
@@ -1097,60 +820,46 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 sub_messages = []
                 for message_content in message.content:
                     if message_content.type == PromptMessageContentType.TEXT:
-                        message_content = cast(
-                            TextPromptMessageContent, message_content
-                        )
+                        message_content = cast(TextPromptMessageContent, message_content)
                         sub_message_dict = {"text": message_content.data}
                         sub_messages.append(sub_message_dict)
                     elif message_content.type == PromptMessageContentType.IMAGE:
-                        message_content = cast(
-                            ImagePromptMessageContent, message_content
-                        )
+                        message_content = cast(ImagePromptMessageContent, message_content)
                         data_split = message_content.data.split(";base64,")
                         mime_type = data_split[0].replace("data:", "")
                         base64_data = data_split[1]
                         image_content = base64.b64decode(base64_data)
 
-                        if mime_type not in {
-                            "image/jpeg",
-                            "image/png",
-                            "image/gif",
-                            "image/webp",
-                        }:
+                        if mime_type not in {"image/jpeg", "image/png", "image/gif", "image/webp"}:
                             raise ValueError(
                                 f"Unsupported image type {mime_type}, "
                                 f"only support image/jpeg, image/png, image/gif, and image/webp"
                             )
 
                         sub_message_dict = {
-                            "image": {
-                                "format": mime_type.replace("image/", ""),
-                                "source": {"bytes": image_content},
-                            }
+                            "image": {"format": mime_type.replace("image/", ""), "source": {"bytes": image_content}}
                         }
                         sub_messages.append(sub_message_dict)
 
                 message_dict = {"role": "user", "content": sub_messages}
         elif isinstance(message, AssistantPromptMessage):
             message = cast(AssistantPromptMessage, message)
-            message_dict = {"role": "assistant", "content": []}
+            message_dict = {
+                "role" : "assistant",
+                "content": []
+            }
 
             if message.tool_calls:
                 for tool_use in message.tool_calls:
-                    message_dict["content"].append(
-                        {
-                            "toolUse": {
-                                "toolUseId": tool_use.id,
-                                "name": tool_use.function.name,
-                                "input": json.loads(tool_use.function.arguments),
-                            }
+                    message_dict["content"].append({
+                        "toolUse": {
+                            "toolUseId": tool_use.id,
+                            "name": tool_use.function.name,
+                            "input": json.loads(tool_use.function.arguments),
                         }
-                    )
+                    })
             else:
-                message_dict = {
-                    "role": "assistant",
-                    "content": [{"text": message.content}],
-                }
+                message_dict = {"role": "assistant", "content": [{"text": message.content}]}
         elif isinstance(message, SystemPromptMessage):
             message = cast(SystemPromptMessage, message)
             message_dict = [{"text": message.content}]
@@ -1187,7 +896,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         :param tools: tools for tool calling
         :return:md = genai.GenerativeModel(model)
         """
-        if model.startswith("us.") or model.startswith("eu."):
+        if model.startswith('us.') or model.startswith('eu.'):
             prefix = model.split(".")[1]
             model_name = model.split(".")[2]
         else:
@@ -1197,18 +906,14 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if isinstance(prompt_messages, str):
             prompt = prompt_messages
         else:
-            prompt = self._convert_messages_to_prompt(
-                prompt_messages, prefix, model_name
-            )
+            prompt = self._convert_messages_to_prompt(prompt_messages, prefix, model_name)
 
         return self._get_num_tokens_by_gpt2(prompt)
 
-    def get_customizable_model_schema(
-        self, model: str, credentials: dict
-    ) -> Optional[AIModelEntity]:
+    def get_customizable_model_schema(self, model: str, credentials: dict) -> Optional[AIModelEntity]:
         """
         Get customizable model schema for inference profiles
-
+        
         :param model: model name
         :param credentials: model credentials
         :return: AIModelEntity
@@ -1217,14 +922,12 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if inference_profile_id:
             try:
                 # Get inference profile info from AWS directly
-                profile_info = get_inference_profile_info(
-                    inference_profile_id, credentials
-                )
-
+                profile_info = get_inference_profile_info(inference_profile_id, credentials)
+                
                 # Extract model name from profile
                 profile_name = profile_info.get("inferenceProfileName", model)
                 context_length = int(credentials.get("context_length", 4096))
-
+                
                 # Find matching predefined model based on underlying model ARN
                 default_pricing = None
                 matched_features = []
@@ -1234,61 +937,45 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     "context_size": context_length,
                 }
                 underlying_models = profile_info.get("models", [])
-
+                
                 if underlying_models:
                     first_model_arn = underlying_models[0].get("modelArn", "")
                     if "foundation-model/" in first_model_arn:
-                        underlying_model_id = first_model_arn.split(
-                            "foundation-model/"
-                        )[1]
+                        underlying_model_id = first_model_arn.split("foundation-model/")[1]
                         model_schemas = self.predefined_models()
-
+                        
                         # Try to get model-specific pricing based on the underlying model ID
                         # Map model ID to model name for pricing lookup
-                        model_name_for_pricing = self._map_model_id_to_name(
-                            underlying_model_id
-                        )
-
+                        model_name_for_pricing = self._map_model_id_to_name(underlying_model_id)
+                        
                         # First try to find individual model schema for pricing
                         if model_name_for_pricing:
-                            individual_pricing = self._get_model_specific_pricing(
-                                "", model_name_for_pricing, model_schemas
-                            )
+                            individual_pricing = self._get_model_specific_pricing("", model_name_for_pricing, model_schemas)
                             if individual_pricing:
                                 default_pricing = individual_pricing
-
+                        
                         # Then find matching schema for features and parameters
                         for model_schema in model_schemas:
-                            if self._model_id_matches_schema(
-                                underlying_model_id, model_schema
-                            ):
+                            if self._model_id_matches_schema(underlying_model_id, model_schema):
                                 # Use individual pricing if found, otherwise fall back to schema pricing
                                 if not default_pricing:
                                     default_pricing = model_schema.pricing
-
+                                    
                                 matched_features = model_schema.features or []
                                 # Extract allowed parameters from model schema, excluding model_name since it's determined by inference profile
-                                matched_parameter_rules = (
-                                    self._get_inference_profile_parameter_rules(
-                                        model_schema, underlying_model_id
-                                    )
-                                )
+                                matched_parameter_rules = self._get_inference_profile_parameter_rules(model_schema, underlying_model_id)
                                 if model_schema.model_properties:
-                                    matched_model_properties.update(
-                                        model_schema.model_properties
-                                    )
+                                    matched_model_properties.update(model_schema.model_properties)
                                     # Override context_size with user-specified value
-                                    matched_model_properties["context_size"] = (
-                                        context_length
-                                    )
+                                    matched_model_properties["context_size"] = context_length
                                 break
-
+                
                 # Fallback to first predefined model pricing if no match found
                 if not default_pricing:
                     model_schemas = self.predefined_models()
                     if model_schemas:
                         default_pricing = model_schemas[0].pricing
-
+                
                 # Use the user-provided model name exactly as entered
                 # Create custom model entity based on inference profile
                 return AIModelEntity(
@@ -1299,7 +986,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
                     model_properties=matched_model_properties,
                     parameter_rules=matched_parameter_rules,
-                    pricing=default_pricing,
+                    pricing=default_pricing
                 )
             except Exception as e:
                 logger.error(f"Failed to get inference profile schema: {str(e)}")
@@ -1311,11 +998,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 fallback_parameter_rules = []
                 if model_schemas:
                     # For fallback, we don't have underlying_model_id, so pass None to get all params except model_name
-                    fallback_parameter_rules = (
-                        self._get_inference_profile_parameter_rules(
-                            model_schemas[0], None
-                        )
-                    )
+                    fallback_parameter_rules = self._get_inference_profile_parameter_rules(model_schemas[0], None)
                 fallback_features = model_schemas[0].features if model_schemas else []
                 fallback_model_properties = {
                     "mode": LLMMode.CHAT,
@@ -1325,7 +1008,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 if model_schemas and model_schemas[0].model_properties:
                     fallback_model_properties.update(model_schemas[0].model_properties)
                     fallback_model_properties["context_size"] = context_length
-
+                
                 return AIModelEntity(
                     model=model,
                     label=I18nObject(en_US=model),
@@ -1334,11 +1017,12 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
                     model_properties=fallback_model_properties,
                     parameter_rules=fallback_parameter_rules,
-                    pricing=default_pricing,
+                    pricing=default_pricing
                 )
-
+        
         # This should not be reached for inference profile models, but keep as final fallback
         return None
+
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
         """
@@ -1354,47 +1038,44 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             if inference_profile_id:
                 # Validate inference profile directly
                 validate_inference_profile(inference_profile_id, credentials)
-                logger.info(
-                    f"Successfully validated inference profile: {inference_profile_id}"
-                )
+                logger.info(f"Successfully validated inference profile: {inference_profile_id}")
                 return
-
+            
             # Traditional model validation
             foundation_model_ids = self._list_foundation_models(credentials=credentials)
             cris_prefix = model_ids.get_region_area(credentials.get("aws_region"))
             if model.startswith(cris_prefix):
-                model = model.split(".", 1)[1]
+                model = model.split('.', 1)[1]
             logger.info(f"get model_ids: {foundation_model_ids}")
             if model not in foundation_model_ids:
                 raise ValueError(f"model id: {model} not found in bedrock")
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 
+
     def _list_foundation_models(self, credentials: dict) -> list[str]:
         """
         List available foundation models from Amazon Bedrock
         """
-
         def remove_context_window_suffix(model_ids):
             """
             使用正则表达式移除模型ID中的context window后缀
             """
             cleaned_ids = []
             for model_id in model_ids:
-                if model_id.endswith("k"):
-                    parts = model_id.split(":")
-                    model_id_no_suffix = ":".join(parts[:-1])
+                if model_id.endswith('k'):
+                    parts = model_id.split(':')
+                    model_id_no_suffix = ':'.join(parts[:-1])
                     cleaned_ids.append(model_id_no_suffix)
                 else:
                     cleaned_ids.append(model_id)
             return list(set(cleaned_ids))
-
         try:
             bedrock_client = get_bedrock_client("bedrock", credentials)
             response = bedrock_client.list_foundation_models()
             models = []
-            for model in response.get("modelSummaries", []):
-                models.append(model.get("modelId"))
+            for model in response.get('modelSummaries', []):
+                models.append(model.get('modelId'))
             return remove_context_window_suffix(models)
         except Exception as e:
             logger.info(f"Error listing Bedrock foundation models: {str(e)}")
@@ -1402,10 +1083,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             raise e
 
     def _convert_one_message_to_text(
-        self,
-        message: PromptMessage,
-        model_prefix: str,
-        model_name: Optional[str] = None,
+        self, message: PromptMessage, model_prefix: str, model_name: Optional[str] = None
     ) -> str:
         """
         Convert a single message to a string.
@@ -1422,9 +1100,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if isinstance(message, UserPromptMessage):
             body = content
             if isinstance(content, list):
-                body = "".join(
-                    [c.data for c in content if c.type == PromptMessageContentType.TEXT]
-                )
+                body = "".join([c.data for c in content if c.type == PromptMessageContentType.TEXT])
             message_text = f"{human_prompt_prefix} {body} {human_prompt_postfix}"
         elif isinstance(message, AssistantPromptMessage):
             message_text = f"{ai_prompt} {content}"
@@ -1438,10 +1114,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         return message_text
 
     def _convert_messages_to_prompt(
-        self,
-        messages: list[PromptMessage],
-        model_prefix: str,
-        model_name: Optional[str] = None,
+            self, messages: list[PromptMessage], model_prefix: str, model_name: Optional[str] = None
     ) -> str:
         """
         Format a list of messages into a full prompt for the Anthropic, Amazon and Llama models
@@ -1457,10 +1130,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if not isinstance(messages[-1], AssistantPromptMessage):
             messages.append(AssistantPromptMessage(content=""))
 
-        text = "".join(
-            self._convert_one_message_to_text(message, model_prefix, model_name)
-            for message in messages
-        )
+        text = "".join(self._convert_one_message_to_text(message, model_prefix, model_name) for message in messages)
 
         # trim off the trailing ' ' that might come from the "Assistant: "
         return text.rstrip()
@@ -1477,11 +1147,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         Create payload for bedrock api call depending on model provider
         """
         payload = {}
-        if (
-            model.startswith("us.")
-            or model.startswith("eu.")
-            or model.startswith("apac.")
-        ):
+        if model.startswith('us.') or model.startswith('eu.') or model.startswith('apac.'):
             model_prefix = model.split(".")[1]
         else:
             model_prefix = model.split(".")[0]
@@ -1490,9 +1156,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             payload["temperature"] = model_parameters.get("temperature")
             payload["topP"] = model_parameters.get("topP")
             payload["maxTokens"] = model_parameters.get("maxTokens")
-            payload["prompt"] = self._convert_messages_to_prompt(
-                prompt_messages, model_prefix
-            )
+            payload["prompt"] = self._convert_messages_to_prompt(prompt_messages, model_prefix)
 
             if model_parameters.get("presencePenalty"):
                 payload["presencePenalty"] = {model_parameters.get("presencePenalty")}
@@ -1536,9 +1200,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         bedrock_client = get_bedrock_client("bedrock-runtime", credentials)
 
         model_prefix = model.split(".")[0]
-        payload = self._create_payload(
-            model, prompt_messages, model_parameters, stop, stream
-        )
+        payload = self._create_payload(model, prompt_messages, model_parameters, stop, stream)
 
         # need workaround for ai21 models which doesn't support streaming
         if stream and model_prefix != "ai21":
@@ -1548,12 +1210,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
         try:
             body_jsonstr = json.dumps(payload)
-            response = invoke(
-                modelId=model,
-                contentType="application/json",
-                accept="*/*",
-                body=body_jsonstr,
-            )
+            response = invoke(modelId=model, contentType="application/json", accept="*/*", body=body_jsonstr)
         except ClientError as ex:
             error_code = ex.response["Error"]["Code"]
             full_error_msg = f"{error_code}: {ex.response['Error']['Message']}"
@@ -1569,20 +1226,12 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             raise InvokeError(str(ex))
 
         if stream:
-            return self._handle_generate_stream_response(
-                model, credentials, response, prompt_messages
-            )
+            return self._handle_generate_stream_response(model, credentials, response, prompt_messages)
 
-        return self._handle_generate_response(
-            model, credentials, response, prompt_messages
-        )
+        return self._handle_generate_response(model, credentials, response, prompt_messages)
 
     def _handle_generate_response(
-        self,
-        model: str,
-        credentials: dict,
-        response: dict,
-        prompt_messages: list[PromptMessage],
+        self, model: str, credentials: dict, response: dict, prompt_messages: list[PromptMessage]
     ) -> LLMResult:
         """
         Handle llm response
@@ -1606,9 +1255,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if model_prefix == "ai21":
             output = response_body.get("completions")[0].get("data").get("text")
             prompt_tokens = len(response_body.get("prompt").get("tokens"))
-            completion_tokens = len(
-                response_body.get("completions")[0].get("data").get("tokens")
-            )
+            completion_tokens = len(response_body.get("completions")[0].get("data").get("tokens"))
 
         elif model_prefix == "cohere":
             output = response_body.get("generations")[0].get("text")
@@ -1616,17 +1263,13 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             completion_tokens = self.get_num_tokens(model, credentials, output or "")
 
         else:
-            raise ValueError(
-                f"Got unknown model prefix {model_prefix} when handling block response"
-            )
+            raise ValueError(f"Got unknown model prefix {model_prefix} when handling block response")
 
         # construct assistant message from output
         assistant_prompt_message = AssistantPromptMessage(content=output)
 
         # calculate usage
-        usage = self._calc_response_usage(
-            model, credentials, prompt_tokens, completion_tokens
-        )
+        usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
 
         # construct response
         result = LLMResult(
@@ -1639,11 +1282,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         return result
 
     def _handle_generate_stream_response(
-        self,
-        model: str,
-        credentials: dict,
-        response: dict,
-        prompt_messages: list[PromptMessage],
+        self, model: str, credentials: dict, response: dict, prompt_messages: list[PromptMessage]
     ) -> Generator:
         """
         Handle llm stream response
@@ -1662,20 +1301,13 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             finish_reason = response_body.get("completions")[0].get("finish_reason")
 
             prompt_tokens = len(response_body.get("prompt").get("tokens"))
-            completion_tokens = len(
-                response_body.get("completions")[0].get("data").get("tokens")
-            )
-            usage = self._calc_response_usage(
-                model, credentials, prompt_tokens, completion_tokens
-            )
+            completion_tokens = len(response_body.get("completions")[0].get("data").get("tokens"))
+            usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
             yield LLMResultChunk(
                 model=model,
                 prompt_messages=prompt_messages,
                 delta=LLMResultChunkDelta(
-                    index=0,
-                    message=AssistantPromptMessage(content=content),
-                    finish_reason=finish_reason,
-                    usage=usage,
+                    index=0, message=AssistantPromptMessage(content=content), finish_reason=finish_reason, usage=usage
                 ),
             )
             return
@@ -1701,9 +1333,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 finish_reason = payload.get("finish_reason")
 
             else:
-                raise ValueError(
-                    f"Got unknown model prefix {model_prefix} when handling stream response"
-                )
+                raise ValueError(f"Got unknown model prefix {model_prefix} when handling stream response")
 
             # transform assistant message to prompt message
             assistant_prompt_message = AssistantPromptMessage(
@@ -1715,33 +1345,22 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 yield LLMResultChunk(
                     model=model,
                     prompt_messages=prompt_messages,
-                    delta=LLMResultChunkDelta(
-                        index=index, message=assistant_prompt_message
-                    ),
+                    delta=LLMResultChunkDelta(index=index, message=assistant_prompt_message),
                 )
 
             else:
                 # get num tokens from metrics in last chunk
-                prompt_tokens = payload["amazon-bedrock-invocationMetrics"][
-                    "inputTokenCount"
-                ]
-                completion_tokens = payload["amazon-bedrock-invocationMetrics"][
-                    "outputTokenCount"
-                ]
+                prompt_tokens = payload["amazon-bedrock-invocationMetrics"]["inputTokenCount"]
+                completion_tokens = payload["amazon-bedrock-invocationMetrics"]["outputTokenCount"]
 
                 # transform usage
-                usage = self._calc_response_usage(
-                    model, credentials, prompt_tokens, completion_tokens
-                )
+                usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
 
                 yield LLMResultChunk(
                     model=model,
                     prompt_messages=prompt_messages,
                     delta=LLMResultChunkDelta(
-                        index=index,
-                        message=assistant_prompt_message,
-                        finish_reason=finish_reason,
-                        usage=usage,
+                        index=index, message=assistant_prompt_message, finish_reason=finish_reason, usage=usage
                     ),
                 )
 
@@ -1763,9 +1382,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             InvokeBadRequestError: [],
         }
 
-    def _map_client_to_invoke_error(
-        self, error_code: str, error_msg: str
-    ) -> type[InvokeError]:
+    def _map_client_to_invoke_error(self, error_code: str, error_msg: str) -> type[InvokeError]:
         """
         Map client error to invoke error
 
@@ -1792,69 +1409,57 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
         return InvokeError(error_msg)
 
-    def _get_inference_profile_parameter_rules(
-        self, model_schema, underlying_model_id: str = None
-    ) -> list:
+    def _get_inference_profile_parameter_rules(self, model_schema, underlying_model_id: str = None) -> list:
         """
         Extract allowed parameter rules from model schema for inference profiles
-
+        
         :param model_schema: The predefined model schema
         :param underlying_model_id: The underlying model ID (for model-specific filtering)
         :return: List of parameter rules suitable for inference profiles
         """
         if not model_schema.parameter_rules:
             return []
-
+        
         # Always exclude model_name since it's determined by inference profile
-        excluded_params = ["model_name"]
-
+        excluded_params = ['model_name']
+        
         # Apply model-specific filtering if underlying_model_id is available
         allowed_parameter_rules = []
         for rule in model_schema.parameter_rules:
             if rule.name in excluded_params:
                 continue
-
+                
             # For Anthropic models, include response_format only if it's an Anthropic model
-            if rule.name == "response_format":
-                if (
-                    underlying_model_id
-                    and "anthropic.claude" not in underlying_model_id
-                ):
+            if rule.name == 'response_format':
+                if underlying_model_id and "anthropic.claude" not in underlying_model_id:
                     continue  # Skip response_format for non-Anthropic models
                 elif not underlying_model_id:
                     # Fallback case: only include if this is an Anthropic schema
-                    if not (
-                        hasattr(model_schema, "model")
-                        and model_schema.model == "anthropic claude"
-                    ):
+                    if not (hasattr(model_schema, 'model') and model_schema.model == "anthropic claude"):
                         continue
-
+            
             allowed_parameter_rules.append(rule)
-
+        
         return allowed_parameter_rules
 
     def _model_id_matches_schema(self, model_id: str, model_schema) -> bool:
         """
         Check if a model ID matches a predefined model schema
-
+        
         :param model_id: The model ID from inference profile (e.g., anthropic.claude-3-5-sonnet-20241022-v2:0)
         :param model_schema: The predefined model schema
         :return: True if the model ID matches the schema
         """
         # Extract the model family from the model ID and check individual models first
         if "anthropic.claude" in model_id:
-            return (
-                model_schema.model == "anthropic claude"
-                or model_schema.model.startswith("claude-")
-            )
+            return (model_schema.model == "anthropic claude" or 
+                   model_schema.model.startswith("claude-"))
         elif "amazon.nova" in model_id:
-            return model_schema.model == "amazon nova" or model_schema.model.startswith(
-                "nova-"
-            )
+            return (model_schema.model == "amazon nova" or 
+                   model_schema.model.startswith("nova-"))
         elif "cohere.command" in model_id:
-            return model_schema.model == "cohere" or model_schema.model.startswith(
-                "cohere-"
-            )
+            return (model_schema.model == "cohere" or 
+                   model_schema.model.startswith("cohere-"))
         elif "ai21" in model_id:
             return model_schema.model == "ai21"
         elif "meta.llama" in model_id:
@@ -1863,39 +1468,37 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             return model_schema.model == "mistral"
         elif "deepseek" in model_id:
             return model_schema.model == "deepseek"
-
+        
         return False
-
+    
     def _map_model_id_to_name(self, model_id: str) -> Optional[str]:
         """
         Map a Bedrock model ID to a model name for pricing lookup.
-
+        
         :param model_id: The Bedrock model ID (e.g., 'anthropic.claude-3-5-sonnet-20241022-v2:0')
         :return: The model name or None
         """
         # Reverse lookup from model_ids
         from . import model_ids
-
+        
         # Remove version suffix if present
-        base_model_id = model_id.split(":")[0] if ":" in model_id else model_id
-
+        base_model_id = model_id.split(':')[0] if ':' in model_id else model_id
+        
         # Search through all model families
         for family, models in model_ids.BEDROCK_MODEL_IDS.items():
             for name, id_value in models.items():
                 # Compare base IDs without version
-                base_id_value = id_value.split(":")[0] if ":" in id_value else id_value
+                base_id_value = id_value.split(':')[0] if ':' in id_value else id_value
                 if base_id_value == base_model_id or id_value == model_id:
                     return name
-
+        
         return None
-
-    def _get_model_specific_pricing(
-        self, model: str, model_name: str, model_schemas: list
-    ):
+    
+    def _get_model_specific_pricing(self, model: str, model_name: str, model_schemas: list):
         """
         Get model-specific pricing based on model name.
         First tries to find exact model match from model_configurations directory, then falls back to family pricing.
-
+        
         :param model: The model family (e.g., 'anthropic-claude')
         :param model_name: The specific model name (e.g., 'Claude 3.5 Sonnet')
         :param model_schemas: List of predefined model schemas
@@ -1904,87 +1507,82 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         # Create model name mapping for individual model files
         model_name_mapping = {
             # Claude models
-            "Claude 4.0 Sonnet": "claude-4-sonnet",
-            "Claude 4.0 Opus": "claude-4-opus",
-            "Claude 3.7 Sonnet": "claude-3-7-sonnet",
-            "Claude 3.5 Haiku": "claude-3-5-haiku",
-            "Claude 3.5 Sonnet": "claude-3-5-sonnet",
-            "Claude 3.5 Sonnet V2": "claude-3-5-sonnet",
-            "Claude 3 Haiku": "claude-3-haiku",
-            "Claude 3 Sonnet": "claude-3-sonnet",
-            "Claude 3 Opus": "claude-3-opus",
+            'Claude 4.0 Sonnet': 'claude-4-sonnet',
+            'Claude 4.0 Opus': 'claude-4-opus',
+            'Claude 3.7 Sonnet': 'claude-3-7-sonnet',
+            'Claude 3.5 Haiku': 'claude-3-5-haiku',
+            'Claude 3.5 Sonnet': 'claude-3-5-sonnet', 
+            'Claude 3.5 Sonnet V2': 'claude-3-5-sonnet',
+            'Claude 3 Haiku': 'claude-3-haiku',
+            'Claude 3 Sonnet': 'claude-3-sonnet',
+            'Claude 3 Opus': 'claude-3-opus',
             # Nova models
-            "Nova Micro": "nova-micro",
-            "Nova Lite": "nova-lite",
-            "Nova Pro": "nova-pro",
+            'Nova Micro': 'nova-micro',
+            'Nova Lite': 'nova-lite',
+            'Nova Pro': 'nova-pro',
             # Cohere models
-            "Command": "cohere-command",
-            "Command Light": "cohere-command-light",
-            "Command R": "cohere-command-r",
-            "Command R+": "cohere-command-rplus",
+            'Command': 'cohere-command',
+            'Command Light': 'cohere-command-light',
+            'Command R': 'cohere-command-r',
+            'Command R+': 'cohere-command-rplus'
         }
-
+        
         # First, try to load individual model pricing from model_configurations subdirectory
         individual_model_name = model_name_mapping.get(model_name)
         if individual_model_name:
             try:
                 import os
                 import yaml
-
                 # Get the directory of this file
                 current_dir = os.path.dirname(os.path.abspath(__file__))
-                individual_model_path = os.path.join(
-                    current_dir, "model_configurations", f"{individual_model_name}.yaml"
-                )
-
+                individual_model_path = os.path.join(current_dir, 'model_configurations', f'{individual_model_name}.yaml')
+                
                 if os.path.exists(individual_model_path):
-                    with open(individual_model_path, "r", encoding="utf-8") as f:
+                    with open(individual_model_path, 'r', encoding='utf-8') as f:
                         model_config = yaml.safe_load(f)
-                        if "pricing" in model_config:
-                            return model_config["pricing"]
+                        if 'pricing' in model_config:
+                            return model_config['pricing']
             except Exception as e:
                 # If individual model file loading fails, continue to fallback
                 pass
-
+        
         # Fallback: try to find individual model in existing schemas (for backward compatibility)
         if individual_model_name:
             for schema in model_schemas:
                 if schema.model == individual_model_name:
                     return schema.pricing
-
+        
         # If no model family provided, skip family pricing lookup
         if not model:
             return None
-
+        
         # If no individual model found, try family pricing
         # Look for exact model match first
         for schema in model_schemas:
             if schema.model == model:
                 return schema.pricing
-
+        
         # If exact match not found, try with different formats
         # Sometimes model might be passed as 'anthropic claude' vs 'anthropic-claude'
         model_variants = [
-            model.replace("-", " "),  # 'anthropic-claude' -> 'anthropic claude'
-            model.replace(" ", "-"),  # 'anthropic claude' -> 'anthropic-claude'
+            model.replace('-', ' '),  # 'anthropic-claude' -> 'anthropic claude'
+            model.replace(' ', '-'),  # 'anthropic claude' -> 'anthropic-claude'
             model.lower(),
-            model.lower().replace("-", " "),
-            model.lower().replace(" ", "-"),
+            model.lower().replace('-', ' '),
+            model.lower().replace(' ', '-')
         ]
-
+        
         for schema in model_schemas:
             for variant in model_variants:
                 if schema.model == variant:
                     return schema.pricing
-
+                    
         return None
-
-    def _calc_response_usage(
-        self, model: str, credentials: dict, prompt_tokens: int, completion_tokens: int
-    ):
+    
+    def _calc_response_usage(self, model: str, credentials: dict, prompt_tokens: int, completion_tokens: int):
         """
         Calculate response usage with per-model pricing support.
-
+        
         :param model: model name
         :param credentials: model credentials
         :param prompt_tokens: number of prompt tokens
@@ -1992,47 +1590,43 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         :return: LLMUsage
         """
         # Get model-specific pricing if available
-        model_parameters = credentials.get("model_parameters", {})
-        model_name = model_parameters.get("model_name")
-
+        model_parameters = credentials.get('model_parameters', {})
+        model_name = model_parameters.get('model_name')
+        
         if model_name:
             # Try to get model-specific pricing
             model_schemas = self.predefined_models()
-            model_pricing = self._get_model_specific_pricing(
-                model, model_name, model_schemas
-            )
-
+            model_pricing = self._get_model_specific_pricing(model, model_name, model_schemas)
+            
             if model_pricing:
                 # Use model-specific pricing
                 from dify_plugin.entities.model.llm import LLMUsage
-
+                
                 # Handle both dict and object pricing formats
                 if isinstance(model_pricing, dict):
-                    input_price = float(model_pricing["input"])
-                    output_price = float(model_pricing["output"])
-                    unit_price = float(model_pricing["unit"])
-                    currency = model_pricing.get("currency", "USD")
+                    input_price = float(model_pricing['input'])
+                    output_price = float(model_pricing['output'])
+                    unit_price = float(model_pricing['unit'])
+                    currency = model_pricing.get('currency', 'USD')
                 else:
                     # Object with attributes
                     input_price = float(model_pricing.input)
                     output_price = float(model_pricing.output)
                     unit_price = float(model_pricing.unit)
                     currency = model_pricing.currency
-
+                
                 # Calculate costs correctly: (tokens × price) ÷ unit_tokens
                 input_cost = (prompt_tokens * input_price) / (1.0 / unit_price)
                 output_cost = (completion_tokens * output_price) / (1.0 / unit_price)
-
+                
                 # Round to avoid floating point precision issues
                 input_cost = round(input_cost, 8)
                 output_cost = round(output_cost, 8)
                 total_cost = round(input_cost + output_cost, 8)
-
+                
                 # Get latency from parent class by calling it first
-                parent_usage = super()._calc_response_usage(
-                    model, credentials, prompt_tokens, completion_tokens
-                )
-
+                parent_usage = super()._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+                
                 return LLMUsage(
                     prompt_tokens=prompt_tokens,
                     prompt_unit_price=input_price,
@@ -2047,8 +1641,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     currency=currency,
                     latency=parent_usage.latency,  # Use parent's latency calculation
                 )
-
+        
         # Fallback to parent class implementation
-        return super()._calc_response_usage(
-            model, credentials, prompt_tokens, completion_tokens
-        )
+        return super()._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+    

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -57,9 +57,12 @@ from . import model_ids
 from utils.inference_profile import (
     get_inference_profile_info,
     validate_inference_profile,
-    extract_model_info_from_profile
+    extract_model_info_from_profile,
 )
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 
 logger = logging.getLogger(__name__)
 ANTHROPIC_BLOCK_MODE_PROMPT = """You should always follow the instructions and output a valid {{block}} object.
@@ -76,26 +79,106 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
     # please refer to the documentation: https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
     # TODO There is invoke issue: context limit on Cohere Model, will add them after fixed.
     CONVERSE_API_ENABLED_MODEL_INFO = [
-        {"prefix": "us.deepseek", "support_system_prompts": True, "support_tool_use": False},
-        {"prefix": "us.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "eu.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "apac.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "amazon.nova", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "us.amazon.nova", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "eu.amazon.nova", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "apac.amazon.nova", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "us.meta.llama", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "eu.meta.llama", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "apac.meta.llama", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "meta.llama", "support_system_prompts": True, "support_tool_use": False},
-        {"prefix": "mistral.mistral-7b-instruct", "support_system_prompts": False, "support_tool_use": False},
-        {"prefix": "mistral.mixtral-8x7b-instruct", "support_system_prompts": False, "support_tool_use": False},
-        {"prefix": "mistral.mistral-large", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "mistral.mistral-small", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "cohere.command-r", "support_system_prompts": True, "support_tool_use": True},
-        {"prefix": "amazon.titan", "support_system_prompts": False, "support_tool_use": False},
-        {"prefix": "ai21.jamba-1-5", "support_system_prompts": True, "support_tool_use": False},
+        {
+            "prefix": "us.deepseek",
+            "support_system_prompts": True,
+            "support_tool_use": False,
+        },
+        {
+            "prefix": "us.anthropic.claude",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "eu.anthropic.claude",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "apac.anthropic.claude",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "anthropic.claude",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "amazon.nova",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "us.amazon.nova",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "eu.amazon.nova",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "apac.amazon.nova",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "us.meta.llama",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "eu.meta.llama",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "apac.meta.llama",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "meta.llama",
+            "support_system_prompts": True,
+            "support_tool_use": False,
+        },
+        {
+            "prefix": "mistral.mistral-7b-instruct",
+            "support_system_prompts": False,
+            "support_tool_use": False,
+        },
+        {
+            "prefix": "mistral.mixtral-8x7b-instruct",
+            "support_system_prompts": False,
+            "support_tool_use": False,
+        },
+        {
+            "prefix": "mistral.mistral-large",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "mistral.mistral-small",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "cohere.command-r",
+            "support_system_prompts": True,
+            "support_tool_use": True,
+        },
+        {
+            "prefix": "amazon.titan",
+            "support_system_prompts": False,
+            "support_tool_use": False,
+        },
+        {
+            "prefix": "ai21.jamba-1-5",
+            "support_system_prompts": True,
+            "support_tool_use": False,
+        },
     ]
 
     @staticmethod
@@ -107,15 +190,15 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         return None
 
     def _code_block_mode_wrapper(
-            self,
-            model: str,
-            credentials: dict,
-            prompt_messages: list[PromptMessage],
-            model_parameters: dict,
-            tools: Optional[list[PromptMessageTool]] = None,
-            stop: Optional[list[str]] = None,
-            stream: bool = True,
-            user: Optional[str] = None,
+        self,
+        model: str,
+        credentials: dict,
+        prompt_messages: list[PromptMessage],
+        model_parameters: dict,
+        tools: Optional[list[PromptMessageTool]] = None,
+        stop: Optional[list[str]] = None,
+        stream: bool = True,
+        user: Optional[str] = None,
     ) -> Union[LLMResult, Generator]:
         """
         Code block mode wrapper for invoking large language model
@@ -128,16 +211,29 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 stop.append("\n```")
             response_format = model_parameters.pop("response_format")
             format_prompt = SystemPromptMessage(
-                content=ANTHROPIC_BLOCK_MODE_PROMPT.replace("{{instructions}}", prompt_messages[0].content).replace(
-                    "{{block}}", response_format
-                )
+                content=ANTHROPIC_BLOCK_MODE_PROMPT.replace(
+                    "{{instructions}}", prompt_messages[0].content
+                ).replace("{{block}}", response_format)
             )
-            if len(prompt_messages) > 0 and isinstance(prompt_messages[0], SystemPromptMessage):
+            if len(prompt_messages) > 0 and isinstance(
+                prompt_messages[0], SystemPromptMessage
+            ):
                 prompt_messages[0] = format_prompt
             else:
                 prompt_messages.insert(0, format_prompt)
-            prompt_messages.append(AssistantPromptMessage(content=f"\n```{response_format}"))
-        return self._invoke(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
+            prompt_messages.append(
+                AssistantPromptMessage(content=f"\n```{response_format}")
+            )
+        return self._invoke(
+            model,
+            credentials,
+            prompt_messages,
+            model_parameters,
+            tools,
+            stop,
+            stream,
+            user,
+        )
 
     def _invoke(
         self,
@@ -173,16 +269,20 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     # Handle response_format for inference profiles only if underlying model is Anthropic
                     if model_parameters.get("response_format"):
                         # Check if the underlying model is Anthropic based
-                        profile_info = get_inference_profile_info(inference_profile_id, credentials)
+                        profile_info = get_inference_profile_info(
+                            inference_profile_id, credentials
+                        )
                         underlying_models = profile_info.get("models", [])
                         is_anthropic = False
-                        
+
                         if underlying_models:
                             first_model_arn = underlying_models[0].get("modelArn", "")
                             if "foundation-model/" in first_model_arn:
-                                underlying_model_id = first_model_arn.split("foundation-model/")[1]
+                                underlying_model_id = first_model_arn.split(
+                                    "foundation-model/"
+                                )[1]
                                 is_anthropic = "anthropic.claude" in underlying_model_id
-                        
+
                         if is_anthropic:
                             stop = stop or []
                             if "```\n" not in stop:
@@ -191,53 +291,89 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                                 stop.append("\n```")
                             response_format = model_parameters.pop("response_format")
                             format_prompt = SystemPromptMessage(
-                                content=ANTHROPIC_BLOCK_MODE_PROMPT.replace("{{instructions}}", prompt_messages[0].content).replace(
-                                    "{{block}}", response_format
-                                )
+                                content=ANTHROPIC_BLOCK_MODE_PROMPT.replace(
+                                    "{{instructions}}", prompt_messages[0].content
+                                ).replace("{{block}}", response_format)
                             )
-                            if len(prompt_messages) > 0 and isinstance(prompt_messages[0], SystemPromptMessage):
+                            if len(prompt_messages) > 0 and isinstance(
+                                prompt_messages[0], SystemPromptMessage
+                            ):
                                 prompt_messages[0] = format_prompt
                             else:
                                 prompt_messages.insert(0, format_prompt)
-                            prompt_messages.append(AssistantPromptMessage(content=f"\n```{response_format}"))
+                            prompt_messages.append(
+                                AssistantPromptMessage(
+                                    content=f"\n```{response_format}"
+                                )
+                            )
                         else:
                             # For non-Anthropic models, just remove response_format parameter
                             model_parameters.pop("response_format", None)
-                    
+
                     return self._generate_with_converse(
-                        model_info, credentials, prompt_messages, model_parameters, stop, stream, user, tools, model
+                        model_info,
+                        credentials,
+                        prompt_messages,
+                        model_parameters,
+                        stop,
+                        stream,
+                        user,
+                        tools,
+                        model,
                     )
                 else:
-                    raise InvokeError(f"Could not get model information for inference profile {inference_profile_id}")
+                    raise InvokeError(
+                        f"Could not get model information for inference profile {inference_profile_id}"
+                    )
             except Exception as e:
                 logger.error(f"Failed to invoke inference profile: {str(e)}")
-                raise InvokeError(f"Failed to invoke inference profile {inference_profile_id}: {str(e)}")
+                raise InvokeError(
+                    f"Failed to invoke inference profile {inference_profile_id}: {str(e)}"
+                )
         else:
             # Traditional model - try converse API first, then fall back if needed
             try:
                 model_info = self._get_model_info(model, credentials, model_parameters)
                 if model_info:
                     return self._generate_with_converse(
-                        model_info, credentials, prompt_messages, model_parameters, stop, stream, user, tools, model
+                        model_info,
+                        credentials,
+                        prompt_messages,
+                        model_parameters,
+                        stop,
+                        stream,
+                        user,
+                        tools,
+                        model,
                     )
             except Exception as e:
                 logger.error(f"Failed to get model info: {str(e)}")
-            
+
             # Fallback to traditional model ID for non-converse API models
-            model_name = model_parameters.get('model_name')
+            model_name = model_parameters.get("model_name")
             if not model_name:
                 raise InvokeError("Model name is required for non-converse API models")
 
         model_id = model_ids.get_model_id(model, model_name)
         # Store model_name in credentials for pricing calculation
         credentials_with_model = credentials.copy()
-        credentials_with_model['model_parameters'] = {'model_name': model_name}
-        return self._generate(model_id, credentials_with_model, prompt_messages, model_parameters, stop, stream, user)
+        credentials_with_model["model_parameters"] = {"model_name": model_name}
+        return self._generate(
+            model_id,
+            credentials_with_model,
+            prompt_messages,
+            model_parameters,
+            stop,
+            stream,
+            user,
+        )
 
-    def _get_model_info(self, model: str, credentials: dict, model_parameters: dict) -> dict:
+    def _get_model_info(
+        self, model: str, credentials: dict, model_parameters: dict
+    ) -> dict:
         """
         Get model information for converse API
-        
+
         :param model: model name
         :param credentials: model credentials
         :param model_parameters: model parameters
@@ -250,7 +386,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             profile_arn = profile_info.get("inferenceProfileArn")
 
             if not profile_arn:
-                raise InvokeError(f"Could not get ARN for inference profile {inference_profile_id}")
+                raise InvokeError(
+                    f"Could not get ARN for inference profile {inference_profile_id}"
+                )
 
             # Use inference profile ARN as model ID
             model_id = profile_arn
@@ -265,42 +403,53 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 # Extract model ID from ARN
                 if "foundation-model/" in first_model_arn:
                     underlying_model_id = first_model_arn.split("foundation-model/")[1]
-                    model_info = BedrockLargeLanguageModel._find_model_info(underlying_model_id)
+                    model_info = BedrockLargeLanguageModel._find_model_info(
+                        underlying_model_id
+                    )
                     if model_info:
                         # Use the inference profile ARN but with underlying model capabilities
                         model_info = model_info.copy()
-                        model_info["model"] = model_id  # Use inference profile ARN for actual API call
-                        logger.info(f"Using inference profile {model_id} with capabilities from {underlying_model_id}")
+                        model_info["model"] = (
+                            model_id  # Use inference profile ARN for actual API call
+                        )
+                        model_info["underlying_model_id"] = underlying_model_id  # Store underlying model ID for cache support
+                        logger.info(
+                            f"Using inference profile {model_id} with capabilities from {underlying_model_id}"
+                        )
                         return model_info
             if not model_info:
-                logger.info(f"Using inference profile {model_id} with default capabilities")
+                logger.info(
+                    f"Using inference profile {model_id} with default capabilities"
+                )
                 return {
                     "model": model_id,
                     "support_system_prompts": True,
-                    "support_tool_use": True
+                    "support_tool_use": True,
                 }
         else:
             # Use traditional model ID resolution
-            model_name = model_parameters.pop('model_name')
+            model_name = model_parameters.pop("model_name")
             model_id = model_ids.get_model_id(model, model_name)
-            
+
             # Store model_name in credentials for pricing calculation
-            if 'model_parameters' not in credentials:
-                credentials['model_parameters'] = {}
-            credentials['model_parameters']['model_name'] = model_name
-            
-            if model_parameters.pop('cross-region', False):
-                region_name = credentials['aws_region']
+            if "model_parameters" not in credentials:
+                credentials["model_parameters"] = {}
+            credentials["model_parameters"]["model_name"] = model_name
+
+            if model_parameters.pop("cross-region", False):
+                region_name = credentials["aws_region"]
                 region_prefix = model_ids.get_region_area(region_name)
                 if not region_prefix:
-                    raise InvokeError(f'Region {region_name} Unsupport cross-region Inference')
+                    raise InvokeError(
+                        f"Region {region_name} Unsupport cross-region Inference"
+                    )
                 model_id = "{}.{}".format(region_prefix, model_id)
 
             model_info = BedrockLargeLanguageModel._find_model_info(model_id)
             if model_info:
                 model_info["model"] = model_id
                 return model_info
-            
+
             return None
 
     def _generate_with_converse(
@@ -330,28 +479,44 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
         # Get cache checkpoint settings from model parameters
         system_cache_checkpoint = model_parameters.pop("system_cache_checkpoint", True)
-        latest_two_messages_cache_checkpoint = model_parameters.pop("latest_two_messages_cache_checkpoint", False)
-        logger.info(f"---cache_checkpoints--- system: {system_cache_checkpoint}, penultimate: {latest_two_messages_cache_checkpoint}")
+        latest_two_messages_cache_checkpoint = model_parameters.pop(
+            "latest_two_messages_cache_checkpoint", False
+        )
+        logger.info(
+            f"---cache_checkpoints--- system: {system_cache_checkpoint}, penultimate: {latest_two_messages_cache_checkpoint}"
+        )
         model_id = model_info["model"]
-        print(f"[CACHE DEBUG] Model: {model_id}, Cache checkpoints - System: {system_cache_checkpoint}, Penultimate: {latest_two_messages_cache_checkpoint}")
-        logger.info(f"[CACHE DEBUG] Model: {model_id}, Cache checkpoints - System: {system_cache_checkpoint}, Penultimate: {latest_two_messages_cache_checkpoint}")
+        print(
+            f"[CACHE DEBUG] Model: {model_id}, Cache checkpoints - System: {system_cache_checkpoint}, Penultimate: {latest_two_messages_cache_checkpoint}"
+        )
+        logger.info(
+            f"[CACHE DEBUG] Model: {model_id}, Cache checkpoints - System: {system_cache_checkpoint}, Penultimate: {latest_two_messages_cache_checkpoint}"
+        )
 
         # Enable cache if either checkpoint is enabled
-        cache_supported = is_cache_supported(model_id)
-        print(f"[CACHE DEBUG] Model: {model_id}, Cache supported: {cache_supported}")
-        logger.info(f"[CACHE DEBUG] Model: {model_id}, Cache supported: {cache_supported}")
+        # For inference profiles, use underlying model ID for cache support check
+        cache_check_model_id = model_info.get("underlying_model_id", model_id)
+        cache_supported = is_cache_supported(cache_check_model_id)
+        print(f"[CACHE DEBUG] Model: {model_id}, Underlying: {cache_check_model_id}, Cache supported: {cache_supported}")
+        logger.info(
+            f"[CACHE DEBUG] Model: {model_id}, Underlying: {cache_check_model_id}, Cache supported: {cache_supported}"
+        )
         if cache_supported == False:
             system_cache_checkpoint = False
             latest_two_messages_cache_checkpoint = False
 
         # Convert messages with cache points if enabled
+        # For inference profiles, use underlying model ID for cache configuration
+        cache_config_model_id = model_info.get("underlying_model_id", model_id)
         system, prompt_message_dicts = self._convert_converse_prompt_messages(
             prompt_messages,
-            model_id=model_id,
+            model_id=cache_config_model_id,
             system_cache_checkpoint=system_cache_checkpoint,
-            latest_two_messages_cache_checkpoint=latest_two_messages_cache_checkpoint
+            latest_two_messages_cache_checkpoint=latest_two_messages_cache_checkpoint,
         )
-        inference_config, additional_model_fields = self._convert_converse_api_model_parameters(model_parameters, stop)
+        inference_config, additional_model_fields = (
+            self._convert_converse_api_model_parameters(model_parameters, stop)
+        )
 
         parameters = {
             "modelId": model_info["model"],
@@ -371,7 +536,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             # if two consecutive user messages found, combine them into one message
             for i in range(len(conversations_list) - 2, -1, -1):
                 if conversations_list[i]["role"] == conversations_list[i + 1]["role"]:
-                    conversations_list[i]["content"].extend(conversations_list.pop(i + 1)["content"])
+                    conversations_list[i]["content"].extend(
+                        conversations_list.pop(i + 1)["content"]
+                    )
 
             if stream:
                 response = bedrock_client.converse_stream(**parameters)
@@ -390,31 +557,51 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
                     # Extract cache metrics if available
                     cache_read_tokens = response["usage"].get("cacheReadInputTokens", 0)
-                    cache_write_tokens = response["usage"].get("cacheWriteInputTokens", 0)
+                    cache_write_tokens = response["usage"].get(
+                        "cacheWriteInputTokens", 0
+                    )
 
                     # Always log the metrics for debugging
-                    print(f"[CACHE METRICS] Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
-                    logger.info(f"[CACHE METRICS] Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
+                    print(
+                        f"[CACHE METRICS] Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
+                    )
+                    logger.info(
+                        f"[CACHE METRICS] Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
+                    )
 
                     # Print the full response usage for debugging
-                    print(f"[CACHE DEBUG] Response usage: {json.dumps(response['usage'], default=str)}")
+                    print(
+                        f"[CACHE DEBUG] Response usage: {json.dumps(response['usage'], default=str)}"
+                    )
 
                     # Log cache usage if any tokens were read or written
                     if cache_read_tokens > 0 or cache_write_tokens > 0:
-                        logger.info(f"Cache metrics - Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
+                        logger.info(
+                            f"Cache metrics - Model: {model_id}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
+                        )
                         # If tokens were read from cache, log the savings
                         if cache_read_tokens > 0:
-                            print(f"[CACHE HIT] {cache_read_tokens} tokens read from cache")
-                            logger.info(f"Cache hit detected - {cache_read_tokens} tokens read from cache")
+                            print(
+                                f"[CACHE HIT] {cache_read_tokens} tokens read from cache"
+                            )
+                            logger.info(
+                                f"Cache hit detected - {cache_read_tokens} tokens read from cache"
+                            )
                         elif cache_write_tokens > 0:
-                            print(f"[CACHE WRITE] {cache_write_tokens} tokens written to cache")
-                            logger.info(f"Cache write detected - {cache_write_tokens} tokens written to cache")
+                            print(
+                                f"[CACHE WRITE] {cache_write_tokens} tokens written to cache"
+                            )
+                            logger.info(
+                                f"Cache write detected - {cache_write_tokens} tokens written to cache"
+                            )
                 else:
                     # Log if usage data is missing
                     print(f"[WARNING] No usage data in response")
                     logger.warning(f"No usage data in response")
 
-                return self._handle_converse_response(model_info["model"], credentials, response, prompt_messages)
+                return self._handle_converse_response(
+                    model_info["model"], credentials, response, prompt_messages
+                )
         except ClientError as ex:
             error_code = ex.response["Error"]["Code"]
             full_error_msg = f"{error_code}: {ex.response['Error']['Message']}"
@@ -429,7 +616,11 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             raise InvokeError(str(ex))
 
     def _handle_converse_response(
-        self, model: str, credentials: dict, response: dict, prompt_messages: list[PromptMessage]
+        self,
+        model: str,
+        credentials: dict,
+        response: dict,
+        prompt_messages: list[PromptMessage],
     ) -> LLMResult:
         """
         Handle llm chat response
@@ -455,9 +646,13 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             )
             tool_calls.append(tool_call)
 
-            assistant_prompt_message = AssistantPromptMessage(content=text, tool_calls=tool_calls)
+            assistant_prompt_message = AssistantPromptMessage(
+                content=text, tool_calls=tool_calls
+            )
         else:
-            assistant_prompt_message = AssistantPromptMessage(content=response_content[0]["text"])
+            assistant_prompt_message = AssistantPromptMessage(
+                content=response_content[0]["text"]
+            )
 
         # calculate num tokens
         if response["usage"]:
@@ -470,17 +665,25 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             cache_write_tokens = response["usage"].get("cacheWriteInputTokens", 0)
 
             if cache_read_tokens > 0 or cache_write_tokens > 0:
-                logger.info(f"Cache metrics - Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
+                logger.info(
+                    f"Cache metrics - Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
+                )
                 # If tokens were read from cache, log the savings
                 if cache_read_tokens > 0:
-                    logger.info(f"Cache hit detected - {cache_read_tokens} tokens read from cache")
+                    logger.info(
+                        f"Cache hit detected - {cache_read_tokens} tokens read from cache"
+                    )
         else:
             # calculate num tokens
             prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
-            completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
+            completion_tokens = self.get_num_tokens(
+                model, credentials, [assistant_prompt_message]
+            )
 
         # transform usage
-        usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+        usage = self._calc_response_usage(
+            model, credentials, prompt_tokens, completion_tokens
+        )
 
         result = LLMResult(
             model=model,
@@ -544,41 +747,71 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     # Safely extract usage data with proper error handling
                     if "usage" in chunk["metadata"]:
                         input_tokens = chunk["metadata"]["usage"].get("inputTokens", 0)
-                        output_tokens = chunk["metadata"]["usage"].get("outputTokens", 0)
+                        output_tokens = chunk["metadata"]["usage"].get(
+                            "outputTokens", 0
+                        )
 
                         # Extract cache metrics if available
-                        cache_read_tokens = chunk["metadata"]["usage"].get("cacheReadInputTokens", 0)
-                        cache_write_tokens = chunk["metadata"]["usage"].get("cacheWriteInputTokens", 0)
+                        cache_read_tokens = chunk["metadata"]["usage"].get(
+                            "cacheReadInputTokens", 0
+                        )
+                        cache_write_tokens = chunk["metadata"]["usage"].get(
+                            "cacheWriteInputTokens", 0
+                        )
 
                         # Always log the metrics for debugging
-                        print(f"[STREAM CACHE METRICS] Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
-                        logger.info(f"[STREAM CACHE METRICS] Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
+                        print(
+                            f"[STREAM CACHE METRICS] Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
+                        )
+                        logger.info(
+                            f"[STREAM CACHE METRICS] Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
+                        )
 
                         # Print the full usage data for debugging
-                        print(f"[STREAM USAGE DATA] {json.dumps(chunk['metadata']['usage'], default=str)}")
+                        print(
+                            f"[STREAM USAGE DATA] {json.dumps(chunk['metadata']['usage'], default=str)}"
+                        )
 
                         # Log cache usage if any tokens were read or written
                         if cache_read_tokens > 0 or cache_write_tokens > 0:
-                            logger.info(f"Cache metrics - Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens")
+                            logger.info(
+                                f"Cache metrics - Model: {model}, Read: {cache_read_tokens} tokens, Write: {cache_write_tokens} tokens"
+                            )
                             # If tokens were read from cache, log the savings
                             if cache_read_tokens > 0:
-                                print(f"[STREAM CACHE HIT] {cache_read_tokens} tokens read from cache")
-                                logger.info(f"Cache hit detected - {cache_read_tokens} tokens read from cache")
+                                print(
+                                    f"[STREAM CACHE HIT] {cache_read_tokens} tokens read from cache"
+                                )
+                                logger.info(
+                                    f"Cache hit detected - {cache_read_tokens} tokens read from cache"
+                                )
                             elif cache_write_tokens > 0:
-                                print(f"[STREAM CACHE WRITE] {cache_write_tokens} tokens written to cache")
-                                logger.info(f"Cache write detected - {cache_write_tokens} tokens written to cache")
+                                print(
+                                    f"[STREAM CACHE WRITE] {cache_write_tokens} tokens written to cache"
+                                )
+                                logger.info(
+                                    f"Cache write detected - {cache_write_tokens} tokens written to cache"
+                                )
                     else:
                         # Log if usage data is missing
-                        print(f"[STREAM WARNING] No usage data in metadata: {json.dumps(chunk['metadata'], default=str)}")
-                        logger.warning(f"No usage data in metadata chunk: {json.dumps(chunk['metadata'], default=str)}")
+                        print(
+                            f"[STREAM WARNING] No usage data in metadata: {json.dumps(chunk['metadata'], default=str)}"
+                        )
+                        logger.warning(
+                            f"No usage data in metadata chunk: {json.dumps(chunk['metadata'], default=str)}"
+                        )
 
-                    usage = self._calc_response_usage(model, credentials, input_tokens, output_tokens)
+                    usage = self._calc_response_usage(
+                        model, credentials, input_tokens, output_tokens
+                    )
                     yield LLMResultChunk(
                         model=return_model,
                         prompt_messages=prompt_messages,
                         delta=LLMResultChunkDelta(
                             index=index,
-                            message=AssistantPromptMessage(content="", tool_calls=tool_calls),
+                            message=AssistantPromptMessage(
+                                content="", tool_calls=tool_calls
+                            ),
                             finish_reason=finish_reason,
                             usage=usage,
                         ),
@@ -586,7 +819,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 elif "contentBlockDelta" in chunk:
                     delta = chunk["contentBlockDelta"]["delta"]
                     if "reasoningContent" in delta:
-                        formatted_reasoning = ''
+                        formatted_reasoning = ""
                         if "text" in delta["reasoningContent"]:
                             # Get reasoning content text
                             reasoning_text = delta["reasoningContent"]["text"] or ""
@@ -637,7 +870,10 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 elif "contentBlockStop" in chunk:
                     # If reasoning was started but never completed (no text content followed)
                     # we need to close the thinking tag
-                    if reasoning_tailer_added is False and full_assistant_content.startswith("<think>"):
+                    if (
+                        reasoning_tailer_added is False
+                        and full_assistant_content.startswith("<think>")
+                    ):
                         assistant_prompt_message = AssistantPromptMessage(
                             content="\n</think>"
                         )
@@ -690,22 +926,27 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             additional_model_fields["top_k"] = model_parameters["top_k"]
 
         if "anthropic_beta" in model_parameters:
-            additional_model_fields["anthropic_beta"] = list(map(lambda v:v.strip(), model_parameters["anthropic_beta"].strip().split(",")))
+            additional_model_fields["anthropic_beta"] = list(
+                map(
+                    lambda v: v.strip(),
+                    model_parameters["anthropic_beta"].strip().split(","),
+                )
+            )
 
         # process reasoning related parameters, construct nested reasoning_config structure
         if "reasoning_type" in model_parameters:
             reasoning_type = model_parameters["reasoning_type"]
             if reasoning_type:
-                reasoning_config = {
-                    "type": "enabled"
-                }
+                reasoning_config = {"type": "enabled"}
                 # set budget_tokens, ensure at least 1024
                 budget_tokens = 1024
                 if "reasoning_budget" in model_parameters:
                     budget_tokens = max(1024, model_parameters["reasoning_budget"])
                 # make sure budget_tokens is less than max_tokens
                 if "max_tokens" in model_parameters:
-                    budget_tokens = min(budget_tokens, model_parameters["max_tokens"] - 1)
+                    budget_tokens = min(
+                        budget_tokens, model_parameters["max_tokens"] - 1
+                    )
                     reasoning_config["budget_tokens"] = budget_tokens
                 additional_model_fields["reasoning_config"] = reasoning_config
                 inference_config["temperature"] = 1
@@ -714,8 +955,13 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
         return inference_config, additional_model_fields
 
-    def _convert_converse_prompt_messages(self, prompt_messages: list[PromptMessage], model_id: str = None,
-        system_cache_checkpoint: bool = True, latest_two_messages_cache_checkpoint: bool = False) -> tuple[list, list[dict]]:
+    def _convert_converse_prompt_messages(
+        self,
+        prompt_messages: list[PromptMessage],
+        model_id: str = None,
+        system_cache_checkpoint: bool = True,
+        latest_two_messages_cache_checkpoint: bool = False,
+    ) -> tuple[list, list[dict]]:
         """
         Convert prompt messages to dict list and system
         Add cache points for supported models when enable_cache is True
@@ -733,8 +979,12 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         cache_config = get_cache_config(model_id)
 
         # Process system messages first
-        system_messages = [msg for msg in prompt_messages if isinstance(msg, SystemPromptMessage)]
-        other_messages = [msg for msg in prompt_messages if not isinstance(msg, SystemPromptMessage)]
+        system_messages = [
+            msg for msg in prompt_messages if isinstance(msg, SystemPromptMessage)
+        ]
+        other_messages = [
+            msg for msg in prompt_messages if not isinstance(msg, SystemPromptMessage)
+        ]
 
         # Add system messages
         for message in system_messages:
@@ -743,9 +993,16 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
             # Add cache point to system if it's not empty and caching is supported for system field
         # and system_cache_checkpoint is enabled
-        if system and cache_config and "system" in cache_config["supported_fields"] and system_cache_checkpoint:
+        if (
+            system
+            and cache_config
+            and "system" in cache_config["supported_fields"]
+            and system_cache_checkpoint
+        ):
             system.append({"cachePoint": {"type": "default"}})
-            print(f"[CACHE DEBUG] Added cache point to system messages for model: {model_id}")
+            print(
+                f"[CACHE DEBUG] Added cache point to system messages for model: {model_id}"
+            )
 
             # Process other messages
         for message in other_messages:
@@ -753,14 +1010,24 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             prompt_message_dicts.append(message_dict)
 
             # Only add cache point to messages if supported and latest_two_messages_cache_checkpoint is enabled
-        if cache_config and "messages" in cache_config["supported_fields"] and latest_two_messages_cache_checkpoint:
+        if (
+            cache_config
+            and "messages" in cache_config["supported_fields"]
+            and latest_two_messages_cache_checkpoint
+        ):
             # Find all user messages
-            user_message_indices = [i for i, msg in enumerate(prompt_message_dicts) if msg["role"] in ["user"]]
+            user_message_indices = [
+                i
+                for i, msg in enumerate(prompt_message_dicts)
+                if msg["role"] in ["user"]
+            ]
 
             # Add cache point to available user messages (up to the latest two)
             if len(user_message_indices) > 0:
                 # Get indices for the latest messages (either one or two depending on availability)
-                indices_to_cache = user_message_indices[-min(2, len(user_message_indices)):]
+                indices_to_cache = user_message_indices[
+                    -min(2, len(user_message_indices)) :
+                ]
                 print(f"[CACHE DEBUG] indices_to_cacheis {indices_to_cache}")
                 for idx in indices_to_cache:
                     message = prompt_message_dicts[idx]
@@ -770,21 +1037,32 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     if isinstance(message["content"], list):
                         # Add cache point to the content array
                         message["content"].append({"cachePoint": {"type": "default"}})
-                        print(f"[CACHE DEBUG] Added cache point to user message content list at index {idx} for model: {model_id}")
+                        print(
+                            f"[CACHE DEBUG] Added cache point to user message content list at index {idx} for model: {model_id}"
+                        )
                     else:
                         # If content is not a list, convert it to a list with the original content and add cache point
                         original_content = message["content"]
-                        message["content"] = [{"text": original_content}, {"cachePoint": {"type": "default"}}]
-                        print(f"[CACHE DEBUG] Converted user message content to list and added cache point at index {idx} for model: {model_id}")
+                        message["content"] = [
+                            {"text": original_content},
+                            {"cachePoint": {"type": "default"}},
+                        ]
+                        print(
+                            f"[CACHE DEBUG] Converted user message content to list and added cache point at index {idx} for model: {model_id}"
+                        )
 
                     prompt_message_dicts[idx] = message
         # Print the final system and messages for debugging
         # print(f"[CACHE DEBUG] System messages: {json.dumps(system, default=str)}")
-        print(f"[CACHE DEBUG] Prompt messages: {json.dumps(prompt_message_dicts, default=str)}")
+        print(
+            f"[CACHE DEBUG] Prompt messages: {json.dumps(prompt_message_dicts, default=str)}"
+        )
 
         return system, prompt_message_dicts
 
-    def _convert_converse_tool_config(self, tools: Optional[list[PromptMessageTool]] = None) -> dict:
+    def _convert_converse_tool_config(
+        self, tools: Optional[list[PromptMessageTool]] = None
+    ) -> dict:
         tool_config = {}
         configs = []
         if tools:
@@ -813,46 +1091,60 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 sub_messages = []
                 for message_content in message.content:
                     if message_content.type == PromptMessageContentType.TEXT:
-                        message_content = cast(TextPromptMessageContent, message_content)
+                        message_content = cast(
+                            TextPromptMessageContent, message_content
+                        )
                         sub_message_dict = {"text": message_content.data}
                         sub_messages.append(sub_message_dict)
                     elif message_content.type == PromptMessageContentType.IMAGE:
-                        message_content = cast(ImagePromptMessageContent, message_content)
+                        message_content = cast(
+                            ImagePromptMessageContent, message_content
+                        )
                         data_split = message_content.data.split(";base64,")
                         mime_type = data_split[0].replace("data:", "")
                         base64_data = data_split[1]
                         image_content = base64.b64decode(base64_data)
 
-                        if mime_type not in {"image/jpeg", "image/png", "image/gif", "image/webp"}:
+                        if mime_type not in {
+                            "image/jpeg",
+                            "image/png",
+                            "image/gif",
+                            "image/webp",
+                        }:
                             raise ValueError(
                                 f"Unsupported image type {mime_type}, "
                                 f"only support image/jpeg, image/png, image/gif, and image/webp"
                             )
 
                         sub_message_dict = {
-                            "image": {"format": mime_type.replace("image/", ""), "source": {"bytes": image_content}}
+                            "image": {
+                                "format": mime_type.replace("image/", ""),
+                                "source": {"bytes": image_content},
+                            }
                         }
                         sub_messages.append(sub_message_dict)
 
                 message_dict = {"role": "user", "content": sub_messages}
         elif isinstance(message, AssistantPromptMessage):
             message = cast(AssistantPromptMessage, message)
-            message_dict = {
-                "role" : "assistant",
-                "content": []
-            }
+            message_dict = {"role": "assistant", "content": []}
 
             if message.tool_calls:
                 for tool_use in message.tool_calls:
-                    message_dict["content"].append({
-                        "toolUse": {
-                            "toolUseId": tool_use.id,
-                            "name": tool_use.function.name,
-                            "input": json.loads(tool_use.function.arguments),
+                    message_dict["content"].append(
+                        {
+                            "toolUse": {
+                                "toolUseId": tool_use.id,
+                                "name": tool_use.function.name,
+                                "input": json.loads(tool_use.function.arguments),
+                            }
                         }
-                    })
+                    )
             else:
-                message_dict = {"role": "assistant", "content": [{"text": message.content}]}
+                message_dict = {
+                    "role": "assistant",
+                    "content": [{"text": message.content}],
+                }
         elif isinstance(message, SystemPromptMessage):
             message = cast(SystemPromptMessage, message)
             message_dict = [{"text": message.content}]
@@ -889,7 +1181,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         :param tools: tools for tool calling
         :return:md = genai.GenerativeModel(model)
         """
-        if model.startswith('us.') or model.startswith('eu.'):
+        if model.startswith("us.") or model.startswith("eu."):
             prefix = model.split(".")[1]
             model_name = model.split(".")[2]
         else:
@@ -899,14 +1191,18 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if isinstance(prompt_messages, str):
             prompt = prompt_messages
         else:
-            prompt = self._convert_messages_to_prompt(prompt_messages, prefix, model_name)
+            prompt = self._convert_messages_to_prompt(
+                prompt_messages, prefix, model_name
+            )
 
         return self._get_num_tokens_by_gpt2(prompt)
 
-    def get_customizable_model_schema(self, model: str, credentials: dict) -> Optional[AIModelEntity]:
+    def get_customizable_model_schema(
+        self, model: str, credentials: dict
+    ) -> Optional[AIModelEntity]:
         """
         Get customizable model schema for inference profiles
-        
+
         :param model: model name
         :param credentials: model credentials
         :return: AIModelEntity
@@ -915,12 +1211,14 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if inference_profile_id:
             try:
                 # Get inference profile info from AWS directly
-                profile_info = get_inference_profile_info(inference_profile_id, credentials)
-                
+                profile_info = get_inference_profile_info(
+                    inference_profile_id, credentials
+                )
+
                 # Extract model name from profile
                 profile_name = profile_info.get("inferenceProfileName", model)
                 context_length = int(credentials.get("context_length", 4096))
-                
+
                 # Find matching predefined model based on underlying model ARN
                 default_pricing = None
                 matched_features = []
@@ -930,45 +1228,61 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     "context_size": context_length,
                 }
                 underlying_models = profile_info.get("models", [])
-                
+
                 if underlying_models:
                     first_model_arn = underlying_models[0].get("modelArn", "")
                     if "foundation-model/" in first_model_arn:
-                        underlying_model_id = first_model_arn.split("foundation-model/")[1]
+                        underlying_model_id = first_model_arn.split(
+                            "foundation-model/"
+                        )[1]
                         model_schemas = self.predefined_models()
-                        
+
                         # Try to get model-specific pricing based on the underlying model ID
                         # Map model ID to model name for pricing lookup
-                        model_name_for_pricing = self._map_model_id_to_name(underlying_model_id)
-                        
+                        model_name_for_pricing = self._map_model_id_to_name(
+                            underlying_model_id
+                        )
+
                         # First try to find individual model schema for pricing
                         if model_name_for_pricing:
-                            individual_pricing = self._get_model_specific_pricing("", model_name_for_pricing, model_schemas)
+                            individual_pricing = self._get_model_specific_pricing(
+                                "", model_name_for_pricing, model_schemas
+                            )
                             if individual_pricing:
                                 default_pricing = individual_pricing
-                        
+
                         # Then find matching schema for features and parameters
                         for model_schema in model_schemas:
-                            if self._model_id_matches_schema(underlying_model_id, model_schema):
+                            if self._model_id_matches_schema(
+                                underlying_model_id, model_schema
+                            ):
                                 # Use individual pricing if found, otherwise fall back to schema pricing
                                 if not default_pricing:
                                     default_pricing = model_schema.pricing
-                                    
+
                                 matched_features = model_schema.features or []
                                 # Extract allowed parameters from model schema, excluding model_name since it's determined by inference profile
-                                matched_parameter_rules = self._get_inference_profile_parameter_rules(model_schema, underlying_model_id)
+                                matched_parameter_rules = (
+                                    self._get_inference_profile_parameter_rules(
+                                        model_schema, underlying_model_id
+                                    )
+                                )
                                 if model_schema.model_properties:
-                                    matched_model_properties.update(model_schema.model_properties)
+                                    matched_model_properties.update(
+                                        model_schema.model_properties
+                                    )
                                     # Override context_size with user-specified value
-                                    matched_model_properties["context_size"] = context_length
+                                    matched_model_properties["context_size"] = (
+                                        context_length
+                                    )
                                 break
-                
+
                 # Fallback to first predefined model pricing if no match found
                 if not default_pricing:
                     model_schemas = self.predefined_models()
                     if model_schemas:
                         default_pricing = model_schemas[0].pricing
-                
+
                 # Use the user-provided model name exactly as entered
                 # Create custom model entity based on inference profile
                 return AIModelEntity(
@@ -979,7 +1293,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
                     model_properties=matched_model_properties,
                     parameter_rules=matched_parameter_rules,
-                    pricing=default_pricing
+                    pricing=default_pricing,
                 )
             except Exception as e:
                 logger.error(f"Failed to get inference profile schema: {str(e)}")
@@ -991,7 +1305,11 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 fallback_parameter_rules = []
                 if model_schemas:
                     # For fallback, we don't have underlying_model_id, so pass None to get all params except model_name
-                    fallback_parameter_rules = self._get_inference_profile_parameter_rules(model_schemas[0], None)
+                    fallback_parameter_rules = (
+                        self._get_inference_profile_parameter_rules(
+                            model_schemas[0], None
+                        )
+                    )
                 fallback_features = model_schemas[0].features if model_schemas else []
                 fallback_model_properties = {
                     "mode": LLMMode.CHAT,
@@ -1001,7 +1319,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 if model_schemas and model_schemas[0].model_properties:
                     fallback_model_properties.update(model_schemas[0].model_properties)
                     fallback_model_properties["context_size"] = context_length
-                
+
                 return AIModelEntity(
                     model=model,
                     label=I18nObject(en_US=model),
@@ -1010,12 +1328,11 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
                     model_properties=fallback_model_properties,
                     parameter_rules=fallback_parameter_rules,
-                    pricing=default_pricing
+                    pricing=default_pricing,
                 )
-        
+
         # This should not be reached for inference profile models, but keep as final fallback
         return None
-
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
         """
@@ -1031,44 +1348,47 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             if inference_profile_id:
                 # Validate inference profile directly
                 validate_inference_profile(inference_profile_id, credentials)
-                logger.info(f"Successfully validated inference profile: {inference_profile_id}")
+                logger.info(
+                    f"Successfully validated inference profile: {inference_profile_id}"
+                )
                 return
-            
+
             # Traditional model validation
             foundation_model_ids = self._list_foundation_models(credentials=credentials)
             cris_prefix = model_ids.get_region_area(credentials.get("aws_region"))
             if model.startswith(cris_prefix):
-                model = model.split('.', 1)[1]
+                model = model.split(".", 1)[1]
             logger.info(f"get model_ids: {foundation_model_ids}")
             if model not in foundation_model_ids:
                 raise ValueError(f"model id: {model} not found in bedrock")
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 
-
     def _list_foundation_models(self, credentials: dict) -> list[str]:
         """
         List available foundation models from Amazon Bedrock
         """
+
         def remove_context_window_suffix(model_ids):
             """
             使用正则表达式移除模型ID中的context window后缀
             """
             cleaned_ids = []
             for model_id in model_ids:
-                if model_id.endswith('k'):
-                    parts = model_id.split(':')
-                    model_id_no_suffix = ':'.join(parts[:-1])
+                if model_id.endswith("k"):
+                    parts = model_id.split(":")
+                    model_id_no_suffix = ":".join(parts[:-1])
                     cleaned_ids.append(model_id_no_suffix)
                 else:
                     cleaned_ids.append(model_id)
             return list(set(cleaned_ids))
+
         try:
             bedrock_client = get_bedrock_client("bedrock", credentials)
             response = bedrock_client.list_foundation_models()
             models = []
-            for model in response.get('modelSummaries', []):
-                models.append(model.get('modelId'))
+            for model in response.get("modelSummaries", []):
+                models.append(model.get("modelId"))
             return remove_context_window_suffix(models)
         except Exception as e:
             logger.info(f"Error listing Bedrock foundation models: {str(e)}")
@@ -1076,7 +1396,10 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             raise e
 
     def _convert_one_message_to_text(
-        self, message: PromptMessage, model_prefix: str, model_name: Optional[str] = None
+        self,
+        message: PromptMessage,
+        model_prefix: str,
+        model_name: Optional[str] = None,
     ) -> str:
         """
         Convert a single message to a string.
@@ -1093,7 +1416,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if isinstance(message, UserPromptMessage):
             body = content
             if isinstance(content, list):
-                body = "".join([c.data for c in content if c.type == PromptMessageContentType.TEXT])
+                body = "".join(
+                    [c.data for c in content if c.type == PromptMessageContentType.TEXT]
+                )
             message_text = f"{human_prompt_prefix} {body} {human_prompt_postfix}"
         elif isinstance(message, AssistantPromptMessage):
             message_text = f"{ai_prompt} {content}"
@@ -1107,7 +1432,10 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         return message_text
 
     def _convert_messages_to_prompt(
-            self, messages: list[PromptMessage], model_prefix: str, model_name: Optional[str] = None
+        self,
+        messages: list[PromptMessage],
+        model_prefix: str,
+        model_name: Optional[str] = None,
     ) -> str:
         """
         Format a list of messages into a full prompt for the Anthropic, Amazon and Llama models
@@ -1123,7 +1451,10 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if not isinstance(messages[-1], AssistantPromptMessage):
             messages.append(AssistantPromptMessage(content=""))
 
-        text = "".join(self._convert_one_message_to_text(message, model_prefix, model_name) for message in messages)
+        text = "".join(
+            self._convert_one_message_to_text(message, model_prefix, model_name)
+            for message in messages
+        )
 
         # trim off the trailing ' ' that might come from the "Assistant: "
         return text.rstrip()
@@ -1140,7 +1471,11 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         Create payload for bedrock api call depending on model provider
         """
         payload = {}
-        if model.startswith('us.') or model.startswith('eu.') or model.startswith('apac.'):
+        if (
+            model.startswith("us.")
+            or model.startswith("eu.")
+            or model.startswith("apac.")
+        ):
             model_prefix = model.split(".")[1]
         else:
             model_prefix = model.split(".")[0]
@@ -1149,7 +1484,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             payload["temperature"] = model_parameters.get("temperature")
             payload["topP"] = model_parameters.get("topP")
             payload["maxTokens"] = model_parameters.get("maxTokens")
-            payload["prompt"] = self._convert_messages_to_prompt(prompt_messages, model_prefix)
+            payload["prompt"] = self._convert_messages_to_prompt(
+                prompt_messages, model_prefix
+            )
 
             if model_parameters.get("presencePenalty"):
                 payload["presencePenalty"] = {model_parameters.get("presencePenalty")}
@@ -1193,7 +1530,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         bedrock_client = get_bedrock_client("bedrock-runtime", credentials)
 
         model_prefix = model.split(".")[0]
-        payload = self._create_payload(model, prompt_messages, model_parameters, stop, stream)
+        payload = self._create_payload(
+            model, prompt_messages, model_parameters, stop, stream
+        )
 
         # need workaround for ai21 models which doesn't support streaming
         if stream and model_prefix != "ai21":
@@ -1203,7 +1542,12 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
         try:
             body_jsonstr = json.dumps(payload)
-            response = invoke(modelId=model, contentType="application/json", accept="*/*", body=body_jsonstr)
+            response = invoke(
+                modelId=model,
+                contentType="application/json",
+                accept="*/*",
+                body=body_jsonstr,
+            )
         except ClientError as ex:
             error_code = ex.response["Error"]["Code"]
             full_error_msg = f"{error_code}: {ex.response['Error']['Message']}"
@@ -1219,12 +1563,20 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             raise InvokeError(str(ex))
 
         if stream:
-            return self._handle_generate_stream_response(model, credentials, response, prompt_messages)
+            return self._handle_generate_stream_response(
+                model, credentials, response, prompt_messages
+            )
 
-        return self._handle_generate_response(model, credentials, response, prompt_messages)
+        return self._handle_generate_response(
+            model, credentials, response, prompt_messages
+        )
 
     def _handle_generate_response(
-        self, model: str, credentials: dict, response: dict, prompt_messages: list[PromptMessage]
+        self,
+        model: str,
+        credentials: dict,
+        response: dict,
+        prompt_messages: list[PromptMessage],
     ) -> LLMResult:
         """
         Handle llm response
@@ -1248,7 +1600,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if model_prefix == "ai21":
             output = response_body.get("completions")[0].get("data").get("text")
             prompt_tokens = len(response_body.get("prompt").get("tokens"))
-            completion_tokens = len(response_body.get("completions")[0].get("data").get("tokens"))
+            completion_tokens = len(
+                response_body.get("completions")[0].get("data").get("tokens")
+            )
 
         elif model_prefix == "cohere":
             output = response_body.get("generations")[0].get("text")
@@ -1256,13 +1610,17 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             completion_tokens = self.get_num_tokens(model, credentials, output or "")
 
         else:
-            raise ValueError(f"Got unknown model prefix {model_prefix} when handling block response")
+            raise ValueError(
+                f"Got unknown model prefix {model_prefix} when handling block response"
+            )
 
         # construct assistant message from output
         assistant_prompt_message = AssistantPromptMessage(content=output)
 
         # calculate usage
-        usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+        usage = self._calc_response_usage(
+            model, credentials, prompt_tokens, completion_tokens
+        )
 
         # construct response
         result = LLMResult(
@@ -1275,7 +1633,11 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         return result
 
     def _handle_generate_stream_response(
-        self, model: str, credentials: dict, response: dict, prompt_messages: list[PromptMessage]
+        self,
+        model: str,
+        credentials: dict,
+        response: dict,
+        prompt_messages: list[PromptMessage],
     ) -> Generator:
         """
         Handle llm stream response
@@ -1294,13 +1656,20 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             finish_reason = response_body.get("completions")[0].get("finish_reason")
 
             prompt_tokens = len(response_body.get("prompt").get("tokens"))
-            completion_tokens = len(response_body.get("completions")[0].get("data").get("tokens"))
-            usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+            completion_tokens = len(
+                response_body.get("completions")[0].get("data").get("tokens")
+            )
+            usage = self._calc_response_usage(
+                model, credentials, prompt_tokens, completion_tokens
+            )
             yield LLMResultChunk(
                 model=model,
                 prompt_messages=prompt_messages,
                 delta=LLMResultChunkDelta(
-                    index=0, message=AssistantPromptMessage(content=content), finish_reason=finish_reason, usage=usage
+                    index=0,
+                    message=AssistantPromptMessage(content=content),
+                    finish_reason=finish_reason,
+                    usage=usage,
                 ),
             )
             return
@@ -1326,7 +1695,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 finish_reason = payload.get("finish_reason")
 
             else:
-                raise ValueError(f"Got unknown model prefix {model_prefix} when handling stream response")
+                raise ValueError(
+                    f"Got unknown model prefix {model_prefix} when handling stream response"
+                )
 
             # transform assistant message to prompt message
             assistant_prompt_message = AssistantPromptMessage(
@@ -1338,22 +1709,33 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 yield LLMResultChunk(
                     model=model,
                     prompt_messages=prompt_messages,
-                    delta=LLMResultChunkDelta(index=index, message=assistant_prompt_message),
+                    delta=LLMResultChunkDelta(
+                        index=index, message=assistant_prompt_message
+                    ),
                 )
 
             else:
                 # get num tokens from metrics in last chunk
-                prompt_tokens = payload["amazon-bedrock-invocationMetrics"]["inputTokenCount"]
-                completion_tokens = payload["amazon-bedrock-invocationMetrics"]["outputTokenCount"]
+                prompt_tokens = payload["amazon-bedrock-invocationMetrics"][
+                    "inputTokenCount"
+                ]
+                completion_tokens = payload["amazon-bedrock-invocationMetrics"][
+                    "outputTokenCount"
+                ]
 
                 # transform usage
-                usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+                usage = self._calc_response_usage(
+                    model, credentials, prompt_tokens, completion_tokens
+                )
 
                 yield LLMResultChunk(
                     model=model,
                     prompt_messages=prompt_messages,
                     delta=LLMResultChunkDelta(
-                        index=index, message=assistant_prompt_message, finish_reason=finish_reason, usage=usage
+                        index=index,
+                        message=assistant_prompt_message,
+                        finish_reason=finish_reason,
+                        usage=usage,
                     ),
                 )
 
@@ -1375,7 +1757,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             InvokeBadRequestError: [],
         }
 
-    def _map_client_to_invoke_error(self, error_code: str, error_msg: str) -> type[InvokeError]:
+    def _map_client_to_invoke_error(
+        self, error_code: str, error_msg: str
+    ) -> type[InvokeError]:
         """
         Map client error to invoke error
 
@@ -1402,57 +1786,69 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
         return InvokeError(error_msg)
 
-    def _get_inference_profile_parameter_rules(self, model_schema, underlying_model_id: str = None) -> list:
+    def _get_inference_profile_parameter_rules(
+        self, model_schema, underlying_model_id: str = None
+    ) -> list:
         """
         Extract allowed parameter rules from model schema for inference profiles
-        
+
         :param model_schema: The predefined model schema
         :param underlying_model_id: The underlying model ID (for model-specific filtering)
         :return: List of parameter rules suitable for inference profiles
         """
         if not model_schema.parameter_rules:
             return []
-        
+
         # Always exclude model_name since it's determined by inference profile
-        excluded_params = ['model_name']
-        
+        excluded_params = ["model_name"]
+
         # Apply model-specific filtering if underlying_model_id is available
         allowed_parameter_rules = []
         for rule in model_schema.parameter_rules:
             if rule.name in excluded_params:
                 continue
-                
+
             # For Anthropic models, include response_format only if it's an Anthropic model
-            if rule.name == 'response_format':
-                if underlying_model_id and "anthropic.claude" not in underlying_model_id:
+            if rule.name == "response_format":
+                if (
+                    underlying_model_id
+                    and "anthropic.claude" not in underlying_model_id
+                ):
                     continue  # Skip response_format for non-Anthropic models
                 elif not underlying_model_id:
                     # Fallback case: only include if this is an Anthropic schema
-                    if not (hasattr(model_schema, 'model') and model_schema.model == "anthropic claude"):
+                    if not (
+                        hasattr(model_schema, "model")
+                        and model_schema.model == "anthropic claude"
+                    ):
                         continue
-            
+
             allowed_parameter_rules.append(rule)
-        
+
         return allowed_parameter_rules
 
     def _model_id_matches_schema(self, model_id: str, model_schema) -> bool:
         """
         Check if a model ID matches a predefined model schema
-        
+
         :param model_id: The model ID from inference profile (e.g., anthropic.claude-3-5-sonnet-20241022-v2:0)
         :param model_schema: The predefined model schema
         :return: True if the model ID matches the schema
         """
         # Extract the model family from the model ID and check individual models first
         if "anthropic.claude" in model_id:
-            return (model_schema.model == "anthropic claude" or 
-                   model_schema.model.startswith("claude-"))
+            return (
+                model_schema.model == "anthropic claude"
+                or model_schema.model.startswith("claude-")
+            )
         elif "amazon.nova" in model_id:
-            return (model_schema.model == "amazon nova" or 
-                   model_schema.model.startswith("nova-"))
+            return model_schema.model == "amazon nova" or model_schema.model.startswith(
+                "nova-"
+            )
         elif "cohere.command" in model_id:
-            return (model_schema.model == "cohere" or 
-                   model_schema.model.startswith("cohere-"))
+            return model_schema.model == "cohere" or model_schema.model.startswith(
+                "cohere-"
+            )
         elif "ai21" in model_id:
             return model_schema.model == "ai21"
         elif "meta.llama" in model_id:
@@ -1461,37 +1857,39 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             return model_schema.model == "mistral"
         elif "deepseek" in model_id:
             return model_schema.model == "deepseek"
-        
+
         return False
-    
+
     def _map_model_id_to_name(self, model_id: str) -> Optional[str]:
         """
         Map a Bedrock model ID to a model name for pricing lookup.
-        
+
         :param model_id: The Bedrock model ID (e.g., 'anthropic.claude-3-5-sonnet-20241022-v2:0')
         :return: The model name or None
         """
         # Reverse lookup from model_ids
         from . import model_ids
-        
+
         # Remove version suffix if present
-        base_model_id = model_id.split(':')[0] if ':' in model_id else model_id
-        
+        base_model_id = model_id.split(":")[0] if ":" in model_id else model_id
+
         # Search through all model families
         for family, models in model_ids.BEDROCK_MODEL_IDS.items():
             for name, id_value in models.items():
                 # Compare base IDs without version
-                base_id_value = id_value.split(':')[0] if ':' in id_value else id_value
+                base_id_value = id_value.split(":")[0] if ":" in id_value else id_value
                 if base_id_value == base_model_id or id_value == model_id:
                     return name
-        
+
         return None
-    
-    def _get_model_specific_pricing(self, model: str, model_name: str, model_schemas: list):
+
+    def _get_model_specific_pricing(
+        self, model: str, model_name: str, model_schemas: list
+    ):
         """
         Get model-specific pricing based on model name.
         First tries to find exact model match from model_configurations directory, then falls back to family pricing.
-        
+
         :param model: The model family (e.g., 'anthropic-claude')
         :param model_name: The specific model name (e.g., 'Claude 3.5 Sonnet')
         :param model_schemas: List of predefined model schemas
@@ -1500,82 +1898,87 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         # Create model name mapping for individual model files
         model_name_mapping = {
             # Claude models
-            'Claude 4.0 Sonnet': 'claude-4-sonnet',
-            'Claude 4.0 Opus': 'claude-4-opus',
-            'Claude 3.7 Sonnet': 'claude-3-7-sonnet',
-            'Claude 3.5 Haiku': 'claude-3-5-haiku',
-            'Claude 3.5 Sonnet': 'claude-3-5-sonnet', 
-            'Claude 3.5 Sonnet V2': 'claude-3-5-sonnet',
-            'Claude 3 Haiku': 'claude-3-haiku',
-            'Claude 3 Sonnet': 'claude-3-sonnet',
-            'Claude 3 Opus': 'claude-3-opus',
+            "Claude 4.0 Sonnet": "claude-4-sonnet",
+            "Claude 4.0 Opus": "claude-4-opus",
+            "Claude 3.7 Sonnet": "claude-3-7-sonnet",
+            "Claude 3.5 Haiku": "claude-3-5-haiku",
+            "Claude 3.5 Sonnet": "claude-3-5-sonnet",
+            "Claude 3.5 Sonnet V2": "claude-3-5-sonnet",
+            "Claude 3 Haiku": "claude-3-haiku",
+            "Claude 3 Sonnet": "claude-3-sonnet",
+            "Claude 3 Opus": "claude-3-opus",
             # Nova models
-            'Nova Micro': 'nova-micro',
-            'Nova Lite': 'nova-lite',
-            'Nova Pro': 'nova-pro',
+            "Nova Micro": "nova-micro",
+            "Nova Lite": "nova-lite",
+            "Nova Pro": "nova-pro",
             # Cohere models
-            'Command': 'cohere-command',
-            'Command Light': 'cohere-command-light',
-            'Command R': 'cohere-command-r',
-            'Command R+': 'cohere-command-rplus'
+            "Command": "cohere-command",
+            "Command Light": "cohere-command-light",
+            "Command R": "cohere-command-r",
+            "Command R+": "cohere-command-rplus",
         }
-        
+
         # First, try to load individual model pricing from model_configurations subdirectory
         individual_model_name = model_name_mapping.get(model_name)
         if individual_model_name:
             try:
                 import os
                 import yaml
+
                 # Get the directory of this file
                 current_dir = os.path.dirname(os.path.abspath(__file__))
-                individual_model_path = os.path.join(current_dir, 'model_configurations', f'{individual_model_name}.yaml')
-                
+                individual_model_path = os.path.join(
+                    current_dir, "model_configurations", f"{individual_model_name}.yaml"
+                )
+
                 if os.path.exists(individual_model_path):
-                    with open(individual_model_path, 'r', encoding='utf-8') as f:
+                    with open(individual_model_path, "r", encoding="utf-8") as f:
                         model_config = yaml.safe_load(f)
-                        if 'pricing' in model_config:
-                            return model_config['pricing']
+                        if "pricing" in model_config:
+                            return model_config["pricing"]
             except Exception as e:
                 # If individual model file loading fails, continue to fallback
                 pass
-        
+
         # Fallback: try to find individual model in existing schemas (for backward compatibility)
         if individual_model_name:
             for schema in model_schemas:
                 if schema.model == individual_model_name:
                     return schema.pricing
-        
+
         # If no model family provided, skip family pricing lookup
         if not model:
             return None
-        
+
         # If no individual model found, try family pricing
         # Look for exact model match first
         for schema in model_schemas:
             if schema.model == model:
                 return schema.pricing
-        
+
         # If exact match not found, try with different formats
         # Sometimes model might be passed as 'anthropic claude' vs 'anthropic-claude'
         model_variants = [
-            model.replace('-', ' '),  # 'anthropic-claude' -> 'anthropic claude'
-            model.replace(' ', '-'),  # 'anthropic claude' -> 'anthropic-claude'
+            model.replace("-", " "),  # 'anthropic-claude' -> 'anthropic claude'
+            model.replace(" ", "-"),  # 'anthropic claude' -> 'anthropic-claude'
             model.lower(),
-            model.lower().replace('-', ' '),
-            model.lower().replace(' ', '-')
+            model.lower().replace("-", " "),
+            model.lower().replace(" ", "-"),
         ]
-        
+
         for schema in model_schemas:
             for variant in model_variants:
                 if schema.model == variant:
                     return schema.pricing
-                    
+
         return None
-    
-    def _calc_response_usage(self, model: str, credentials: dict, prompt_tokens: int, completion_tokens: int):
+
+    def _calc_response_usage(
+        self, model: str, credentials: dict, prompt_tokens: int, completion_tokens: int
+    ):
         """
         Calculate response usage with per-model pricing support.
-        
+
         :param model: model name
         :param credentials: model credentials
         :param prompt_tokens: number of prompt tokens
@@ -1583,43 +1986,47 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         :return: LLMUsage
         """
         # Get model-specific pricing if available
-        model_parameters = credentials.get('model_parameters', {})
-        model_name = model_parameters.get('model_name')
-        
+        model_parameters = credentials.get("model_parameters", {})
+        model_name = model_parameters.get("model_name")
+
         if model_name:
             # Try to get model-specific pricing
             model_schemas = self.predefined_models()
-            model_pricing = self._get_model_specific_pricing(model, model_name, model_schemas)
-            
+            model_pricing = self._get_model_specific_pricing(
+                model, model_name, model_schemas
+            )
+
             if model_pricing:
                 # Use model-specific pricing
                 from dify_plugin.entities.model.llm import LLMUsage
-                
+
                 # Handle both dict and object pricing formats
                 if isinstance(model_pricing, dict):
-                    input_price = float(model_pricing['input'])
-                    output_price = float(model_pricing['output'])
-                    unit_price = float(model_pricing['unit'])
-                    currency = model_pricing.get('currency', 'USD')
+                    input_price = float(model_pricing["input"])
+                    output_price = float(model_pricing["output"])
+                    unit_price = float(model_pricing["unit"])
+                    currency = model_pricing.get("currency", "USD")
                 else:
                     # Object with attributes
                     input_price = float(model_pricing.input)
                     output_price = float(model_pricing.output)
                     unit_price = float(model_pricing.unit)
                     currency = model_pricing.currency
-                
+
                 # Calculate costs correctly: (tokens × price) ÷ unit_tokens
                 input_cost = (prompt_tokens * input_price) / (1.0 / unit_price)
                 output_cost = (completion_tokens * output_price) / (1.0 / unit_price)
-                
+
                 # Round to avoid floating point precision issues
                 input_cost = round(input_cost, 8)
                 output_cost = round(output_cost, 8)
                 total_cost = round(input_cost + output_cost, 8)
-                
+
                 # Get latency from parent class by calling it first
-                parent_usage = super()._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
-                
+                parent_usage = super()._calc_response_usage(
+                    model, credentials, prompt_tokens, completion_tokens
+                )
+
                 return LLMUsage(
                     prompt_tokens=prompt_tokens,
                     prompt_unit_price=input_price,
@@ -1634,7 +2041,8 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     currency=currency,
                     latency=parent_usage.latency,  # Use parent's latency calculation
                 )
-        
+
         # Fallback to parent class implementation
-        return super()._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
-    
+        return super()._calc_response_usage(
+            model, credentials, prompt_tokens, completion_tokens
+        )

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -412,7 +412,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                         model_info["model"] = (
                             model_id  # Use inference profile ARN for actual API call
                         )
-                        model_info["underlying_model_id"] = underlying_model_id  # Store underlying model ID for cache support
+                        model_info["underlying_model_id"] = (
+                            underlying_model_id  # Store underlying model ID for cache support
+                        )
                         logger.info(
                             f"Using inference profile {model_id} with capabilities from {underlying_model_id}"
                         )
@@ -478,7 +480,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         bedrock_client = get_bedrock_client("bedrock-runtime", credentials)
 
         # Get cache checkpoint settings from model parameters
-        system_cache_checkpoint = model_parameters.pop("system_cache_checkpoint", True)
+        # Log the incoming parameters for debugging
+        logger.info(f"[CACHE PARAMS] Received model_parameters: {model_parameters}")
+        system_cache_checkpoint = model_parameters.pop("system_cache_checkpoint", False)  # Default to False
         latest_two_messages_cache_checkpoint = model_parameters.pop(
             "latest_two_messages_cache_checkpoint", False
         )
@@ -497,7 +501,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         # For inference profiles, use underlying model ID for cache support check
         cache_check_model_id = model_info.get("underlying_model_id", model_id)
         cache_supported = is_cache_supported(cache_check_model_id)
-        print(f"[CACHE DEBUG] Model: {model_id}, Underlying: {cache_check_model_id}, Cache supported: {cache_supported}")
+        print(
+            f"[CACHE DEBUG] Model: {model_id}, Underlying: {cache_check_model_id}, Cache supported: {cache_supported}"
+        )
         logger.info(
             f"[CACHE DEBUG] Model: {model_id}, Underlying: {cache_check_model_id}, Cache supported: {cache_supported}"
         )
@@ -661,8 +667,8 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             completion_tokens = response["usage"]["outputTokens"]
 
             # Log cache metrics if available
-            cache_read_tokens = response["usage"].get("cacheReadInputTokens", 0)
-            cache_write_tokens = response["usage"].get("cacheWriteInputTokens", 0)
+            cache_read_tokens = response["usage"].get("cacheReadInputTokensCount", 0)
+            cache_write_tokens = response["usage"].get("cacheWriteInputTokensCount", 0)
 
             if cache_read_tokens > 0 or cache_write_tokens > 0:
                 logger.info(


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

Context: Fixed cache support detection for AWS Bedrock inference profiles. Previously, cache support was incorrectly evaluated as false for inference profiles even when the underlying model supported caching (e.g., Nova Pro, Claude 3.7 Sonnet).

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->
**Changes to Prompt Caching for Inference Profiles:**
- Fixed cache support detection for AWS Bedrock inference profiles
- Cache support now correctly uses underlying model ID instead of inference profile ARN
- Cache settings from UI are properly respected (defaults changed from True to False)

**Testing Results:**
```
Before Fix:
[CACHE DEBUG] Model: arn:aws:bedrock:XXX:application-inference-profile/XXX, Cache supported: False
[CACHE METRICS] Read: 0 tokens, Write: 0 tokens (even with cache-supported models)

After Fix:
[CACHE DEBUG] Model: arn:aws:bedrock:XXX:application-inference-profile/XXX, Underlying: amazon.nova-pro-v1:0, Cache supported: True
When cache enabled in UI: [CACHE METRICS] Read: 0 tokens, Write: 1128 tokens
When cache disabled in UI: [CACHE METRICS] Read: 0 tokens, Write: 0 tokens
```

- [x] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->
**Bug Fix:** Corrected cache parameter defaults to respect UI settings

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->
Version bumped from 0.0.33 to 0.0.34 (PATCH - bug fix)

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: 1.2.0+, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->
Tested with both Nova Pro and Claude 3.5 Sonnet inference profiles on local Dify deployment.

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->


These images reflect logs when enabled the cache from UI and disabled from UI for system prompt. Observe the diff in Cache checkpoints - System: True/False
<img width="1605" height="49" alt="Screenshot 2025-08-30 at 5 09 55 PM" src="https://github.com/user-attachments/assets/aab6980a-434b-49f3-885e-65c46758d069" />
0-4c5e22c17025" />
<img width="1655" height="55" alt="Screenshot 2025-08-30 at 5 10 09 PM" src="https://github.com/user-attachments/assets/859e0c8a-61d3-42d3-9caf-1301a7be610d" />
When true is reads from cache

<img width="1542" height="47" alt="Screenshot 2025-08-30 at 5 07 56 PM" src="https://github.com/user-attachments/assets/7a252016-3241-4e73-b4a0-c645bb448132" />
<img width="1563" height="82" alt="Screenshot 2025-08-30 at 5 07 42 PM" src="https://github.com/user-attachments/assets/3d787d24-7985-403f-807f-12c526f4d3ef" />

When false nothing read from cache 
<img width="1577" height="64" alt="Screenshot 2025-08-30 at 5 11 55 PM" src="https://github.com/user-attachments/assets/5235a5e8-e4d5-4fd8-8670-fe75fc024b49" />
