### PR TITLE
feat(vertex-ai): support Claude region override and configurable globals

### DIFF
--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.23
+version: 0.0.24

--- a/models/vertex_ai/provider/vertex_ai.yaml
+++ b/models/vertex_ai/provider/vertex_ai.yaml
@@ -51,6 +51,20 @@ provider_credential_schema:
     required: false
     type: secret-input
     variable: vertex_service_account_key
+  - label:
+      en_US: Anthropic Models Location (optional)
+    placeholder:
+      en_US: Enter your Google Cloud Location for Anthropic (Claude) models, overrides default location for Claude on Vertex
+    required: false
+    type: text-input
+    variable: vertex_anthropic_location
+  - label:
+      en_US: Global-only Models (optional)
+    placeholder:
+      en_US: Comma-separated model IDs that must use the global endpoint, overrides defaults
+    required: false
+    type: text-input
+    variable: vertex_global_models
 supported_model_types:
 - llm
 - text-embedding


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

Currently the `vertex_ai` plugin only uses hardcoded **US** GCP locations for Anthropic models which does not suit organizations having location constraints (e.g. Use only `EU` regions).
The change provides the following changes :

- Add provider credential parameter `vertex_anthropic_location` to decouple Claude location from `vertex_location` (quota project/Gemini region)
- Resolution order for Anthropic LLM region: `vertex_anthropic_location` → `vertex_location` → model defaults (Claude=us-east5, others=us-central1)
- Add provider credential parameter `vertex_global_models` to override the default list of global-only models
- Rename `GLOBAL_ONLY_MODELS` to `GLOBAL_ONLY_MODELS_DEFAULT` and read custom values from credentials
- Bump plugin version to 0.0.24

Impact: Enables using Anthropic (Claude) on Vertex AI from EU or other non-US locations (e.g., europe-west4) without being blocked by hard-coded US regions.

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

<img width="1226" height="818" alt="image" src="https://github.com/user-attachments/assets/92622532-fcab-48ad-b649-bc2b6e000032" />


## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: 1.8.0, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->
<img width="1145" height="805" alt="image" src="https://github.com/user-attachments/assets/11814341-1dca-434c-96cc-dc0dcb572fcd" />
<img width="1904" height="887" alt="image" src="https://github.com/user-attachments/assets/feb48374-98e7-4fb6-9d97-7d3369a6229b" />

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
<img width="1120" height="809" alt="image" src="https://github.com/user-attachments/assets/e9a1cafb-e819-4ac4-9d81-9dfcbecc94e3" />
<img width="1904" height="900" alt="image" src="https://github.com/user-attachments/assets/8df36420-94b9-42df-a1b5-d2b2c6741bfb" />


