### PR TITLE
fix: bedrock provider "Model name is required for non-converse API models" error

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.34
+version: 0.0.35
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -279,7 +279,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 }
         else:
             # Use traditional model ID resolution
-            model_name = model_parameters.pop('model_name')
+            model_name = model_parameters.get('model_name')
             model_id = model_ids.get_model_id(model, model_name)
             
             # Store model_name in credentials for pricing calculation


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->
- Link Related Issues if Applicable: [#1400](https://github.com/langgenius/dify-official-plugins/issues/1400)

This error occurs sporadically - sometimes the same model configuration works, sometimes it fails.

### Root Cause
The issue is in the `_get_model_info` method where `model_parameters.pop('model_name')` removes the `model_name` parameter from the dictionary. When the Converse API call fails and the code falls back to the traditional API, the fallback logic tries to retrieve `model_name` using `model_parameters.get('model_name')`, but the parameter has already been removed by the previous `pop()` operation.

**Flow that causes the error:**
1. `_get_model_info()` is called with `model_parameters` containing `model_name`
2. Line 282: `model_name = model_parameters.pop('model_name')` - **removes** `model_name` from the dictionary
3. If `_find_model_info(model_id)` returns `None` (model not found in Converse API support list), an exception is thrown
4. Exception is caught, code enters fallback logic
5. Line 227: `model_name = model_parameters.get('model_name')` - but `model_name` **has already been removed**!
6. `model_name` is `None`, causing the error: "Model name is required for non-converse API models"

### Solution
Change `model_parameters.pop('model_name')` to `model_parameters.get('model_name')` in the `_get_model_info` method. This preserves the `model_name` parameter for the fallback logic while maintaining the same functionality.

### Changes
- **File**: `dify-official-plugins/models/bedrock/models/llm/llm.py`
- **Line 282**: Changed `model_parameters.pop('model_name')` to `model_parameters.get('model_name')`

### Testing
This fix resolves the intermittent failure and ensures that the fallback to traditional API works correctly when Converse API is not available for certain models.

### Impact
- ✅ Fixes intermittent failures for Bedrock Claude models
- ✅ Maintains backward compatibility
- ✅ No breaking changes to existing functionality
- ✅ Fallback mechanism now works reliably

## This PR contains Changes to *Non-Plugin* 
- [ ] Documentation
- [x] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->


