### PR TITLE
fix: Remove `rag` tag for Knowledge Pipeline related plugins, bump `minimum_dify_version`

### DIFF
--- a/tools/dify_extractor/manifest.yaml
+++ b/tools/dify_extractor/manifest.yaml
@@ -28,9 +28,8 @@ meta:
     language: python
     version: "3.12"
     entrypoint: main
-  minimum_dify_version: 1.0.0
+  minimum_dify_version: 2.0.0-beta1
 created_at: 2025-05-06T17:36:36.427192+08:00
 privacy: PRIVACY.md
 verified: false
-tags:
-  - rag
+tags: []

--- a/tools/dify_extractor/provider/dify_extractor.yaml
+++ b/tools/dify_extractor/provider/dify_extractor.yaml
@@ -10,8 +10,7 @@ identity:
     zh_Hans: Dify Extractor
     pt_BR: Dify Extractor
   icon: icon.svg
-  tags:
-    - rag
+  tags: []
 tools:
   - tools/dify_extractor.yaml
 extra:

--- a/tools/general_chunk/manifest.yaml
+++ b/tools/general_chunk/manifest.yaml
@@ -19,6 +19,7 @@ meta:
     language: python
     version: '3.12'
   version: 0.0.1
+  minimum_dify_version: 2.0.0-beta1 
 name: general_chunker
 plugins:
   tools:
@@ -28,10 +29,9 @@ resource:
   permission:
     model:
       enabled: true
-      llm: true 
+      llm: true
     tool:
       enabled: true
-tags:
-  - rag
+tags: []
 type: plugin
 version: 0.0.5

--- a/tools/general_chunk/provider/general_chunk.yaml
+++ b/tools/general_chunk/provider/general_chunk.yaml
@@ -8,12 +8,11 @@ identity:
     pt_BR: General text chunking mode, the chunks retrieved and recalled are the same.
     zh_Hans: 通用文本分块模式，检索和召回的块是相同的。
   icon: icon.svg
+  tags: []
   label:
     en_US: General Chunker
     pt_BR: General Chunker
     zh_Hans: 通用文本分块
   name: general_chunker
-  tags:
-  - rag
 tools:
 - tools/general.yaml

--- a/tools/parent_child_chunk/manifest.yaml
+++ b/tools/parent_child_chunk/manifest.yaml
@@ -28,9 +28,8 @@ meta:
     language: python
     version: "3.12"
     entrypoint: main
-  minimum_dify_version: null
+  minimum_dify_version: 2.0.0-beta1 
 created_at: 2025-05-20T16:54:07.682646+08:00
 privacy: PRIVACY.md
 verified: false
-tags:
-  - rag
+tags: []

--- a/tools/parent_child_chunk/provider/parent_child_chunk.yaml
+++ b/tools/parent_child_chunk/provider/parent_child_chunk.yaml
@@ -10,8 +10,7 @@ identity:
     zh_Hans: Parent-child Chunk Structure
     pt_BR: Parent-child Chunk Structure
   icon: icon.svg
-  tags:
-    - rag
+  tags: []
 tools:
   - tools/parent_child_chunk.yaml
 extra:

--- a/tools/qa_chunk/manifest.yaml
+++ b/tools/qa_chunk/manifest.yaml
@@ -19,6 +19,7 @@ meta:
     language: python
     version: '3.12'
   version: 0.0.1
+  minimum_dify_version: 2.0.0-beta1
 name: qa_chunk
 plugins:
   tools:
@@ -32,7 +33,6 @@ resource:
     tool:
       enabled: true
 tags:
-  - utilities
-  - rag
+- utilities
 type: plugin
 version: 0.0.6

--- a/tools/qa_chunk/provider/qa_chunk.yaml
+++ b/tools/qa_chunk/provider/qa_chunk.yaml
@@ -15,6 +15,5 @@ identity:
   name: qa_chunk
   tags:
   - utilities
-  - rag
 tools:
 - tools/qa.yaml

--- a/tools/unstructured/manifest.yaml
+++ b/tools/unstructured/manifest.yaml
@@ -31,9 +31,8 @@ meta:
     language: python
     version: "3.12"
     entrypoint: main
-  minimum_dify_version: 1.0.0
+  minimum_dify_version: 2.0.0-beta1 
 created_at: 2025-04-23T17:46:21.256715+08:00
 privacy: PRIVACY.md
 verified: false
-tags:
-  - rag
+tags: []

--- a/tools/unstructured/provider/unstructured.yaml
+++ b/tools/unstructured/provider/unstructured.yaml
@@ -57,8 +57,7 @@ identity:
     zh_Hans: unstructured
     pt_BR: unstructured
   icon: icon.svg
-  tags:
-    - rag
+  tags: []
 tools:
   - tools/partition.yaml
 extra:


### PR DESCRIPTION
## Related Issues or Context

The `rag` tag is not supported by current frontend code. Remove it
to avoid breaking existing Dify deployments.

The `minimum_dify_version` field is raised to `2.0.0-beta1` to ensure
users of old version get proper compatibility notice while trying to
install those plugins.

## This PR contains Changes to *Non-Plugin* 

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*

- [ ] I have Run Comprehensive Tests Relevant to My Changes

## This PR contains Changes to *LLM Models Plugin*

NO

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [ ] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)


## Dify Plugin SDK Version

- [ ] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a 

### SaaS Environment

- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration

