### PR TITLE
feat(mineru): add backend options for mineru2.5

### DIFF
--- a/tools/mineru/manifest.yaml
+++ b/tools/mineru/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.4.3
+version: 0.5.0
 type: plugin
 author: langgenius
 name: mineru

--- a/tools/mineru/tools/parse.py
+++ b/tools/mineru/tools/parse.py
@@ -71,6 +71,7 @@ class MineruTool(Tool):
             return {
                 'Authorization': f'Bearer {credentials.token}',
                 'Content-Type': 'application/json',
+                'source': 'dify'
             }
         return {
             'accept': 'application/json'
@@ -199,6 +200,9 @@ class MineruTool(Tool):
         if tool_parameters.get('language') and tool_parameters.get('language') != "auto":
             lang_list = tool_parameters.get('language')
 
+        if (tool_parameters.get('backend', 'pipeline') == 'vlm-sglang-client' or tool_parameters.get('backend', 'pipeline') == 'vlm-http-client') and not tool_parameters.get('server_url'):
+            raise ToolProviderCredentialValidationError("When backend is vlm-sglang-client or vlm-http-client, server_url is required")
+
         body = {
             'parse_method': tool_parameters.get('parse_method', 'auto'),
             'return_md': True,
@@ -209,7 +213,7 @@ class MineruTool(Tool):
             'backend': tool_parameters.get('backend', 'pipeline'),
             'formula_enable': tool_parameters.get('formula_enable', True),
             'table_enable': tool_parameters.get('table_enable', True),
-            'server_url': tool_parameters.get('sglang_server_url', ""),
+            'server_url': tool_parameters.get('server_url'),
             'return_middle_json': False,
         }
 

--- a/tools/mineru/tools/parse.yaml
+++ b/tools/mineru/tools/parse.yaml
@@ -157,14 +157,19 @@ parameters:
           ja_JP: vlm-transformers
       - value: vlm-sglang-engine
         label:
-          zh_Hans: vlm-sglang-engine
-          en_US: vlm-sglang-engine
-          ja_JP: vlm-sglang-engine
+          zh_Hans: vlm-sglang-engine (v2.2)
+          en_US: vlm-sglang-engine (v2.2)
+          ja_JP: vlm-sglang-engine (v2.2)
       - value: vlm-sglang-client
         label:
-          zh_Hans: vlm-sglang-client
-          en_US: vlm-sglang-client
-          ja_JP: vlm-sglang-client
+          zh_Hans: vlm-sglang-client (v2.2)
+          en_US: vlm-sglang-client (v2.2)
+          ja_JP: vlm-sglang-client (v2.2)
+      - value: vlm-http-client
+        label:
+          zh_Hans: vlm-http-client (v2.5)
+          en_US: vlm-http-client (v2.5)
+          ja_JP: vlm-http-client (v2.5)
       - value: vlm-vllm-async-engine
         label:
           zh_Hans: vlm-vllm-async-engine (v2.5)
@@ -181,19 +186,19 @@ parameters:
     llm_description: '(For local deployment v2/v2.5) Example: pipeline, vlm-transformers, vlm-sglang-engine, vlm-sglang-client, default is pipeline'
     form: form
 
-  - name: sglang_server_url
+  - name: server_url
     type: string
     required: false
     default: ""
     label:
-      zh_Hans: sglang-server地址
-      en_US: sglang-server url
-      ja_JP: sglang-serverアドレス
+      zh_Hans: server地址
+      en_US: server url
+      ja_JP: serverアドレス
     human_description:
-      zh_Hans: '（用于本地部署v2版本 解析后端为vlm-sglang-client时）示例：http://127.0.0.1:8000，默认值为空'
-      en_US: '(For local deployment v2 when backend is vlm-sglang-client) Example: http://127.0.0.1:8000, default is empty'
-      ja_JP: '（ローカルデプロイメントv2用 解析後端がvlm-sglang-clientの場合）例：http://127.0.0.1:8000、デフォルトは空'
-    llm_description: '(For local deployment v2 when backend is vlm-sglang-client) Example: http://127.0.0.1:8000, default is empty' 
+      zh_Hans: '（用于本地部署v2版本 解析后端为 vlm-sglang-client 或 vlm-http-client 时）示例：http://127.0.0.1:30000，默认值为空'
+      en_US: '(For local deployment v2 when backend is vlm-sglang-client or vlm-http-client) Example: http://127.0.0.1:30000, default is empty'
+      ja_JP: '（ローカルデプロイメントv2用 解析後端が vlm-sglang-client 或 vlm-http-client の場合）例：http://127.0.0.1:30000、デフォルトは空'
+    llm_description: '(For local deployment v2 when backend is vlm-sglang-client or vlm-http-client) Example: http://127.0.0.1:30000, default is empty' 
     form: form
 
 output_schema:


### PR DESCRIPTION
update: backend option description

update: sglang_server_url -> server_url simplified

update: bump version to 0.5.0

## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [x] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: 1.6.0<!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
