### PR TITLE
fix: (fix) [jina/rerank]: use local document text instead of text from response

### DIFF
--- a/models/jina/manifest.yaml
+++ b/models/jina/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: "langgenius"
 name: "jina"

--- a/models/jina/models/rerank/rerank.py
+++ b/models/jina/models/rerank/rerank.py
@@ -76,6 +76,7 @@ class JinaRerankModel(RerankModel):
             "query": query,
             "documents": [transform_jina_input_text(model, doc) for doc in docs],
             "top_n": top_n,
+            "return_documents": False,
         }
 
         try:
@@ -85,9 +86,10 @@ class JinaRerankModel(RerankModel):
 
             rerank_documents = []
             for result in results["results"]:
+                original_index = result["index"]
                 rerank_document = RerankDocument(
                     index=result["index"],
-                    text=result["document"]["text"],
+                    text=docs[original_index],
                     score=result["relevance_score"],
                 )
                 if (


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

Resolves #1799 1799


## This PR contains Changes to *LLM Models Plugin*

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
- [ ] My Changes Affect Token Consumption Metrics
- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
- [x ] Other Changes (Add New Models, Fix Model Parameters etc.)

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x ] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
### Local Deployment Environment
- [x ] Dify Version is: 1.9.1, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->
<img width="1195" height="636" alt="image" src="https://github.com/user-attachments/assets/6dfd3fc9-4cf9-4b33-9378-8dcb2c85b7c1" />

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
