### PR TITLE
fix(confluence): Add token_type selector for Cloud/Server auth support

### DIFF
--- a/tools/confluence/manifest.yaml
+++ b/tools/confluence/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: confluence

--- a/tools/confluence/provider/confluence.yaml
+++ b/tools/confluence/provider/confluence.yaml
@@ -23,6 +23,25 @@ credentials_for_provider:
     help:
       en_US: The base URL of your Confluence instance.
       zh_Hans: 您的 Confluence 实例的基础 URL。
+  token_type:
+    type: select
+    required: true
+    default: Bearer
+    label:
+      en_US: Token Type
+      zh_Hans: 令牌类型
+    options:
+      - value: Basic
+        label:
+          en_US: Basic (Confluence Cloud)
+          zh_Hans: Basic (Confluence Cloud)
+      - value: Bearer
+        label:
+          en_US: Bearer (Confluence Server/Data Center)
+          zh_Hans: Bearer (Confluence Server/Data Center)
+    help:
+      en_US: Select the authentication type. Use Basic for Confluence Cloud, Bearer for on-premise installations.
+      zh_Hans: 选择认证类型。Confluence Cloud 使用 Basic，本地部署使用 Bearer。
   token:
     type: secret-input
     required: true
@@ -30,8 +49,8 @@ credentials_for_provider:
       en_US: Access Token
       zh_Hans: 访问令牌
     placeholder:
-      en_US: Please input your Confluence access token with auth method, like "Basic <token>"
-      zh_Hans: 请输入您的带有认证方法的 Confluence 访问令牌，如"Basic <token>"
+      en_US: "e.g., base64(email:token) for Basic, or PAT for Bearer"
+      zh_Hans: "例：Basic 使用 base64(email:token)，Bearer 使用 PAT"
     help:
       en_US: Create an API token from your Atlassian account settings.
       zh_Hans: 从您的 Atlassian 帐户设置创建 API 令牌。


### PR DESCRIPTION
  ## Related Issues or Context
  <!--
  ⚠️ NOTE: This repository is for Dify Official Plugins only.
  For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

  - Link Related Issues if Applicable: #issue_number
  - Or Provide Context about Why this Change is Needed
  -->

  This PR completes the fix for Confluence plugin authentication that was partially addressed in PR #1392.

  - Fixes #1372 (Add dropdown to ask for Basic vs PAT token)
  - Closes #1807 (token_type selector missing in UI)
  - Related to PR #1392 (Added backend support but missing UI field)

  ### Context
  Issue #1372 requested a dropdown to select between Basic and Bearer token types. PR #1392 partially fixed this by updating `auth.py` to read the `token_type` parameter, but the UI field in
  `confluence.yaml` was never added. This means:
  - Confluence Cloud users cannot use the plugin (requires Basic auth)
  - Users must manually understand and prefix tokens with "Bearer " or "Basic "
  - The `token_type` parameter always defaults to 'Bearer' with no way to change it

  This PR adds the missing UI component to complete the fix.

  ## This PR contains Changes to *Non-Plugin*
  <!-- Put an `x` in all the boxes that apply by replacing [ ] with [x]
  For example:
  - [x] Documentation -->

  - [ ] Documentation
  - [ ] Other

  ## This PR contains Changes to *Non-LLM Models Plugin*
  - [x] I have Run Comprehensive Tests Relevant to My Changes
  <!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->



  ### Changes Made:
  1. Added `token_type` select field in `confluence.yaml`:
     - Basic (for Confluence Cloud)
     - Bearer (for Confluence Server/Data Center)
     - Default: Bearer (maintains backward compatibility)

  2. Updated token field placeholder and help text:
     - Placeholder: Simple input format examples
     - Help: Detailed instructions for each auth type

  3. Bumped version from 0.0.3 to 0.0.4

  ### Before:
  - No token_type selector visible to users
  - Confusing placeholder text asking for "Basic <token>" format

<img width="645" height="485" alt="image" src="https://github.com/user-attachments/assets/ff417261-fd3f-4640-8c9c-33cf7e5358ab" />

### After:
  - Clear token_type dropdown with Cloud/Server distinction
  - Simplified placeholder showing input format examples for each auth type

<img width="645" height="561" alt="image" src="https://github.com/user-attachments/assets/478b57bf-0544-4414-9974-6083904c513f" />


  ## This PR contains Changes to *LLM Models Plugin*

  <!-- LLM Models Test Example: -->
  <!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

  - [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
  <!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

  - [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
  <!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

  - [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
  <!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

  - [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
  <!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

  - [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
  <!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

  - [ ] My Changes Affect Token Consumption Metrics
  <!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

  - [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
  <!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

  - [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
  <!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

  ## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
  - [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
  <!--
  ⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
  - MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
  - MINOR (x.0.x): For New feature additions while maintaining backward compatibility
  - PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
  - Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
  -->

  Version bumped: 0.0.3 → 0.0.4 (PATCH version for backward-compatible bug fix)

  ## Dify Plugin SDK Version
  - [x] I have Ensured `dify_plugin>=0.3.0,<0.5.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

  Current requirements.txt already specifies the correct SDK version range.

  ## Environment Verification (If Any Code Changes)
  <!--
  ⚠️ NOTE: At Least One Environment Must Be Tested.
  -->

  ### Local Deployment Environment
  - [x] Dify Version is: 1.9.1, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration.
  <!--
  - Python Virtual Env Matching Manifest.yaml & requirements.txt
  - No Breaking Changes in Dify That May Affect the Testing Result
  -->

  Testing performed:
  - Verified token_type dropdown appears correctly in UI
  - Tested Basic authentication with Confluence Cloud (base64 encoded email:token)
  - Confirmed Bearer authentication still works for on-premise installations
  - Validated backward compatibility (default Bearer maintains existing behavior)

  ### SaaS Environment
  - [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
  <!--
  - Python Virtual Env Matching Manifest.yaml & requirements.txt
  -->
