### PR TITLE
feat(gemini): add `aspect_ratio` configuration for Gemini image generation

### DIFF
--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.6.2
+version: 0.6.3

--- a/models/gemini/models/llm/gemini-2.5-flash-image.yaml
+++ b/models/gemini/models/llm/gemini-2.5-flash-image.yaml
@@ -11,18 +11,51 @@ model_properties:
   context_size: 32768
 parameter_rules:
   - name: temperature
-    use_template: temperature
+    type:  float
+    required: true
     default: 1
     min: 0
-    max: 2
-  - name: top_p
-    use_template: top_p
-    default: 0.95
+    max: 1
+    label:
+      en_US: Temperature
+      zh_Hans: 温度
+    help:
+      en_US: Creativity allowed in the response
+      zh_Hans: 响应创造性
+  - name: aspect_ratio
+    type: string
+    required: true
+    default: "Auto"
+    options:
+      - "Auto"
+      - "1:1"
+      - "9:16"
+      - "16:9"
+      - "3:4"
+      - "4:3"
+      - "3:2"
+      - "2:3"
+      - "5:4"
+      - "4:5"
+      - "21:9"
+    label:
+      en_US: Aspect ratio
+      zh_Hans: 宽高比
+    help:
+      en_US: Aspect ratio of the generated images.
+      zh_Hans: 生成图片的宽高比。
   - name: max_output_tokens
-    use_template: max_tokens
-    default: 8192
+    type: float
+    required: true
+    default: 32768
     min: 1
     max: 32768
+    label:
+        en_US: Output length
+        zh_Hans: 输出长度
+    help:
+      en_US: Maximum number of tokens in response
+      zh_Hans: 最大生成 tokens 数
 # https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash-image
 pricing:
   input: '0.30'

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -279,6 +279,32 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 config.media_resolution = types.MediaResolution.MEDIA_RESOLUTION_HIGH
 
     @staticmethod
+    def _set_image_config(
+        *, config: types.GenerateContentConfig, model_parameters: Mapping[str, Any], model: str
+    ):
+        if model not in IMAGE_GENERATION_MODELS:
+            return
+
+        aspect_ratio = model_parameters.get("aspect_ratio")
+        if (
+            not aspect_ratio
+            or not isinstance(aspect_ratio, str)
+            or aspect_ratio
+            not in ["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"]
+        ):
+            aspect_ratio = None
+
+        image_size = model_parameters.get("image_size")
+        if (
+            not image_size
+            or not isinstance(image_size, str)
+            or image_size not in ["1K", "2K", "4K"]
+        ):
+            image_size = None
+
+        config.image_config = types.ImageConfig(image_size=image_size, aspect_ratio=aspect_ratio)
+
+    @staticmethod
     def _set_thinking_config(
         *, config: types.GenerateContentConfig, model_parameters: Mapping[str, Any], model_name: str
     ) -> None:
@@ -884,6 +910,10 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             config=config,
             file_server_url_prefix=file_server_url_prefix,
         )
+
+        # == ImageConfig == #
+
+        self._set_image_config(config=config, model_parameters=model_parameters, model=model)
 
         # == ThinkingConfig == #
 


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

- Added aspect_ratio parameter to gemini-2.5-flash-image model with predefined options (Auto, 1:1, 9:16, 16:9, 3:4, 4:3, 3:2, 2:3, 5:4, 4:5, 21:9)
- Implemented _set_image_config method to handle image generation settings including aspect ratio and image size
- Updated temperature parameter max value from 2 to 1
- Bumped plugin version to 0.6.3

### Gallery

`aspect_ratio: 9:16`

| panel | chat | preview |
| ----- | ---- | ------- |
|   <img width="579" height="458" alt="image" src="https://github.com/user-attachments/assets/ab11f533-9b4d-4ad0-aa43-dd12138e32c7" />    |  <img width="857" height="744" alt="image" src="https://github.com/user-attachments/assets/29d62ac6-a00d-410f-81cd-e1f9a4ea1565" />    |    <img width="768" height="1344" alt="93d6e041-f054-404f-b341-4ccf58a6cb5e" src="https://github.com/user-attachments/assets/5c0c916b-5b97-4798-86b3-eed73960f23f" />     |

`aspect_ratio: 21:9`

| panel                                                        | chat                                                         | preview                                                      |
| ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
| <img width="581" height="460" alt="image" src="https://github.com/user-attachments/assets/2d2a1f66-3b99-425b-9574-20b19f9a217d" /> | <img width="849" height="719" alt="image" src="https://github.com/user-attachments/assets/6a52583a-27c1-4beb-9fed-77598451b062" /> | <img width="1536" height="672" alt="677a163e-5595-43dd-8271-c1175b9ca727" src="https://github.com/user-attachments/assets/5004bc67-7233-423b-bd46-f1de5a973b5a" /> |








## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
