### PR TITLE
fix(vertex_ai): Fix YAML syntax error in gemini-3-pro-preview

### DIFF
--- a/models/vertex_ai/models/llm/gemini-3-pro-preview.yaml
+++ b/models/vertex_ai/models/llm/gemini-3-pro-preview.yaml
@@ -56,8 +56,8 @@ parameter_rules:
       - High
     required: false
     help:
-      zh_Hans: 控制模型推理深度。High 提供更深入的推理，Low 适合简单任务。默认为 High。注意：此参数仅适用于 Gemini 3，与 thinking_budget 互斥。
-      en_US: Controls the maximum depth of the model's reasoning. High provides deeper reasoning, Low is suitable for simpler tasks. Defaults to High. Note: This parameter is only for Gemini 3 and is mutually exclusive with thinking_budget.
+      zh_Hans: 控制模型推理深度。High 提供更深入的推理，Low 适合简单任务。默认为 High。注意此参数仅适用于 Gemini 3，与 thinking_budget 互斥。
+      en_US: Controls the maximum depth of the model's reasoning. High provides deeper reasoning, Low is suitable for simpler tasks. Defaults to High. Note this parameter is only for Gemini 3 and is mutually exclusive with thinking_budget.
   - name: include_thoughts
     type: boolean
     required: false


### PR DESCRIPTION
## Summary

Fix YAML syntax error in `gemini-3-pro-preview.yaml` that causes parsing failures.

### Problem

The merged version in PR #2111 contains a YAML syntax error on line 60:
```
Note: This parameter is only for Gemini 3...
```

The colon `:` after "Note" is interpreted by YAML parser as a key-value separator, causing:
```
yaml.scanner.ScannerError: mapping values are not allowed here
  in "gemini-3-pro-preview.yaml", line 60, column 156
```

### Solution

Remove colons from help text:
- `注意：` → `注意` (Chinese)
- `Note:` → `Note` (English)

### Changes

**Modified**: `models/vertex_ai/models/llm/gemini-3-pro-preview.yaml`
- Line 59: Remove colon from Chinese help text
- Line 60: Remove colon from English help text

### Testing

✅ Local YAML parsing validation passed:
```bash
python3 -c "import yaml; yaml.safe_load(open('models/llm/gemini-3-pro-preview.yaml'))"
✅ YAML 语法正确
```

✅ Plugin loading test passed

### References

- Original PR: #2111 (merged with syntax error)
- Error location: Line 60, column 156
- Related: thinking_level parameter help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)