### PR TITLE
add integration tests for openai

### DIFF
--- a/tests/models/__mockserver/openai.py
+++ b/tests/models/__mockserver/openai.py
@@ -17,9 +17,53 @@ def openai_server_mock():
     if request_body.get("stream"):
 
         def stream_response():
+            # First chunk with role
             yield "data: "
-            yield json.dumps({"choices": [{"message": {"content": "Hello, world!"}}]})
+            yield json.dumps({
+                "id": "chatcmpl-123",
+                "object": "chat.completion.chunk",
+                "created": 1715806438,
+                "model": request_body["model"],
+                "choices": [{
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": ""},
+                    "finish_reason": None
+                }]
+            })
             yield "\n\n"
+            
+            # Content chunk
+            yield "data: "
+            yield json.dumps({
+                "id": "chatcmpl-123",
+                "object": "chat.completion.chunk",
+                "created": 1715806438,
+                "model": request_body["model"],
+                "choices": [{
+                    "index": 0,
+                    "delta": {"content": "Hello, world!"},
+                    "finish_reason": None
+                }]
+            })
+            yield "\n\n"
+            
+            # Final chunk
+            yield "data: "
+            yield json.dumps({
+                "id": "chatcmpl-123",
+                "object": "chat.completion.chunk",
+                "created": 1715806438,
+                "model": request_body["model"],
+                "choices": [{
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop"
+                }]
+            })
+            yield "\n\n"
+            
+            # End marker
+            yield "data: [DONE]\n\n"
 
         return Response(stream_response(), mimetype="text/event-stream")
     else:
@@ -43,6 +87,101 @@ def openai_server_mock():
                 },
             }
         )
+
+
+@app.post("/v1/moderations")
+def openai_moderation_mock():
+    return jsonify({
+        "id": "modr-123",
+        "model": "text-moderation-latest",
+        "results": [
+            {
+                "flagged": False,
+                "categories": {
+                    "sexual": False,
+                    "hate": False,
+                    "harassment": False,
+                    "self-harm": False,
+                    "sexual/minors": False,
+                    "hate/threatening": False,
+                    "violence/graphic": False,
+                    "self-harm/intent": False,
+                    "self-harm/instructions": False,
+                    "harassment/threatening": False,
+                    "violence": False,
+                },
+                "category_scores": {
+                    "sexual": 1.2e-4,
+                    "hate": 2.1e-4,
+                    "harassment": 3.4e-4,
+                    "self-harm": 4.5e-4,
+                    "sexual/minors": 5.6e-4,
+                    "hate/threatening": 6.7e-4,
+                    "violence/graphic": 7.8e-4,
+                    "self-harm/intent": 8.9e-4,
+                    "self-harm/instructions": 9.0e-4,
+                    "harassment/threatening": 1.2e-3,
+                    "violence": 2.3e-3,
+                }
+            }
+        ]
+    })
+
+
+@app.post("/v1/audio/transcriptions")
+def openai_audio_transcriptions_mock():
+    return jsonify({"text": "Hello, world!"})
+
+
+@app.post("/v1/embeddings")
+def openai_embeddings_mock():
+    request_body = request.get_json(force=True)
+    input_text = request_body.get("input")
+    if isinstance(input_text, str):
+        input_text = [input_text]
+    
+    data = []
+    import base64
+    import numpy as np
+
+    is_base64 = request_body.get("encoding_format") == "base64"
+
+    for i, _ in enumerate(input_text):
+        # Create a dummy embedding of size 1536 (common for openai models)
+        embedding = [0.1] * 1536
+        
+        if is_base64:
+             # Create a numpy array of float32
+            embedding_array = np.array(embedding, dtype="float32")
+            # Convert to bytes
+            embedding_bytes = embedding_array.tobytes()
+            # Encode to base64 string
+            embedding_value = base64.b64encode(embedding_bytes).decode('utf-8')
+        else:
+            embedding_value = embedding
+
+        data.append({
+            "object": "embedding",
+            "index": i,
+            "embedding": embedding_value
+        })
+
+    return jsonify({
+        "object": "list",
+        "data": data,
+        "model": request_body.get("model", "text-embedding-3-small"),
+        "usage": {
+            "prompt_tokens": 10,
+            "total_tokens": 10
+        }
+    })
+
+
+@app.post("/v1/audio/speech")
+def openai_audio_speech_mock():
+    # Return a dummy audio mp3 content
+    dummy_audio_content = b"ID3\x03\x00\x00\x00\x00\nTIT2\x00\x00\x00\x05\x00\x00\x00Test"
+    return Response(dummy_audio_content, mimetype="audio/mpeg")
 
 
 class OpenAIMockServer:

--- a/tests/models/openai/conftest.py
+++ b/tests/models/openai/conftest.py
@@ -1,0 +1,40 @@
+"""
+Pytest configuration and fixtures for OpenAI tests.
+"""
+import pytest
+from tests.models.__mockserver.openai import OpenAIMockServer
+from dify_plugin.integration.run import PluginRunner
+from dify_plugin.config.integration_config import IntegrationConfig
+
+
+@pytest.fixture(scope="module")
+def mock_server():
+    """
+    Module-scoped fixture that starts the mock server once for all tests in the module.
+    This significantly speeds up test execution by avoiding repeated server startup/shutdown.
+    """
+    print("\n🚀 Starting OpenAI Mock Server (once per module)...")
+    server = OpenAIMockServer()
+    print(f"✅ Mock Server started on port {server.process.pid}")
+    yield server
+    print("\n🛑 Shutting down OpenAI Mock Server...")
+    server.process.terminate()
+    print("✅ Mock Server terminated")
+
+
+@pytest.fixture(scope="module")
+def plugin_runner():
+    """
+    Module-scoped fixture that creates a PluginRunner once for all tests.
+    This dramatically speeds up tests by avoiding repeated plugin process startup.
+    """
+    print("\n🔌 Starting PluginRunner (once per module)...")
+    with PluginRunner(
+        config=IntegrationConfig(),
+        plugin_package_path="models/openai",
+    ) as runner:
+        print("✅ PluginRunner started")
+        yield runner
+        print("\n🔌 Shutting down PluginRunner...")
+    print("✅ PluginRunner terminated")
+

--- a/tests/models/openai/test_openai.py
+++ b/tests/models/openai/test_openai.py
@@ -2,48 +2,390 @@ from dify_plugin.integration.run import (
     PluginRunner,
 )
 
-from tests.models.__mockserver.openai import OPENAI_MOCK_SERVER_PORT, OpenAIMockServer
+from tests.models.__mockserver.openai import OPENAI_MOCK_SERVER_PORT
 from dify_plugin.config.integration_config import IntegrationConfig
 from dify_plugin.core.entities.plugin.request import (
     ModelActions,
     ModelInvokeLLMRequest,
+    ModelInvokeModerationRequest,
+    ModelInvokeSpeech2TextRequest,
+    ModelInvokeTextEmbeddingRequest,
+    ModelInvokeTTSRequest,
     PluginInvokeType,
 )
+from dify_plugin.entities.model.moderation import ModerationResult
+from dify_plugin.entities.model.speech2text import Speech2TextResult
+from dify_plugin.entities.model.text_embedding import TextEmbeddingResult
+from dify_plugin.entities.model.tts import TTSResult
 from dify_plugin.entities.model import ModelType
 from dify_plugin.entities.model.llm import LLMResultChunk
-from dify_plugin.entities.model.message import UserPromptMessage
+from dify_plugin.entities.model.message import (
+    AssistantPromptMessage,
+    PromptMessageTool,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
 
 
-def test_openai_blocking():
-    with OpenAIMockServer():
-        with PluginRunner(
-            config=IntegrationConfig(),
-            plugin_package_path="models/openai",
-        ) as runner:
-            for result in runner.invoke(
-                access_type=PluginInvokeType.Model,
-                access_action=ModelActions.InvokeLLM,
-                payload=ModelInvokeLLMRequest(
-                    prompt_messages=[
-                        UserPromptMessage(content="Hello, world!"),
-                    ],
-                    user_id="",
-                    provider="openai",
-                    model_type=ModelType.LLM,
-                    model="gpt-3.5-turbo",
-                    credentials={
-                        "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
-                        "openai_api_key": "test",
+def test_openai_blocking(mock_server, plugin_runner):
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeLLM,
+        payload=ModelInvokeLLMRequest(
+            prompt_messages=[
+                UserPromptMessage(content="Hello, world!"),
+            ],
+            user_id="",
+            provider="openai",
+            model_type=ModelType.LLM,
+            model="gpt-3.5-turbo",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+            model_parameters={},
+            stop=[],
+            tools=[],
+            stream=False,
+        ),
+        response_type=LLMResultChunk,
+    ):
+        assert result.delta.message.content == "Hello, world!"
+
+
+def test_openai_streaming(mock_server, plugin_runner):
+    chunks = []
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeLLM,
+        payload=ModelInvokeLLMRequest(
+            prompt_messages=[
+                UserPromptMessage(content="Hello, world!"),
+            ],
+            user_id="",
+            provider="openai",
+            model_type=ModelType.LLM,
+            model="gpt-3.5-turbo",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+            model_parameters={},
+            stop=[],
+            tools=[],
+            stream=True,
+        ),
+        response_type=LLMResultChunk,
+    ):
+        chunks.append(result)
+    
+    # Verify we received streaming chunks
+    assert len(chunks) > 0, "Should receive at least one chunk"
+    
+    # Collect all content from chunks
+    full_content = "".join(
+        chunk.delta.message.content 
+        for chunk in chunks 
+        if chunk.delta.message.content
+    )
+    
+    assert full_content == "Hello, world!"
+
+
+def test_openai_with_system_message(mock_server, plugin_runner):
+    """Test with system message"""
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeLLM,
+        payload=ModelInvokeLLMRequest(
+            prompt_messages=[
+                SystemPromptMessage(content="You are a helpful assistant."),
+                UserPromptMessage(content="Hello, world!"),
+            ],
+            user_id="",
+            provider="openai",
+            model_type=ModelType.LLM,
+            model="gpt-3.5-turbo",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+            model_parameters={},
+            stop=[],
+            tools=[],
+            stream=False,
+        ),
+        response_type=LLMResultChunk,
+    ):
+        assert result.delta.message.content == "Hello, world!"
+
+
+def test_openai_multi_turn_conversation(mock_server, plugin_runner):
+    """Test multi-turn conversation"""
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeLLM,
+        payload=ModelInvokeLLMRequest(
+            prompt_messages=[
+                SystemPromptMessage(content="You are a helpful assistant."),
+                UserPromptMessage(content="Hi there!"),
+                AssistantPromptMessage(content="Hello! How can I help you?"),
+                UserPromptMessage(content="Hello, world!"),
+            ],
+            user_id="",
+            provider="openai",
+            model_type=ModelType.LLM,
+            model="gpt-3.5-turbo",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+            model_parameters={},
+            stop=[],
+            tools=[],
+            stream=False,
+        ),
+        response_type=LLMResultChunk,
+    ):
+        assert result.delta.message.content == "Hello, world!"
+
+
+def test_openai_with_temperature(mock_server, plugin_runner):
+    """Test with temperature parameter"""
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeLLM,
+        payload=ModelInvokeLLMRequest(
+            prompt_messages=[
+                UserPromptMessage(content="Hello, world!"),
+            ],
+            user_id="",
+            provider="openai",
+            model_type=ModelType.LLM,
+            model="gpt-3.5-turbo",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+            model_parameters={"temperature": 0.7},
+            stop=[],
+            tools=[],
+            stream=False,
+        ),
+        response_type=LLMResultChunk,
+    ):
+        assert result.delta.message.content == "Hello, world!"
+
+
+def test_openai_with_max_tokens(mock_server, plugin_runner):
+    """Test with max_tokens parameter"""
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeLLM,
+        payload=ModelInvokeLLMRequest(
+            prompt_messages=[
+                UserPromptMessage(content="Hello, world!"),
+            ],
+            user_id="",
+            provider="openai",
+            model_type=ModelType.LLM,
+            model="gpt-3.5-turbo",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+            model_parameters={"max_tokens": 100},
+            stop=[],
+            tools=[],
+            stream=False,
+        ),
+        response_type=LLMResultChunk,
+    ):
+        assert result.delta.message.content == "Hello, world!"
+
+
+def test_openai_with_tools(mock_server, plugin_runner):
+    """Test with function/tool calling"""
+    tools = [
+        PromptMessageTool(
+            name="get_weather",
+            description="Get the current weather for a location",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city name, e.g. San Francisco",
                     },
-                    model_parameters={},
-                    stop=[],
-                    tools=[],
-                    stream=False,
-                ),
-                response_type=LLMResultChunk,
-            ):
-                assert result.delta.message.content == "Hello, world!"
+                    "unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                    },
+                },
+                "required": ["location"],
+            },
+        )
+    ]
+    
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeLLM,
+        payload=ModelInvokeLLMRequest(
+            prompt_messages=[
+                UserPromptMessage(content="Hello, world!"),
+            ],
+            user_id="",
+            provider="openai",
+            model_type=ModelType.LLM,
+            model="gpt-3.5-turbo",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+            model_parameters={},
+            stop=[],
+            tools=tools,
+            stream=False,
+        ),
+        response_type=LLMResultChunk,
+    ):
+        # With tools, the response might be a tool call or regular message
+        assert result.delta.message is not None
 
 
-def test_openai_streaming():
-    pass
+def test_openai_streaming_with_parameters(mock_server, plugin_runner):
+    """Test streaming with multiple parameters"""
+    chunks = []
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeLLM,
+        payload=ModelInvokeLLMRequest(
+            prompt_messages=[
+                SystemPromptMessage(content="You are a helpful assistant."),
+                UserPromptMessage(content="Hello, world!"),
+            ],
+            user_id="test_user",
+            provider="openai",
+            model_type=ModelType.LLM,
+            model="gpt-3.5-turbo",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+            model_parameters={
+                "temperature": 0.5,
+                "max_tokens": 150,
+            },
+            stop=[],
+            tools=[],
+            stream=True,
+        ),
+        response_type=LLMResultChunk,
+    ):
+        chunks.append(result)
+    
+    assert len(chunks) > 0
+    
+    full_content = "".join(
+        chunk.delta.message.content 
+        for chunk in chunks 
+        if chunk.delta.message.content
+    )
+    
+    assert full_content == "Hello, world!"
+
+
+def test_openai_moderation(mock_server, plugin_runner):
+    """Test moderation"""
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeModeration,
+        payload=ModelInvokeModerationRequest(
+            text="I want to kill them.",
+            user_id="test_user",
+            provider="openai",
+            model_type=ModelType.MODERATION,
+            model="text-moderation-stable",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+        ),
+        response_type=ModerationResult,
+    ):
+        assert result.result is False
+
+
+def test_openai_text_embedding(mock_server, plugin_runner):
+    """Test text embedding"""
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeTextEmbedding,
+        payload=ModelInvokeTextEmbeddingRequest(
+            texts=["Hello, world!"],
+            user_id="test_user",
+            provider="openai",
+            model_type=ModelType.TEXT_EMBEDDING,
+            model="text-embedding-3-small",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+        ),
+        response_type=TextEmbeddingResult,
+    ):
+        assert len(result.embeddings) == 1
+        assert len(result.embeddings[0]) == 1536
+        assert result.usage.total_tokens == 10
+
+
+def test_openai_tts(mock_server, plugin_runner):
+    """Test text to speech"""
+    chunks = []
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeTTS,
+        payload=ModelInvokeTTSRequest(
+            content_text="Hello, world!",
+            voice="alloy",
+            user_id="test_user",
+            tenant_id="test_tenant",
+            provider="openai",
+            model_type=ModelType.TTS,
+            model="tts-1",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+        ),
+        response_type=TTSResult,
+    ):
+        chunks.append(result)
+
+    assert len(chunks) > 0
+
+
+def test_openai_speech2text(mock_server, plugin_runner, tmp_path):
+    """Test speech to text"""
+    # Create dummy audio file
+    audio_file = tmp_path / "test.mp3"
+    audio_file.write_bytes(b"dummy audio content")
+
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Model,
+        access_action=ModelActions.InvokeSpeech2Text,
+        payload=ModelInvokeSpeech2TextRequest(
+            file=audio_file.read_bytes().hex(),
+            user_id="test_user",
+            provider="openai",
+            model_type=ModelType.SPEECH2TEXT,
+            model="whisper-1",
+            credentials={
+                "openai_api_base": f"http://localhost:{OPENAI_MOCK_SERVER_PORT}",
+                "openai_api_key": "test",
+            },
+        ),
+        response_type=Speech2TextResult,
+    ):
+        assert result.result == "Hello, world!"
+


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [ ] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
