### PR TITLE
Replace gpt-5.3 model entry with gpt-5.2

### DIFF
--- a/models/openai/manifest.yaml
+++ b/models/openai/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.7
+version: 0.2.8
 type: plugin
 author: "langgenius"
 name: "openai"

--- a/models/openai/models/llm/_position.yaml
+++ b/models/openai/models/llm/_position.yaml
@@ -1,5 +1,6 @@
 - gpt-5-chat-latest
 - gpt-5.1
+- gpt-5.2
 - gpt-5
 - gpt-5-2025-08-07
 - gpt-5-mini

--- a/models/openai/models/llm/gpt-5.2.yaml
+++ b/models/openai/models/llm/gpt-5.2.yaml
@@ -1,0 +1,78 @@
+# https://platform.openai.com/docs/models/gpt-5.2
+model: gpt-5.2
+label:
+  zh_Hans: gpt-5.2
+  en_US: gpt-5.2
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 400000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理努力程度
+      en_US: Reasoning Effort
+    type: string
+    help:
+      zh_Hans: 约束推理模型的推理努力程度。支持的值包括none、low、medium和high。降低推理努力可以获得更快的响应和更少的推理token使用。GPT-5.2 中默认值为 none。
+      en_US: Constrains effort on reasoning for reasoning models. Currently supported values are none, low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response. The default for GPT-5.2 is none.
+    required: false
+    default: none
+    options:
+      - none
+      - low
+      - medium
+      - high
+  - name: verbosity
+    label:
+      zh_Hans: 详细程度
+      en_US: Verbosity
+    type: string
+    help:
+      zh_Hans: 约束模型响应的详细程度。较低的值将产生更简洁的响应，而较高的值将产生更详细的响应。支持的值包括low、medium和high
+      en_US: Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high
+    required: false
+    default: medium
+    options:
+      - low
+      - medium
+      - high
+  - name: enable_stream
+    label:
+      zh_Hans: 流式响应
+      en_US: Streaming
+    type: boolean
+    help:
+      zh_Hans: GPT-5 系列模型流式输出需要 KYC 验证，若想跳过这个限制使用模型，请关闭流式响应。
+      en_US: GPT-5 series models require KYC validation for streaming output, if you want to use the models without this limitation, please turn off streaming responses.
+    required: true
+    default: true
+pricing:
+  input: '1.25'
+  output: '10.00'
+  unit: '0.000001'
+  currency: USD


### PR DESCRIPTION
## Summary
- replace the mistakenly added gpt-5.3 schema with the intended gpt-5.2 schema and documentation link
- update the OpenAI LLM ordering list to surface gpt-5.2 instead of gpt-5.3

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693fada896cc83268817d9ce41ea4fc9)