### PR TITLE
add trigger integration test example

### DIFF
--- a/tests/triggers/telegram_trigger/conftest.py
+++ b/tests/triggers/telegram_trigger/conftest.py
@@ -1,0 +1,22 @@
+"""
+Pytest configuration and fixtures for telegram_trigger tests.
+"""
+import pytest
+from dify_plugin.integration.run import PluginRunner
+from dify_plugin.config.integration_config import IntegrationConfig
+
+
+@pytest.fixture(scope="module")
+def plugin_runner():
+    """
+    Module-scoped fixture that creates a PluginRunner once for all tests.
+    """
+    print("\n🔌 Starting PluginRunner (once per module)...")
+    with PluginRunner(
+        config=IntegrationConfig(),
+        plugin_package_path="triggers/telegram_trigger",
+    ) as runner:
+        print("✅ PluginRunner started")
+        yield runner
+        print("\n🔌 Shutting down PluginRunner...")
+    print("✅ PluginRunner terminated")

--- a/tests/triggers/telegram_trigger/test_telegram_trigger.py
+++ b/tests/triggers/telegram_trigger/test_telegram_trigger.py
@@ -1,0 +1,234 @@
+"""
+Integration tests for telegram_trigger plugin.
+
+These tests verify the trigger dispatch logic - parsing Telegram webhook
+payloads and routing them to the correct events.
+"""
+import json
+from dify_plugin.core.entities.plugin.request import (
+    PluginInvokeType,
+    TriggerActions,
+    TriggerDispatchEventRequest,
+    TriggerDispatchResponse,
+)
+
+
+def build_telegram_webhook_request(
+    payload: dict,
+    headers: dict | None = None,
+) -> str:
+    """
+    Build a hex-encoded HTTP request for Telegram webhook.
+    """
+    body_str = json.dumps(payload)
+    
+    default_headers = {
+        "Content-Type": "application/json",
+        "Content-Length": str(len(body_str)),
+    }
+    if headers:
+        default_headers.update(headers)
+    
+    headers_str = "\r\n".join(f"{k}: {v}" for k, v in default_headers.items())
+    raw_request = f"POST /webhook HTTP/1.1\r\n{headers_str}\r\n\r\n{body_str}"
+    
+    return raw_request.encode("utf-8").hex()
+
+
+def test_dispatch_message_event(plugin_runner):
+    """
+    Test that a Telegram message webhook payload correctly dispatches
+    to the 'message_received' event.
+    """
+    telegram_payload = {
+        "update_id": 123456789,
+        "message": {
+            "message_id": 1,
+            "from": {
+                "id": 12345,
+                "is_bot": False,
+                "first_name": "Test",
+                "username": "testuser",
+            },
+            "chat": {
+                "id": 12345,
+                "first_name": "Test",
+                "username": "testuser",
+                "type": "private",
+            },
+            "date": 1234567890,
+            "text": "Hello, bot!",
+        }
+    }
+    
+    raw_request = build_telegram_webhook_request(telegram_payload)
+    
+    subscription = {
+        "endpoint": "https://example.com/webhook",
+        "properties": {},  # No secret_token check
+        "parameters": {},
+        "expires_at": -1,
+    }
+    
+    response_chunks = []
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Trigger,
+        access_action=TriggerActions.DispatchTriggerEvent,
+        payload=TriggerDispatchEventRequest(
+            provider="telegram_trigger",
+            subscription=subscription,
+            credentials={"bot_token": "test_token"},
+            credential_type="api-key",
+            raw_http_request=raw_request,
+            user_id="test_user",
+        ),
+        response_type=TriggerDispatchResponse,
+    ):
+        response_chunks.append(result)
+    
+    assert len(response_chunks) == 1
+    response = response_chunks[0]
+    
+    # Should dispatch to 'message_received' event
+    assert len(response.events) == 1
+    assert response.events[0] == "message_received"
+
+
+def test_dispatch_callback_query_event(plugin_runner):
+    """
+    Test that a callback query webhook payload dispatches to 
+    'callback_query_received' event.
+    """
+    telegram_payload = {
+        "update_id": 123456790,
+        "callback_query": {
+            "id": "callback123",
+            "from": {
+                "id": 12345,
+                "is_bot": False,
+                "first_name": "Test",
+            },
+            "chat_instance": "chat_instance_123",
+            "data": "button_clicked",
+        }
+    }
+    
+    raw_request = build_telegram_webhook_request(telegram_payload)
+    
+    subscription = {
+        "endpoint": "https://example.com/webhook",
+        "properties": {},
+        "parameters": {},
+        "expires_at": -1,
+    }
+    
+    response_chunks = []
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Trigger,
+        access_action=TriggerActions.DispatchTriggerEvent,
+        payload=TriggerDispatchEventRequest(
+            provider="telegram_trigger",
+            subscription=subscription,
+            credentials={"bot_token": "test_token"},
+            credential_type="api-key",
+            raw_http_request=raw_request,
+            user_id="test_user",
+        ),
+        response_type=TriggerDispatchResponse,
+    ):
+        response_chunks.append(result)
+    
+    assert len(response_chunks) == 1
+    response = response_chunks[0]
+    
+    # Should dispatch to 'callback_query_received' event
+    assert len(response.events) == 1
+    assert response.events[0] == "callback_query_received"
+
+
+def test_dispatch_invalid_secret_token(plugin_runner):
+    """
+    Test that an invalid secret token raises a validation error.
+    """
+    telegram_payload = {
+        "update_id": 123456791,
+        "message": {
+            "message_id": 1,
+            "text": "Hello!",
+        }
+    }
+    
+    raw_request = build_telegram_webhook_request(
+        telegram_payload,
+        headers={"X-Telegram-Bot-Api-Secret-Token": "wrong_token"}
+    )
+    
+    subscription = {
+        "endpoint": "https://example.com/webhook",
+        "properties": {"secret_token": "correct_token"},  # Require secret token
+        "parameters": {},
+        "expires_at": -1,
+    }
+    
+    try:
+        for result in plugin_runner.invoke(
+            access_type=PluginInvokeType.Trigger,
+            access_action=TriggerActions.DispatchTriggerEvent,
+            payload=TriggerDispatchEventRequest(
+                provider="telegram_trigger",
+                subscription=subscription,
+                credentials={"bot_token": "test_token"},
+                credential_type="api-key",
+                raw_http_request=raw_request,
+                user_id="test_user",
+            ),
+            response_type=TriggerDispatchResponse,
+        ):
+            pass
+        # Should have raised an error
+        assert False, "Expected validation error for invalid secret token"
+    except ValueError as e:
+        # Expected error
+        error_str = str(e)
+        assert "secret" in error_str.lower() or "Invalid" in error_str
+
+
+def test_dispatch_empty_events(plugin_runner):
+    """
+    Test that unknown payload type returns empty events list.
+    """
+    # Payload with no known update type
+    telegram_payload = {
+        "update_id": 123456795,
+    }
+    
+    raw_request = build_telegram_webhook_request(telegram_payload)
+    
+    subscription = {
+        "endpoint": "https://example.com/webhook",
+        "properties": {},
+        "parameters": {},
+        "expires_at": -1,
+    }
+    
+    response_chunks = []
+    for result in plugin_runner.invoke(
+        access_type=PluginInvokeType.Trigger,
+        access_action=TriggerActions.DispatchTriggerEvent,
+        payload=TriggerDispatchEventRequest(
+            provider="telegram_trigger",
+            subscription=subscription,
+            credentials={"bot_token": "test_token"},
+            credential_type="api-key",
+            raw_http_request=raw_request,
+            user_id="test_user",
+        ),
+        response_type=TriggerDispatchResponse,
+    ):
+        response_chunks.append(result)
+    
+    assert len(response_chunks) == 1
+    response = response_chunks[0]
+    
+    # Unknown update type should return empty events list
+    assert len(response.events) == 0


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [ ] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
