### PR TITLE
feat(xinference): add think parameter to control deep thinking mode

### DIFF
--- a/models/xinference/manifest.yaml
+++ b/models/xinference/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.8
+version: 0.0.9


### PR DESCRIPTION
## Background

Some OpenAI-compatible models (e.g. Qwen3, DeepSeek-V3.1) support a thinking / reasoning mode.
However, Xinference currently does not provide an explicit way to enable or disable this behavior at the request level.

In real-world business scenarios, we found that Xinference-deployed model plugins do not support dynamically enabling or disabling deep thinking.
Previously, the common workaround was to control this behavior via environment variables at deployment time.
This approach is coarse-grained and inflexible: within the same service, different business workflows may have different requirements — some benefit from deep reasoning, while others prioritize latency and cost and do not need it.

To address this limitation, this PR introduces a request-level parameter to explicitly control whether deep thinking is enabled.

This PR adds an optional think boolean parameter to allow explicit control of this behavior.

---

## What’s changed

- Add a customizable `think` parameter (boolean) for Xinference LLM models
- When `think=false`, automatically disable deep thinking at request level by passing:
  - `extra_body.chat_template_kwargs.enable_thinking = false`
  - `extra_body.thinking = false`
- Align behavior with Ollama’s `think` parameter for easier configuration and migration
- If `think` is not provided, the server-side default behavior is preserved
- This change is non-breaking and does not affect existing configurations

---
## How to use
- **In Dify UI**: New “Thinking Mode” option in model parameters switch
<img width="783" height="517" alt="image" src="https://github.com/user-attachments/assets/08e160ba-fd8e-4c19-ad3e-7be3921c54d8" />