### PR TITLE
fix: tool call add empty assistant messages that not expected

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.28
+version: 0.0.29
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/requirements.txt
+++ b/agent-strategies/cot_agent/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin>=0.5.0,<0.6.0
+dify_plugin~=0.7.1


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->
fixes https://github.com/langgenius/dify-official-plugins/issues/2350
| Before | After |
|--------|-------|
|<img width="560" height="1204" alt="图片" src="https://github.com/user-attachments/assets/db078967-b14e-4af9-b1ed-107e05055879" />|<img width="461" height="1030" alt="图片" src="https://github.com/user-attachments/assets/3b020d8b-435b-4783-af3e-2d678a94f60e" />|

## before log:
```
[on_llm_before_invoke]
Model: deepseek-reasoner
Parameters:
	Tools:
		current_time
		lunar_query
		get_weather
Stream: True
User: 591e49a8-e188-48dd-8548-2dc0ba9f00dc
Prompt messages:
	role: system
	content: 你是一名助手
	role: user
	content: 同时查询下当前时间和北京天气
	role: assistant
	content: <think>
用户想要同时查询两件事：当前时间和北京天气。我需要同时使用current_time和get_weather这两个工具。current_time不需要参数，get_weather需要城市参数，这里应该是"北京"。那么，我就同时调用这两个工具。
</think>
	role: assistant
	content: 
	name: current_time
	role: tool
	content: 2025-12-31 09:21:49
	role: assistant
	content: 
	name: get_weather
	role: tool
	content: tool response: {"error_code": 0, "reason": "查询成功!", "result": {"city": "北京", "future": [{"date": "2025-12-31", "direct": "北风转西南风", "temperature": "-9/0℃", "weather": "晴", "wid": {"day": "00", "night": "00"}}, {"date": "2026-01-01", "direct": "东北风转北风", "temperature": "-8/1℃", "weather": "多云转晴", "wid": {"day": "01", "night": "00"}}, {"date": "2026-01-02", "direct": "西南风", "temperature": "-8/3℃", "weather": "晴", "wid": {"day": "00", "night": "00"}}, {"date": "2026-01-03", "direct": "西北风转北风", "temperature": "-4/5℃", "weather": "晴转多云", "wid": {"day": "00", "night": "01"}}, {"date": "2026-01-04", "direct": "西风转北风", "temperature": "-6/5℃", "weather": "多云转晴", "wid": {"day": "01", "night": "00"}}], "realtime": {"aqi": "13", "direct": "北风", "humidity": "26", "info": "晴", "power": "4级", "temperature": "-6", "wid": "00"}}}.
```

## after log：
```
[on_llm_before_invoke]
Model: deepseek-reasoner
Parameters:
	Tools:
		current_time
		lunar_query
		get_weather
Stream: True
User: bb27860c-6220-4a6b-99c6-a889424c611f
Prompt messages:
	role: system
	content: 你是一名助手
	role: user
	content: 同时查询下当前时间和北京天气
	role: assistant
	content: <think>
用户想同时查询当前时间和北京天气。我需要同时使用current_time和get_weather这两个工具。我会并行调用它们。
</think>
	name: current_time
	role: tool
	content: 2025-12-31 09:30:46
	name: get_weather
	role: tool
	content: tool response: {"error_code": 0, "reason": "查询成功!", "result": {"city": "北京", "future": [{"date": "2025-12-31", "direct": "北风转西南风", "temperature": "-9/0℃", "weather": "晴", "wid": {"day": "00", "night": "00"}}, {"date": "2026-01-01", "direct": "东北风转北风", "temperature": "-8/1℃", "weather": "多云转晴", "wid": {"day": "01", "night": "00"}}, {"date": "2026-01-02", "direct": "西南风", "temperature": "-8/3℃", "weather": "晴", "wid": {"day": "00", "night": "00"}}, {"date": "2026-01-03", "direct": "西北风转北风", "temperature": "-4/5℃", "weather": "晴转多云", "wid": {"day": "00", "night": "01"}}, {"date": "2026-01-04", "direct": "西风转北风", "temperature": "-6/5℃", "weather": "多云转晴", "wid": {"day": "01", "night": "00"}}], "realtime": {"aqi": "13", "direct": "东北风", "humidity": "25", "info": "晴", "power": "3级", "temperature": "-6", "wid": "00"}}}.
```



## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [x] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
