### PR TITLE
chore: check packaging before uv sync and add `Check Complete` job for branch protection

### DIFF
--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -47,7 +47,7 @@ jobs:
 
           if [ ${#VALID_PLUGINS[@]} -eq 0 ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "plugins=[]" >> $GITHUB_OUTPUT
+            echo "plugins=[\"__no_changes__\"]" >> $GITHUB_OUTPUT
           else
             JSON=$(printf '%s\n' "${VALID_PLUGINS[@]}" | jq -R . | jq -s -c .)
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -57,6 +57,7 @@ jobs:
 
   test:
     needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Related Issues or Context

This workflow failed because the plugin dir contains `.venv` produced by `uv sync`.

https://github.com/langgenius/dify-official-plugins/actions/runs/21243111105/job/61125611739?pr=2440

And this PR cannot be merged because branch protection rule. #2440 

## This PR contains Changes to *Non-Plugin* 
- [ ] Documentation
- [x] CI