### PR TITLE
feat: Add client-side thinking content filtering for Minimax M2.1

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.32
+version: 0.0.33
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"


### PR DESCRIPTION
## Summary

This PR adds client-side filtering support for models like Minimax M2.1 that don't support server-side thinking mode control via API parameters.

## Problem

Minimax M2.1 model deployed on SGLang/vLLM frameworks doesn't respond to API parameters like `thinking: {type: "disabled"}` or `chat_template_kwargs: {enable_thinking: false}`. The model always returns thinking content wrapped in `<think>` tags, even when the user disables thinking mode in Dify UI.

### Testing Results

Tested 10+ different API parameter combinations:
- ❌ `thinking.type = "disabled"` (GLM format)
- ❌ `chat_template_kwargs.enable_thinking = false` (vLLM format)
- ❌ `reasoning_split = true` (Minimax official parameter)
- ❌ All other common parameter combinations

**Conclusion**: Minimax M2.1's SGLang deployment does not support server-side thinking mode control.

## Solution

Added client-side response filtering that:
- Detects and removes `<think>...</think>` blocks from responses
- Only activates when `enable_thinking` is explicitly set to `False`
- Supports both streaming and non-streaming responses
- Maintains full compatibility with models that support server-side control (like GLM)

## Implementation Details

### Smart Triggering Logic

The filter only activates when:
1. User explicitly disables thinking mode (`enable_thinking = False`)
2. Response actually contains `<think>` tags (prevents unnecessary processing)
3. Server-side control didn't work (automatic fallback)

## Compatibility

### Models NOT Affected

- **GLM 4.7**: Server-side control works, no `<think>` tags in response when disabled
- **OpenAI GPT**: No thinking feature, no filtering triggered
- **Other models**: Only filters if `<think>` present AND user disabled thinking

### Models Benefited

- **Minimax M2.1**: Client-side filtering removes `<think>` blocks when SGLang ignores parameters
- **Similar models**: Automatic fallback to client-side filtering

## Testing

✅ Tested with Minimax M2.1 on SGLang framework
✅ Tested 10+ different API parameter combinations
✅ Confirmed GLM models are not affected
✅ Verified backward compatibility

## Impact

- No impact on existing models (GLM, OpenAI, etc.)
- Fixes thinking mode control for Minimax M2.1 and similar models
- Improves user experience when server-side control is unavailable
- Minimal processing overhead (only when filtering is needed)