### PR TITLE
feat(seltz): update SDK to 0.1.3 and adapt to new API

### DIFF
--- a/tests/tools/seltz/test_integration.py
+++ b/tests/tools/seltz/test_integration.py
@@ -27,10 +27,11 @@ def api_key():
 def test_seltz_client_search(api_key):
     """Test basic Seltz client search functionality."""
     from seltz import Seltz
+    from seltz.types import Includes
 
     client = Seltz(api_key=api_key)
 
-    response = client.search(text="Python programming", max_documents=3)
+    response = client.search("Python programming", includes=Includes(max_documents=3))
 
     assert response is not None
     assert hasattr(response, "documents")
@@ -48,10 +49,11 @@ def test_seltz_client_search(api_key):
 def test_seltz_search_different_query(api_key):
     """Test search with a different query."""
     from seltz import Seltz
+    from seltz.types import Includes
 
     client = Seltz(api_key=api_key)
 
-    response = client.search(text="climate change solutions", max_documents=5)
+    response = client.search("climate change solutions", includes=Includes(max_documents=5))
 
     assert response is not None
     assert hasattr(response, "documents")

--- a/tools/seltz/manifest.yaml
+++ b/tools/seltz/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 type: plugin
 author: "langgenius"
 name: "seltz"
@@ -29,7 +29,7 @@ plugins:
   tools:
     - "provider/seltz.yaml"
 meta:
-  version: 0.0.1
+  version: 0.0.2
   arch:
     - "amd64"
     - "arm64"

--- a/tools/seltz/provider/seltz.py
+++ b/tools/seltz/provider/seltz.py
@@ -8,6 +8,7 @@ from seltz import (
     SeltzConfigurationError,
     SeltzConnectionError,
 )
+from seltz.types import Includes
 
 
 class SeltzProvider(ToolProvider):
@@ -24,7 +25,7 @@ class SeltzProvider(ToolProvider):
         try:
             # Perform a test search to validate credentials
             client = Seltz(api_key=api_key)
-            client.search(text="test", max_documents=1)
+            client.search("test", includes=Includes(max_documents=1))
         except SeltzAuthenticationError:
             raise ToolProviderCredentialValidationError(
                 "Invalid Seltz API key."

--- a/tools/seltz/tools/seltz_search.py
+++ b/tools/seltz/tools/seltz_search.py
@@ -11,6 +11,7 @@ from seltz import (
     SeltzRateLimitError,
     SeltzTimeoutError,
 )
+from seltz.types import Includes
 
 
 class SeltzSearchTool(Tool):
@@ -56,7 +57,7 @@ class SeltzSearchTool(Tool):
             client = Seltz(api_key=api_key)
 
             # Perform search
-            response = client.search(text=query, max_documents=max_documents)
+            response = client.search(query, includes=Includes(max_documents=max_documents))
 
             # Check if we have results
             if not response.documents:

--- a/tools/seltz/uv.lock
+++ b/tools/seltz/uv.lock
@@ -649,17 +649,16 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.33.4"
+version = "5.29.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/b8/cda15d9d46d03d4aa3a67cb6bffe05173440ccf86a9541afaf7ac59a1b6b/protobuf-6.33.4.tar.gz", hash = "sha256:dc2e61bca3b10470c1912d166fe0af67bfc20eb55971dcef8dfa48ce14f0ed91", size = 444346, upload-time = "2026-01-12T18:33:40.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/29/d09e70352e4e88c9c7a198d5645d7277811448d76c23b00345670f7c8a38/protobuf-5.29.5.tar.gz", hash = "sha256:bc1463bafd4b0929216c35f437a8e28731a2b7fe3d98bb77a600efced5a15c84", size = 425226, upload-time = "2025-05-28T23:51:59.82Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/be/24ef9f3095bacdf95b458543334d0c4908ccdaee5130420bf064492c325f/protobuf-6.33.4-cp310-abi3-win32.whl", hash = "sha256:918966612c8232fc6c24c78e1cd89784307f5814ad7506c308ee3cf86662850d", size = 425612, upload-time = "2026-01-12T18:33:29.656Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ad/e5693e1974a28869e7cd244302911955c1cebc0161eb32dfa2b25b6e96f0/protobuf-6.33.4-cp310-abi3-win_amd64.whl", hash = "sha256:8f11ffae31ec67fc2554c2ef891dcb561dae9a2a3ed941f9e134c2db06657dbc", size = 436962, upload-time = "2026-01-12T18:33:31.345Z" },
-    { url = "https://files.pythonhosted.org/packages/66/15/6ee23553b6bfd82670207ead921f4d8ef14c107e5e11443b04caeb5ab5ec/protobuf-6.33.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:2fe67f6c014c84f655ee06f6f66213f9254b3a8b6bda6cda0ccd4232c73c06f0", size = 427612, upload-time = "2026-01-12T18:33:32.646Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/48/d301907ce6d0db75f959ca74f44b475a9caa8fcba102d098d3c3dd0f2d3f/protobuf-6.33.4-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:757c978f82e74d75cba88eddec479df9b99a42b31193313b75e492c06a51764e", size = 324484, upload-time = "2026-01-12T18:33:33.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/1c/e53078d3f7fe710572ab2dcffd993e1e3b438ae71cfc031b71bae44fcb2d/protobuf-6.33.4-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c7c64f259c618f0bef7bee042075e390debbf9682334be2b67408ec7c1c09ee6", size = 339256, upload-time = "2026-01-12T18:33:35.231Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/8e/971c0edd084914f7ee7c23aa70ba89e8903918adca179319ee94403701d5/protobuf-6.33.4-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:3df850c2f8db9934de4cf8f9152f8dc2558f49f298f37f90c517e8e5c84c30e9", size = 323311, upload-time = "2026-01-12T18:33:36.305Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b1/1dc83c2c661b4c62d56cc081706ee33a4fc2835bd90f965baa2663ef7676/protobuf-6.33.4-py3-none-any.whl", hash = "sha256:1fe3730068fcf2e595816a6c34fe66eeedd37d51d0400b72fabc848811fdc1bc", size = 170532, upload-time = "2026-01-12T18:33:39.199Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/11/6e40e9fc5bba02988a214c07cf324595789ca7820160bfd1f8be96e48539/protobuf-5.29.5-cp310-abi3-win32.whl", hash = "sha256:3f1c6468a2cfd102ff4703976138844f78ebd1fb45f49011afc5139e9e283079", size = 422963, upload-time = "2025-05-28T23:51:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7f/73cefb093e1a2a7c3ffd839e6f9fcafb7a427d300c7f8aef9c64405d8ac6/protobuf-5.29.5-cp310-abi3-win_amd64.whl", hash = "sha256:3f76e3a3675b4a4d867b52e4a5f5b78a2ef9565549d4037e06cf7b0942b1d3fc", size = 434818, upload-time = "2025-05-28T23:51:44.297Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/73/10e1661c21f139f2c6ad9b23040ff36fee624310dc28fba20d33fdae124c/protobuf-5.29.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e38c5add5a311f2a6eb0340716ef9b039c1dfa428b28f25a7838ac329204a671", size = 418091, upload-time = "2025-05-28T23:51:45.907Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/04/98f6f8cf5b07ab1294c13f34b4e69b3722bb609c5b701d6c169828f9f8aa/protobuf-5.29.5-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:fa18533a299d7ab6c55a238bf8629311439995f2e7eca5caaff08663606e9015", size = 319824, upload-time = "2025-05-28T23:51:47.545Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e4/07c80521879c2d15f321465ac24c70efe2381378c00bf5e56a0f4fbac8cd/protobuf-5.29.5-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:63848923da3325e1bf7e9003d680ce6e14b07e55d0473253a690c3a8b8fd6e61", size = 319942, upload-time = "2025-05-28T23:51:49.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/cc/7e77861000a0691aeea8f4566e5d3aa716f2b1dece4a24439437e41d3d25/protobuf-5.29.5-py3-none-any.whl", hash = "sha256:6cf42630262c59b2d8de33954443d94b746c952b01434fc58a417fdbd2e84bd5", size = 172823, upload-time = "2025-05-28T23:51:58.157Z" },
 ]
 
 [[package]]
@@ -931,15 +930,15 @@ wheels = [
 
 [[package]]
 name = "seltz"
-version = "0.1.1"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/51/9820ecb20c6d907384fd53951c555025154c36e36a2bd2f99dc86126ec8a/seltz-0.1.1.tar.gz", hash = "sha256:79b497229d6b848d08681a22a738763cb7551c9fc6b7a7d39c4bcebf40b92eef", size = 7430, upload-time = "2025-12-13T10:22:00.134Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/f3/a81823416850ec97f5d95f330d13e0ca5d0352caa9ebaa65732f4c0ff073/seltz-0.1.3.tar.gz", hash = "sha256:c77f024fe4eb1dc3ce1a439d8cbb72060b2102520c0b99a9d16b1bc738b0dec3", size = 11533, upload-time = "2026-02-03T00:34:11.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/ab/9124b2a2e3f5b965c104e87931dde27590fc5454f0058e585a65c6d2a7b2/seltz-0.1.1-py3-none-any.whl", hash = "sha256:2d5db38994f355106325fc19bd3811b9592e79121c179c63e11551aa971c0af8", size = 8612, upload-time = "2025-12-13T10:21:58.286Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c1/4db9fcfc1102d99b33f0925101b6182ab2f844c671c3d8a98d4b3df96d90/seltz-0.1.3-py3-none-any.whl", hash = "sha256:16a3e576a2fbcc855d139c6b8a9e0a512e5fc171d8b3c0ff97d8580068b1f078", size = 12363, upload-time = "2026-02-03T00:34:10.185Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  ## Related Issues or Context
  Update seltz SDK to version 0.1.3 and adapt to the new search API changes:
  - `text` → `query`
  - `max_documents` → `Includes()`

  ## This PR contains Changes to *Non-Plugin*
  - [ ] Documentation
  - [ ] Other

  ## This PR contains Changes to *Non-LLM Models Plugin*
  - [x] I have Run Comprehensive Tests Relevant to My Changes

  ## This PR contains Changes to *LLM Models Plugin*
  - [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
  - [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
  - [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
  - [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
  - [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
  - [ ] My Changes Affect Token Consumption Metrics
  - [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
  - [ ] Other Changes (Add New Models, Fix Model Parameters etc.)

  ## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
  - [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)

  ## Dify Plugin SDK Version
  - [x] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

  ## Environment Verification (If Any Code Changes)

  ### Local Deployment Environment
  - [ ] Dify Version is: <!-- fill in your version -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration.

  ### SaaS Environment
  - [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration