### PR TITLE
feat(tongyi): add Kimi K2 series models support

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.1.26
+version: 0.1.27
 created_at: "2024-12-10T16:13:50.29298939+08:00"

--- a/models/tongyi/models/llm/Moonshot-Kimi-K2-Instruct.yaml
+++ b/models/tongyi/models/llm/Moonshot-Kimi-K2-Instruct.yaml
@@ -1,0 +1,70 @@
+# for more details, please refer to https://help.aliyun.com/zh/model-studio/kimi-api
+model: Moonshot-Kimi-K2-Instruct
+label:
+  zh_Hans: Moonshot-Kimi-K2-Instruct
+  en_US: Moonshot-Kimi-K2-Instruct
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 131072
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    type: float
+    default: 0.6
+    min: 0.0
+    max: 2.0
+    help:
+      zh_Hans: 采样温度。
+      en_US: Sampling temperature.
+  - name: top_p
+    use_template: top_p
+    type: float
+    default: 1.0
+    min: 0.0
+    max: 1.0
+    help:
+      zh_Hans: 核采样参数。
+      en_US: Nucleus sampling parameter.
+  - name: presence_penalty
+    type: float
+    default: 0
+    min: -2.0
+    max: 2.0
+    label:
+      zh_Hans: 存在惩罚
+      en_US: Presence Penalty
+    help:
+      zh_Hans: 用于控制模型生成时的主题重复度。正值会鼓励模型讨论新主题。
+      en_US: Controls the tendency to repeat topics. Positive values encourage new topics.
+  - name: max_tokens
+    use_template: max_tokens
+    type: int
+    default: 1024
+    min: 1
+    max: 8192
+    help:
+      zh_Hans: 用于指定模型在生成内容时token的最大数量，它定义了生成的上限，但不保证每次都会生成到这个数量。
+      en_US: It is used to specify the maximum number of tokens when the model generates content. It defines the upper limit of generation, but does not guarantee that this number will be generated every time.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '4'
+  output: '16'
+  unit: '0.000001'
+  currency: RMB

--- a/models/tongyi/models/llm/_position.yaml
+++ b/models/tongyi/models/llm/_position.yaml
@@ -3,6 +3,9 @@
 - qwq-plus-0305
 - qwq-plus
 - qwq-32b
+- kimi-k2.5
+- kimi-k2-thinking
+- Moonshot-Kimi-K2-Instruct
 - deepseek-r1
 - deepseek-r1-distill-qwen-14b
 - deepseek-r1-distill-qwen-32b

--- a/models/tongyi/models/llm/kimi-k2-thinking.yaml
+++ b/models/tongyi/models/llm/kimi-k2-thinking.yaml
@@ -1,0 +1,50 @@
+# for more details, please refer to https://help.aliyun.com/zh/model-studio/kimi-api
+model: kimi-k2-thinking
+label:
+  zh_Hans: kimi-k2-thinking
+  en_US: kimi-k2-thinking
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    type: float
+    default: 1.0
+    min: 0.0
+    max: 2.0
+    help:
+      zh_Hans: 采样温度。思考模式下建议使用 1.0。
+      en_US: Sampling temperature. Recommended 1.0 for thinking mode.
+  - name: max_tokens
+    use_template: max_tokens
+    type: int
+    default: 1024
+    min: 1
+    max: 16384
+    help:
+      zh_Hans: 用于指定模型在生成内容时token的最大数量，它定义了生成的上限，但不保证每次都会生成到这个数量。
+      en_US: It is used to specify the maximum number of tokens when the model generates content. It defines the upper limit of generation, but does not guarantee that this number will be generated every time.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '4'
+  output: '16'
+  unit: '0.000001'
+  currency: RMB

--- a/models/tongyi/models/llm/kimi-k2.5.yaml
+++ b/models/tongyi/models/llm/kimi-k2.5.yaml
@@ -1,0 +1,82 @@
+# for more details, please refer to https://help.aliyun.com/zh/model-studio/kimi-api
+model: kimi-k2.5
+label:
+  zh_Hans: kimi-k2.5
+  en_US: kimi-k2.5
+model_type: llm
+features:
+  - vision
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    type: float
+    default: 0.6
+    min: 0.0
+    max: 2.0
+    help:
+      zh_Hans: 采样温度。思考模式下建议使用 1.0，非思考模式下建议使用 0.6。
+      en_US: Sampling temperature. Recommended 1.0 for thinking mode, 0.6 for instant mode.
+  - name: top_p
+    use_template: top_p
+    type: float
+    default: 0.95
+    min: 0.0
+    max: 1.0
+    help:
+      zh_Hans: 核采样参数。思考模式下建议使用 0.95。
+      en_US: Nucleus sampling parameter. Recommended 0.95 for thinking mode.
+  - name: max_tokens
+    use_template: max_tokens
+    type: int
+    default: 1024
+    min: 1
+    max: 32768
+    help:
+      zh_Hans: 用于指定模型在生成内容时token的最大数量，它定义了生成的上限，但不保证每次都会生成到这个数量。
+      en_US: It is used to specify the maximum number of tokens when the model generates content. It defines the upper limit of generation, but does not guarantee that this number will be generated every time.
+  - name: enable_thinking
+    label:
+      zh_Hans: 深度思考
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 启用深度思考模式，使模型具备强大的推理能力，适合解决复杂的逻辑推理、数学问题和代码编写等任务。
+      en_US: Enable thinking mode for enhanced reasoning capabilities, suitable for complex logical reasoning, math problems, and coding tasks.
+  - name: thinking_budget
+    required: false
+    type: int
+    default: 512
+    min: 1
+    max: 32768
+    label:
+      zh_Hans: 思考长度限制
+      en_US: Thinking budget
+    help:
+      zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
+      en_US: The maximum length of the thinking process, only effective when thinking mode is true.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '4'
+  output: '21'
+  unit: '0.000001'
+  currency: RMB

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -48,7 +48,8 @@ from dify_plugin.entities.model.message import (
     TextPromptMessageContent,
     ToolPromptMessage,
     UserPromptMessage,
-    VideoPromptMessageContent, AudioPromptMessageContent,
+    VideoPromptMessageContent,
+    AudioPromptMessageContent,
 )
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,
@@ -210,7 +211,9 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             if len(prompt_messages) > 1:
                 prompt_messages = prompt_messages[-1:]
             if prompt_messages[-1].role != PromptMessageRole.USER:
-                raise ValueError("There is one and only one User Message in the messages array.")
+                raise ValueError(
+                    "There is one and only one User Message in the messages array."
+                )
 
         params = {
             "model": model,
@@ -222,26 +225,35 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
 
         incremental_output = False if tools else stream
 
-        thinking_business_qwen3 = model in ("qwen-plus-latest", "qwen-plus-2025-04-28",
-                                            "qwen-turbo-latest", "qwen-turbo-2025-04-28",
-                                            "qwen3-max-2026-01-23") \
-                                  and model_parameters.get("enable_thinking", False)
+        thinking_business_qwen3 = model in (
+            "qwen-plus-latest",
+            "qwen-plus-2025-04-28",
+            "qwen-turbo-latest",
+            "qwen-turbo-2025-04-28",
+            "qwen3-max-2026-01-23",
+        ) and model_parameters.get("enable_thinking", False)
 
-        # Qwen3 business edition (Thinking Mode), Qwen3 open-source edition (excluding coder and max variants), QwQ, and QVQ models only supports streaming output.
+        # Kimi models with thinking capability: kimi-k2.5 (when enable_thinking=true) and kimi-k2-thinking
+        thinking_kimi = (
+            model == "kimi-k2.5" and model_parameters.get("enable_thinking", False)
+        ) or model == "kimi-k2-thinking"
+
+        # Qwen3 business edition (Thinking Mode), Qwen3 open-source edition (excluding coder and max variants), QwQ, QVQ, and Kimi thinking models only supports streaming output.
         # Note: qwen3-coder-xx and qwen3-max-xx models support non-streaming output.
-        qwen3_requires_stream = (
-            model.startswith("qwen3-") 
-            and not model.startswith(("qwen3-coder", "qwen3-max"))
+        qwen3_requires_stream = model.startswith("qwen3-") and not model.startswith(
+            ("qwen3-coder", "qwen3-max")
         )
-        common_force_condition = thinking_business_qwen3 or qwen3_requires_stream
+        common_force_condition = (
+            thinking_business_qwen3 or qwen3_requires_stream or thinking_kimi
+        )
         if common_force_condition or model.startswith(("qwq-", "qvq-")):
             stream = True
-        # Qwen3 business edition (Thinking Mode), Qwen3 open-source edition (excluding coder and max variants), QwQ, and QVQ models only supports incremental_output set to True.
+        # Qwen3 business edition (Thinking Mode), Qwen3 open-source edition (excluding coder and max variants), QwQ, QVQ, and Kimi thinking models only supports incremental_output set to True.
         if common_force_condition or model.startswith(("qwq-", "qvq-")):
             incremental_output = True
 
         base_address = get_http_base_address(credentials)
-        
+
         # The parameter `enable_omni_output_audio_url` must be set to true when using the Omni model in non-streaming mode.
         if model.startswith("qwen3-omni-") and not stream:
             params["enable_omni_output_audio_url"] = True
@@ -255,7 +267,8 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 stream=stream,
                 headers=self._get_market_bury_point_header(params["messages"]),
                 incremental_output=incremental_output,
-                base_address=base_address)
+                base_address=base_address,
+            )
         else:
             params["messages"] = self._convert_prompt_messages_to_tongyi_messages(
                 credentials, prompt_messages
@@ -266,11 +279,15 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 result_format="message",
                 stream=stream,
                 incremental_output=incremental_output,
-                base_address=base_address
+                base_address=base_address,
             )
         if stream:
             return self._handle_generate_stream_response(
-                model, credentials, response, prompt_messages, incremental_output,
+                model,
+                credentials,
+                response,
+                prompt_messages,
+                incremental_output,
             )
         return self._handle_generate_response(
             model, credentials, response, prompt_messages
@@ -295,8 +312,10 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         try:
             if response.status_code not in {200, HTTPStatus.OK}:
                 # Get request_id (if present) and forward it to the error handler.
-                request_id = getattr(response, 'request_id', None)
-                self._handle_error_response(response.status_code, response.message, model, request_id)
+                request_id = getattr(response, "request_id", None)
+                self._handle_error_response(
+                    response.status_code, response.message, model, request_id
+                )
 
             resp_content = response.output.choices[0].message.content
             # special for qwen-vl
@@ -325,24 +344,24 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
     def _handle_tool_call_stream(self, response, tool_calls, incremental_output):
         tool_calls_stream = response.output.choices[0].message["tool_calls"]
         for tool_call_stream in tool_calls_stream:
-            idx = tool_call_stream.get('index')
+            idx = tool_call_stream.get("index")
             if idx >= len(tool_calls):
                 tool_calls.append(tool_call_stream)
             else:
-                if tool_call_stream.get('function'):
-                    func_name = tool_call_stream.get('function').get('name')
+                if tool_call_stream.get("function"):
+                    func_name = tool_call_stream.get("function").get("name")
                     tool_call_obj = tool_calls[idx]
                     if func_name:
                         if incremental_output:
-                            tool_call_obj['function']['name'] += func_name
+                            tool_call_obj["function"]["name"] += func_name
                         else:
-                            tool_call_obj['function']['name'] = func_name
-                    args = tool_call_stream.get('function').get('arguments')
+                            tool_call_obj["function"]["name"] = func_name
+                    args = tool_call_stream.get("function").get("arguments")
                     if args:
                         if incremental_output:
-                            tool_call_obj['function']['arguments'] += args
+                            tool_call_obj["function"]["arguments"] += args
                         else:
-                            tool_call_obj['function']['arguments'] = args
+                            tool_call_obj["function"]["arguments"] = args
 
     def _handle_generate_stream_response(
         self,
@@ -370,15 +389,19 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             for index, response in enumerate(responses):
                 if response.status_code not in {200, HTTPStatus.OK}:
                     # Get request_id (if present) and forward it to the error handler.
-                    request_id = getattr(response, 'request_id', None)
-                    self._handle_error_response(response.status_code, response.message, model, request_id)
+                    request_id = getattr(response, "request_id", None)
+                    self._handle_error_response(
+                        response.status_code, response.message, model, request_id
+                    )
 
                 resp_finish_reason = response.output.choices[0].finish_reason
                 if resp_finish_reason is not None and resp_finish_reason != "null":
                     resp_content = response.output.choices[0].message.content
                     assistant_prompt_message = AssistantPromptMessage(content="")
                     if "tool_calls" in response.output.choices[0].message:
-                        self._handle_tool_call_stream(response, tool_calls, incremental_output)
+                        self._handle_tool_call_stream(
+                            response, tool_calls, incremental_output
+                        )
                     elif resp_content:
                         if isinstance(resp_content, list):
                             resp_content = resp_content[0]["text"]
@@ -423,10 +446,10 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 else:
                     message = response.output.choices[0].message
 
-                    resp_content, is_reasoning = self._wrap_thinking_by_reasoning_content(
-                        message, is_reasoning
+                    resp_content, is_reasoning = (
+                        self._wrap_thinking_by_reasoning_content(message, is_reasoning)
                     )
-                    
+
                     content_to_yield = []
                     if resp_content:
                         if incremental_output:
@@ -447,8 +470,10 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                             if incremental_output:
                                 full_text += "\n</think>"
                             is_reasoning = False
-                        self._handle_tool_call_stream(response, tool_calls, incremental_output)
-                    
+                        self._handle_tool_call_stream(
+                            response, tool_calls, incremental_output
+                        )
+
                     if content_to_yield:
                         assistant_prompt_message = AssistantPromptMessage(
                             content="".join(content_to_yield)
@@ -493,7 +518,9 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                         message_text = f"{human_prompt} {sub_message.data}"
                         break
             else:
-                raise TypeError(f"[convert_one_message_to_text] Unexpected content type: {type(content)}")
+                raise TypeError(
+                    f"[convert_one_message_to_text] Unexpected content type: {type(content)}"
+                )
         elif isinstance(message, AssistantPromptMessage):
             message_text = f"{ai_prompt} {content}"
         elif isinstance(message, SystemPromptMessage | ToolPromptMessage):
@@ -568,7 +595,9 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                             )
                             image_url = message_content.data
                             if message_content.data.startswith("data:"):
-                                image_url = self._save_base64_to_file(message_content.data)
+                                image_url = self._save_base64_to_file(
+                                    message_content.data
+                                )
                             sub_message_dict = {"image": image_url}
                             user_messages.append(sub_message_dict)
                         elif message_content.type == PromptMessageContentType.VIDEO:
@@ -577,7 +606,9 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                             )
                             video_url = message_content.data
                             if message_content.data.startswith("data:"):
-                                video_url = self._save_base64_to_file(message_content.data)
+                                video_url = self._save_base64_to_file(
+                                    message_content.data
+                                )
                             sub_message_dict = {"video": video_url}
                             user_messages.append(sub_message_dict)
                         elif message_content.type == PromptMessageContentType.AUDIO:
@@ -706,7 +737,9 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 try:
                     os.remove(temp_file_path)
                 except Exception as e:
-                    logger.warning(f"Failed to remove temporary file {temp_file_path}: {e}")
+                    logger.warning(
+                        f"Failed to remove temporary file {temp_file_path}: {e}"
+                    )
 
     def _convert_tools(self, tools: list[PromptMessageTool]) -> list[dict]:
         """
@@ -737,7 +770,9 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             tool_definitions.append(tool_definition)
         return tool_definitions
 
-    def _wrap_thinking_by_reasoning_content(self, delta: dict, is_reasoning: bool) -> tuple[str, bool]:
+    def _wrap_thinking_by_reasoning_content(
+        self, delta: dict, is_reasoning: bool
+    ) -> tuple[str, bool]:
         """
         If the reasoning response is from delta.get("reasoning_content"), we wrap
         it with HTML think tag.
@@ -773,12 +808,12 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 content = "\n</think>" + content
                 is_reasoning = False
         except Exception as ex:
-            raise ValueError(
-                f"[wrap_thinking_by_reasoning_content-2] {ex}"
-            ) from ex
+            raise ValueError(f"[wrap_thinking_by_reasoning_content-2] {ex}") from ex
         return content, is_reasoning
 
-    def _handle_error_response(self, status_code: int, message: str, model: str = None, request_id: str = None) -> None:
+    def _handle_error_response(
+        self, status_code: int, message: str, model: str = None, request_id: str = None
+    ) -> None:
         """
         Handle error response based on HTTP status code
 
@@ -919,25 +954,26 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             dict: Bury point header information dictionary containing moduleCode, accountId and other fields;
                   If no valid information can be extracted, returns the default BURY_POINT_HEADER
         """
-        system_entries = [entry for entry in messages if entry['role'] == 'system']
+        system_entries = [entry for entry in messages if entry["role"] == "system"]
         if system_entries:
-            system_entry = system_entries[0].get('content', '')
+            system_entry = system_entries[0].get("content", "")
             if system_entry:
                 try:
                     system_entry_split = system_entry.split("||||||")
                     if len(system_entry_split) >= 2:
-                        burn = system_entry_split[0].split(',')
-                        bury_point_header = json.loads(BURY_POINT_HEADER.get('x-dashscope-euid'))
+                        burn = system_entry_split[0].split(",")
+                        bury_point_header = json.loads(
+                            BURY_POINT_HEADER.get("x-dashscope-euid")
+                        )
                         if len(burn) in (1, 2):
                             product_code = burn[0]
                             buyer_uid = burn[1] if len(burn) == 2 else ""
-                            bury_point_header['moduleCode'] = product_code.strip()
-                            bury_point_header['accountId'] = buyer_uid.strip()
+                            bury_point_header["moduleCode"] = product_code.strip()
+                            bury_point_header["accountId"] = buyer_uid.strip()
 
-                        system_entries[0]['content'] = "".join(system_entry_split[1:])
-                        return {'x-dashscope-euid': json.dumps(bury_point_header)}
+                        system_entries[0]["content"] = "".join(system_entry_split[1:])
+                        return {"x-dashscope-euid": json.dumps(bury_point_header)}
                 except Exception:
                     return BURY_POINT_HEADER
 
         return BURY_POINT_HEADER
-


### PR DESCRIPTION
## Summary

Add three new Kimi models from Alibaba Cloud Bailian platform to the Tongyi plugin:

### New Models

1. **kimi-k2.5** - The most versatile model in the Kimi series
   - Supports vision (multimodal)
   - Supports thinking mode (toggle via \enable_thinking\ parameter)
   - Supports tool calling
   - Context size: 262,144 tokens
   - Pricing: ¥4/M input, ¥21/M output

2. **kimi-k2-thinking** - Dedicated thinking model
   - Always in thinking mode
   - Returns reasoning_content for step-by-step reasoning display
   - Supports tool calling
   - Context size: 262,144 tokens
   - Pricing: ¥4/M input, ¥16/M output

3. **Moonshot-Kimi-K2-Instruct** - Fast non-thinking model
   - Direct response without thinking
   - Faster response time
   - Supports tool calling
   - Context size: 131,072 tokens
   - Pricing: ¥4/M input, ¥16/M output

### Changes

- Added model YAML configurations for the three new models
- Updated \llm.py\ to handle thinking mode for kimi models:
  - kimi-k2.5 with enable_thinking=true forces streaming output
  - kimi-k2-thinking always forces streaming output
  - Both support incremental_output for proper reasoning display
- Updated \_position.yaml\ to include new models
- Bumped version from 0.1.26 to 0.1.27

### Reference

- https://help.aliyun.com/zh/model-studio/kimi-api
- https://bailian.console.aliyun.com/cn-beijing/?tab=model#/model-market/detail/kimi-k2.5