### PR TITLE
fix(tongyi): explicitly set enable_thinking=False when not provided

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.1.30
+version: 0.1.31
 created_at: "2024-12-10T16:13:50.29298939+08:00"

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -214,6 +214,16 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 raise ValueError(
                     "There is one and only one User Message in the messages array."
                 )
+        # For models that support enable_thinking parameter, explicitly set it to False if not provided
+        # This overrides API-level defaults (e.g., qwen3.5-plus defaults to thinking mode enabled)
+        thinking_capable_models = {
+            "qwen-plus-latest", "qwen-plus-2025-04-28",
+            "qwen-turbo-latest", "qwen-turbo-2025-04-28",
+            "qwen3-max-2026-01-23",
+            "qwen3.5-plus", "qwen3.5-plus-2026-02-15",
+        }
+        if model in thinking_capable_models and "enable_thinking" not in model_parameters:
+            model_parameters["enable_thinking"] = False
 
         params = {
             "model": model,


### PR DESCRIPTION
## Summary

Fix a bug where qwen3.5-plus and other thinking-capable models were running in thinking mode by default, even when users didn't enable it.

## Problem

According to Alibaba Cloud Bailian API documentation:
> "qwen3.5-plus、qwen3-vl-plus、qwen3-vl-flash可通过enable_thinking开启或关闭思考（**其中qwen3.5-plus默认开启**）"

This means the API-level default for qwen3.5-plus is `enable_thinking=true`, but Dify's YAML configuration sets `default: false`.

When users don't explicitly set the `enable_thinking` parameter:
1. The parameter is NOT included in the API request
2. The API uses its default (qwen3.5-plus: true)
3. Users experience unexpected slow responses due to hidden thinking mode

## Root Cause

```python
# Before: enable_thinking not in model_parameters -> not sent to API
params = {
    "model": model,
    **model_parameters,  # Missing enable_thinking
    ...
}
```

## Fix

Explicitly set `enable_thinking=False` when not provided by the user:

```python
# After: Always send enable_thinking to override API defaults
thinking_capable_models = {
    "qwen-plus-latest", "qwen-plus-2025-04-28",
    "qwen-turbo-latest", "qwen-turbo-2025-04-28",
    "qwen3-max-2026-01-23",
    "qwen3.5-plus", "qwen3.5-plus-2026-02-15",
}
if model in thinking_capable_models and "enable_thinking" not in model_parameters:
    model_parameters["enable_thinking"] = False
```

## Affected Models

- qwen-plus-latest, qwen-plus-2025-04-28
- qwen-turbo-latest, qwen-turbo-2025-04-28
- qwen3-max-2026-01-23
- qwen3.5-plus, qwen3.5-plus-2026-02-15

## Version

Bumped to 0.1.31

## Related

- Issue reported: qwen3.5-plus always running in thinking mode
- Issue reported: qwen3-max-2026-01-23 responses slower than 0.1.27