### PR TITLE
fix(gemini): handle NoneType in usage_metadata, grounding_metadata an…

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.18
+version: 0.0.19
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/google.py
+++ b/models/aihubmix/models/llm/google.py
@@ -225,6 +225,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         """
         Render google search source links
         """
+        if not grounding_metadata or not grounding_metadata.grounding_chunks:
+            return ""
+            
         result = "\n\n**Search Sources:**\n"
         for index, entry in enumerate(grounding_metadata.grounding_chunks, start=1):
             result += f"{index}. [{entry.web.title}]({entry.web.uri})\n"
@@ -266,16 +269,17 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         # https://ai.google.dev/gemini-api/docs/pricing?hl=zh-cn#gemini-2.5-pro
         # FIXME: Currently, Dify's pricing model cannot cover the tokens of multimodal resources
         # FIXME: Unable to track caching, Grounding, Live API
-        for _mtc in usage_metadata.prompt_tokens_details:
-            if _mtc.modality in [
-                types.MediaModality.TEXT,
-                types.MediaModality.IMAGE,
-                types.MediaModality.VIDEO,
-                types.MediaModality.MODALITY_UNSPECIFIED,
-                types.MediaModality.AUDIO,
-                types.MediaModality.DOCUMENT,
-            ]:
-                prompt_tokens_standard += _mtc.token_count
+        if usage_metadata.prompt_tokens_details:
+            for _mtc in usage_metadata.prompt_tokens_details:
+                if _mtc.modality in [
+                    types.MediaModality.TEXT,
+                    types.MediaModality.IMAGE,
+                    types.MediaModality.VIDEO,
+                    types.MediaModality.MODALITY_UNSPECIFIED,
+                    types.MediaModality.AUDIO,
+                    types.MediaModality.DOCUMENT,
+                ]:
+                    prompt_tokens_standard += _mtc.token_count
 
         # Number of tokens present in thoughts output.
         thoughts_token_count = usage_metadata.thoughts_token_count or 0
@@ -700,7 +704,8 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         # Always use _parse_parts to ensure consistent response format (list of PromptMessageContent)
         # This fixes the "'str' object has no attribute 'get'" error that occurs when
         # downstream code expects structured content but receives a plain string
-        assistant_prompt_message = self._parse_parts(response.candidates[0].content.parts)
+        parts = response.candidates[0].content.parts if response.candidates[0].content else []
+        assistant_prompt_message = self._parse_parts(parts)
 
         # calculate num tokens
         prompt_tokens, completion_tokens = self._calculate_tokens_from_usage_metadata(
@@ -776,9 +781,10 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             ):
                 continue
             candidate = chunk.candidates[0]
-            message = self._parse_parts(candidate.content.parts)
+            parts = candidate.content.parts if candidate.content else []
+            message = self._parse_parts(parts)
 
-            index += len(candidate.content.parts)
+            index += len(parts) if parts else 0
 
             # if the stream is not finished, yield the chunk
             if not candidate.finish_reason:
@@ -822,7 +828,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     ),
                 )
 
-    def _parse_parts(self, parts: Sequence[types.Part], /) -> AssistantPromptMessage:
+    def _parse_parts(self, parts: Sequence[types.Part] | None, /) -> AssistantPromptMessage:
         """
 
         Args:
@@ -846,6 +852,13 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         """
         contents: list[PromptMessageContent] = []
         function_calls = []
+        
+        if not parts:
+            return AssistantPromptMessage(
+                content=contents,
+                tool_calls=function_calls,  # type: ignore
+            )
+            
         for part in parts:
             if part.text:
                 # Check if we need to start thinking mode

--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.7.9
+version: 0.7.10


### PR DESCRIPTION
…d content.parts

## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->
#2630 

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [x] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
