### PR TITLE
feat(seltz): upgrade seltz SDK to 0.2.0 and bump plugin to 0.0.3

### DIFF
--- a/tests/tools/seltz/test_integration.py
+++ b/tests/tools/seltz/test_integration.py
@@ -27,7 +27,7 @@ def api_key():
 def test_seltz_client_search(api_key):
     """Test basic Seltz client search functionality."""
     from seltz import Seltz
-    from seltz.types import Includes
+    from seltz import Includes
 
     client = Seltz(api_key=api_key)
 
@@ -37,6 +37,7 @@ def test_seltz_client_search(api_key):
     assert hasattr(response, "documents")
     # We expect at least one result for a common query
     assert len(response.documents) > 0
+    assert len(response.documents) <= 3
 
     # Check document structure
     for doc in response.documents:
@@ -49,7 +50,7 @@ def test_seltz_client_search(api_key):
 def test_seltz_search_different_query(api_key):
     """Test search with a different query."""
     from seltz import Seltz
-    from seltz.types import Includes
+    from seltz import Includes
 
     client = Seltz(api_key=api_key)
 
@@ -58,6 +59,7 @@ def test_seltz_search_different_query(api_key):
     assert response is not None
     assert hasattr(response, "documents")
     assert len(response.documents) > 0
+    assert len(response.documents) <= 5
 
     # Verify document structure
     doc = response.documents[0]

--- a/tools/seltz/manifest.yaml
+++ b/tools/seltz/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 type: plugin
 author: "langgenius"
 name: "seltz"
@@ -29,7 +29,7 @@ plugins:
   tools:
     - "provider/seltz.yaml"
 meta:
-  version: 0.0.2
+  version: 0.0.3
   arch:
     - "amd64"
     - "arm64"

--- a/tools/seltz/provider/seltz.py
+++ b/tools/seltz/provider/seltz.py
@@ -8,7 +8,7 @@ from seltz import (
     SeltzConfigurationError,
     SeltzConnectionError,
 )
-from seltz.types import Includes
+from seltz import Includes
 
 
 class SeltzProvider(ToolProvider):

--- a/tools/seltz/pyproject.toml
+++ b/tools/seltz/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 dependencies = [
     "dify_plugin>=0.3.0,<0.6.0",
-    "seltz",
+    "seltz>=0.2.0",
 ]
 
 [dependency-groups]

--- a/tools/seltz/requirements.txt
+++ b/tools/seltz/requirements.txt
@@ -1,2 +1,2 @@
 dify_plugin>=0.3.0,<0.6.0
-seltz
+seltz>=0.2.0

--- a/tools/seltz/tools/seltz_search.py
+++ b/tools/seltz/tools/seltz_search.py
@@ -11,7 +11,7 @@ from seltz import (
     SeltzRateLimitError,
     SeltzTimeoutError,
 )
-from seltz.types import Includes
+from seltz import Includes
 
 
 class SeltzSearchTool(Tool):

--- a/tools/seltz/uv.lock
+++ b/tools/seltz/uv.lock
@@ -179,7 +179,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "dify-plugin", specifier = ">=0.3.0,<0.6.0" },
-    { name = "seltz" },
+    { name = "seltz", specifier = ">=0.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -930,15 +930,15 @@ wheels = [
 
 [[package]]
 name = "seltz"
-version = "0.1.3"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/f3/a81823416850ec97f5d95f330d13e0ca5d0352caa9ebaa65732f4c0ff073/seltz-0.1.3.tar.gz", hash = "sha256:c77f024fe4eb1dc3ce1a439d8cbb72060b2102520c0b99a9d16b1bc738b0dec3", size = 11533, upload-time = "2026-02-03T00:34:11.122Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/9a/fb73753caabb67f59daabb4eef1dea39c8309161d2ceba325963967e3118/seltz-0.2.0.tar.gz", hash = "sha256:6549ab29507195231af180d0d665f6b90490f1d6cbd8bc2cdba1561139f3a82d", size = 9504, upload-time = "2026-03-04T19:02:23.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/c1/4db9fcfc1102d99b33f0925101b6182ab2f844c671c3d8a98d4b3df96d90/seltz-0.1.3-py3-none-any.whl", hash = "sha256:16a3e576a2fbcc855d139c6b8a9e0a512e5fc171d8b3c0ff97d8580068b1f078", size = 12363, upload-time = "2026-02-03T00:34:10.185Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/27/26d7d21f44a559b7a99dce66f61db294b868f1e0f646cd954f751bb63af8/seltz-0.2.0-py3-none-any.whl", hash = "sha256:c0bc5399f48d3284dadf7860e0682e5f013ce0bc14abbd731d4491fb4b6843e5", size = 10223, upload-time = "2026-03-04T19:02:22.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related Issues or Context
Upgrade seltz SDK from 0.1.3 to 0.2.0. The new version moves `Includes` from `seltz.types` to the top-level `seltz` module, requiring import path updates.

## This PR contains Changes to *Non-Plugin* 
- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [x] I have Run Comprehensive Tests Relevant to My Changes

## This PR contains Changes to *LLM Models Plugin*
- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
- [ ] My Changes Affect Token Consumption Metrics
- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt

## Environment Verification (If Any Code Changes)

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration

-----

Twitter/X: [@WilliamEpegren](https://x.com/WilliamEspegren)