### PR TITLE
fix: normalize text-only prompt atoms in deepseek and tongyi

### DIFF
--- a/models/deepseek/models/llm/llm.py
+++ b/models/deepseek/models/llm/llm.py
@@ -7,6 +7,7 @@ from dify_plugin.entities.model.message import (
     PromptMessage,
     PromptMessageTool,
     SystemPromptMessage,
+    TextPromptMessageContent,
     ToolPromptMessage,
     UserPromptMessage,
 )
@@ -17,6 +18,24 @@ import re
 class DeepseekLargeLanguageModel(OAICompatLargeLanguageModel):
     # Pattern to match <think>...</think> blocks (case-insensitive, non-greedy)
     _THINK_PATTERN = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
+
+    @staticmethod
+    def _normalize_text_content(content):
+        if isinstance(content, list) and all(
+            isinstance(item, TextPromptMessageContent) for item in content
+        ):
+            return "".join(item.data or "" for item in content)
+        return content
+
+    def _normalize_prompt_messages(
+        self, messages: list[PromptMessage]
+    ) -> list[PromptMessage]:
+        normalized: list[PromptMessage] = []
+        for message in messages:
+            message_copy = message.model_copy()
+            message_copy.content = self._normalize_text_content(message_copy.content)
+            normalized.append(message_copy)
+        return normalized
 
     def _invoke(
         self,
@@ -30,6 +49,7 @@ class DeepseekLargeLanguageModel(OAICompatLargeLanguageModel):
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator]:
         self._add_custom_parameters(credentials)
+        prompt_messages = self._normalize_prompt_messages(prompt_messages)
         # Merge consecutive messages with the same role to strictly follow API specs
         prompt_messages = self._clean_messages(prompt_messages)
         response = super()._invoke(

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -75,6 +75,24 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         super().__init__(*args, **kwargs)
         self._temp_files = []
 
+    @staticmethod
+    def _normalize_text_content(content):
+        if isinstance(content, list) and all(
+            isinstance(item, TextPromptMessageContent) for item in content
+        ):
+            return "".join(item.data or "" for item in content)
+        return content
+
+    def _normalize_prompt_messages(
+        self, messages: list[PromptMessage]
+    ) -> list[PromptMessage]:
+        normalized: list[PromptMessage] = []
+        for message in messages:
+            message_copy = message.model_copy()
+            message_copy.content = self._normalize_text_content(message_copy.content)
+            normalized.append(message_copy)
+        return normalized
+
     def _invoke(
         self,
         model: str,
@@ -183,6 +201,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         :param user: unique user id
         :return: full response or stream response chunk generator result
         """
+        prompt_messages = self._normalize_prompt_messages(prompt_messages)
         credentials_kwargs = self._to_credential_kwargs(credentials)
         mode = self.get_model_mode(model, credentials)
         if model in {"qwen-turbo-chat", "qwen-plus-chat"}:


### PR DESCRIPTION
### Summary
This PR normalizes prompt message content in the `deepseek` and `tongyi` official plugins before provider-specific conversion runs.

It fixes a compatibility issue where Dify can pass prompt content as `list[TextPromptMessageContent]`, which currently leaks into JSON serialization or provider adapters and causes runtime failures such as:

- `Object of type TextPromptMessageContent is not JSON serializable`
- `Unsupported atom data type: <class 'dify_plugin.entities.model.message.TextPromptMessageContent'>`

This is the same failure pattern we reproduced on Dify `1.13.1` with:
- `langgenius/deepseek:0.0.11`
- `langgenius/tongyi:0.1.33`

Related issues: 
FIx #2753
Fix #2761

### What changed
- Added `_normalize_text_content()` helper to `deepseek` and `tongyi` LLM implementations.
- Added `_normalize_prompt_messages()` helper to copy prompt messages and collapse pure text atom lists into plain strings.
- Invoked normalization before the existing provider-specific message cleanup / conversion logic.

### Why this is safe
The change is intentionally narrow:
- It only converts content when the message content is a list and every item is `TextPromptMessageContent`.
- Mixed multimodal content remains untouched.
- Existing provider-specific handling for images, audio, video, documents, tool calls, and reasoning content is preserved.

### Validation
- `python -m py_compile models/deepseek/models/llm/llm.py models/tongyi/models/llm/llm.py`
- Reproduced the original failure in a live Dify `1.13.1` deployment, applied equivalent hot patches, restarted plugin daemon / workers, and confirmed the workflow stopped producing `TextPromptMessageContent`, `UnsupportedDataType`, and `PluginInvokeError` log entries.
