### PR TITLE
feat(models/anthropic): add customizable-model support, 1M context for Opus 4.6

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.6
+version: 0.3.7

--- a/models/anthropic/models/llm/claude-opus-4-6.yaml
+++ b/models/anthropic/models/llm/claude-opus-4-6.yaml
@@ -10,7 +10,7 @@ features:
   - document
 model_properties:
   mode: chat
-  context_size: 200000
+  context_size: 1000000
 parameter_rules:
   - name: thinking
     label:
@@ -115,6 +115,16 @@ parameter_rules:
     help:
       zh_Hans: 启用工具结果的提示缓存。
       en_US: Enable prompt caching for tool results.
+  - name: context_1m
+    label:
+      zh_Hans: 1M上下文窗口
+      en_US: 1M Context Window
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用1M令牌上下文窗口。需要使用层级4或自定义速率限制的组织。注意, 超过200K令牌的请求将按高级费率收费（输入2倍，输出1.5倍定价）, Dify显示的价格计算可能不准确。
+      en_US: Enable 1M token context window. Requires organizations in usage tier 4 or with custom rate limits. Note, Requests exceeding 200K tokens are charged at premium rates (2x input, 1.5x output pricing), Dify's displayed pricing calculations may be inaccurate.
 pricing:
   input: '5.00'
   output: '25.00'

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -19,7 +19,18 @@ from anthropic.types import (
     MessageStreamEvent,
     completion_create_params,
 )
+from dify_plugin.entities.model import (
+    AIModelEntity,
+    FetchFrom,
+    I18nObject,
+    ModelFeature,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    ParameterType,
+)
 from dify_plugin.entities.model.llm import (
+    LLMMode,
     LLMResult,
     LLMResultChunk,
     LLMResultChunkDelta,
@@ -151,6 +162,71 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         self._document_cache_enabled = False
         self._tool_results_cache_enabled = False
         self._message_flow_cache_threshold: int = 0
+
+    def get_customizable_model_schema(self, model: str, credentials: dict) -> Optional[AIModelEntity]:
+        """
+        Return schema for a custom model name entered by the user.
+        This allows users to use any Anthropic-compatible model name
+        (e.g. from third-party proxies) without being limited to predefined models.
+        """
+        return AIModelEntity(
+            model=model,
+            label=I18nObject(en_US=model, zh_Hans=model),
+            model_type=ModelType.LLM,
+            features=[
+                ModelFeature.AGENT_THOUGHT,
+                ModelFeature.VISION,
+                ModelFeature.TOOL_CALL,
+                ModelFeature.STREAM_TOOL_CALL,
+            ],
+            fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
+            model_properties={
+                ModelPropertyKey.CONTEXT_SIZE: int(credentials.get("context_size", 200000)),
+                ModelPropertyKey.MODE: LLMMode.CHAT.value,
+            },
+            parameter_rules=[
+                ParameterRule(
+                    name="temperature",
+                    use_template="temperature",
+                    label=I18nObject(en_US="Temperature", zh_Hans="温度"),
+                    type=ParameterType.FLOAT,
+                ),
+                ParameterRule(
+                    name="top_p",
+                    use_template="top_p",
+                    label=I18nObject(en_US="Top P", zh_Hans="Top P"),
+                    type=ParameterType.FLOAT,
+                ),
+                ParameterRule(
+                    name="top_k",
+                    label=I18nObject(en_US="Top K", zh_Hans="取样数量"),
+                    type=ParameterType.INT,
+                ),
+                ParameterRule(
+                    name="max_tokens",
+                    use_template="max_tokens",
+                    default=4096,
+                    min=1,
+                    max=int(credentials.get("max_tokens", 128000)),
+                    label=I18nObject(en_US="Max Tokens", zh_Hans="最大标记"),
+                    type=ParameterType.INT,
+                ),
+                ParameterRule(
+                    name="thinking",
+                    label=I18nObject(en_US="Thinking Mode", zh_Hans="推理模式"),
+                    type=ParameterType.BOOLEAN,
+                    default=False,
+                ),
+                ParameterRule(
+                    name="thinking_budget",
+                    label=I18nObject(en_US="Thinking Budget", zh_Hans="推理预算"),
+                    type=ParameterType.INT,
+                    default=1024,
+                    min=1024,
+                    max=128000,
+                ),
+            ],
+        )
 
     def _invoke(
         self,

--- a/models/anthropic/provider/anthropic.py
+++ b/models/anthropic/provider/anthropic.py
@@ -17,7 +17,7 @@ class AnthropicProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="claude-opus-4-20250514", credentials=credentials)
+            model_instance.validate_credentials(model="claude-sonnet-4-6", credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:

--- a/models/anthropic/provider/anthropic.yaml
+++ b/models/anthropic/provider/anthropic.yaml
@@ -1,6 +1,7 @@
 background: '#F0F0EB'
 configurate_methods:
 - predefined-model
+- customizable-model
 description:
   en_US: Anthropic’s powerful models, such as Claude 3.
   zh_Hans: Anthropic 的强大模型，例如 Claude 3。
@@ -21,6 +22,31 @@ icon_small:
   en_US: icon_s_en.svg
 label:
   en_US: Anthropic
+model_credential_schema:
+  model:
+    label:
+      en_US: Model Name
+      zh_Hans: 模型名称
+    placeholder:
+      en_US: Enter your model name
+      zh_Hans: 在此输入模型名称
+  credential_form_schemas:
+  - label:
+      en_US: API Key
+    placeholder:
+      en_US: Enter your API Key
+      zh_Hans: 在此输入您的 API Key
+    required: true
+    type: secret-input
+    variable: anthropic_api_key
+  - label:
+      en_US: API URL
+    placeholder:
+      en_US: Enter your API URL
+      zh_Hans: 在此输入您的 API URL
+    required: false
+    type: text-input
+    variable: anthropic_api_url
 models:
   llm:
     position: models/llm/_position.yaml


### PR DESCRIPTION
## Summary
- Add `customizable-model` support alongside `predefined-model`, allowing users to enter arbitrary model names when using third-party Anthropic-compatible API proxies (follows the same pattern as OpenAI, Moonshot, and 22 other providers)
- Add `context_1m` parameter toggle to `claude-opus-4-6` and update `context_size` to 1M (matching `claude-sonnet-4-6`)
- Fix provider credential validation: change hardcoded model from deprecated `claude-opus-4-20250514` to `claude-sonnet-4-6`

## Context
Community users reported that third-party Anthropic API proxies that no longer support older models (e.g., `claude-opus-4-20250514`) cannot even add the Anthropic provider in Dify, because the credential validation was hardcoded to use the old model name. Additionally, users with proxy-specific model names had no way to add them since the plugin only supported `predefined-model` mode.

## Changes
| File | Change |
|------|--------|
| `provider/anthropic.py` | Validation model: `claude-opus-4-20250514` → `claude-sonnet-4-6` |
| `provider/anthropic.yaml` | Add `customizable-model` to `configurate_methods` + `model_credential_schema` |
| `models/llm/llm.py` | Add `get_customizable_model_schema()` method with thinking/tool-call support |
| `models/llm/claude-opus-4-6.yaml` | `context_size` 200K→1M, add `context_1m` parameter toggle |
| `manifest.yaml` | Version 0.3.6 → 0.3.7 |

## Test plan
- [x] Verified `Add Model` button appears in Dify UI (customizable-model mode enabled)
- [x] Verified `claude-opus-4-6` shows 1000K context in model list
- [x] Verified custom model names are correctly passed to Anthropic API for validation
- [ ] Third-party proxy testing (requires Anthropic-compatible proxy environment)