### PR TITLE
feat(firecrawl_datasource): follow pagination when crawl status is completed

### DIFF
--- a/datasources/firecrawl_datasource/datasources/crawl.py
+++ b/datasources/firecrawl_datasource/datasources/crawl.py
@@ -94,7 +94,8 @@ class CrawlDatasource(WebsiteCrawlDatasource):
 
     @staticmethod
     def _process_completed_job(app: FirecrawlApp, status: dict, crawl_res: WebSiteInfo):
-        _format_res = app.format_crawl_status_response(status["status"], status)
+        url_data_list = app._collect_all_crawl_pages(status)
+        _format_res = app.format_crawl_status_response(status["status"], status, url_data_list)
 
         crawl_res.web_info_list = [
             WebSiteInfoDetail(

--- a/datasources/firecrawl_datasource/datasources/firecrawl_app.py
+++ b/datasources/firecrawl_datasource/datasources/firecrawl_app.py
@@ -108,21 +108,44 @@ class FirecrawlApp:
         while True:
             status = self.check_crawl_status(job_id)
             if status["status"] == "completed":
-                status = self.format_crawl_status_response(status["status"], status)
-                return status
+                url_data_list = self._collect_all_crawl_pages(status)
+                return self.format_crawl_status_response(status["status"], status, url_data_list)
             elif status["status"] == "failed":
                 raise HTTPError(f"Job {job_id} failed: {status['error']}")
             time.sleep(poll_interval)
 
+    def _collect_all_crawl_pages(self, first_page: dict[str, Any]) -> list[dict[str, Any]]:
+        """Collect all crawl result pages by following pagination links.
+
+        Raises an exception if any paginated request fails, to avoid returning
+        partial data that is inconsistent with the reported total.
+
+        The number of pages processed is capped at ``total`` (the
+        server-reported page count) to guard against infinite loops caused by
+        a misbehaving server that keeps returning a ``next`` URL.
+        """
+        # Normalize to avoid None bypassing the zero-guard when the API returns null.
+        total: int = first_page.get("total") or 0
+        url_data_list: list[dict[str, Any]] = []
+        current_page = first_page
+        pages_processed = 0
+        while True:
+            for item in current_page.get("data", []):
+                if isinstance(item, dict) and "metadata" in item and "markdown" in item:
+                    url_data_list.append(self._extract_common_fields(item))
+            next_url: str | None = current_page.get("next")
+            pages_processed += 1
+            if not next_url or pages_processed >= total:
+                break
+            next_response = self._request("GET", next_url)
+            if next_response is None:
+                raise HTTPError(f"Failed to fetch next crawl page after multiple retries")
+            current_page = next_response
+        return url_data_list
+
     def format_crawl_status_response(
-        self, status: str, crawl_status_response: dict[str, Any]
+        self, status: str, crawl_status_response: dict[str, Any], url_data_list: list[dict[str, Any]]
     ) -> dict[str, Any]:
-        data = crawl_status_response.get("data", [])
-        url_data_list = []
-        for item in data:
-            if isinstance(item, dict) and "metadata" in item and "markdown" in item:
-                url_data = self._extract_common_fields(item)
-                url_data_list.append(url_data)
         return {
             "status": status,
             "total": crawl_status_response.get("total"),

--- a/datasources/firecrawl_datasource/manifest.yaml
+++ b/datasources/firecrawl_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.5
+version: 0.2.6
 type: plugin
 author: langgenius
 name: firecrawl_datasource


### PR DESCRIPTION
## Related Issues or Context

This PR enables Firecrawl crawls beyond the 100-page limit.

Current firecrawl_datasource plugin was only reading the first page of crawl results. The Firecrawl API returns at most 100 items per response and provides a `next` URL for subsequent pages, so any crawl with more than 100 pages silently returned incomplete data.

This PR changes:

- Follow `next` URLs until the last page (`next` is absent).
- Cap additional fetches at `total` (server-reported page count) to prevent infinite loops against misbehaving self-hosted servers.

Follow-up for: https://github.com/langgenius/dify/pull/33864

## This PR contains Changes to *Non-Plugin* 

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [x] I have Run Comprehensive Tests Relevant to My Changes

<img width="1423" height="819" alt="image" src="https://github.com/user-attachments/assets/11660a1d-2254-4a86-bbfa-fd2edd0a2677" />
<img width="1451" height="862" alt="image" src="https://github.com/user-attachments/assets/68ebf373-90ed-4b2b-b2bb-9a5e3e4c448f" />

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [x] Dify Version is: 1.13.2, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
