### PR TITLE
Add ShopSavvy tool provider plugin

### DIFF
--- a/tools/shopsavvy/PRIVACY.md
+++ b/tools/shopsavvy/PRIVACY.md
@@ -1,0 +1,38 @@
+## Privacy Policy
+
+This plugin ("ShopSavvy Plugin") is developed by ShopSavvy (Monolith Technologies, Inc.) to connect Dify with the ShopSavvy Data API for product search, price comparison, and price history lookups.
+
+### Data Collection
+
+- The plugin requires a **ShopSavvy API Key** to authenticate requests to the ShopSavvy Data API.
+- No other personal data is collected, stored, or shared by this plugin.
+
+### Data Usage
+
+- The ShopSavvy API Key is used solely to authenticate API requests to the ShopSavvy Data API.
+- All operations (product searches, offer lookups, price history queries) are performed via secure HTTPS API calls to ShopSavvy.
+- The plugin does **not** store or transmit your data to any third-party services except ShopSavvy.
+
+### Data Storage
+
+- The plugin does **not** persistently store any user data, search queries, or API keys outside of the Dify runtime environment.
+- All data processed by the plugin remains within your Dify and ShopSavvy environments.
+
+### Data Sharing
+
+- No data is shared with any external parties.
+- All API requests are made directly to ShopSavvy using your provided credentials.
+
+### User Responsibility
+
+- You are responsible for safeguarding your ShopSavvy API Key.
+- Do not share your API key with untrusted parties.
+- Revoke your API key from your ShopSavvy Data API Dashboard if you suspect unauthorized access.
+
+### Changes to This Policy
+
+- This privacy policy may be updated as needed. Please review it regularly for any changes.
+
+For questions or concerns about privacy, please contact support@shopsavvy.com.
+
+_Last updated: April 1, 2026_

--- a/tools/shopsavvy/README.md
+++ b/tools/shopsavvy/README.md
@@ -1,0 +1,65 @@
+# ShopSavvy Plugin for Dify
+
+**Author:** shopsavvy
+**Version:** 0.0.1
+**Type:** Tool
+
+---
+
+## Overview
+
+The ShopSavvy Plugin connects [Dify](https://dify.ai/) with the [ShopSavvy Data API](https://shopsavvy.com/data) for product search, real-time price comparison across thousands of retailers, and price history tracking.
+
+---
+
+## Features
+
+- Search products by keyword with relevance-ranked results
+- Get current offers and prices from thousands of retailers for any product
+- Retrieve historical price data over custom date ranges
+- Identify products by barcode/UPC, Amazon ASIN, model number, URL, or product name
+- Filter offers by specific retailer
+
+---
+
+## Configuration
+
+### 1. Get a ShopSavvy API Key
+
+Sign up at [shopsavvy.com/data](https://shopsavvy.com/data) and create an API key from your [dashboard](https://shopsavvy.com/data/api-keys).
+
+### 2. Install the Plugin
+
+Find ShopSavvy in the Dify Plugin Marketplace and install it.
+
+### 3. Authorize
+
+Navigate to `Tools > ShopSavvy > Authorize` and enter your API key.
+
+---
+
+## Available Tools
+
+- **Search Products** — Search for products by keyword. Returns matching products with titles, brands, categories, barcodes, and images.
+- **Get Offers** — Get current prices and availability for a product across all retailers, with optional filtering to a single retailer.
+- **Price History** — Retrieve historical price and availability data over a specified date range.
+
+Each tool's YAML file in `tools/` documents the required and optional parameters.
+
+---
+
+## Security & Privacy
+
+- Your ShopSavvy API Key is used only for authenticating requests to the ShopSavvy Data API.
+- No personal data is stored or shared by this plugin.
+- See [PRIVACY.md](./PRIVACY.md) for full details.
+
+---
+
+## License
+
+This plugin is provided as-is for integration with Dify and ShopSavvy.
+
+---
+
+_Last updated: April 1, 2026_

--- a/tools/shopsavvy/_assets/icon.svg
+++ b/tools/shopsavvy/_assets/icon.svg
@@ -1,0 +1,8 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="56" height="56" rx="8" fill="#2563EB"/>
+  <path d="M20 16C20 14.8954 20.8954 14 22 14H34C35.1046 14 36 14.8954 36 16V18H20V16Z" fill="white"/>
+  <path d="M16 20H40C41.1046 20 42 20.8954 42 22V40C42 41.1046 41.1046 42 40 42H16C14.8954 42 14 41.1046 14 40V22C14 20.8954 14.8954 20 16 20Z" fill="white"/>
+  <path d="M22 28H34M22 33H30" stroke="#2563EB" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="18" cy="28" r="2" fill="#2563EB"/>
+  <circle cx="18" cy="33" r="2" fill="#2563EB"/>
+</svg>

--- a/tools/shopsavvy/main.py
+++ b/tools/shopsavvy/main.py
@@ -1,0 +1,6 @@
+from dify_plugin import Plugin, DifyPluginEnv
+
+plugin = Plugin(DifyPluginEnv(MAX_REQUEST_TIMEOUT=120))
+
+if __name__ == '__main__':
+    plugin.run()

--- a/tools/shopsavvy/manifest.yaml
+++ b/tools/shopsavvy/manifest.yaml
@@ -1,0 +1,51 @@
+version: 0.0.1
+type: plugin
+author: shopsavvy
+name: shopsavvy
+label:
+  en_US: ShopSavvy
+  zh_Hans: ShopSavvy
+  pt_BR: ShopSavvy
+description:
+  en_US: Price comparison and product data API. Search products, compare prices across thousands of retailers, and track price history.
+  zh_Hans: 价格比较和产品数据 API。搜索产品、在数千家零售商之间比较价格并跟踪价格历史。
+  pt_BR: API de comparação de preços e dados de produtos. Pesquise produtos, compare preços em milhares de varejistas e acompanhe o histórico de preços.
+icon: icon.svg
+resource:
+  memory: 268435456
+  permission:
+    tool:
+      enabled: true
+    model:
+      enabled: true
+      llm: true
+      text_embedding: false
+      rerank: false
+      tts: false
+      speech2text: false
+      moderation: false
+    node:
+      enabled: false
+    endpoint:
+      enabled: false
+    app:
+      enabled: false
+    storage:
+      enabled: false
+plugins:
+  tools:
+    - provider/shopsavvy.yaml
+meta:
+  version: 0.0.1
+  arch:
+    - amd64
+    - arm64
+  runner:
+    language: python
+    version: "3.12"
+    entrypoint: main
+tags:
+  - business
+created_at: 2026-04-01T00:00:00.000000+00:00
+privacy: PRIVACY.md
+repo: https://github.com/langgenius/dify-official-plugins

--- a/tools/shopsavvy/provider/shopsavvy.py
+++ b/tools/shopsavvy/provider/shopsavvy.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+import requests
+from dify_plugin import ToolProvider
+from dify_plugin.errors.tool import ToolProviderCredentialValidationError
+
+
+class ShopSavvyProvider(ToolProvider):
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
+        api_key = credentials.get("shopsavvy_api_key")
+        if not api_key:
+            raise ToolProviderCredentialValidationError("ShopSavvy API key is required.")
+
+        base_url = credentials.get("base_url", "").strip()
+        if not base_url:
+            base_url = "https://api.shopsavvy.com/v1"
+
+        try:
+            response = requests.get(
+                f"{base_url}/usage",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": "ShopSavvy-Dify/1.0",
+                },
+                timeout=15,
+            )
+            if not response.ok:
+                raise ToolProviderCredentialValidationError(
+                    f"ShopSavvy API returned {response.status_code}: {response.text}"
+                )
+        except requests.RequestException as e:
+            raise ToolProviderCredentialValidationError(
+                f"Failed to connect to ShopSavvy API: {str(e)}"
+            )

--- a/tools/shopsavvy/provider/shopsavvy.yaml
+++ b/tools/shopsavvy/provider/shopsavvy.yaml
@@ -1,0 +1,53 @@
+credentials_for_provider:
+  shopsavvy_api_key:
+    help:
+      en_US: Get your API key from the ShopSavvy Data API Dashboard at shopsavvy.com/data
+      zh_Hans: 从 ShopSavvy 数据 API 仪表板 shopsavvy.com/data 获取您的 API 密钥
+      pt_BR: Obtenha sua chave de API no Painel da API de Dados ShopSavvy em shopsavvy.com/data
+    label:
+      en_US: ShopSavvy API Key
+      zh_Hans: ShopSavvy API 密钥
+      pt_BR: Chave de API ShopSavvy
+    placeholder:
+      en_US: ss_live_...
+      zh_Hans: ss_live_...
+      pt_BR: ss_live_...
+    required: true
+    type: secret-input
+    url: https://shopsavvy.com/data/api-keys
+  base_url:
+    help:
+      en_US: Override the default API base URL (optional, defaults to https://api.shopsavvy.com/v1)
+      zh_Hans: 覆盖默认的 API 基础 URL（可选，默认为 https://api.shopsavvy.com/v1）
+      pt_BR: Substituir a URL base padrão da API (opcional, padrão https://api.shopsavvy.com/v1)
+    label:
+      en_US: API Base URL
+      zh_Hans: API 基础 URL
+      pt_BR: URL Base da API
+    placeholder:
+      en_US: https://api.shopsavvy.com/v1
+      zh_Hans: https://api.shopsavvy.com/v1
+      pt_BR: https://api.shopsavvy.com/v1
+    required: false
+    type: text-input
+extra:
+  python:
+    source: provider/shopsavvy.py
+identity:
+  author: shopsavvy
+  description:
+    en_US: Price comparison and product data API. Search products, compare prices across thousands of retailers, and track price history.
+    zh_Hans: 价格比较和产品数据 API。搜索产品、在数千家零售商之间比较价格并跟踪价格历史。
+    pt_BR: API de comparação de preços e dados de produtos. Pesquise produtos, compare preços em milhares de varejistas e acompanhe o histórico de preços.
+  icon: icon.svg
+  label:
+    en_US: ShopSavvy
+    zh_Hans: ShopSavvy
+    pt_BR: ShopSavvy
+  name: shopsavvy
+  tags:
+    - business
+tools:
+  - tools/search_products.yaml
+  - tools/get_offers.yaml
+  - tools/price_history.yaml

--- a/tools/shopsavvy/pyproject.toml
+++ b/tools/shopsavvy/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "shopsavvy"
+version = "0.0.1"
+description = "ShopSavvy price comparison and product data tools for Dify"
+readme = "README.md"
+requires-python = ">=3.12"
+
+# uv pip compile pyproject.toml -o ./requirements.txt
+dependencies = [
+    "dify_plugin>=0.5.0",
+    "requests>=2.31.0",
+]
+
+# uv run black . -C -l 100 && uv run ruff check --fix
+[dependency-groups]
+dev = []

--- a/tools/shopsavvy/requirements.txt
+++ b/tools/shopsavvy/requirements.txt
@@ -1,0 +1,2 @@
+dify_plugin>=0.5.0
+requests>=2.31.0

--- a/tools/shopsavvy/tools/get_offers.py
+++ b/tools/shopsavvy/tools/get_offers.py
@@ -1,0 +1,53 @@
+from collections.abc import Generator
+from typing import Any
+
+import requests
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+class GetOffersTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        api_key = self.runtime.credentials.get("shopsavvy_api_key")
+        if not api_key:
+            yield self.create_text_message("ShopSavvy API key is required.")
+            return
+
+        base_url = self.runtime.credentials.get("base_url", "").strip()
+        if not base_url:
+            base_url = "https://api.shopsavvy.com/v1"
+
+        identifier = tool_parameters.get("identifier", "").strip()
+        if not identifier:
+            yield self.create_text_message("Product identifier is required.")
+            return
+
+        params: dict[str, str] = {"ids": identifier}
+
+        retailer = tool_parameters.get("retailer", "").strip()
+        if retailer:
+            params["retailer"] = retailer
+
+        try:
+            response = requests.get(
+                f"{base_url}/products/offers",
+                params=params,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": "ShopSavvy-Dify/1.0",
+                },
+                timeout=30,
+            )
+        except requests.RequestException as e:
+            yield self.create_text_message(f"Request failed: {str(e)}")
+            return
+
+        if not response.ok:
+            yield self.create_text_message(
+                f"ShopSavvy API error {response.status_code}: {response.text}"
+            )
+            return
+
+        yield self.create_json_message(response.json())

--- a/tools/shopsavvy/tools/get_offers.yaml
+++ b/tools/shopsavvy/tools/get_offers.yaml
@@ -1,0 +1,43 @@
+description:
+  human:
+    en_US: Get current offers and prices for a product across all retailers. Supports barcodes, ASINs, model numbers, URLs, and product names as identifiers.
+    zh_Hans: 获取产品在所有零售商的当前报价和价格。支持条形码、ASIN、型号、URL 和产品名称作为标识符。
+    pt_BR: Obtenha ofertas e preços atuais de um produto em todos os varejistas. Suporta códigos de barras, ASINs, números de modelo, URLs e nomes de produtos como identificadores.
+  llm: Get current offers and prices for a product from thousands of retailers. Pass a barcode/UPC, Amazon ASIN, model number, product URL, or product name. Optionally filter to a single retailer. Returns price, availability, condition, retailer name, and URL for each offer.
+extra:
+  python:
+    source: tools/get_offers.py
+identity:
+  author: shopsavvy
+  label:
+    en_US: Get Offers
+    zh_Hans: 获取报价
+    pt_BR: Obter Ofertas
+  name: get_offers
+parameters:
+  - form: llm
+    human_description:
+      en_US: Product identifier — barcode/UPC, Amazon ASIN, model number, product URL, or product name
+      zh_Hans: 产品标识符 — 条形码/UPC、亚马逊 ASIN、型号、产品 URL 或产品名称
+      pt_BR: Identificador do produto — código de barras/UPC, ASIN da Amazon, número do modelo, URL do produto ou nome do produto
+    label:
+      en_US: Product Identifier
+      zh_Hans: 产品标识符
+      pt_BR: Identificador do Produto
+    llm_description: The product identifier to look up offers for. Can be a barcode/UPC (e.g., "611247373064"), Amazon ASIN (e.g., "B0CHX3TW6K"), model number, product URL, or product name.
+    name: identifier
+    required: true
+    type: string
+  - form: form
+    human_description:
+      en_US: Filter offers to a single retailer domain (e.g., "amazon.com", "bestbuy.com"). Leave empty for all retailers.
+      zh_Hans: 筛选单个零售商域名的报价（例如 "amazon.com"、"bestbuy.com"）。留空以显示所有零售商。
+      pt_BR: Filtrar ofertas para um único domínio de varejista (ex. "amazon.com", "bestbuy.com"). Deixe vazio para todos os varejistas.
+    label:
+      en_US: Retailer Filter
+      zh_Hans: 零售商筛选
+      pt_BR: Filtro de Varejista
+    llm_description: Optional retailer domain to filter offers (e.g., "amazon.com", "walmart.com")
+    name: retailer
+    required: false
+    type: string

--- a/tools/shopsavvy/tools/price_history.py
+++ b/tools/shopsavvy/tools/price_history.py
@@ -1,0 +1,57 @@
+from collections.abc import Generator
+from typing import Any
+
+import requests
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+class PriceHistoryTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        api_key = self.runtime.credentials.get("shopsavvy_api_key")
+        if not api_key:
+            yield self.create_text_message("ShopSavvy API key is required.")
+            return
+
+        base_url = self.runtime.credentials.get("base_url", "").strip()
+        if not base_url:
+            base_url = "https://api.shopsavvy.com/v1"
+
+        identifier = tool_parameters.get("identifier", "").strip()
+        if not identifier:
+            yield self.create_text_message("Product identifier is required.")
+            return
+
+        params: dict[str, str] = {"ids": identifier}
+
+        start_date = tool_parameters.get("start_date", "").strip()
+        if start_date:
+            params["start"] = start_date
+
+        end_date = tool_parameters.get("end_date", "").strip()
+        if end_date:
+            params["end"] = end_date
+
+        try:
+            response = requests.get(
+                f"{base_url}/products/offers/history",
+                params=params,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": "ShopSavvy-Dify/1.0",
+                },
+                timeout=30,
+            )
+        except requests.RequestException as e:
+            yield self.create_text_message(f"Request failed: {str(e)}")
+            return
+
+        if not response.ok:
+            yield self.create_text_message(
+                f"ShopSavvy API error {response.status_code}: {response.text}"
+            )
+            return
+
+        yield self.create_json_message(response.json())

--- a/tools/shopsavvy/tools/price_history.yaml
+++ b/tools/shopsavvy/tools/price_history.yaml
@@ -1,0 +1,56 @@
+description:
+  human:
+    en_US: Get historical price data for a product across retailers. Specify a date range to see how prices changed over time.
+    zh_Hans: 获取产品在各零售商的历史价格数据。指定日期范围以查看价格随时间的变化。
+    pt_BR: Obtenha dados históricos de preços de um produto em varejistas. Especifique um intervalo de datas para ver como os preços mudaram ao longo do tempo.
+  llm: Get historical price data for a product. Returns offers with a history field showing price and availability changes over the specified date range. Use YYYY-MM-DD format for dates.
+extra:
+  python:
+    source: tools/price_history.py
+identity:
+  author: shopsavvy
+  label:
+    en_US: Price History
+    zh_Hans: 价格历史
+    pt_BR: Histórico de Preços
+  name: price_history
+parameters:
+  - form: llm
+    human_description:
+      en_US: Product identifier — barcode/UPC, Amazon ASIN, model number, product URL, or product name
+      zh_Hans: 产品标识符 — 条形码/UPC、亚马逊 ASIN、型号、产品 URL 或产品名称
+      pt_BR: Identificador do produto — código de barras/UPC, ASIN da Amazon, número do modelo, URL do produto ou nome do produto
+    label:
+      en_US: Product Identifier
+      zh_Hans: 产品标识符
+      pt_BR: Identificador do Produto
+    llm_description: The product identifier to get price history for. Can be a barcode/UPC, Amazon ASIN, model number, product URL, or product name.
+    name: identifier
+    required: true
+    type: string
+  - form: form
+    human_description:
+      en_US: Start date for price history in YYYY-MM-DD format
+      zh_Hans: 价格历史开始日期，格式为 YYYY-MM-DD
+      pt_BR: Data de início do histórico de preços no formato AAAA-MM-DD
+    label:
+      en_US: Start Date
+      zh_Hans: 开始日期
+      pt_BR: Data de Início
+    llm_description: Start date for the price history range in YYYY-MM-DD format
+    name: start_date
+    required: false
+    type: string
+  - form: form
+    human_description:
+      en_US: End date for price history in YYYY-MM-DD format
+      zh_Hans: 价格历史结束日期，格式为 YYYY-MM-DD
+      pt_BR: Data de fim do histórico de preços no formato AAAA-MM-DD
+    label:
+      en_US: End Date
+      zh_Hans: 结束日期
+      pt_BR: Data de Fim
+    llm_description: End date for the price history range in YYYY-MM-DD format
+    name: end_date
+    required: false
+    type: string

--- a/tools/shopsavvy/tools/search_products.py
+++ b/tools/shopsavvy/tools/search_products.py
@@ -1,0 +1,51 @@
+from collections.abc import Generator
+from typing import Any
+
+import requests
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+class SearchProductsTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        api_key = self.runtime.credentials.get("shopsavvy_api_key")
+        if not api_key:
+            yield self.create_text_message("ShopSavvy API key is required.")
+            return
+
+        base_url = self.runtime.credentials.get("base_url", "").strip()
+        if not base_url:
+            base_url = "https://api.shopsavvy.com/v1"
+
+        query = tool_parameters.get("query", "").strip()
+        if not query:
+            yield self.create_text_message("Search query is required.")
+            return
+
+        max_results = tool_parameters.get("max_results", 5)
+        if isinstance(max_results, float):
+            max_results = int(max_results)
+
+        try:
+            response = requests.get(
+                f"{base_url}/products/search",
+                params={"q": query, "limit": max_results},
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": "ShopSavvy-Dify/1.0",
+                },
+                timeout=30,
+            )
+        except requests.RequestException as e:
+            yield self.create_text_message(f"Request failed: {str(e)}")
+            return
+
+        if not response.ok:
+            yield self.create_text_message(
+                f"ShopSavvy API error {response.status_code}: {response.text}"
+            )
+            return
+
+        yield self.create_json_message(response.json())

--- a/tools/shopsavvy/tools/search_products.yaml
+++ b/tools/shopsavvy/tools/search_products.yaml
@@ -1,0 +1,44 @@
+description:
+  human:
+    en_US: Search for products by keyword. Returns matching products with titles, brands, categories, barcodes, and images.
+    zh_Hans: 按关键词搜索产品。返回匹配的产品，包括标题、品牌、类别、条形码和图片。
+    pt_BR: Pesquise produtos por palavra-chave. Retorna produtos correspondentes com títulos, marcas, categorias, códigos de barras e imagens.
+  llm: Search for products by keyword or product name. Returns matching products with details like title, brand, category, barcode, ASIN, and images. Use this to find products when you have a name or description but not a specific identifier.
+extra:
+  python:
+    source: tools/search_products.py
+identity:
+  author: shopsavvy
+  label:
+    en_US: Search Products
+    zh_Hans: 搜索产品
+    pt_BR: Pesquisar Produtos
+  name: search_products
+parameters:
+  - form: llm
+    human_description:
+      en_US: Search query or keyword (e.g., "iPhone 15 Pro", "Samsung TV", "Nike shoes")
+      zh_Hans: 搜索查询或关键词（例如"iPhone 15 Pro"、"三星电视"、"耐克鞋"）
+      pt_BR: Consulta de pesquisa ou palavra-chave (ex. "iPhone 15 Pro", "Samsung TV", "Nike shoes")
+    label:
+      en_US: Search Query
+      zh_Hans: 搜索查询
+      pt_BR: Consulta de Pesquisa
+    llm_description: The search query or keyword to find products (e.g., "iPhone 15 Pro", "Samsung TV", "Nike shoes")
+    name: query
+    required: true
+    type: string
+  - default: 5
+    form: form
+    human_description:
+      en_US: Maximum number of results to return (1-100, default 5)
+      zh_Hans: 返回的最大结果数（1-100，默认 5）
+      pt_BR: Número máximo de resultados a retornar (1-100, padrão 5)
+    label:
+      en_US: Max Results
+      zh_Hans: 最大结果数
+      pt_BR: Máximo de Resultados
+    llm_description: Maximum number of product results to return
+    name: max_results
+    required: false
+    type: number


### PR DESCRIPTION
Adds a ShopSavvy tool provider with three tools (product search, current offers, price history) that hit the ShopSavvy Data API for price comparison across thousands of retailers. Includes full i18n, credential validation via the usage endpoint, and a privacy policy.