### PR TITLE
Add native Structured Outputs support via Converse API in AWS bedrock

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.63
+version: 0.0.64
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/anthropic-claude.yaml
+++ b/models/bedrock/models/llm/anthropic-claude.yaml
@@ -165,6 +165,15 @@ parameter_rules:
     help:
       zh_Hans: anthropic beta 参数是一串测试版标题的列表，用于表示选择加入一组特定的测试版功能。使用英文逗号连接。
       en_US: The anthropic beta parameter is a list of strings of beta headers used to indicate opt-in to a particular set of beta features. Use commas to join.
+  - name: json_schema
+    label:
+      zh_Hans: JSON Schema
+      en_US: JSON Schema
+    type: string
+    required: false
+    help:
+      zh_Hans: JSON Schema for structured output
+      en_US: JSON Schema for structured output
   - name: response_format
     use_template: response_format
 pricing:

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -125,7 +125,14 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         """
         Code block mode wrapper for invoking large language model
         """
-        if model_parameters.get("response_format"):
+        # When Dify's structured output is enabled, the Dify backend detects the "json_schema"
+        # parameter in the model YAML and passes the user-defined schema via model_parameters.
+        # We intercept it here and forward it to Bedrock's native outputConfig (Converse API),
+        # which uses constrained decoding to guarantee schema-compliant JSON output.
+        if model_parameters.get("json_schema"):
+            model_parameters.pop("response_format", None)
+            model_parameters["_structured_output_schema"] = model_parameters.pop("json_schema")
+        elif model_parameters.get("response_format"):
             stop = stop or []
             if "```\n" not in stop:
                 stop.append("```\n")
@@ -175,8 +182,14 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             try:
                 model_info = self._get_model_info(model, credentials, model_parameters)
                 if model_info:
+                    # Native Bedrock Structured Outputs: json_schema takes priority.
+                    # Same logic as _code_block_mode_wrapper — intercept the schema before
+                    # the legacy response_format handling runs.
+                    if model_parameters.get("json_schema"):
+                        model_parameters.pop("response_format", None)
+                        model_parameters["_structured_output_schema"] = model_parameters.pop("json_schema")
                     # Handle response_format for inference profiles only if underlying model is Anthropic
-                    if model_parameters.get("response_format"):
+                    elif model_parameters.get("response_format"):
                         # Check if the underlying model is Anthropic based
                         profile_info = get_inference_profile_info(inference_profile_id, credentials)
                         underlying_models = profile_info.get("models", [])
@@ -377,6 +390,31 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             "inferenceConfig": inference_config,
             "additionalModelRequestFields": additional_model_fields,
         }
+
+        # Bedrock native Structured Outputs via Converse API outputConfig.
+        # When a user-defined JSON schema is provided (from Dify's structured output UI),
+        # we inject it into the Converse API's outputConfig.textFormat parameter.
+        # Bedrock uses constrained decoding to guarantee the response conforms to the schema.
+        # Requires boto3 >= 1.42.42.
+        # See: https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
+        structured_schema = model_parameters.pop("_structured_output_schema", None)
+        if structured_schema:
+            if isinstance(structured_schema, str):
+                schema_dict = json.loads(structured_schema)
+            else:
+                schema_dict = structured_schema
+            # Dify wraps the user schema as {"schema": {...}, "name": "llm_response"}
+            parameters["outputConfig"] = {
+                "textFormat": {
+                    "type": "json_schema",
+                    "structure": {
+                        "jsonSchema": {
+                            "schema": json.dumps(schema_dict.get("schema", schema_dict)),
+                            "name": schema_dict.get("name", "response"),
+                        }
+                    }
+                }
+            }
 
         if model_info["support_system_prompts"] and system and len(system) > 0:
             parameters["system"] = system

--- a/models/bedrock/pyproject.toml
+++ b/models/bedrock/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 # uv pip compile pyproject.toml -o ./requirements.txt
 dependencies = [
     "dify_plugin>=0.5.0",
-    "boto3~=1.40.70",
+    "boto3>=1.42.42",
     "tiktoken~=0.8.0",
 ]
 

--- a/models/bedrock/requirements.txt
+++ b/models/bedrock/requirements.txt
@@ -1,3 +1,3 @@
 dify_plugin==0.7.0
-boto3~=1.40.70
+boto3>=1.42.42
 tiktoken~=0.8.0


### PR DESCRIPTION
Description:

  Summary

fixing this issue https://github.com/langgenius/dify-official-plugins/issues/2824

 which requires to add support for Bedrock native Structured Outputs when Dify's structured output feature is enabled. The model response is guaranteed to conform to the user-defined JSON schema via constrained decoding at
  the API level.

  Changes

  - anthropic-claude.yaml: Add json_schema parameter declaration, which signals the Dify backend that this model supports native structured output (support_structure_output=True)
  - llm.py: Intercept json_schema parameter in _code_block_mode_wrapper and _invoke, forward the user-defined schema to Bedrock Converse API's outputConfig.textFormat
  - pyproject.toml / requirements.txt: Bump boto3 minimum to >=1.42.42 (first version with outputConfig support)

  How it works

  1. User defines a JSON schema in Dify's Structured Output UI
  2. Dify backend detects json_schema in model parameter rules → sets support_structure_output=True
  3. Dify passes the schema to the plugin via model_parameters["json_schema"]
  4. Plugin injects it into Bedrock Converse API's outputConfig.textFormat with type: json_schema
  5. Bedrock uses constrained decoding to guarantee schema-compliant output

  Ref

  - https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html (https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html)
