### PR TITLE
fix(notion): skip inaccessible pages instead of failing entire listing

### DIFF
--- a/datasources/notion_datasource/datasources/utils/notion_client.py
+++ b/datasources/notion_datasource/datasources/utils/notion_client.py
@@ -456,12 +456,15 @@ class NotionClient:
             icon = None
             parent = page_result["parent"]
             parent_type = parent["type"]
-            if parent_type == "block_id":
-                parent_id = self.notion_block_parent_page_id(access_token, parent[parent_type])
-            elif parent_type == "workspace":
-                parent_id = "root"
-            else:
-                parent_id = parent[parent_type]
+            try:
+                if parent_type == "block_id":
+                    parent_id = self.notion_block_parent_page_id(access_token, parent[parent_type])
+                elif parent_type == "workspace":
+                    parent_id = "root"
+                else:
+                    parent_id = parent[parent_type]
+            except ValueError:
+                continue
             page = OnlineDocumentPage(
                 page_id=page_id,
                 page_name=page_name,
@@ -479,12 +482,15 @@ class NotionClient:
             icon = None
             parent = database_result["parent"]
             parent_type = parent["type"]
-            if parent_type == "block_id":
-                parent_id = self.notion_block_parent_page_id(access_token, parent[parent_type])
-            elif parent_type == "workspace":
-                parent_id = "root"
-            else:
-                parent_id = parent[parent_type]
+            try:
+                if parent_type == "block_id":
+                    parent_id = self.notion_block_parent_page_id(access_token, parent[parent_type])
+                elif parent_type == "workspace":
+                    parent_id = "root"
+                else:
+                    parent_id = parent[parent_type]
+            except ValueError:
+                continue
             page = OnlineDocumentPage(
                 page_id=page_id,
                 page_name=page_name,

--- a/datasources/notion_datasource/manifest.yaml
+++ b/datasources/notion_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.15
+version: 0.1.16
 type: plugin
 author: langgenius
 name: notion_datasource


### PR DESCRIPTION
## Related Issues or Context

Fixes #2890

When using the Notion datasource plugin, `get_authorized_pages()` raises a `ValueError` and aborts entirely if any parent block is inaccessible to the integration. This prevents all pages from being listed, even those the integration can access.

## This PR contains Changes to *Non-LLM Models Plugin*
- [x] I have Run Comprehensive Tests Relevant to My Changes

Tested locally by installing the modified plugin as a `.difypkg` package and confirming that accessible pages are listed correctly while inaccessible ones are silently skipped.

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)

`0.1.13` → `0.1.14` (PATCH: backward-compatible bug fix)

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

### Local Deployment Environment
- [x] Dify Version is: 1.3.1, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration.