### PR TITLE
fix(models/azure_openai): handle system prompt multimodal content for GPT-5 Responses API

### DIFF
--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.50
+version: 0.0.51

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -23,6 +23,7 @@ from dify_plugin.entities.model.message import (
     ImagePromptMessageContent,
     PromptMessage,
     PromptMessageContentType,
+    PromptMessageContentUnionTypes,
     PromptMessageFunction,
     PromptMessageTool,
     SystemPromptMessage,
@@ -545,7 +546,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                         "content": message.content
                     })
                 else:
-                    content_parts = self._convert_multimodal_content_to_responses_parts(
+                    content_parts = AzureOpenAILargeLanguageModel._convert_multimodal_content_to_responses_parts(
                         message.content
                     )
                     if content_parts:
@@ -561,7 +562,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                     })
                 else:
                     # Handle multimodal content
-                    content_parts = self._convert_multimodal_content_to_responses_parts(
+                    content_parts = AzureOpenAILargeLanguageModel._convert_multimodal_content_to_responses_parts(
                         message.content
                     )
                     if content_parts:
@@ -610,7 +611,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
     @staticmethod
     def _convert_multimodal_content_to_responses_parts(
-        content_items: Any,
+        content_items: Optional[list[PromptMessageContentUnionTypes]],
     ) -> list[dict[str, Any]]:
         content_parts: list[dict[str, Any]] = []
         for content_item in content_items or []:

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -539,10 +539,20 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
         for message in prompt_messages:
             if isinstance(message, SystemPromptMessage):
-                input_messages.append({
-                    "role": "developer",
-                    "content": message.content
-                })
+                if isinstance(message.content, str):
+                    input_messages.append({
+                        "role": "developer",
+                        "content": message.content
+                    })
+                else:
+                    content_parts = self._convert_multimodal_content_to_responses_parts(
+                        message.content
+                    )
+                    if content_parts:
+                        input_messages.append({
+                            "role": "developer",
+                            "content": content_parts
+                        })
             elif isinstance(message, UserPromptMessage):
                 if isinstance(message.content, str):
                     input_messages.append({
@@ -551,40 +561,9 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                     })
                 else:
                     # Handle multimodal content
-                    content_parts = []
-                    for content_item in message.content or []:
-                        if content_item.type == PromptMessageContentType.TEXT:
-                            text_content = cast(TextPromptMessageContent, content_item)
-                            content_parts.append({
-                                "type": "input_text",
-                                "text": text_content.data
-                            })
-                        elif content_item.type == PromptMessageContentType.IMAGE:
-                            image_content = cast(ImagePromptMessageContent, content_item)
-                            image_part = {
-                                "type": "input_image",
-                            }
-                            if image_content.url:
-                                image_part["image_url"] = image_content.url
-                            else:
-                                image_part["image_url"] = image_content.data
-                            if image_content.detail:
-                                image_part["detail"] = image_content.detail.value
-                            content_parts.append(image_part)
-                        elif content_item.type == PromptMessageContentType.DOCUMENT:
-                            doc_content = cast(DocumentPromptMessageContent, content_item)
-                            file_part: dict[str, Any] = {"type": "input_file"}
-                            if doc_content.url:
-                                file_part["file_url"] = doc_content.url
-                            elif doc_content.base64_data:
-                                file_part["filename"] = doc_content.filename or "document"
-                                file_part["file_data"] = (
-                                    f"data:{doc_content.mime_type}"
-                                    f";base64,{doc_content.base64_data}"
-                                )
-                            if len(file_part) > 1:
-                                content_parts.append(file_part)
-
+                    content_parts = self._convert_multimodal_content_to_responses_parts(
+                        message.content
+                    )
                     if content_parts:
                         input_messages.append({
                             "role": "user",
@@ -628,6 +607,44 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                 })
 
         return input_messages
+
+    @staticmethod
+    def _convert_multimodal_content_to_responses_parts(
+        content_items: Any,
+    ) -> list[dict[str, Any]]:
+        content_parts: list[dict[str, Any]] = []
+        for content_item in content_items or []:
+            if content_item.type == PromptMessageContentType.TEXT:
+                text_content = cast(TextPromptMessageContent, content_item)
+                content_parts.append({
+                    "type": "input_text",
+                    "text": text_content.data
+                })
+            elif content_item.type == PromptMessageContentType.IMAGE:
+                image_content = cast(ImagePromptMessageContent, content_item)
+                image_part = {
+                    "type": "input_image",
+                }
+                if image_content.url:
+                    image_part["image_url"] = image_content.url
+                else:
+                    image_part["image_url"] = image_content.data
+                if image_content.detail:
+                    image_part["detail"] = image_content.detail.value
+                content_parts.append(image_part)
+            elif content_item.type == PromptMessageContentType.DOCUMENT:
+                doc_content = cast(DocumentPromptMessageContent, content_item)
+                file_part: dict[str, Any] = {"type": "input_file"}
+                if doc_content.url:
+                    file_part["file_url"] = doc_content.url
+                elif doc_content.base64_data:
+                    file_part["filename"] = doc_content.filename or "document"
+                    file_part["file_data"] = (
+                        f"data:{doc_content.mime_type};base64,{doc_content.base64_data}"
+                    )
+                if len(file_part) > 1:
+                    content_parts.append(file_part)
+        return content_parts
 
     def _handle_responses_response(
         self,

--- a/models/azure_openai/tests/test_llm.py
+++ b/models/azure_openai/tests/test_llm.py
@@ -75,6 +75,22 @@ class TestConvertPromptMessagesToResponsesInput(unittest.TestCase):
         self.assertEqual(result[0]["role"], "developer")
         self.assertEqual(result[0]["content"], "You are helpful.")
 
+    def test_system_text_content_item_becomes_input_text(self):
+        """System prompt multimodal text should use Responses API input_text."""
+        messages = [
+            SystemPromptMessage(
+                content=[TextPromptMessageContent(data="Context from retrieval")]
+            )
+        ]
+        result = self.llm._convert_prompt_messages_to_responses_input(messages)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["role"], "developer")
+        content = result[0]["content"]
+        self.assertIsInstance(content, list)
+        self.assertEqual(content[0]["type"], "input_text")
+        self.assertEqual(content[0]["text"], "Context from retrieval")
+
     def test_user_string_message(self):
         messages = [UserPromptMessage(content="Hello")]
         result = self.llm._convert_prompt_messages_to_responses_input(messages)


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->
closes #2892 

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [x] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [x] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->
I verified the converter behavior with local unit tests:
```
rintaro@RintaronoMacBook-Pro dify-official-plugins % python -m unittest models/azure_openai/tests/test_llm.py
...................
----------------------------------------------------------------------
Ran 19 tests in 0.001s

OK
```

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
