### PR TITLE
fix(vertex_ai): remove invalid date suffix from Claude 4.6 model IDs

### DIFF
--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.49
+version: 0.0.50

--- a/models/vertex_ai/models/llm/anthropic.claude-opus-4-6.yaml
+++ b/models/vertex_ai/models/llm/anthropic.claude-opus-4-6.yaml
@@ -1,4 +1,4 @@
-model: claude-opus-4-6@20260205
+model: claude-opus-4-6
 label:
   en_US: Claude Opus 4.6
 model_type: llm

--- a/models/vertex_ai/models/llm/anthropic.claude-sonnet-4-6.yaml
+++ b/models/vertex_ai/models/llm/anthropic.claude-sonnet-4-6.yaml
@@ -1,4 +1,4 @@
-model: claude-sonnet-4-6@20260217
+model: claude-sonnet-4-6
 label:
   en_US: Claude Sonnet 4.6
 model_type: llm


### PR DESCRIPTION
## Summary
- Drop the date suffix from `claude-sonnet-4-6@20260217` and `claude-opus-4-6@20260205` — Vertex AI rejects those versioned IDs with a 404, breaking every LLM call against these models.
- Unversioned IDs (`claude-sonnet-4-6`, `claude-opus-4-6`) are what Vertex currently publishes for Anthropic's 4.6 models.

## Context
Fixes langgenius/dify#35386. Users on Dify Cloud hit:

```
404 ... /v1/projects/.../publishers/anthropic/models/claude-sonnet-4-6@20260217:streamRawPredict
```

Other Claude entries in this folder (e.g. `claude-sonnet-4-5@20250929`) use versioned IDs successfully, so this is specifically the 4.6 date suffixes being wrong, not versioning in general.

## Test plan
- [ ] Configure Vertex AI provider with a GCP project that has Anthropic Claude enabled.
- [ ] Send a message through an LLM node using `Claude Sonnet 4.6` — request should succeed.
- [ ] Repeat for `Claude Opus 4.6`.