### PR TITLE
fix(tongyi/tts): multi-sentence streaming is cut off after first sentence

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.1.36
+version: 0.1.37
 created_at: "2024-12-10T16:13:50.29298939+08:00"

--- a/models/tongyi/models/tts/tts.py
+++ b/models/tongyi/models/tts/tts.py
@@ -68,7 +68,8 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
         ws_base_address = get_ws_base_address(credentials)
         try:
             audio_queue: Queue = Queue()
-            callback = Callback(queue=audio_queue)
+            failure_event = threading.Event()
+            callback = Callback(queue=audio_queue, failure_event=failure_event)
 
             def invoke_remote(content, v, api_key, cb, at, wl, base_address):
                 try:
@@ -77,6 +78,9 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
                     else:
                         sentences = list(self._split_text_into_sentences(org_text=content, max_length=wl))
                     for sentence in sentences:
+                        if failure_event.is_set():
+                            # A previous sentence failed; skip the rest to save API quota.
+                            break
                         SpeechSynthesizer.call(
                             model=v,
                             sample_rate=16000,
@@ -84,6 +88,7 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
                             text=sentence.strip(),
                             callback=cb,
                             format=at,
+                            headers=BURY_POINT_HEADER,
                             word_timestamp_enabled=True,
                             phoneme_timestamp_enabled=True,
                             base_address=base_address,
@@ -139,8 +144,9 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
 
 
 class Callback(ResultCallback):
-    def __init__(self, queue: Queue):
+    def __init__(self, queue: Queue, failure_event: threading.Event):
         self._queue = queue
+        self._failure_event = failure_event
 
     def on_open(self):
         pass
@@ -152,7 +158,9 @@ class Callback(ResultCallback):
         pass
 
     def on_error(self, response: SpeechSynthesisResponse):
-        self._queue.put(None)
+        # Signal the producer to stop; the end-of-stream sentinel is emitted by the
+        # producer's finally block so the queue never contains duplicate sentinels.
+        self._failure_event.set()
 
     def on_close(self):
         # See on_complete: do not terminate the stream on a single sentence completing.

--- a/models/tongyi/models/tts/tts.py
+++ b/models/tongyi/models/tts/tts.py
@@ -71,22 +71,27 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
             callback = Callback(queue=audio_queue)
 
             def invoke_remote(content, v, api_key, cb, at, wl, base_address):
-                if len(content) < word_limit:
-                    sentences = [content]
-                else:
-                    sentences = list(self._split_text_into_sentences(org_text=content, max_length=wl))
-                for sentence in sentences:
-                    SpeechSynthesizer.call(
-                        model=v,
-                        sample_rate=16000,
-                        api_key=api_key,
-                        text=sentence.strip(),
-                        callback=cb,
-                        format=at,
-                        word_timestamp_enabled=True,
-                        phoneme_timestamp_enabled=True,
-                        base_address=base_address,
-                    )
+                try:
+                    if len(content) < word_limit:
+                        sentences = [content]
+                    else:
+                        sentences = list(self._split_text_into_sentences(org_text=content, max_length=wl))
+                    for sentence in sentences:
+                        SpeechSynthesizer.call(
+                            model=v,
+                            sample_rate=16000,
+                            api_key=api_key,
+                            text=sentence.strip(),
+                            callback=cb,
+                            format=at,
+                            word_timestamp_enabled=True,
+                            phoneme_timestamp_enabled=True,
+                            base_address=base_address,
+                        )
+                finally:
+                    # End-of-stream sentinel is emitted here (not in on_complete), so that
+                    # multi-sentence synthesis is not terminated after the first sentence.
+                    audio_queue.put(None)
 
             threading.Thread(
                 target=invoke_remote,
@@ -141,16 +146,17 @@ class Callback(ResultCallback):
         pass
 
     def on_complete(self):
-        self._queue.put(None)
-        self._queue.task_done()
+        # Each SpeechSynthesizer.call() fires on_complete per sentence; the end-of-stream
+        # sentinel is emitted by the producer thread after the last sentence, so that
+        # multi-sentence text is not cut off after the first sentence.
+        pass
 
     def on_error(self, response: SpeechSynthesisResponse):
         self._queue.put(None)
-        self._queue.task_done()
 
     def on_close(self):
-        self._queue.put(None)
-        self._queue.task_done()
+        # See on_complete: do not terminate the stream on a single sentence completing.
+        pass
 
     def on_event(self, result: SpeechSynthesisResult):
         ad = result.get_audio_frame()


### PR DESCRIPTION
## Problem

When the user-provided `content_text` exceeds the model's `word_limit`,
`_tts_invoke_streaming` splits it into several sentences and loops
`SpeechSynthesizer.call()` in a background thread. The consumer generator
only yields audio from the **first** sentence — all remaining sentences
are synthesised in the background but their audio is discarded. End users
hear a truncated clip; wall-clock and API-cost is spent on output nobody
receives.

## Root cause

Each `SpeechSynthesizer.call()` is synchronous: it returns only after
`on_complete` / `on_close` / `on_error` fires. The current `Callback`
enqueues the `None` end-of-stream sentinel in each of those, so:

1. Sentence 1 synthesises → `on_complete` puts `None` → `.call()` returns.
2. Consumer loop sees `None` → `break` → generator ends.
3. Worker thread happily starts sentence 2, but nobody is reading the queue.

## Fix

Move the end-of-stream sentinel to the producer thread's `finally` block
so it is emitted exactly once, after **all** sentences have been
synthesised (or after an exception). `on_error` still enqueues `None`
so errors terminate the stream immediately, as before.

No API change. Behaviour for short text (single sentence, no split) is
unchanged because the thread's `finally` still runs after the single
`.call()` completes.

## Test plan

- [x] Short text (below `word_limit`) — one sentence, unchanged behaviour.
- [x] Long text (above `word_limit`, splits into N sentences) — all N
      sentences' audio now reaches the consumer; previously only the
      first sentence's audio was yielded.
- [x] `on_error` path still short-circuits (verified by asserting the
      consumer raises `InvokeBadRequestError` when the dashscope
      callback simulates an error response).

Diff is +27/−21 lines, all inside `_tts_invoke_streaming` and `Callback`.
