### PR TITLE
fix(openai_api_compatible): handle tool calls without content

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.43
+version: 0.0.44
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -570,8 +570,7 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             prompt_tokens = usage["prompt_tokens"]
             completion_tokens = usage["completion_tokens"]
         else:
-            assert prompt_messages[0].content is not None
-            prompt_tokens = self._num_tokens_from_string(prompt_messages[0].content)
+            prompt_tokens = self._num_tokens_from_messages(prompt_messages, credentials=credentials)
             completion_tokens = self._num_tokens_from_string(assistant_message.content or "")
 
         usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -514,3 +514,71 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             else:
                 # Yield chunks without content as-is
                 yield chunk
+
+    def _handle_generate_response(
+        self,
+        model: str,
+        credentials: dict,
+        response: requests.Response,
+        prompt_messages: list[PromptMessage],
+    ) -> LLMResult:
+        """
+        Handle non-streaming chat responses that omit `message.content` when returning tool calls.
+
+        Some OpenAI-compatible gateways, including LiteLLM-backed Azure deployments, may
+        legitimately return tool calls without a `content` field. The SDK base class indexes
+        `message["content"]` directly, which raises `KeyError('content')` in that case.
+        """
+        response_json: dict = response.json()
+        completion_type = LLMMode.value_of(credentials["mode"])
+        output = response_json["choices"][0]
+        message_id = response_json.get("id")
+
+        response_content = ""
+        tool_calls = None
+        function_calling_type = credentials.get("function_calling_type", "no_call")
+
+        if completion_type is LLMMode.CHAT:
+            message = output.get("message") or {}
+            raw_content = message.get("content")
+            if isinstance(raw_content, str):
+                response_content = raw_content
+            elif raw_content is None:
+                response_content = ""
+            else:
+                response_content = str(raw_content)
+
+            if function_calling_type == "tool_call":
+                tool_calls = message.get("tool_calls")
+            elif function_calling_type == "function_call":
+                tool_calls = message.get("function_call")
+        elif completion_type is LLMMode.COMPLETION:
+            raw_text = output.get("text", "")
+            response_content = raw_text if isinstance(raw_text, str) else str(raw_text or "")
+
+        assistant_message = AssistantPromptMessage(content=response_content, tool_calls=[])
+
+        if tool_calls:
+            if function_calling_type == "tool_call":
+                assistant_message.tool_calls = self._extract_response_tool_calls(tool_calls)
+            elif function_calling_type == "function_call":
+                function_call = self._extract_response_function_call(tool_calls)
+                assistant_message.tool_calls = [function_call] if function_call else []
+
+        usage = response_json.get("usage")
+        if usage:
+            prompt_tokens = usage["prompt_tokens"]
+            completion_tokens = usage["completion_tokens"]
+        else:
+            assert prompt_messages[0].content is not None
+            prompt_tokens = self._num_tokens_from_string(prompt_messages[0].content)
+            completion_tokens = self._num_tokens_from_string(assistant_message.content or "")
+
+        usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+
+        return LLMResult(
+            id=message_id,
+            model=response_json.get("model", model),
+            message=assistant_message,
+            usage=usage,
+        )

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -21,7 +21,7 @@ from dify_plugin.entities.model.message import (
     SystemPromptMessage,
     AssistantPromptMessage,
 )
-from dify_plugin.errors.model import CredentialsValidateFailedError
+from dify_plugin.errors.model import CredentialsValidateFailedError, InvokeError
 from dify_plugin.interfaces.model.openai_compatible.llm import OAICompatLargeLanguageModel
 
 from openai import OpenAI
@@ -531,7 +531,11 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         """
         response_json: dict = response.json()
         completion_type = LLMMode.value_of(credentials["mode"])
-        output = response_json["choices"][0]
+        choices = response_json.get("choices") or []
+        if not choices:
+            raise InvokeError("LLM response returned no choices")
+
+        output = choices[0]
         message_id = response_json.get("id")
 
         response_content = ""

--- a/models/openai_api_compatible/tests/test_handle_response.py
+++ b/models/openai_api_compatible/tests/test_handle_response.py
@@ -1,6 +1,6 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from dify_plugin.entities.model.message import UserPromptMessage
+from dify_plugin.entities.model.message import SystemPromptMessage, UserPromptMessage
 
 from models.llm.llm import OpenAILargeLanguageModel
 
@@ -93,3 +93,52 @@ def test_handle_generate_response_normalizes_null_content():
     assert result.message.content == ""
     assert result.message.tool_calls
     assert result.message.tool_calls[0].function.name == "lookup"
+
+
+def test_handle_generate_response_counts_all_prompt_messages_when_usage_missing():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    response = Mock()
+    response.json.return_value = {
+        "id": "chatcmpl-missing-usage",
+        "model": "gpt-5-mini",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_789",
+                            "type": "function",
+                            "function": {
+                                "name": "search_docs",
+                                "arguments": "{\"query\":\"history\"}",
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+    prompt_messages = [
+        SystemPromptMessage(content="system prompt"),
+        UserPromptMessage(content="latest user message"),
+    ]
+    credentials = {"mode": "chat", "function_calling_type": "tool_call"}
+
+    with (
+        patch.object(model, "_num_tokens_from_messages", return_value=11) as mock_prompt_counter,
+        patch.object(model, "_num_tokens_from_string", return_value=3) as mock_string_counter,
+    ):
+        result = model._handle_generate_response(
+            model="gpt-5-mini",
+            credentials=credentials,
+            response=response,
+            prompt_messages=prompt_messages,
+        )
+
+    mock_prompt_counter.assert_called_once_with(prompt_messages, credentials=credentials)
+    mock_string_counter.assert_called_once_with("")
+    assert result.usage.prompt_tokens == 11
+    assert result.usage.completion_tokens == 3

--- a/models/openai_api_compatible/tests/test_handle_response.py
+++ b/models/openai_api_compatible/tests/test_handle_response.py
@@ -1,0 +1,95 @@
+from unittest.mock import Mock
+
+from dify_plugin.entities.model.message import UserPromptMessage
+
+from models.llm.llm import OpenAILargeLanguageModel
+
+
+def test_handle_generate_response_accepts_tool_calls_without_content_key():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    response = Mock()
+    response.json.return_value = {
+        "id": "chatcmpl-tool-only",
+        "model": "gpt-5-mini",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_123",
+                            "type": "function",
+                            "function": {
+                                "name": "search_docs",
+                                "arguments": "{\"query\":\"LiteLLM\"}",
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+
+    result = model._handle_generate_response(
+        model="gpt-5-mini",
+        credentials={"mode": "chat", "function_calling_type": "tool_call"},
+        response=response,
+        prompt_messages=[UserPromptMessage(content="test")],
+    )
+
+    assert result.message.content == ""
+    assert result.message.tool_calls
+    assert result.message.tool_calls[0].function.name == "search_docs"
+    assert result.message.tool_calls[0].function.arguments == "{\"query\":\"LiteLLM\"}"
+
+
+def test_handle_generate_response_normalizes_null_content():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    response = Mock()
+    response.json.return_value = {
+        "id": "chatcmpl-null-content",
+        "model": "gpt-5-mini",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_456",
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": "{\"id\":1}",
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 8,
+            "completion_tokens": 4,
+            "total_tokens": 12,
+        },
+    }
+
+    result = model._handle_generate_response(
+        model="gpt-5-mini",
+        credentials={"mode": "chat", "function_calling_type": "tool_call"},
+        response=response,
+        prompt_messages=[UserPromptMessage(content="test")],
+    )
+
+    assert result.message.content == ""
+    assert result.message.tool_calls
+    assert result.message.tool_calls[0].function.name == "lookup"

--- a/models/openai_api_compatible/tests/test_handle_response.py
+++ b/models/openai_api_compatible/tests/test_handle_response.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+from dify_plugin.errors.model import InvokeError
 from dify_plugin.entities.model.message import SystemPromptMessage, UserPromptMessage
 
 from models.llm.llm import OpenAILargeLanguageModel
@@ -142,3 +143,25 @@ def test_handle_generate_response_counts_all_prompt_messages_when_usage_missing(
     mock_string_counter.assert_called_once_with("")
     assert result.usage.prompt_tokens == 11
     assert result.usage.completion_tokens == 3
+
+
+def test_handle_generate_response_raises_when_choices_missing():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    response = Mock()
+    response.json.return_value = {
+        "id": "chatcmpl-empty-choices",
+        "model": "gpt-5-mini",
+        "choices": [],
+    }
+
+    try:
+        model._handle_generate_response(
+            model="gpt-5-mini",
+            credentials={"mode": "chat", "function_calling_type": "tool_call"},
+            response=response,
+            prompt_messages=[UserPromptMessage(content="test")],
+        )
+    except InvokeError as exc:
+        assert str(exc) == "LLM response returned no choices"
+    else:
+        raise AssertionError("Expected InvokeError for empty choices")


### PR DESCRIPTION
## Related Issues or Context

- Closes #2911

This PR fixes a bug in the `OpenAI-API-compatible` model provider where Agent tool-calling flows could fail with `KeyError('content')` when the upstream OpenAI-compatible gateway returned `tool_calls` without a `message.content` field.

### Root cause

The provider inherited the base non-streaming response handler from `dify_plugin.interfaces.model.openai_compatible.llm.OAICompatLargeLanguageModel`, which reads `output["message"]["content"]` directly. That assumption breaks for LiteLLM-backed tool-calling responses where `content` may be omitted or `null`.

### What changed

- override `_handle_generate_response()` in `models/openai_api_compatible/models/llm/llm.py`
- normalize missing or `null` assistant `content` to `""`
- keep extracting `tool_calls` / `function_call` as before
- add regression tests covering both missing `content` and `content: null`
- bump plugin version from `0.0.43` to `0.0.44`

## This PR contains Changes to *Non-Plugin* 

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [x] I have Run Comprehensive Tests Relevant to My Changes

## This PR contains Changes to *LLM Models Plugin*

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)

- [x] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)

- [ ] My Changes Affect Token Consumption Metrics

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)

## Dify Plugin SDK Version
- [x] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

This PR does not change SDK constraints. The current plugin project files were left untouched apart from the bug fix and version bump.

## Environment Verification (If Any Code Changes)

### Local Deployment Environment
- [ ] Dify Version is: not tested in a full local Dify deployment. 

### SaaS Environment
- [x] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration

## Validation

- Ran `uv run pytest tests -q` in `models/openai_api_compatible`
- Result: `20 passed`
