### PR TITLE
fix: firecrawl can't work when user not input  base_url

### DIFF
--- a/tools/firecrawl/manifest.yaml
+++ b/tools/firecrawl/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - utilities
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/firecrawl/tools/crawl.py
+++ b/tools/firecrawl/tools/crawl.py
@@ -12,7 +12,7 @@ class CrawlTool(Tool):
         https://docs.firecrawl.dev/api-reference/endpoint/crawl
         """
         app = FirecrawlApp(
-            api_key=self.runtime.credentials["firecrawl_api_key"], base_url=self.runtime.credentials["base_url"]
+            api_key=self.runtime.credentials.get("firecrawl_api_key"), base_url=self.runtime.credentials.get("base_url")
         )
         scrapeOptions = {}
         payload = {}

--- a/tools/firecrawl/tools/crawl_job.py
+++ b/tools/firecrawl/tools/crawl_job.py
@@ -8,7 +8,7 @@ from .firecrawl_appx import FirecrawlApp
 class CrawlJobTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
         app = FirecrawlApp(
-            api_key=self.runtime.credentials["firecrawl_api_key"], base_url=self.runtime.credentials["base_url"]
+            api_key=self.runtime.credentials.get("firecrawl_api_key"), base_url=self.runtime.credentials.get("base_url")
         )
         operation = tool_parameters.get("operation", "get")
         if operation == "get":

--- a/tools/firecrawl/tools/map.py
+++ b/tools/firecrawl/tools/map.py
@@ -12,7 +12,7 @@ class MapTool(Tool):
         https://docs.firecrawl.dev/api-reference/endpoint/map
         """
         app = FirecrawlApp(
-            api_key=self.runtime.credentials["firecrawl_api_key"], base_url=self.runtime.credentials["base_url"]
+            api_key=self.runtime.credentials.get("firecrawl_api_key"), base_url=self.runtime.credentials.get("base_url")
         )
         payload = {}
         payload["search"] = tool_parameters.get("search")

--- a/tools/firecrawl/tools/scrape.py
+++ b/tools/firecrawl/tools/scrape.py
@@ -11,7 +11,7 @@ class ScrapeTool(Tool):
         https://docs.firecrawl.dev/api-reference/endpoint/scrape
         """
         app = FirecrawlApp(
-            api_key=self.runtime.credentials["firecrawl_api_key"], base_url=self.runtime.credentials["base_url"]
+            api_key=self.runtime.credentials.get("firecrawl_api_key"), base_url=self.runtime.credentials.get("base_url")
         )
         payload = {}
         extract = {}


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

<img width="1302" height="1100" alt="image" src="https://github.com/user-attachments/assets/7ea9830f-e065-4e51-8be4-d553d672ff44" />

when user not input the base url,  it will raise error:

```
{
    "code": "invalid_param",
    "message": "req_id: 07238eebcd PluginInvokeError: {\"args\":{},\"error_type\":\"ToolProviderCredentialValidationError\",\"message\":\"'base_url'\"}",
    "status": 400
}
```

error stack:
```
ERROR:dify_plugin.core.server.io_server:Unexpected error occurred when executing request
Traceback (most recent call last):
  File "/Users/hejl/projects/dify-official-plugins/tools/firecrawl/provider/firecrawl.py", line 8, in _validate_credentials
    for _ in ScrapeTool.from_credentials(credentials, user_id="").invoke(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify-official-plugins/tools/firecrawl/tools/scrape.py", line 14, in _invoke
    api_key=self.runtime.credentials["firecrawl_api_key"], base_url=self.runtime.credentials["base_url"]
                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'base_url'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/hejl/projects/dify-official-plugins/.venv/lib/python3.12/site-packages/dify_plugin/core/server/io_server.py", line 94, in _execute_request_in_thread
    self._execute_request(
  File "/Users/hejl/projects/dify-official-plugins/.venv/lib/python3.12/site-packages/dify_plugin/plugin.py", line 455, in _execute_request
    response = self.dispatch(session, data)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify-official-plugins/.venv/lib/python3.12/site-packages/dify_plugin/core/server/router.py", line 79, in dispatch
    return route.func(session, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify-official-plugins/.venv/lib/python3.12/site-packages/dify_plugin/core/server/router.py", line 72, in wrapper
    return f(session, data)
           ^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify-official-plugins/.venv/lib/python3.12/site-packages/dify_plugin/core/plugin_executor.py", line 94, in validate_tool_provider_credentials
    provider_instance.validate_credentials(data.credentials)
  File "/Users/hejl/projects/dify-official-plugins/.venv/lib/python3.12/site-packages/dify_plugin/interfaces/tool/__init__.py", line 235, in validate_credentials
    return self._validate_credentials(credentials)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hejl/projects/dify-official-plugins/tools/firecrawl/provider/firecrawl.py", line 13, in _validate_credentials
    raise ToolProviderCredentialValidationError(str(e))
dify_plugin.errors.tool.ToolProviderCredentialValidationError: 'base_url'
```



## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [ ] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python Virtual Env Matching Manifest.yaml & requirements.txt
-->
