### PR TITLE
fix(models/minimax): align provider help URL region and clarify Group ID usage

### DIFF
--- a/models/minimax/manifest.yaml
+++ b/models/minimax/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.14
+version: 0.0.15

--- a/models/minimax/provider/minimax.yaml
+++ b/models/minimax/provider/minimax.yaml
@@ -44,8 +44,8 @@ provider_credential_schema:
   - label:
       en_US: Group ID
     placeholder:
-      en_US: Enter your group ID
-      zh_Hans: 在此输入您的 Group ID
+      en_US: Required only for legacy ABAB chat, embedding, and TTS models. Leave empty for MiniMax-M2.x.
+      zh_Hans: 仅在使用 ABAB chat、Embedding、TTS 模型时需要；MiniMax-M2.x 留空即可。
     required: false
     type: text-input
     variable: minimax_group_id

--- a/models/minimax/provider/minimax.yaml
+++ b/models/minimax/provider/minimax.yaml
@@ -13,7 +13,7 @@ help:
     en_US: Get your API Key from Minimax
     zh_Hans: 从 Minimax 获取您的 API Key
   url:
-    en_US: https://platform.minimaxi.com/user-center/basic-information/interface-key
+    en_US: https://platform.minimax.io/user-center/payment/token-plan
 icon_large:
   en_US: icon_l_en.png
 icon_small:


### PR DESCRIPTION
## Related Issues or Context

Two related provider-metadata bugs surfaced when users self-configure the Minimax provider in Dify. Both are zero-runtime-risk YAML edits and ship together to keep version churn low.

### 1. `help.url` region mismatch

| Field | Current value | Region |
|---|---|---|
| `endpoint_url` default | `https://api.minimax.io` | Global |
| `help.url` (en_US) | `https://platform.minimaxi.com/user-center/basic-information/interface-key` | China + PAYG console |

A user who accepts the default Base URL and clicks **Get API Key** lands on the China platform's pay-as-you-go interface-key page, which doesn't match the global host their credentials will actually call. The two MiniMax regions (`minimax.io` global vs `minimaxi.com` China) are independent accounts — keys from one don't authenticate against the other — so the link routes new users to the wrong console entirely.

```diff
   url:
-    en_US: https://platform.minimaxi.com/user-center/basic-information/interface-key
+    en_US: https://platform.minimax.io/user-center/payment/token-plan
```

China-region users can still reach the China console manually after switching `endpoint_url` to `https://api.minimaxi.com`; matching guidance lives in MiniMax's own docs.

### 2. Group ID placeholder is misleading for M2.x users

`provider/minimax.yaml` exposes a `minimax_group_id` field with placeholder `Enter your group ID`, suggesting it's universally needed.

In reality:

- **Read by** legacy paths only — `models/llm/chat_completion.py:41`, `chat_completion_pro.py:43`, `text_embedding/text_embedding.py:61`, `tts/tts.py:71` all append `?GroupId={group_id}` to the request URL.
- **Ignored by** the modern M2.x path — `models/llm/llm.py:602` `_to_credential_kwargs` only reads `minimax_api_key` + `endpoint_url` and hands them to the Anthropic SDK; `minimax_group_id` is never touched.

So users on `MiniMax-M2.7` / `M2.5` / `M2.1` waste time hunting down a Group ID that the SDK call ignores. Replace the generic placeholder with bilingual text spelling out exactly when the field matters:

```diff
     placeholder:
-      en_US: Enter your group ID
-      zh_Hans: 在此输入您的 Group ID
+      en_US: Required only for legacy ABAB chat, embedding, and TTS models. Leave empty for MiniMax-M2.x.
+      zh_Hans: 仅在使用 ABAB chat、Embedding、TTS 模型时需要；MiniMax-M2.x 留空即可。
```

Field stays `required: false`, and legacy ABAB / embedding / TTS users keep working unchanged.

## This PR contains Changes to *Non-Plugin*

- [x] Documentation

(Metadata only — no plugin runtime code is changed.)

## This PR contains Changes to *Non-LLM Models Plugin*

- [ ] I have Run Comprehensive Tests Relevant to My Changes

Not applicable: this PR only edits static strings in `provider/minimax.yaml`. No model loading, request, or credential validation paths are touched.

## This PR contains Changes to *LLM Models Plugin*

None of the LLM behaviors below are affected:

- [ ] My Changes Affect Message Flow Handling
- [ ] My Changes Affect Tool Interaction Flow
- [ ] My Changes Affect Multimodal Input Handling
- [ ] My Changes Affect Multimodal Output Generation
- [ ] My Changes Affect Structured Output Format
- [ ] My Changes Affect Token Consumption Metrics
- [ ] My Changes Affect Other LLM Functionalities
- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)

## Version Control

- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section) — `0.0.14` → `0.0.15` (PATCH, backward-compatible metadata fix).

## Dify Plugin SDK Version

- [x] No SDK requirement change; `requirements.txt` is untouched.

## Environment Verification

No code paths exercised. Both changes are static strings in a YAML metadata file rendered by Dify's UI as the **Get API Key** link target and the Group ID input placeholder. Verified visually by inspecting the diff against the production schema.