### PR TITLE
fix(notion): retrieve_page — paginate + recurse into nested children, with budget/telemetry

### DIFF
--- a/tools/notion/README.md
+++ b/tools/notion/README.md
@@ -76,6 +76,16 @@ Create a new Notion page titled "Meeting Notes" with content "Discussed project 
 Get the Notion page with ID "abc123" and include its content
 ```
 
+`retrieve_page` fetches every block on the page, paginating `blocks.children.list`
+and recursing into blocks with `has_children` (toggles, callouts, quotes, bulleted /
+numbered list items, columns, etc.). It does **not** descend into `child_page` /
+`child_database` blocks — those are separate resources and should be fetched
+separately. Recursion is bounded by `max_depth` (default 5) and total Notion API
+calls are capped by `max_api_calls` (default 500). The response includes
+`api_calls_made`, `total_blocks_fetched`, and `elapsed_seconds`, plus
+`fetch_truncated: true` if the cap was hit. Large or deeply-nested pages can take
+several seconds; tune `max_depth` / `max_api_calls` for latency-sensitive contexts.
+
 ### Update a Page
 ```
 Update the title of Notion page "abc123" to "Updated Meeting Notes" and add "Follow-up scheduled for next week" to the content

--- a/tools/notion/manifest.yaml
+++ b/tools/notion/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: notion

--- a/tools/notion/tools/retrieve_page.py
+++ b/tools/notion/tools/retrieve_page.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import Generator
 from typing import Any, Dict, List
 import requests
@@ -7,7 +8,8 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 
 from tools.notion_client import NotionClient
 
-DEFAULT_MAX_DEPTH = 10
+DEFAULT_MAX_DEPTH = 5
+DEFAULT_MAX_API_CALLS = 500
 
 # Block types whose "children" are separate pages/databases, not nested content
 # of the current page. Recursing into them would silently pull in arbitrary
@@ -16,18 +18,39 @@ DEFAULT_MAX_DEPTH = 10
 NON_CONTENT_CONTAINER_TYPES = frozenset({"child_page", "child_database"})
 
 
+class _FetchBudget:
+    """Tracks API calls and blocks fetched for a single retrieve_page invocation."""
+
+    def __init__(self, max_api_calls: int):
+        self.max_api_calls = max_api_calls
+        self.api_calls_made = 0
+        self.total_blocks_fetched = 0
+        self.truncated = False
+
+    def can_spend(self) -> bool:
+        return self.api_calls_made < self.max_api_calls
+
+    def spend(self) -> None:
+        self.api_calls_made += 1
+
+    def mark_truncated(self) -> None:
+        self.truncated = True
+
+
 class RetrievePageTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
         # Extract parameters
         page_id = tool_parameters.get("page_id", "")
         include_content = tool_parameters.get("include_content", True)
-        max_depth = tool_parameters.get("max_depth", DEFAULT_MAX_DEPTH)
-        try:
-            max_depth = int(max_depth)
-        except (TypeError, ValueError):
-            max_depth = DEFAULT_MAX_DEPTH
-        if max_depth < 0:
-            max_depth = 0
+        max_depth = _coerce_positive_int(
+            tool_parameters.get("max_depth"), DEFAULT_MAX_DEPTH
+        )
+        max_api_calls = _coerce_positive_int(
+            tool_parameters.get("max_api_calls"), DEFAULT_MAX_API_CALLS
+        )
+        # max_api_calls must be at least 1 so the initial page fetch can run.
+        if max_api_calls < 1:
+            max_api_calls = 1
 
         # Validate parameters
         if not page_id:
@@ -46,41 +69,53 @@ class RetrievePageTool(Tool):
 
             # Retrieve the page
             try:
+                started_at = time.monotonic()
                 page_data = client.retrieve_page(page_id)
 
                 # Format the page data
                 formatted_page = self._format_page_data(client, page_data)
 
+                budget = _FetchBudget(max_api_calls=max_api_calls)
                 # Retrieve page content if requested
                 if include_content:
                     try:
-                        all_blocks = self._fetch_all_children(client, page_id)
+                        all_blocks = self._fetch_all_children(client, page_id, budget)
                         formatted_page["content"] = self._format_blocks(
-                            client, all_blocks, depth=0, max_depth=max_depth
+                            client, all_blocks, budget, depth=0, max_depth=max_depth
                         )
                     except requests.HTTPError as e:
                         # If we can't get the content, just return the page data
                         formatted_page["content_error"] = str(e)
-                
+
                 # Format URL
                 formatted_page["url"] = client.format_page_url(page_id)
-                
+
+                # Telemetry: observable cost of this retrieval.
+                formatted_page["api_calls_made"] = budget.api_calls_made
+                formatted_page["total_blocks_fetched"] = budget.total_blocks_fetched
+                formatted_page["elapsed_seconds"] = round(time.monotonic() - started_at, 3)
+                if budget.truncated:
+                    formatted_page["fetch_truncated"] = True
+                    formatted_page["fetch_truncated_reason"] = (
+                        f"max_api_calls={max_api_calls} exceeded; increase the limit or raise max_depth with care."
+                    )
+
                 # Return results
                 title = formatted_page.get("title", "Untitled")
                 yield self.create_text_message(f"Retrieved page: {title}")
                 yield self.create_json_message(formatted_page)
-                
+
             except requests.HTTPError as e:
                 if e.response.status_code == 404:
                     yield self.create_text_message(f"Page not found or you don't have access to it: {page_id}")
                 else:
                     yield self.create_text_message(f"Error retrieving page: {e}")
                 return
-                
+
         except Exception as e:
             yield self.create_text_message(f"Error retrieving Notion page: {str(e)}")
             return
-    
+
     def _format_page_data(self, client: NotionClient, page_data: Dict[str, Any]) -> Dict[str, Any]:
         """Format the page data for the response."""
         result = {
@@ -89,15 +124,15 @@ class RetrievePageTool(Tool):
             "last_edited_time": page_data.get("last_edited_time", ""),
             "archived": page_data.get("archived", False),
         }
-        
+
         # Extract properties
         properties = page_data.get("properties", {})
         formatted_properties = {}
-        
+
         title = "Untitled"
         for prop_name, prop_data in properties.items():
             prop_type = prop_data.get("type")
-            
+
             # Extract value based on property type
             if prop_type == "title":
                 title_content = prop_data.get("title", [])
@@ -131,20 +166,31 @@ class RetrievePageTool(Tool):
             else:
                 # For other property types, just note the type
                 value = f"<{prop_type}>"
-            
+
             formatted_properties[prop_name] = value
-        
+
         result["title"] = title
         result["properties"] = formatted_properties
         return result
-    
-    def _fetch_all_children(self, client: NotionClient, block_id: str) -> List[Dict[str, Any]]:
-        """Fetch every child block of the given block, paginating until exhausted."""
+
+    def _fetch_all_children(
+        self,
+        client: NotionClient,
+        block_id: str,
+        budget: "_FetchBudget",
+    ) -> List[Dict[str, Any]]:
+        """Fetch every child block of the given block, paginating until exhausted or the budget is reached."""
         blocks: List[Dict[str, Any]] = []
         start_cursor = None
         while True:
+            if not budget.can_spend():
+                budget.mark_truncated()
+                break
+            budget.spend()
             response = client.retrieve_block_children(block_id, start_cursor=start_cursor)
-            blocks.extend(response.get("results", []))
+            page_results = response.get("results", [])
+            blocks.extend(page_results)
+            budget.total_blocks_fetched += len(page_results)
             if not response.get("has_more"):
                 break
             start_cursor = response.get("next_cursor")
@@ -156,6 +202,7 @@ class RetrievePageTool(Tool):
         self,
         client: NotionClient,
         blocks: List[Dict[str, Any]],
+        budget: "_FetchBudget",
         depth: int = 0,
         max_depth: int = DEFAULT_MAX_DEPTH,
     ) -> List[Dict[str, Any]]:
@@ -240,11 +287,14 @@ class RetrievePageTool(Tool):
             if has_children and block_type not in NON_CONTENT_CONTAINER_TYPES:
                 if depth >= max_depth:
                     formatted_block["children_truncated"] = True
+                elif not budget.can_spend():
+                    formatted_block["children_truncated"] = True
+                    budget.mark_truncated()
                 else:
                     try:
-                        child_blocks = self._fetch_all_children(client, block_id)
+                        child_blocks = self._fetch_all_children(client, block_id, budget)
                         formatted_block["children"] = self._format_blocks(
-                            client, child_blocks, depth=depth + 1, max_depth=max_depth
+                            client, child_blocks, budget, depth=depth + 1, max_depth=max_depth
                         )
                     except requests.HTTPError as e:
                         # Record per-block failure but keep the rest of the page intact
@@ -253,3 +303,12 @@ class RetrievePageTool(Tool):
             formatted_blocks.append(formatted_block)
 
         return formatted_blocks
+
+
+def _coerce_positive_int(value: Any, default: int) -> int:
+    """Best-effort int coercion; negatives clamp to 0 so callers can disable recursion."""
+    try:
+        coerced = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+    return max(coerced, 0)

--- a/tools/notion/tools/retrieve_page.py
+++ b/tools/notion/tools/retrieve_page.py
@@ -245,15 +245,15 @@ class RetrievePageTool(Tool):
                 formatted_block["checked"] = checked
             elif block_type == "toggle":
                 rich_text = block.get("toggle", {}).get("rich_text", [])
-                text = "".join([rt.get("plain_text", "") for rt in rich_text])
+                text = client.extract_plain_text(rich_text)
                 formatted_block["text"] = text
             elif block_type == "quote":
                 rich_text = block.get("quote", {}).get("rich_text", [])
-                text = "".join([rt.get("plain_text", "") for rt in rich_text])
+                text = client.extract_plain_text(rich_text)
                 formatted_block["text"] = text
             elif block_type == "callout":
                 rich_text = block.get("callout", {}).get("rich_text", [])
-                text = "".join([rt.get("plain_text", "") for rt in rich_text])
+                text = client.extract_plain_text(rich_text)
                 formatted_block["text"] = text
             elif block_type == "code":
                 code_block = block.get("code", {})

--- a/tools/notion/tools/retrieve_page.py
+++ b/tools/notion/tools/retrieve_page.py
@@ -7,40 +7,51 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 
 from tools.notion_client import NotionClient
 
+DEFAULT_MAX_DEPTH = 10
+
+
 class RetrievePageTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
         # Extract parameters
         page_id = tool_parameters.get("page_id", "")
         include_content = tool_parameters.get("include_content", True)
-        
+        max_depth = tool_parameters.get("max_depth", DEFAULT_MAX_DEPTH)
+        try:
+            max_depth = int(max_depth)
+        except (TypeError, ValueError):
+            max_depth = DEFAULT_MAX_DEPTH
+        if max_depth < 0:
+            max_depth = 0
+
         # Validate parameters
         if not page_id:
             yield self.create_text_message("Page ID is required.")
             return
-            
+
         try:
             # Get integration token from credentials
             integration_token = self.runtime.credentials.get("integration_token")
             if not integration_token:
                 yield self.create_text_message("Notion Integration Token is required.")
                 return
-                
+
             # Initialize the Notion client
             client = NotionClient(integration_token)
-            
+
             # Retrieve the page
             try:
                 page_data = client.retrieve_page(page_id)
-                
+
                 # Format the page data
                 formatted_page = self._format_page_data(client, page_data)
-                
+
                 # Retrieve page content if requested
                 if include_content:
                     try:
-                        blocks_data = client.retrieve_block_children(page_id)
-                        blocks = blocks_data.get("results", [])
-                        formatted_page["content"] = self._format_blocks(blocks)
+                        all_blocks = self._fetch_all_children(client, page_id)
+                        formatted_page["content"] = self._format_blocks(
+                            client, all_blocks, depth=0, max_depth=max_depth
+                        )
                     except requests.HTTPError as e:
                         # If we can't get the content, just return the page data
                         formatted_page["content_error"] = str(e)
@@ -121,21 +132,41 @@ class RetrievePageTool(Tool):
         result["properties"] = formatted_properties
         return result
     
-    def _format_blocks(self, blocks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Format block content for the response."""
+    def _fetch_all_children(self, client: NotionClient, block_id: str) -> List[Dict[str, Any]]:
+        """Fetch every child block of the given block, paginating until exhausted."""
+        blocks: List[Dict[str, Any]] = []
+        start_cursor = None
+        while True:
+            response = client.retrieve_block_children(block_id, start_cursor=start_cursor)
+            blocks.extend(response.get("results", []))
+            if not response.get("has_more"):
+                break
+            start_cursor = response.get("next_cursor")
+            if not start_cursor:
+                break
+        return blocks
+
+    def _format_blocks(
+        self,
+        client: NotionClient,
+        blocks: List[Dict[str, Any]],
+        depth: int = 0,
+        max_depth: int = DEFAULT_MAX_DEPTH,
+    ) -> List[Dict[str, Any]]:
+        """Format block content for the response, recursing into nested children."""
         formatted_blocks = []
-        
+
         for block in blocks:
             block_id = block.get("id", "")
             block_type = block.get("type", "")
             has_children = block.get("has_children", False)
-            
+
             formatted_block = {
                 "id": block_id,
                 "type": block_type,
                 "has_children": has_children
             }
-            
+
             # Extract content based on block type
             if block_type == "paragraph":
                 rich_text = block.get("paragraph", {}).get("rich_text", [])
@@ -159,6 +190,18 @@ class RetrievePageTool(Tool):
                 checked = block.get("to_do", {}).get("checked", False)
                 formatted_block["text"] = text
                 formatted_block["checked"] = checked
+            elif block_type == "toggle":
+                rich_text = block.get("toggle", {}).get("rich_text", [])
+                text = "".join([rt.get("plain_text", "") for rt in rich_text])
+                formatted_block["text"] = text
+            elif block_type == "quote":
+                rich_text = block.get("quote", {}).get("rich_text", [])
+                text = "".join([rt.get("plain_text", "") for rt in rich_text])
+                formatted_block["text"] = text
+            elif block_type == "callout":
+                rich_text = block.get("callout", {}).get("rich_text", [])
+                text = "".join([rt.get("plain_text", "") for rt in rich_text])
+                formatted_block["text"] = text
             elif block_type == "code":
                 code_block = block.get("code", {})
                 rich_text = code_block.get("rich_text", [])
@@ -170,7 +213,7 @@ class RetrievePageTool(Tool):
                 image_block = block.get("image", {})
                 caption = image_block.get("caption", [])
                 caption_text = "".join([rt.get("plain_text", "") for rt in caption])
-                
+
                 # Get image URL based on type
                 image_type = image_block.get("type", "")
                 if image_type == "external":
@@ -179,13 +222,27 @@ class RetrievePageTool(Tool):
                     image_url = image_block.get("file", {}).get("url", "")
                 else:
                     image_url = ""
-                
+
                 formatted_block["caption"] = caption_text
                 formatted_block["url"] = image_url
             else:
                 # For unsupported block types, just include the type
                 formatted_block["text"] = f"<{block_type} block>"
-            
+
+            # Recurse into children when available
+            if has_children:
+                if depth >= max_depth:
+                    formatted_block["children_truncated"] = True
+                else:
+                    try:
+                        child_blocks = self._fetch_all_children(client, block_id)
+                        formatted_block["children"] = self._format_blocks(
+                            client, child_blocks, depth=depth + 1, max_depth=max_depth
+                        )
+                    except requests.HTTPError as e:
+                        # Record per-block failure but keep the rest of the page intact
+                        formatted_block["children_error"] = str(e)
+
             formatted_blocks.append(formatted_block)
-            
-        return formatted_blocks 
+
+        return formatted_blocks

--- a/tools/notion/tools/retrieve_page.py
+++ b/tools/notion/tools/retrieve_page.py
@@ -9,6 +9,12 @@ from tools.notion_client import NotionClient
 
 DEFAULT_MAX_DEPTH = 10
 
+# Block types whose "children" are separate pages/databases, not nested content
+# of the current page. Recursing into them would silently pull in arbitrary
+# linked pages, so we skip them. Users can call retrieve_page on those IDs
+# explicitly if needed.
+NON_CONTENT_CONTAINER_TYPES = frozenset({"child_page", "child_database"})
+
 
 class RetrievePageTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
@@ -229,8 +235,9 @@ class RetrievePageTool(Tool):
                 # For unsupported block types, just include the type
                 formatted_block["text"] = f"<{block_type} block>"
 
-            # Recurse into children when available
-            if has_children:
+            # Recurse into children when available, but skip linked sub-pages
+            # and sub-databases (those are separately retrievable).
+            if has_children and block_type not in NON_CONTENT_CONTAINER_TYPES:
                 if depth >= max_depth:
                     formatted_block["children_truncated"] = True
                 else:

--- a/tools/notion/tools/retrieve_page.yaml
+++ b/tools/notion/tools/retrieve_page.yaml
@@ -51,6 +51,24 @@ parameters:
       zh_Hant: 是否在回應中包含頁面內容
     llm_description: Whether to include the page blocks/content in the response. If set to false, only page properties will be returned.
     form: llm
+  - name: max_depth
+    type: number
+    required: false
+    default: 10
+    label:
+      en_US: Max Nested Block Depth
+      zh_Hans: 最大嵌套块深度
+      pt_BR: Profundidade Máxima de Blocos Aninhados
+      ja_JP: ネストブロックの最大深度
+      zh_Hant: 最大巢狀區塊深度
+    human_description:
+      en_US: "Maximum depth to recurse into nested child blocks (e.g. toggle, callout, list items). 0 disables recursion."
+      zh_Hans: "递归获取嵌套子块（如 toggle、callout、列表项）的最大深度。0 表示禁用递归。"
+      pt_BR: "Profundidade máxima para recursão em blocos filhos aninhados (ex.: toggle, callout, itens de lista). 0 desativa a recursão."
+      ja_JP: "ネストされた子ブロック（トグル、コールアウト、リストアイテムなど）を再帰取得する最大深度。0 で再帰を無効化します。"
+      zh_Hant: "遞迴取得巢狀子區塊（如 toggle、callout、清單項目）的最大深度。0 表示停用遞迴。"
+    llm_description: Maximum recursion depth when fetching nested child blocks. Defaults to 10. Set to 0 to disable recursion and return only top-level blocks.
+    form: llm
 extra:
   python:
     source: tools/retrieve_page.py 

--- a/tools/notion/tools/retrieve_page.yaml
+++ b/tools/notion/tools/retrieve_page.yaml
@@ -14,7 +14,7 @@ description:
     pt_BR: Recuperar uma página do Notion pelo seu ID
     ja_JP: ID で Notion ページを取得します
     zh_Hant: 通過 ID 獲取 Notion 頁面
-  llm: Retrieve a Notion page by its ID. Returns page content, properties, and metadata. The page must be shared with your integration.
+  llm: Retrieve a Notion page by its ID. Returns page content (recursively including nested child blocks like toggles, callouts, and list sub-items), properties, and metadata. The page must be shared with your integration. Large or deeply nested pages may take several seconds and multiple API calls; use max_depth / max_api_calls to cap cost. The response includes api_calls_made, total_blocks_fetched, and elapsed_seconds for observability, and sets fetch_truncated=true when the budget was hit.
 parameters:
   - name: page_id
     type: string
@@ -54,7 +54,7 @@ parameters:
   - name: max_depth
     type: number
     required: false
-    default: 10
+    default: 5
     label:
       en_US: Max Nested Block Depth
       zh_Hans: 最大嵌套块深度
@@ -62,12 +62,30 @@ parameters:
       ja_JP: ネストブロックの最大深度
       zh_Hant: 最大巢狀區塊深度
     human_description:
-      en_US: "Maximum depth to recurse into nested child blocks (e.g. toggle, callout, list items). 0 disables recursion."
-      zh_Hans: "递归获取嵌套子块（如 toggle、callout、列表项）的最大深度。0 表示禁用递归。"
-      pt_BR: "Profundidade máxima para recursão em blocos filhos aninhados (ex.: toggle, callout, itens de lista). 0 desativa a recursão."
-      ja_JP: "ネストされた子ブロック（トグル、コールアウト、リストアイテムなど）を再帰取得する最大深度。0 で再帰を無効化します。"
-      zh_Hant: "遞迴取得巢狀子區塊（如 toggle、callout、清單項目）的最大深度。0 表示停用遞迴。"
-    llm_description: Maximum recursion depth when fetching nested child blocks. Defaults to 10. Set to 0 to disable recursion and return only top-level blocks.
+      en_US: "Maximum depth to recurse into nested child blocks (e.g. toggle, callout, list items). 0 disables recursion. Default 5 covers typical documents; raise cautiously on deeply nested pages."
+      zh_Hans: "递归获取嵌套子块（如 toggle、callout、列表项）的最大深度。0 表示禁用递归。默认 5，可覆盖常见文档；深度嵌套时谨慎提高。"
+      pt_BR: "Profundidade máxima para recursão em blocos filhos aninhados (ex.: toggle, callout, itens de lista). 0 desativa a recursão. Padrão 5; aumente com cautela em páginas muito aninhadas."
+      ja_JP: "ネストされた子ブロック（トグル、コールアウト、リストアイテムなど）を再帰取得する最大深度。0 で再帰を無効化します。既定値 5 は一般的な文書をカバーします。深いネストが必要な場合のみ慎重に引き上げてください。"
+      zh_Hant: "遞迴取得巢狀子區塊（如 toggle、callout、清單項目）的最大深度。0 表示停用遞迴。預設 5，可涵蓋一般文件；深度巢狀時請謹慎提高。"
+    llm_description: Maximum recursion depth when fetching nested child blocks. Default 5 (covers most documents). Set to 0 to disable recursion and return only top-level blocks. Deeper values multiply API cost.
+    form: llm
+  - name: max_api_calls
+    type: number
+    required: false
+    default: 500
+    label:
+      en_US: Max API Calls
+      zh_Hans: 最大 API 调用次数
+      pt_BR: Máximo de Chamadas de API
+      ja_JP: 最大 API 呼び出し回数
+      zh_Hant: 最大 API 呼叫次數
+    human_description:
+      en_US: "Safety cap on total Notion API calls per retrieval. At Notion's ~3 req/sec rate limit, 500 calls ≈ up to 3 minutes; lower for tighter SLAs. When hit, partial content is returned with fetch_truncated=true."
+      zh_Hans: "单次请求允许的 Notion API 调用次数上限。Notion 限速约 3 req/sec，500 次约需 3 分钟；可调低以满足更严格的超时。达到上限时返回部分内容并标记 fetch_truncated=true。"
+      pt_BR: "Limite de segurança para chamadas totais à API do Notion por recuperação. Com o limite de ~3 req/s do Notion, 500 chamadas ≈ até 3 minutos; reduza para SLAs mais apertados. Ao atingir, o conteúdo parcial é retornado com fetch_truncated=true."
+      ja_JP: "1 回の取得で発行する Notion API 呼び出し数の上限。Notion のレート制限は約 3 req/sec のため、500 回で最大約 3 分かかります。厳しいタイムアウト要件があれば下げてください。上限到達時は部分結果を fetch_truncated=true 付きで返します。"
+      zh_Hant: "單次擷取允許的 Notion API 呼叫次數上限。Notion 速率限制約 3 req/sec，500 次約 3 分鐘；可依 SLA 調低。達到上限時回傳部分內容並標記 fetch_truncated=true。"
+    llm_description: Safety cap on total Notion API calls for this retrieval. Default 500 (~3 min at Notion's rate limit). If exceeded, the response returns partial content with fetch_truncated=true. Lower this when running in latency-sensitive contexts.
     form: llm
 extra:
   python:


### PR DESCRIPTION
## Related Issues or Context

Fixes #2950.

The official Notion plugin's `retrieve_page`:

1. Calls `blocks.children.list` once and ignores `has_more` — so any page with more than 100 top-level blocks is silently truncated.
2. Never recurses into `has_children=true` blocks — so toggles, callouts, quotes, list items with nested content, columns, synced blocks etc. return only the parent. The formatter even outputs literal `<toggle block>` / `<quote block>` / `<callout block>` placeholders instead of the text.

This PR fixes both and makes the behavior observable and bounded.

### Changes

- **Pagination** — `_fetch_all_children` loops on `has_more` / `next_cursor` until Notion stops returning a cursor, so all top-level blocks are returned.
- **Recursion** — when a block has `has_children: true`, its children are fetched and attached under `children` in the formatted block. Depth-first.
- **Skip linked sub-resources** — `child_page` / `child_database` are intentionally **not** descended into. Those are separate Notion resources and callers should invoke `retrieve_page` / `retrieve_database` on them directly (otherwise a recursive `retrieve_page` can silently pull in whole sub-trees of a workspace).
- **Text extraction for `toggle` / `quote` / `callout`** — they now return their actual text instead of the placeholder strings.
- **`max_depth` parameter** (default 5) — caps recursion depth. When a deeper block is hit, `children_truncated: true` is set on it instead of raising, so the rest of the page still returns.
- **`max_api_calls` parameter** (default 500, min 1) — caps the total number of Notion API calls per invocation. When the cap is hit, already-fetched content is returned with `fetch_truncated: true` and a human-readable `fetch_truncated_reason`. Prevents a deep / wide page from quietly spending minutes against Notion's 3 req/s average rate limit and blowing workflow timeouts.
- **Telemetry on the response** — `api_calls_made`, `total_blocks_fetched`, `elapsed_seconds`, `fetch_truncated`, `fetch_truncated_reason`. Callers (and LLMs using the tool) can now see how much work a retrieval actually cost.
- **Per-block isolation** — if Notion returns an HTTP error for a specific sub-block (e.g. permission changed mid-recursion), it surfaces as `children_error` on that block instead of aborting the whole page.
- `manifest.yaml` version bump `0.0.5 → 0.0.6`.
- `README.md` and `retrieve_page.yaml` updated to document the new parameters and their cost characteristics (so the tool's LLM description guides good tool-use decisions).

### Verification

Reproduced on a mixed-content test page (long paragraphs + 5 levels of nested toggles + a toggle containing 110 list items):

| | 0.0.5 (before) | This PR |
| --- | --- | --- |
| Top-level blocks returned | 100 (silently truncated) | 132 (all) |
| Total blocks returned | 100 | 267 |
| Toggle / quote / callout text | `<toggle block>` placeholder | actual text |
| Nested children (L1–L5 toggles) | not returned | returned, correctly nested |
| Response telemetry | none | `api_calls_made: 21`, `total_blocks_fetched: 267`, `elapsed_seconds: ~9.5–11.8` |
| `child_page` / `child_database` expansion | n/a | not recursed (by design) |

Also verified the budget cap works: setting `max_api_calls` low returns partial content with `fetch_truncated: true` and a reason string, instead of silently hanging or timing out.

### Backward compatibility

- Existing callers that don't pass `max_depth` / `max_api_calls` get the fixed behavior with safe defaults.
- The extra keys in the response (`children`, `api_calls_made`, `total_blocks_fetched`, `elapsed_seconds`, `fetch_truncated`, `fetch_truncated_reason`) are additive.
- Consumers that previously read `<toggle block>` / `<quote block>` / `<callout block>` as sentinel strings will now receive real text — but that placeholder was never useful content, so this is strictly an improvement.

## This PR contains Changes to *Non-Plugin*

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*

- [x] I have Run Comprehensive Tests Relevant to My Changes

## This PR contains Changes to *LLM Models Plugin*

_Not applicable — this is a tool plugin, not an LLM models plugin._

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)

- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section) — `0.0.5 → 0.0.6` (PATCH: backward-compatible bug fix).

## Dify Plugin SDK Version

- [x] `dify_plugin~=0.6.2` is already pinned in `tools/notion/requirements.txt` (pre-existing; this PR does not touch it).

## Environment Verification

### Local Deployment Environment

- [x] Tested on a local Dify deployment against a real Notion workspace with a page containing >100 blocks and 5-level-deep nested toggles. See the verification table above.

### SaaS Environment

- [ ] _Not tested on cloud.dify.ai._