### PR TITLE
ci: fix plugin change detection for large pull requests

### DIFF
--- a/.github/scripts/detect-changed-plugins.sh
+++ b/.github/scripts/detect-changed-plugins.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${GITHUB_OUTPUT:-}" ]; then
+  echo "GITHUB_OUTPUT is required" >&2
+  exit 1
+fi
+
+if [ -z "${CHANGED_FILES_FILE:-}" ] && { [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; }; then
+  echo "Either CHANGED_FILES_FILE or both BASE_SHA and HEAD_SHA are required" >&2
+  exit 1
+fi
+
+is_zero_sha() {
+  [[ "$1" =~ ^0+$ ]]
+}
+
+json_array() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -R . | jq -s -c .
+  else
+    python3 -c 'import json, sys; print(json.dumps([line.rstrip("\n") for line in sys.stdin]))'
+  fi
+}
+
+manifest_dir() {
+  if [ "$1" = "manifest.yaml" ]; then
+    printf '.\n'
+  else
+    printf '%s\n' "${1%/manifest.yaml}"
+  fi
+}
+
+changed_files=()
+declare -A manifest_statuses=()
+
+if [ -n "${CHANGED_FILES_FILE:-}" ]; then
+  while IFS=$'\t' read -r status path; do
+    [ -n "$path" ] || continue
+    changed_files+=("$path")
+
+    if [[ "$path" == "manifest.yaml" || "$path" == */manifest.yaml ]]; then
+      plugin_path=$(manifest_dir "$path")
+      manifest_statuses["$plugin_path"]=$status
+    fi
+  done < "$CHANGED_FILES_FILE"
+
+  if [ -n "${EXPECTED_CHANGED_FILES:-}" ] && [ "${#changed_files[@]}" -ne "$EXPECTED_CHANGED_FILES" ]; then
+    echo "Expected $EXPECTED_CHANGED_FILES changed files, got ${#changed_files[@]}" >&2
+    exit 1
+  fi
+elif is_zero_sha "$BASE_SHA"; then
+  if git rev-parse --verify --quiet "${HEAD_SHA}^" >/dev/null; then
+    mapfile -t changed_files < <(git diff --name-only "${HEAD_SHA}^" "$HEAD_SHA")
+  else
+    mapfile -t changed_files < <(git ls-tree -r --name-only "$HEAD_SHA")
+  fi
+else
+  diff_base_sha=$BASE_SHA
+  if [ "${USE_MERGE_BASE:-false}" = "true" ]; then
+    diff_base_sha=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+  fi
+
+  echo "Diff base: $diff_base_sha"
+  echo "Diff head: $HEAD_SHA"
+  mapfile -t changed_files < <(git diff --name-only "$diff_base_sha" "$HEAD_SHA")
+fi
+
+declare -A manifest_dirs=()
+if [ -n "${HEAD_SHA:-}" ] && git rev-parse --verify --quiet "$HEAD_SHA^{tree}" >/dev/null; then
+  while IFS= read -r manifest; do
+    manifest_dirs["$(manifest_dir "$manifest")"]=1
+  done < <(
+    git ls-tree -r --name-only "$HEAD_SHA" |
+      awk -F/ '$NF == "manifest.yaml" { for (i = 1; i < NF; i++) if ($i ~ /^\./) next; print }'
+  )
+else
+  while IFS= read -r manifest; do
+    manifest=${manifest#./}
+    manifest_dirs["$(manifest_dir "$manifest")"]=1
+  done < <(find . -name "manifest.yaml" -not -path "*/.*" | sort)
+fi
+
+for plugin_path in "${!manifest_statuses[@]}"; do
+  if [ "${manifest_statuses[$plugin_path]}" = "removed" ]; then
+    unset "manifest_dirs[$plugin_path]"
+  else
+    manifest_dirs["$plugin_path"]=1
+  fi
+done
+
+declare -A candidate_plugins=()
+for changed_file in "${changed_files[@]}"; do
+  if [[ "$changed_file" == */* ]]; then
+    dir=${changed_file%/*}
+  else
+    dir=.
+  fi
+
+  while true; do
+    if [ -n "${manifest_dirs[$dir]:-}" ]; then
+      candidate_plugins["$dir"]=1
+      break
+    fi
+
+    if [ "$dir" = "." ] || [[ "$dir" != */* ]]; then
+      break
+    fi
+
+    dir=${dir%/*}
+  done
+done
+
+valid_plugins=()
+if [ ${#candidate_plugins[@]} -gt 0 ]; then
+  mapfile -t valid_plugins < <(printf '%s\n' "${!candidate_plugins[@]}" | sort)
+fi
+
+if [ ${#valid_plugins[@]} -eq 0 ]; then
+  {
+    echo "has_changes=false"
+    echo "plugins=[]"
+  } >> "$GITHUB_OUTPUT"
+else
+  json=$(printf '%s\n' "${valid_plugins[@]}" | json_array)
+  {
+    echo "has_changes=true"
+    echo "plugins=$json"
+  } >> "$GITHUB_OUTPUT"
+  echo "Detected plugins: $json"
+fi

--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -16,45 +16,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Fetch changed file list
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --paginate \
+            "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
+            --jq '.[] | [.status, .filename] | @tsv' > "$RUNNER_TEMP/changed-files.tsv"
 
       - id: filter
         name: Detect changed plugins
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "pull_request_target" ]; then
-            CHANGED_FILES=$(gh pr view -R ${{ github.repository }} ${{ github.event.pull_request.number }} --json files --jq '.files[].path')
-          else
-            if [ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]; then
-              BASE_SHA="HEAD~1"
-            else
-              BASE_SHA="${{ github.event.before }}"
-            fi
-            CHANGED_FILES=$(git diff --name-only $BASE_SHA HEAD)
-          fi
-
-          # Find all manifest.yaml files
-          MANIFESTS=$(find . -name "manifest.yaml" -not -path "*/.*")
-
-          VALID_PLUGINS=()
-          for m in $MANIFESTS; do
-            PLUGIN_PATH=$(dirname "$m" | sed 's|^\./||')
-            # If any changed file starts with this plugin path
-            if echo "$CHANGED_FILES" | grep -q "^$PLUGIN_PATH/"; then
-              VALID_PLUGINS+=("$PLUGIN_PATH")
-            fi
-          done
-
-          if [ ${#VALID_PLUGINS[@]} -eq 0 ]; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "plugins=[]" >> $GITHUB_OUTPUT
-          else
-            JSON=$(printf '%s\n' "${VALID_PLUGINS[@]}" | jq -R . | jq -s -c .)
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "plugins=$JSON" >> $GITHUB_OUTPUT
-            echo "Detected plugins: $JSON"
-          fi
+          CHANGED_FILES_FILE: ${{ runner.temp }}/changed-files.tsv
+          EXPECTED_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
+        run: .github/scripts/detect-changed-plugins.sh
 
   test:
     needs: detect-changes

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -26,38 +26,9 @@ jobs:
       - id: filter
         name: Detect changed plugins
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            CHANGED_FILES=$(gh pr view -R ${{ github.repository }} ${{ github.event.pull_request.number }} --json files --jq '.files[].path')
-          else
-            if [ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]; then
-              BASE_SHA="HEAD~1"
-            else
-              BASE_SHA="${{ github.event.before }}"
-            fi
-            CHANGED_FILES=$(git diff --name-only $BASE_SHA HEAD)
-          fi
-
-          MANIFESTS=$(find . -name "manifest.yaml" -not -path "*/.*")
-
-          VALID_PLUGINS=()
-          for m in $MANIFESTS; do
-            PLUGIN_PATH=$(dirname "$m" | sed 's|^\./||')
-            if echo "$CHANGED_FILES" | grep -q "^$PLUGIN_PATH/"; then
-              VALID_PLUGINS+=("$PLUGIN_PATH")
-            fi
-          done
-
-          if [ ${#VALID_PLUGINS[@]} -eq 0 ]; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "plugins=[]" >> $GITHUB_OUTPUT
-          else
-            JSON=$(printf '%s\n' "${VALID_PLUGINS[@]}" | jq -R . | jq -s -c .)
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "plugins=$JSON" >> $GITHUB_OUTPUT
-            echo "Detected plugins: $JSON"
-          fi
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: .github/scripts/detect-changed-plugins.sh
 
   upload-merged-plugin:
     needs: detect-changes


### PR DESCRIPTION
## Summary
- replace the truncated PR file-list lookup with paginated PR file retrieval plus changed-file count validation
- share plugin detection logic between PR checks and merged-plugin upload
- detect plugins by walking changed-file parent directories against known manifest directories, including added and removed manifests

Fixes #2968

## Verification
- bash -n .github/scripts/detect-changed-plugins.sh
- ruby YAML parse for updated workflows
- git diff --check
- local paginated PR file detection against PR #2965 returns 251 plugins from 1073 files
- local git diff detection against PR #2965 base/head returns 251 plugins
- root-level manifest and removed-plugin edge cases
