### PR TITLE
feat(vertex_ai): add Claude Opus 4.7

### DIFF
--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.51
+version: 0.0.52

--- a/models/vertex_ai/models/llm/anthropic.claude-opus-4-7.yaml
+++ b/models/vertex_ai/models/llm/anthropic.claude-opus-4-7.yaml
@@ -1,0 +1,57 @@
+model: claude-opus-4-7
+label:
+  en_US: Claude Opus 4.7
+model_type: llm
+features:
+  - agent-thought
+  - vision
+model_properties:
+  mode: chat
+  context_size: 200000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    type: int
+    default: 128000
+    min: 1
+    max: 128000
+    help:
+      zh_Hans: 停止前生成的最大令牌数。请注意，Anthropic Claude 模型可能会在达到 max_tokens 的值之前停止生成令牌。不同的 Anthropic Claude 模型对此参数具有不同的最大值。
+      en_US: The maximum number of tokens to generate before stopping. Note that Anthropic Claude models might stop generating tokens before reaching the value of max_tokens. Different Anthropic Claude models have different maximum values for this parameter.
+  - name: temperature
+    use_template: temperature
+    required: false
+    type: float
+    default: 1
+    min: 0.0
+    max: 1.0
+    help:
+      zh_Hans: 生成内容的随机性。
+      en_US: The amount of randomness injected into the response.
+  - name: top_p
+    use_template: top_p
+    required: false
+    type: float
+    default: 0.999
+    min: 0.000
+    max: 1.000
+    help:
+      zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
+      en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
+  - name: top_k
+    use_template: top_k
+    required: false
+    type: int
+    default: 0
+    min: 0
+    # tip docs from aws has error, max value is 500
+    max: 500
+    help:
+      zh_Hans: 对于每个后续标记，仅从前 K 个选项中进行采样。使用 top_k 删除长尾低概率响应。
+      en_US: Only sample from the top K options for each subsequent token. Use top_k to remove long tail low probability responses.
+pricing:
+  input: '0.005'
+  output: '0.025'
+  unit: '0.001'
+  currency: USD

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -204,7 +204,8 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
             location = vertex_location
         elif any(m in model for m in
                  ["opus", "claude-3-5-sonnet", "claude-3-7-sonnet", "claude-sonnet-4", "claude-haiku-4-5",
-                  "claude-sonnet-4-5", "claude-opus-4-5", "claude-sonnet-4-6", "claude-opus-4-6"]):
+                  "claude-sonnet-4-5", "claude-opus-4-5", "claude-sonnet-4-6", "claude-opus-4-6",
+                  "claude-opus-4-7"]):
             location = "us-east5"
         else:
             location = "us-central1"


### PR DESCRIPTION
## Summary

Anthropic released **Claude Opus 4.7** on 2026-04-16 and it is GA on Vertex AI in both `europe-west1` and `us-east5`. The model already ships in the Anthropic-direct plugin (`models/anthropic/models/llm/claude-opus-4-7.yaml`, plugin v0.3.11) but is missing from the Vertex AI plugin, so users routing Claude through Vertex cannot select it.

## Changes

Mirrors the pattern of #2727 (which added Claude 4.6 to this plugin):

- **New** `models/vertex_ai/models/llm/anthropic.claude-opus-4-7.yaml` — uses the unversioned model ID accepted by Vertex (per #2905). Parameter rules and pricing follow the existing Opus 4.6 file in this plugin (Anthropic published Opus 4.7 at the same $5 / $25 per 1M-token rate as 4.6).
- **Patch** `models/vertex_ai/models/llm/llm.py` — extend the Anthropic-region allowlist with `claude-opus-4-7` so default routing falls back to `us-east5` when `vertex_anthropic_location` is unset (consistent with how 4-6 was added).
- **Bump** `models/vertex_ai/manifest.yaml` version 0.0.51 → 0.0.52.

## Verification

Tested directly against the Vertex Anthropic SDK from a service-account-authenticated environment:

| Region | Model | Result |
|---|---|---|
| `europe-west1` | `claude-opus-4-7` | ✅ publisher model resolves (429 quota error indicates new-model quota = 0; model exists) |
| `us-east5` | `claude-opus-4-7` | ✅ publisher model resolves (429) |

A 429 (quota exhausted) on a new model is the expected GCP behavior — default per-model online-prediction quotas are 0 until the customer requests them; the response confirms the model is registered with Vertex.

## Test plan

- [x] `claude-opus-4-7` resolves on Vertex `europe-west1` and `us-east5`
- [x] YAML structure mirrors `anthropic.claude-opus-4-6.yaml` in the same plugin
- [x] Allowlist edit follows the #2727 pattern
- [x] Manifest version bumped per project convention
- [ ] Maintainer review

## References

- Anthropic announcement: <https://www.anthropic.com/news/claude-opus-4-7>
- Anthropic-direct plugin precedent: `models/anthropic/models/llm/claude-opus-4-7.yaml` (plugin v0.3.11)
- Prior PR adding Claude 4.6 to this plugin: #2727
- Prior PR fixing Vertex's unversioned-ID requirement: #2905