### PR TITLE
chore(ci): migrate plugin workflows to depot runners

### DIFF
--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   detect-changes:
-    runs-on: ${{ github.repository == 'langgenius/dify-official-plugins' && 'depot-ubuntu-24.04' || 'ubuntu-24.04' }}
+    runs-on: depot-ubuntu-24.04
     outputs:
       plugins: ${{ steps.filter.outputs.plugins }}
       has_changes: ${{ steps.filter.outputs.has_changes }}
@@ -36,7 +36,7 @@ jobs:
   test:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
-    runs-on: ${{ github.repository == 'langgenius/dify-official-plugins' && 'depot-ubuntu-24.04-4' || 'ubuntu-24.04' }}
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         plugin_path: ${{ fromJson(needs.detect-changes.outputs.plugins) }}
@@ -257,7 +257,7 @@ jobs:
       - detect-changes
       - test
     if: always()
-    runs-on: ${{ github.repository == 'langgenius/dify-official-plugins' && 'depot-ubuntu-24.04' || 'ubuntu-24.04' }}
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Verify check results
         run: |

--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   detect-changes:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     outputs:
       plugins: ${{ steps.filter.outputs.plugins }}
       has_changes: ${{ steps.filter.outputs.has_changes }}
@@ -36,7 +36,7 @@ jobs:
   test:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         plugin_path: ${{ fromJson(needs.detect-changes.outputs.plugins) }}
@@ -254,7 +254,7 @@ jobs:
       - detect-changes
       - test
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Verify check results
         run: |

--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   detect-changes:
-    runs-on: depot-ubuntu-24.04
+    runs-on: ${{ github.repository == 'langgenius/dify-official-plugins' && 'depot-ubuntu-24.04' || 'ubuntu-24.04' }}
     outputs:
       plugins: ${{ steps.filter.outputs.plugins }}
       has_changes: ${{ steps.filter.outputs.has_changes }}
@@ -36,7 +36,7 @@ jobs:
   test:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ${{ github.repository == 'langgenius/dify-official-plugins' && 'depot-ubuntu-24.04-4' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         plugin_path: ${{ fromJson(needs.detect-changes.outputs.plugins) }}
@@ -85,6 +85,7 @@ jobs:
           echo "DIFY_CLI_PATH=$GITHUB_WORKSPACE/.scripts/dify" >> $GITHUB_ENV
 
       - name: Export All Secrets to Environment
+        if: github.repository == 'langgenius/dify-official-plugins'
         uses: oNaiPs/secrets-to-env-action@v1
         with:
           secrets: ${{ toJSON(secrets) }}
@@ -98,6 +99,7 @@ jobs:
           fi
 
       - name: Check If Version Exists
+        if: github.repository == 'langgenius/dify-official-plugins'
         run: |
           VERSION=$(yq '.version' "${{ matrix.plugin_path }}/manifest.yaml")
           AUTHOR=$(yq '.author' "${{ matrix.plugin_path }}/manifest.yaml")
@@ -130,6 +132,7 @@ jobs:
           fi
 
       - name: Check Packaging
+        if: github.repository == 'langgenius/dify-official-plugins'
         run: |
           uv run --with requests --with dify_plugin python .scripts/uploader/upload-package.py -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f --test
 
@@ -254,7 +257,7 @@ jobs:
       - detect-changes
       - test
     if: always()
-    runs-on: depot-ubuntu-24.04
+    runs-on: ${{ github.repository == 'langgenius/dify-official-plugins' && 'depot-ubuntu-24.04' || 'ubuntu-24.04' }}
     steps:
       - name: Verify check results
         run: |

--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -85,7 +85,6 @@ jobs:
           echo "DIFY_CLI_PATH=$GITHUB_WORKSPACE/.scripts/dify" >> $GITHUB_ENV
 
       - name: Export All Secrets to Environment
-        if: github.repository == 'langgenius/dify-official-plugins'
         uses: oNaiPs/secrets-to-env-action@v1
         with:
           secrets: ${{ toJSON(secrets) }}
@@ -99,7 +98,6 @@ jobs:
           fi
 
       - name: Check If Version Exists
-        if: github.repository == 'langgenius/dify-official-plugins'
         run: |
           VERSION=$(yq '.version' "${{ matrix.plugin_path }}/manifest.yaml")
           AUTHOR=$(yq '.author' "${{ matrix.plugin_path }}/manifest.yaml")
@@ -132,7 +130,6 @@ jobs:
           fi
 
       - name: Check Packaging
-        if: github.repository == 'langgenius/dify-official-plugins'
         run: |
           uv run --with requests --with dify_plugin python .scripts/uploader/upload-package.py -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f --test
 

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   detect-changes:
+    if: github.repository == 'langgenius/dify-official-plugins'
     runs-on: depot-ubuntu-24.04
     outputs:
       plugins: ${{ steps.filter.outputs.plugins }}
@@ -32,7 +33,7 @@ jobs:
 
   upload-merged-plugin:
     needs: detect-changes
-    if: needs.detect-changes.outputs.has_changes == 'true'
+    if: github.repository == 'langgenius/dify-official-plugins' && needs.detect-changes.outputs.has_changes == 'true'
     runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   detect-changes:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     outputs:
       plugins: ${{ steps.filter.outputs.plugins }}
       has_changes: ${{ steps.filter.outputs.has_changes }}
@@ -33,7 +33,7 @@ jobs:
   upload-merged-plugin:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         plugin_path: ${{ fromJson(needs.detect-changes.outputs.plugins) }}

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   detect-changes:
-    if: github.repository == 'langgenius/dify-official-plugins'
     runs-on: depot-ubuntu-24.04
     outputs:
       plugins: ${{ steps.filter.outputs.plugins }}
@@ -33,7 +32,7 @@ jobs:
 
   upload-merged-plugin:
     needs: detect-changes
-    if: github.repository == 'langgenius/dify-official-plugins' && needs.detect-changes.outputs.has_changes == 'true'
+    if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:


### PR DESCRIPTION
Migrates the plugin validation and post-merge upload workflows to Depot runners while keeping public forks usable.

What changed:
- upstream jobs keep using Depot runners for faster plugin validation and post-merge processing
- forked repositories fall back to GitHub-hosted `ubuntu-24.04` for the pre-PR validation workflow
- secret-dependent marketplace checks run only in the upstream repository
- post-merge upload jobs run only in the upstream repository

Runner sizing:
- `detect-changes` and `check-complete` use `depot-ubuntu-24.04` in the upstream repository because they only fetch metadata, diff files, and aggregate results
- `test` in `pre-pr-check-per-plugin.yaml` uses `depot-ubuntu-24.04-4` in the upstream repository because it fans out across changed plugins and performs packaging, dependency resolution, install validation, and optional test execution
- `upload-merged-plugin` in `upload-merged-plugin.yaml` uses `depot-ubuntu-24.04-4` in the upstream repository because it resolves dependencies and uploads packaged plugins per changed plugin

Fork compatibility:
- this repository uses Depot only as a GitHub Actions runner provider
- it does not use Depot container builds or Depot image publishing
- forked repositories do not need Depot configured just to run the pre-PR validation workflow
- forked repositories also skip the upstream-only marketplace upload workflow, which depends on organization secrets and should not run outside the canonical repository

No macOS, Windows, or ARM workflows were present in this repository.
