### PR TITLE
fix: fix deepseek model is not exist

### DIFF
--- a/models/deepseek/manifest.yaml
+++ b/models/deepseek/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.14
+version: 0.0.15

--- a/models/deepseek/provider/deepseek.py
+++ b/models/deepseek/provider/deepseek.py
@@ -7,6 +7,9 @@ logger = logging.getLogger(__name__)
 
 
 class DeepSeekProvider(ModelProvider):
+    _PRIMARY_VALIDATION_MODEL = "deepseek-v4-flash"
+    _FALLBACK_VALIDATION_MODEL = "deepseek-chat"
+
     def validate_provider_credentials(self, credentials: dict) -> None:
         """
         Validate provider credentials
@@ -16,9 +19,23 @@ class DeepSeekProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="deepseek-v4-flash", credentials=credentials)
+            try:
+                model_instance.validate_credentials(model=self._PRIMARY_VALIDATION_MODEL, credentials=credentials)
+            except CredentialsValidateFailedError as ex:
+                if not self._should_fallback_to_legacy_model(ex):
+                    raise ex
+                model_instance.validate_credentials(model=self._FALLBACK_VALIDATION_MODEL, credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:
             logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
             raise ex
+
+    @staticmethod
+    def _should_fallback_to_legacy_model(error: CredentialsValidateFailedError) -> bool:
+        error_message = str(error).lower()
+        fallback_signals = (
+            "model",
+            "not exist",
+        )
+        return all(signal in error_message for signal in fallback_signals)


### PR DESCRIPTION
## Related Issues or Context
<!--
⚠️ NOTE: This repository is for Dify Official Plugins only. 
For community contributions, please submit to https://github.com/langgenius/dify-plugins instead.

- Link Related Issues if Applicable: #issue_number
- Or Provide Context about Why this Change is Needed
-->

fix #2989

## This PR contains Changes to *Non-Plugin* 
<!-- Put an `x` in all the boxes that apply by replacing [ ] with [x] 
For example:
- [x] Documentation -->

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*
- [ ] I have Run Comprehensive Tests Relevant to My Changes
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## This PR contains Changes to *LLM Models Plugin*

<!-- LLM Models Test Example: -->
<!-- https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md -->

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Token Consumption Metrics
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

- [ ] Other Changes (Add New Models, Fix Model Parameters etc.)
<!-- 📷 Include Screenshots/Videos Demonstrating the Fix, New Feature, or the Behavior Before/After Breaking Changes. -->

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)
- [ ] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)
<!--
⚠️ NOTE: Version Format: MAJOR.MINOR.PATCH
- MAJOR (0.x.x): Reserved for Significant architectural changes or incompatible API modifications
- MINOR (x.0.x): For New feature additions while maintaining backward compatibility
- PATCH (x.x.0): For Backward-compatible bug fixes and minor improvements
- Note: Each Version Component (MAJOR, MINOR, PATCH) Can Be 2 Digits, e.g., 10.11.22
-->

## Dify Plugin SDK Version
- [ ] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`, or kept in `requirements.txt` only for legacy plugins without `uv.lock` ([SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md))

## Environment Verification (If Any Code Changes)
<!-- 
⚠️ NOTE: At Least One Environment Must Be Tested. 
-->

### Local Deployment Environment
- [ ] Dify Version is: <!-- Specify Your Version (e.g., 1.2.0) -->, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration. 
<!--
- Python virtual environment matching `Manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins without `uv.lock`)
- No Breaking Changes in Dify That May Affect the Testing Result
-->

### SaaS Environment
- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration
<!--
- Python virtual environment matching `Manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins without `uv.lock`)
-->
