### PR TITLE
fix: add legacy requirements for plugin packages

### DIFF
--- a/.github/scripts/export-legacy-requirements.sh
+++ b/.github/scripts/export-legacy-requirements.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <plugin-path>" >&2
+  exit 1
+fi
+
+plugin_path=$1
+
+if [ ! -d "$plugin_path" ]; then
+  echo "!!! Plugin path does not exist: $plugin_path" >&2
+  exit 1
+fi
+
+if [ ! -f "$plugin_path/uv.lock" ]; then
+  echo "No uv.lock found in $plugin_path; skipping legacy requirements export"
+  exit 0
+fi
+
+if [ ! -f "$plugin_path/pyproject.toml" ]; then
+  echo "!!! uv.lock exists but pyproject.toml is missing in $plugin_path" >&2
+  exit 1
+fi
+
+echo "Generating requirements.txt for legacy package compatibility: $plugin_path"
+uv export \
+  --project "$plugin_path" \
+  --frozen \
+  --format requirements.txt \
+  --no-hashes \
+  --no-header \
+  --no-annotate \
+  --no-emit-project \
+  --no-dev \
+  --output-file "$plugin_path/requirements.txt" \
+  > /dev/null

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -101,6 +101,10 @@ jobs:
             exit 1
           fi
 
+      - name: Generate Legacy Requirements for Packaging
+        run: |
+          bash .github/scripts/export-legacy-requirements.sh "${{ matrix.plugin_path }}"
+
       - name: Upload Plugin
         run: |
           uv run --with requests --with dify_plugin python .scripts/uploader/upload-package.py -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f

--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.36
+version: 0.0.37
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/datasources/aws_s3_storage/manifest.yaml
+++ b/datasources/aws_s3_storage/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.3.8
+version: 0.3.9
 type: plugin
 author: langgenius
 name: aws_s3_storage

--- a/datasources/azure_blob/manifest.yaml
+++ b/datasources/azure_blob/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.11
+version: 0.2.12
 type: plugin
 author: langgenius
 name: azure_blob_datasource

--- a/datasources/box_datasource/manifest.yaml
+++ b/datasources/box_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.4
+version: 0.1.5
 type: plugin
 author: langgenius
 name: box_datasource

--- a/datasources/brightdata_datasource/manifest.yaml
+++ b/datasources/brightdata_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.7
+version: 0.1.8
 type: plugin
 author: langgenius
 name: brightdata_datasource

--- a/datasources/confluence_datasource/manifest.yaml
+++ b/datasources/confluence_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.6
+version: 0.2.7
 type: plugin
 author: langgenius
 name: confluence_datasource

--- a/datasources/dropbox_datasource/manifest.yaml
+++ b/datasources/dropbox_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.5
+version: 0.2.6
 type: plugin
 author: langgenius
 name: dropbox_datasource

--- a/datasources/firecrawl_datasource/manifest.yaml
+++ b/datasources/firecrawl_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.8
+version: 0.2.9
 type: plugin
 author: langgenius
 name: firecrawl_datasource

--- a/datasources/github/manifest.yaml
+++ b/datasources/github/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.4.4
+version: 0.4.5
 type: plugin
 author: langgenius
 name: github_datasource

--- a/datasources/gitlab_datasource/manifest.yaml
+++ b/datasources/gitlab_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.3.8
+version: 0.3.9
 type: plugin
 author: langgenius
 name: gitlab_datasource

--- a/datasources/google_cloud_storage/manifest.yaml
+++ b/datasources/google_cloud_storage/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.10
+version: 0.2.11
 type: plugin
 author: langgenius
 name: google_cloud_storage

--- a/datasources/google_drive/manifest.yaml
+++ b/datasources/google_drive/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.10
+version: 0.1.11
 type: plugin
 author: langgenius
 name: google_drive

--- a/datasources/jina_datasource/manifest.yaml
+++ b/datasources/jina_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: jina_datasource

--- a/datasources/notion_datasource/manifest.yaml
+++ b/datasources/notion_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.17
+version: 0.1.18
 type: plugin
 author: langgenius
 name: notion_datasource

--- a/datasources/onedrive/manifest.yaml
+++ b/datasources/onedrive/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.8
+version: 0.1.9
 type: plugin
 author: langgenius
 name: onedrive_datasource

--- a/datasources/sharepoint_datasource/manifest.yaml
+++ b/datasources/sharepoint_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.6
+version: 0.2.7
 type: plugin
 author: langgenius
 name: sharepoint_datasource

--- a/datasources/tavily_datasource/manifest.yaml
+++ b/datasources/tavily_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.7
+version: 0.1.8
 type: plugin
 author: langgenius
 name: tavily_datasource

--- a/datasources/tencent_cos_storage/manifest.yaml
+++ b/datasources/tencent_cos_storage/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.3.6
+version: 0.3.7
 type: plugin
 author: langgenius
 name: tencent_cos_storage

--- a/extensions/aws_bedrock_knowledge_base/manifest.yaml
+++ b/extensions/aws_bedrock_knowledge_base/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: aws_bedrock_knowledge_base

--- a/extensions/badapple/manifest.yaml
+++ b/extensions/badapple/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 description:
   en_US: Why not play Bad Apple with Dify?

--- a/extensions/llamacloud/manifest.yaml
+++ b/extensions/llamacloud/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: langgenius
 name: llamacloud

--- a/extensions/oaicompat_dify_model/manifest.yaml
+++ b/extensions/oaicompat_dify_model/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: oaicompat_dify_model

--- a/extensions/openai_compatible/manifest.yaml
+++ b/extensions/openai_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 type: plugin
 author: "langgenius"
 name: "oaicompat_dify_app"

--- a/extensions/slack_bot/manifest.yaml
+++ b/extensions/slack_bot/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: langgenius
 name: slack-bot

--- a/extensions/wecom_bot/manifest.yaml
+++ b/extensions/wecom_bot/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: wecom-bot

--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.25
+version: 0.0.26
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.11
+version: 0.3.12

--- a/models/azure_ai_studio/manifest.yaml
+++ b/models/azure_ai_studio/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.13
+version: 0.0.14

--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.53
+version: 0.0.54

--- a/models/baichuan/manifest.yaml
+++ b/models/baichuan/manifest.yaml
@@ -23,4 +23,4 @@ resource:
   memory: 268435456
   permission: {}
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.65
+version: 0.0.66
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/chatglm/manifest.yaml
+++ b/models/chatglm/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/cohere/manifest.yaml
+++ b/models/cohere/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.11
+version: 0.0.12

--- a/models/cometapi/manifest.yaml
+++ b/models/cometapi/manifest.yaml
@@ -1,4 +1,4 @@
-version: 1.0.4
+version: 1.0.5
 type: plugin
 author: langgenius
 name: cometapi

--- a/models/deepseek/manifest.yaml
+++ b/models/deepseek/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.14
+version: 0.0.15

--- a/models/deerapi/manifest.yaml
+++ b/models/deerapi/manifest.yaml
@@ -1,4 +1,4 @@
-version: 1.0.4
+version: 1.0.5
 type: plugin
 author: langgenius
 name: deerapi

--- a/models/fireworks/manifest.yaml
+++ b/models/fireworks/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/fishaudio/manifest.yaml
+++ b/models/fishaudio/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: "langgenius"
 name: "fishaudio"

--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.7.21
+version: 0.7.22

--- a/models/gitee_ai/manifest.yaml
+++ b/models/gitee_ai/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.6
+version: 0.1.7

--- a/models/gmicloud/manifest.yaml
+++ b/models/gmicloud/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: gmicloud

--- a/models/gpustack/manifest.yaml
+++ b/models/gpustack/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.10
+version: 0.0.11

--- a/models/groq/manifest.yaml
+++ b/models/groq/manifest.yaml
@@ -36,4 +36,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.14
+version: 0.0.15

--- a/models/huaweicloud_maas/manifest.yaml
+++ b/models/huaweicloud_maas/manifest.yaml
@@ -26,5 +26,5 @@ resource:
       enabled: true
       llm: true
 type: plugin
-version: 0.0.15
+version: 0.0.16
 created_at: 2025-06-04T12:32:17.824356+08:00

--- a/models/huaweicloud_maas_hk/manifest.yaml
+++ b/models/huaweicloud_maas_hk/manifest.yaml
@@ -26,5 +26,5 @@ resource:
       enabled: true
       llm: true
 type: plugin
-version: 0.0.3
+version: 0.0.4
 created_at: 2025-11-08T12:32:17.824356+08:00

--- a/models/huggingface_hub/manifest.yaml
+++ b/models/huggingface_hub/manifest.yaml
@@ -26,4 +26,4 @@ resource:
     tool:
       enabled: false
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/models/huggingface_tei/manifest.yaml
+++ b/models/huggingface_tei/manifest.yaml
@@ -27,4 +27,4 @@ resource:
     tool:
       enabled: false
 type: plugin
-version: 0.1.5
+version: 0.1.6

--- a/models/hunyuan/manifest.yaml
+++ b/models/hunyuan/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/models/jina/manifest.yaml
+++ b/models/jina/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.19
+version: 0.0.20
 type: plugin
 author: "langgenius"
 name: "jina"

--- a/models/lemonade/manifest.yaml
+++ b/models/lemonade/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: "langgenius"
 name: "lemonade"

--- a/models/leptonai/manifest.yaml
+++ b/models/leptonai/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/llama_api/manifest.yaml
+++ b/models/llama_api/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: llama-api

--- a/models/localai/manifest.yaml
+++ b/models/localai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/models/longcat/manifest.yaml
+++ b/models/longcat/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/models/mimo/manifest.yaml
+++ b/models/mimo/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/models/minimax/manifest.yaml
+++ b/models/minimax/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.16
+version: 0.0.17

--- a/models/mistralai/manifest.yaml
+++ b/models/mistralai/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/mixedbread/manifest.yaml
+++ b/models/mixedbread/manifest.yaml
@@ -28,4 +28,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/modelscope/manifest.yaml
+++ b/models/modelscope/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 type: plugin
 author: langgenius
 name: modelscope

--- a/models/moonshot/manifest.yaml
+++ b/models/moonshot/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.4
+version: 0.1.5

--- a/models/nomic/manifest.yaml
+++ b/models/nomic/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/novita/manifest.yaml
+++ b/models/novita/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/models/nvidia/manifest.yaml
+++ b/models/nvidia/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/models/nvidia_nim/manifest.yaml
+++ b/models/nvidia_nim/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/models/oci/manifest.yaml
+++ b/models/oci/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.13
+version: 0.0.14
 type: plugin
 author: langgenius
 privacy: PRIVACY.md

--- a/models/ollama/manifest.yaml
+++ b/models/ollama/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.4
+version: 0.1.5

--- a/models/openai/manifest.yaml
+++ b/models/openai/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.3.7
+version: 0.3.8
 type: plugin
 author: "langgenius"
 name: "openai"

--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.46
+version: 0.0.47
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openllm/manifest.yaml
+++ b/models/openllm/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -26,5 +26,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.0.48
+version: 0.0.49
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/perfxcloud/manifest.yaml
+++ b/models/perfxcloud/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/models/regolo/manifest.yaml
+++ b/models/regolo/manifest.yaml
@@ -32,5 +32,5 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.2.2
+version: 0.2.3
 

--- a/models/replicate/manifest.yaml
+++ b/models/replicate/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/models/sagemaker/manifest.yaml
+++ b/models/sagemaker/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.13
+version: 0.0.14
 type: plugin
 author: langgenius
 name: sagemaker

--- a/models/sambanova/manifest.yaml
+++ b/models/sambanova/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.2
+version: 0.1.3
 type: plugin
 author: langgenius
 name: sambanova

--- a/models/siliconflow/manifest.yaml
+++ b/models/siliconflow/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.50
+version: 0.0.51
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/stepfun/manifest.yaml
+++ b/models/stepfun/manifest.yaml
@@ -38,4 +38,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/tencent/manifest.yaml
+++ b/models/tencent/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/togetherai/manifest.yaml
+++ b/models/togetherai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.1.40
+version: 0.1.41
 created_at: "2024-12-10T16:13:50.29298939+08:00"

--- a/models/triton_inference_server/manifest.yaml
+++ b/models/triton_inference_server/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/upstage/manifest.yaml
+++ b/models/upstage/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.52
+version: 0.0.53

--- a/models/vessl_ai/manifest.yaml
+++ b/models/vessl_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/volcengine/manifest.yaml
+++ b/models/volcengine/manifest.yaml
@@ -32,4 +32,4 @@ resource:
       text_embedding: false
       tts: false
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/models/volcengine_maas/manifest.yaml
+++ b/models/volcengine_maas/manifest.yaml
@@ -35,4 +35,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.48
+version: 0.0.49

--- a/models/voyage/manifest.yaml
+++ b/models/voyage/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/models/wenxin/manifest.yaml
+++ b/models/wenxin/manifest.yaml
@@ -24,4 +24,4 @@ resource:
   memory: 268435456
   permission: {}
 type: plugin
-version: 0.1.4
+version: 0.1.5

--- a/models/x/manifest.yaml
+++ b/models/x/manifest.yaml
@@ -35,4 +35,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.18
+version: 0.0.19

--- a/models/xinference/manifest.yaml
+++ b/models/xinference/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.11
+version: 0.0.12

--- a/models/yi/manifest.yaml
+++ b/models/yi/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/zhinao/manifest.yaml
+++ b/models/zhinao/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/zhipuai/manifest.yaml
+++ b/models/zhipuai/manifest.yaml
@@ -1,5 +1,5 @@
 type: plugin
-version: 0.0.25
+version: 0.0.26
 author: langgenius
 name: zhipuai
 created_at: '2024-09-20T00:13:50.29298939-04:00'

--- a/tools/aihubmix_image/manifest.yaml
+++ b/tools/aihubmix_image/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: aihubmix-image

--- a/tools/aliyuque/manifest.yaml
+++ b/tools/aliyuque/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - productivity
 - search
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/alphavantage/manifest.yaml
+++ b/tools/alphavantage/manifest.yaml
@@ -37,4 +37,4 @@ resource:
 tags:
 - finance
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/apitemplate/manifest.yaml
+++ b/tools/apitemplate/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: apitemplate

--- a/tools/arxiv/manifest.yaml
+++ b/tools/arxiv/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 tags:
 - search

--- a/tools/attio/manifest.yaml
+++ b/tools/attio/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: attio

--- a/tools/aws/manifest.yaml
+++ b/tools/aws/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.22
+version: 0.0.23
 type: plugin
 author: langgenius
 name: aws_tools

--- a/tools/azure_openai_tool/manifest.yaml
+++ b/tools/azure_openai_tool/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/azuredalle/manifest.yaml
+++ b/tools/azuredalle/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/baidu_translate/manifest.yaml
+++ b/tools/baidu_translate/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/bailian_memory/manifest.yaml
+++ b/tools/bailian_memory/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: "langgenius"
 name: bailian_memory

--- a/tools/baserow/manifest.yaml
+++ b/tools/baserow/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: baserow

--- a/tools/bing/manifest.yaml
+++ b/tools/bing/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: "langgenius"
 name: "bing"

--- a/tools/bitbucket/manifest.yaml
+++ b/tools/bitbucket/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: bitbucket

--- a/tools/brave/manifest.yaml
+++ b/tools/brave/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
   - search
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/chart/manifest.yaml
+++ b/tools/chart/manifest.yaml
@@ -39,4 +39,4 @@ tags:
   - productivity
   - utilities
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/cogview/manifest.yaml
+++ b/tools/cogview/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - image
   - productivity
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/comfyui/manifest.yaml
+++ b/tools/comfyui/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - image
 type: plugin
-version: 0.3.7
+version: 0.3.8

--- a/tools/confluence/manifest.yaml
+++ b/tools/confluence/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: confluence

--- a/tools/crossref/manifest.yaml
+++ b/tools/crossref/manifest.yaml
@@ -35,4 +35,4 @@ resource:
 tags:
   - search
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/deepl/manifest.yaml
+++ b/tools/deepl/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.2
+version: 0.1.3
 type: plugin
 author: langgenius
 name: deepl

--- a/tools/devdocs/manifest.yaml
+++ b/tools/devdocs/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - productivity
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/dicom_reader/manifest.yaml
+++ b/tools/dicom_reader/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: langgenius
 name: dicom_reader

--- a/tools/did/manifest.yaml
+++ b/tools/did/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - videos
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/dify_extractor/manifest.yaml
+++ b/tools/dify_extractor/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.9
+version: 0.0.10
 type: plugin
 author: langgenius
 name: dify_extractor

--- a/tools/dingo/manifest.yaml
+++ b/tools/dingo/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.6.6
+version: 0.6.7
 type: plugin
 author: langgenius
 name: dingo

--- a/tools/dingtalk/manifest.yaml
+++ b/tools/dingtalk/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/discord/manifest.yaml
+++ b/tools/discord/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/dropbox/manifest.yaml
+++ b/tools/dropbox/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 type: plugin
 author: langgenius
 name: dropbox

--- a/tools/duckduckgo/manifest.yaml
+++ b/tools/duckduckgo/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: "langgenius"
 name: "duckduckgo"

--- a/tools/e2b/manifest.yaml
+++ b/tools/e2b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: langgenius
 name: e2b

--- a/tools/echarts/manifest.yaml
+++ b/tools/echarts/manifest.yaml
@@ -35,4 +35,4 @@ tags:
   - productivity
   - utilities
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/email/manifest.yaml
+++ b/tools/email/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.13
+version: 0.0.14

--- a/tools/fal/manifest.yaml
+++ b/tools/fal/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - image
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/feishu/manifest.yaml
+++ b/tools/feishu/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/feishu_base/manifest.yaml
+++ b/tools/feishu_base/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/feishu_calendar/manifest.yaml
+++ b/tools/feishu_calendar/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/feishu_document/manifest.yaml
+++ b/tools/feishu_document/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/feishu_message/manifest.yaml
+++ b/tools/feishu_message/manifest.yaml
@@ -37,4 +37,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/feishu_spreadsheet/manifest.yaml
+++ b/tools/feishu_spreadsheet/manifest.yaml
@@ -37,4 +37,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/feishu_task/manifest.yaml
+++ b/tools/feishu_task/manifest.yaml
@@ -38,4 +38,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/feishu_wiki/manifest.yaml
+++ b/tools/feishu_wiki/manifest.yaml
@@ -36,4 +36,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/firecrawl/manifest.yaml
+++ b/tools/firecrawl/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - utilities
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/fishaudio/manifest.yaml
+++ b/tools/fishaudio/manifest.yaml
@@ -27,4 +27,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.11
+version: 0.0.12

--- a/tools/frontapp/manifest.yaml
+++ b/tools/frontapp/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.3
+version: 0.1.4

--- a/tools/gaode/manifest.yaml
+++ b/tools/gaode/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - travel
 - weather
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/gemini_image/manifest.yaml
+++ b/tools/gemini_image/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.1.6
+version: 0.1.7

--- a/tools/gemini_video/manifest.yaml
+++ b/tools/gemini_video/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 type: plugin
 author: langgenius
 name: gemini_video

--- a/tools/general_chunk/manifest.yaml
+++ b/tools/general_chunk/manifest.yaml
@@ -35,4 +35,4 @@ resource:
 tags: 
   - rag
 type: plugin
-version: 0.0.10
+version: 0.0.11

--- a/tools/getimgai/manifest.yaml
+++ b/tools/getimgai/manifest.yaml
@@ -30,4 +30,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/gitee_ai/manifest.yaml
+++ b/tools/gitee_ai/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/github/manifest.yaml
+++ b/tools/github/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.3.4
+version: 0.3.5

--- a/tools/gitlab/manifest.yaml
+++ b/tools/gitlab/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 0.0.10
+version: 0.0.11

--- a/tools/gmail/manifest.yaml
+++ b/tools/gmail/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.3
+version: 0.2.4
 type: plugin
 author: langgenius
 name: dify-gmail

--- a/tools/google/manifest.yaml
+++ b/tools/google/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.2
+version: 0.1.3
 type: plugin
 author: "langgenius"
 name: "google"

--- a/tools/google_calendar/manifest.yaml
+++ b/tools/google_calendar/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.2
+version: 0.1.3

--- a/tools/google_contacts/manifest.yaml
+++ b/tools/google_contacts/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.2
+version: 0.1.3

--- a/tools/google_tasks/manifest.yaml
+++ b/tools/google_tasks/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.2
+version: 0.1.3

--- a/tools/google_translate/manifest.yaml
+++ b/tools/google_translate/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/gpustack/manifest.yaml
+++ b/tools/gpustack/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: gpustack_tools

--- a/tools/hackernews/manifest.yaml
+++ b/tools/hackernews/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.2
+version: 0.1.3

--- a/tools/hap/manifest.yaml
+++ b/tools/hap/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
   - productivity
 type: plugin
-version: 0.1.2
+version: 0.1.3

--- a/tools/hubspot/manifest.yaml
+++ b/tools/hubspot/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: hubspot

--- a/tools/jiandaoyun/manifest.yaml
+++ b/tools/jiandaoyun/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: jiandaoyun

--- a/tools/jina/manifest.yaml
+++ b/tools/jina/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - search
 - productivity
 type: plugin
-version: 0.0.10
+version: 0.0.11

--- a/tools/jira/manifest.yaml
+++ b/tools/jira/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: jira

--- a/tools/json_process/manifest.yaml
+++ b/tools/json_process/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/judge0ce/manifest.yaml
+++ b/tools/judge0ce/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - utilities
 - other
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/lark_base/manifest.yaml
+++ b/tools/lark_base/manifest.yaml
@@ -36,4 +36,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/lark_calendar/manifest.yaml
+++ b/tools/lark_calendar/manifest.yaml
@@ -38,4 +38,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/lark_document/manifest.yaml
+++ b/tools/lark_document/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/lark_message_and_group/manifest.yaml
+++ b/tools/lark_message_and_group/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/lark_spreadsheet/manifest.yaml
+++ b/tools/lark_spreadsheet/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/lark_task/manifest.yaml
+++ b/tools/lark_task/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/lark_wiki/manifest.yaml
+++ b/tools/lark_wiki/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/linear/manifest.yaml
+++ b/tools/linear/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: langgenius
 name: linear

--- a/tools/llama_parse/manifest.yaml
+++ b/tools/llama_parse/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 tags:
   - utilities

--- a/tools/maths/manifest.yaml
+++ b/tools/maths/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - utilities
 - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/microsoft_excel_365/manifest.yaml
+++ b/tools/microsoft_excel_365/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.1.3
+version: 0.1.4

--- a/tools/microsoft_todo/manifest.yaml
+++ b/tools/microsoft_todo/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: microsoft_todo

--- a/tools/mineru/manifest.yaml
+++ b/tools/mineru/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.5.3
+version: 0.5.4
 type: plugin
 author: langgenius
 name: mineru

--- a/tools/minimax_tts/manifest.yaml
+++ b/tools/minimax_tts/manifest.yaml
@@ -29,4 +29,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/tools/monday/manifest.yaml
+++ b/tools/monday/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: monday

--- a/tools/neo4j/manifest.yaml
+++ b/tools/neo4j/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: neo4j

--- a/tools/nextcloud/manifest.yaml
+++ b/tools/nextcloud/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.2
+version: 0.1.3
 type: plugin
 author: langgenius
 name: nextcloud

--- a/tools/nocodb/manifest.yaml
+++ b/tools/nocodb/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: langgenius
 name: nocodb

--- a/tools/nominatim/manifest.yaml
+++ b/tools/nominatim/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - search
 - utilities
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/notion/manifest.yaml
+++ b/tools/notion/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: notion

--- a/tools/novitaai/manifest.yaml
+++ b/tools/novitaai/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/onebot/manifest.yaml
+++ b/tools/onebot/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/onedrive/manifest.yaml
+++ b/tools/onedrive/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: onedrive

--- a/tools/openai/manifest.yaml
+++ b/tools/openai/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.1.6
+version: 0.1.7

--- a/tools/openweather/manifest.yaml
+++ b/tools/openweather/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - weather
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/oracle_ai_db/manifest.yaml
+++ b/tools/oracle_ai_db/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: oracle_ai_db

--- a/tools/outlook/manifest.yaml
+++ b/tools/outlook/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.2
+version: 0.2.3
 type: plugin
 author: langgenius
 name: outlook

--- a/tools/paddleocr/manifest.yaml
+++ b/tools/paddleocr/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.3
+version: 0.2.4
 type: plugin
 author: langgenius
 name: paddleocr

--- a/tools/parent_child_chunk/manifest.yaml
+++ b/tools/parent_child_chunk/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 type: plugin
 author: langgenius
 name: parentchild_chunker

--- a/tools/perplexity/manifest.yaml
+++ b/tools/perplexity/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
 - search
 type: plugin
-version: 1.0.3
+version: 1.0.4

--- a/tools/plivo_sms/manifest.yaml
+++ b/tools/plivo_sms/manifest.yaml
@@ -28,4 +28,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/plivo_verify/manifest.yaml
+++ b/tools/plivo_verify/manifest.yaml
@@ -28,4 +28,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/podcast_generator/manifest.yaml
+++ b/tools/podcast_generator/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/pubmed/manifest.yaml
+++ b/tools/pubmed/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - medical
 - search
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/pushover/manifest.yaml
+++ b/tools/pushover/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: pushover

--- a/tools/qa_chunk/manifest.yaml
+++ b/tools/qa_chunk/manifest.yaml
@@ -36,4 +36,4 @@ tags:
   - utilities
   - rag
 type: plugin
-version: 0.0.10
+version: 0.0.11

--- a/tools/qrcode/manifest.yaml
+++ b/tools/qrcode/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.3
+version: 0.1.4

--- a/tools/rapidapi/manifest.yaml
+++ b/tools/rapidapi/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - news
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/regex/manifest.yaml
+++ b/tools/regex/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - utilities
 - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/salesforce/manifest.yaml
+++ b/tools/salesforce/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: salesforce

--- a/tools/searchapi/manifest.yaml
+++ b/tools/searchapi/manifest.yaml
@@ -42,4 +42,4 @@ tags:
   - news
   - productivity
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/searxng/manifest.yaml
+++ b/tools/searxng/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - productivity
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/tools/seltz/manifest.yaml
+++ b/tools/seltz/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: "langgenius"
 name: "seltz"

--- a/tools/serper/manifest.yaml
+++ b/tools/serper/manifest.yaml
@@ -37,4 +37,4 @@ resource:
 tags:
   - search
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/siliconflow/manifest.yaml
+++ b/tools/siliconflow/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
   - image
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/tools/slack/manifest.yaml
+++ b/tools/slack/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/slidespeak/manifest.yaml
+++ b/tools/slidespeak/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 1.0.2
+version: 1.0.3

--- a/tools/smartsheet/manifest.yaml
+++ b/tools/smartsheet/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: smartsheet

--- a/tools/snowflake/manifest.yaml
+++ b/tools/snowflake/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: snowflake_sql

--- a/tools/somark/manifest.yaml
+++ b/tools/somark/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 created_at: '2026-01-30T03:17:37.000000000Z'
 type: plugin
 author: langgenius

--- a/tools/spark/manifest.yaml
+++ b/tools/spark/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/spider/manifest.yaml
+++ b/tools/spider/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - search
 - utilities
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/spotify/manifest.yaml
+++ b/tools/spotify/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.2
+version: 0.1.3

--- a/tools/sqlite/manifest.yaml
+++ b/tools/sqlite/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: sqlite

--- a/tools/stability/manifest.yaml
+++ b/tools/stability/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/stablediffusion/manifest.yaml
+++ b/tools/stablediffusion/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/stackexchange/manifest.yaml
+++ b/tools/stackexchange/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - search
 - utilities
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/stepfun/manifest.yaml
+++ b/tools/stepfun/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/supabase/manifest.yaml
+++ b/tools/supabase/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.2
+version: 0.1.3
 type: plugin
 author: langgenius
 name: supabase

--- a/tools/tavily/manifest.yaml
+++ b/tools/tavily/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - search
 type: plugin
-version: 0.1.6
+version: 0.1.7

--- a/tools/telegraph/manifest.yaml
+++ b/tools/telegraph/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: telegraph

--- a/tools/tianditu/manifest.yaml
+++ b/tools/tianditu/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - utilities
 - travel
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/todoist/manifest.yaml
+++ b/tools/todoist/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: todoist

--- a/tools/transcript/manifest.yaml
+++ b/tools/transcript/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
 - videos
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/trello/manifest.yaml
+++ b/tools/trello/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - productivity
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/twilio/manifest.yaml
+++ b/tools/twilio/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/twitter/manifest.yaml
+++ b/tools/twitter/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.2
+version: 0.1.3

--- a/tools/unstructured/manifest.yaml
+++ b/tools/unstructured/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: unstructured

--- a/tools/vanna/manifest.yaml
+++ b/tools/vanna/manifest.yaml
@@ -33,4 +33,4 @@ tags:
 - utilities
 - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/vectorizer/manifest.yaml
+++ b/tools/vectorizer/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - productivity
   - image
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/websearch/manifest.yaml
+++ b/tools/websearch/manifest.yaml
@@ -38,4 +38,4 @@ tags:
 - news
 - productivity
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/wecom/manifest.yaml
+++ b/tools/wecom/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/whatsapp-bot/manifest.yaml
+++ b/tools/whatsapp-bot/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: whatsapp-bot

--- a/tools/wikipedia/manifest.yaml
+++ b/tools/wikipedia/manifest.yaml
@@ -35,4 +35,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/wolframalpha/manifest.yaml
+++ b/tools/wolframalpha/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - productivity
 - utilities
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/yahoo/manifest.yaml
+++ b/tools/yahoo/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - business
 - finance
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/youtube/manifest.yaml
+++ b/tools/youtube/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - videos
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/tools/zhipuai/manifest.yaml
+++ b/tools/zhipuai/manifest.yaml
@@ -33,4 +33,4 @@ tags:
   - image
   - videos
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/zoom/manifest.yaml
+++ b/tools/zoom/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.3
+version: 0.1.4

--- a/triggers/airtable_trigger/manifest.yaml
+++ b/triggers/airtable_trigger/manifest.yaml
@@ -38,4 +38,4 @@ tags:
 - productivity
 - utilities
 type: plugin
-version: 1.0.2
+version: 1.0.3

--- a/triggers/github_trigger/manifest.yaml
+++ b/triggers/github_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 1.4.4
+version: 1.4.5

--- a/triggers/gmail_trigger/manifest.yaml
+++ b/triggers/gmail_trigger/manifest.yaml
@@ -37,4 +37,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/triggers/google_calendar_trigger/manifest.yaml
+++ b/triggers/google_calendar_trigger/manifest.yaml
@@ -37,4 +37,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/triggers/google_drive_trigger/manifest.yaml
+++ b/triggers/google_drive_trigger/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       size: 1048576
       enabled: true
 type: plugin
-version: 1.3.2
+version: 1.3.3

--- a/triggers/lark_trigger/manifest.yaml
+++ b/triggers/lark_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/triggers/linear_trigger/manifest.yaml
+++ b/triggers/linear_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - productivity
 type: plugin
-version: 0.5.4
+version: 0.5.5

--- a/triggers/notion_trigger/manifest.yaml
+++ b/triggers/notion_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - productivity
 type: plugin
-version: 0.1.2
+version: 0.1.3

--- a/triggers/outlook_trigger/manifest.yaml
+++ b/triggers/outlook_trigger/manifest.yaml
@@ -36,4 +36,4 @@ resource:
       size: 1048576
 tags: []
 type: plugin
-version: 0.1.3
+version: 0.1.4

--- a/triggers/rsshub_trigger/manifest.yaml
+++ b/triggers/rsshub_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/triggers/slack_trigger/manifest.yaml
+++ b/triggers/slack_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.2.2
+version: 0.2.3

--- a/triggers/telegram_trigger/manifest.yaml
+++ b/triggers/telegram_trigger/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.3
+version: 0.0.4

--- a/triggers/twilio_trigger/manifest.yaml
+++ b/triggers/twilio_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.0.2
+version: 0.0.3

--- a/triggers/typeform_trigger/manifest.yaml
+++ b/triggers/typeform_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - productivity
 type: plugin
-version: 0.1.3
+version: 0.1.4

--- a/triggers/woocommerce_trigger/manifest.yaml
+++ b/triggers/woocommerce_trigger/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 1.0.2
+version: 1.0.3

--- a/triggers/zendesk_trigger/manifest.yaml
+++ b/triggers/zendesk_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 1.0.2
+version: 1.0.3


### PR DESCRIPTION
## Related Issues or Context

Fixes #2991.

This is a batch fix for official plugins that were affected by the uv migration. For deployments that have not upgraded plugin daemon yet, plugins packaged with only `pyproject.toml` and `uv.lock` may fail to start because older plugin daemon versions still expect `requirements.txt`. plugin daemon support for uv is only available in the latest version.

Sorry for the compatibility break this caused for users running not-yet-upgraded plugin daemon versions.

This PR:

- generates a legacy `requirements.txt` from `uv.lock` during the deploy packaging flow only
- keeps dependency validation using the source `uv.lock` / existing legacy `requirements.txt` behavior
- excludes the current project and dev dependencies from the generated file
- bumps all affected plugin manifest patch versions so fixed packages can be published
- removes three Volcengine Ark predefined models that currently return `InvalidEndpointOrModel.NotFound` in integration tests: `doubao-lite-32k-character-250228`, `kimi-k2-thinking-251104`, and `kimi-k2-250905`

## This PR contains Changes to *Non-Plugin* 

- [ ] Documentation
- [x] Other

## This PR contains Changes to *Non-LLM Models Plugin*

- [x] I have Run Comprehensive Tests Relevant to My Changes

Validation performed:

- `bash -n .github/scripts/export-legacy-requirements.sh`
- exported requirements from a temporary `tools/arxiv` copy using `uv export`
- `git diff --cached --check`
- verified 256 manifest patch bumps are exactly `major.minor.patch + 1`
- parsed all plugin `manifest.yaml` files as YAML
- verified Volcengine `_position.yaml` entries map exactly to existing model YAML files
- packaged `models/volcengine` successfully after removing inaccessible predefined models

## This PR contains Changes to *LLM Models Plugin*

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
- [ ] My Changes Affect Token Consumption Metrics
- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
- [x] Other Changes (Add New Models, Fix Model Parameters etc.)

Volcengine predefined model catalog cleanup only; no model invocation flow changes.

## Version Control (Any Changes to the Plugin Will Require Bumping the Version)

- [x] I have Bumped Up the Version in Manifest.yaml (Top-Level `Version` Field, Not in Meta Section)

## Dify Plugin SDK Version

- [ ] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`, or kept in `requirements.txt` only for legacy plugins without `uv.lock`

Not applicable for this PR: no SDK dependency constraints are changed.

## Environment Verification (If Any Code Changes)

### Local Deployment Environment

- [ ] Dify Version is: N/A, I have Tested My Changes on Local Deployment Dify with a Clean Environment That Matches the Production Configuration.

### SaaS Environment

- [ ] I have Tested My Changes on cloud.dify.ai with a Clean Environment That Matches the Production Configuration

Not run: this change is limited to CI packaging compatibility, manifest patch version bumps, and removal of Volcengine predefined models that returned provider-side 404s in integration tests.