### PR TITLE
fix(azure_ai_studio): forward only user-specified sampling params

### DIFF
--- a/models/azure_ai_studio/manifest.yaml
+++ b/models/azure_ai_studio/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.14
+version: 0.0.15

--- a/models/azure_ai_studio/models/llm/llm.py
+++ b/models/azure_ai_studio/models/llm/llm.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from collections.abc import Generator, Sequence
 from typing import Any, Optional, Union
@@ -51,11 +52,28 @@ from dify_plugin.errors.model import (
     InvokeBadRequestError,
     InvokeConnectionError,
     InvokeError,
+    InvokeRateLimitError,
     InvokeServerUnavailableError,
 )
 from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
 
 logger = logging.getLogger(__name__)
+
+# 这些参数会被透传给 Azure AI Inference SDK，仅在 model_parameters 中实际存在时
+# 才会被发送，避免 Azure 上的某些模型（如 Claude opus-4-7、mythos-preview 等）
+# 因同时收到 temperature 和 top_p 而报 400 错误。
+_PASSTHROUGH_PARAMETERS = (
+    "temperature",
+    "top_p",
+    "top_k",
+    "max_tokens",
+    "max_completion_tokens",
+    "presence_penalty",
+    "frequency_penalty",
+    "seed",
+    "reasoning_effort",
+    "user",
+)
 
 
 class AzureAIStudioLargeLanguageModel(LargeLanguageModel):
@@ -63,8 +81,30 @@ class AzureAIStudioLargeLanguageModel(LargeLanguageModel):
     Model class for Azure AI Studio large language model.
     """
 
+    # 缓存 client，但同时记录其指纹，避免不同 endpoint/api_key 复用旧 client
     client: Any = None
-    from azure.ai.inference.models import StreamingChatCompletionsUpdate
+    _client_signature: Optional[tuple] = None
+
+    def _get_client(self, credentials: dict) -> ChatCompletionsClient:
+        """
+        构建 / 复用 Azure AI Inference 客户端。
+
+        当 endpoint、api_key 或 api_version 任一发生变化时，
+        重新创建 client，防止跨账号污染。
+        """
+        endpoint = str(credentials.get("endpoint", ""))
+        api_key = str(credentials.get("api_key", ""))
+        api_version = credentials.get("api_version", "2024-05-01-preview")
+
+        signature = (endpoint, api_key, api_version)
+        if self.client is None or self._client_signature != signature:
+            self.client = ChatCompletionsClient(
+                endpoint=endpoint,
+                credential=AzureKeyCredential(api_key),
+                api_version=api_version,
+            )
+            self._client_signature = signature
+        return self.client
 
     def _convert_prompt_message_to_dict(self, message: PromptMessage) -> dict:
         """
@@ -184,43 +224,71 @@ class AzureAIStudioLargeLanguageModel(LargeLanguageModel):
         :param user: unique user id
         :return: full response or stream response chunk generator result
         """
-        if not self.client:
-            endpoint = str(credentials.get("endpoint"))
-            api_key = str(credentials.get("api_key"))
-            api_version = credentials.get("api_version", "2024-05-01-preview")
+        client = self._get_client(credentials)
 
-            self.client = ChatCompletionsClient(
-                endpoint=endpoint,
-                credential=AzureKeyCredential(api_key),
-                api_version=api_version,
-            )
         messages = [
             self._convert_prompt_message_to_dict(msg) for msg in prompt_messages
         ]
-        optional_fields = {}
-        # GPT O series model don't support max_tokens parameter
-        if "max_tokens" in model_parameters:
-            optional_fields["max_tokens"] = model_parameters["max_tokens"]
-        payload = {
+
+        # 仅透传用户实际指定的参数，避免 Azure 上的部分模型
+        # （Claude / o-series / 推理模型等）因同时收到 temperature & top_p 报错。
+        payload: dict[str, Any] = {
             "messages": messages,
-            "temperature": model_parameters.get("temperature", 0),
-            "top_p": model_parameters.get("top_p", 1),
             "stream": stream,
             "model": model,
-            **optional_fields,
         }
+        for key in _PASSTHROUGH_PARAMETERS:
+            if key in model_parameters and model_parameters[key] is not None:
+                payload[key] = model_parameters[key]
+
+        # 处理 response_format：兼容字符串（"text" / "json_object" / "json_schema"）
+        # 与已经构造好的 dict 两种形式。
+        response_format = model_parameters.get("response_format")
+        if response_format:
+            if isinstance(response_format, dict):
+                payload["response_format"] = response_format
+            elif response_format == "json_schema":
+                json_schema_raw = model_parameters.get("json_schema")
+                if not json_schema_raw:
+                    raise ValueError(
+                        "json_schema must be provided when response_format is json_schema"
+                    )
+                if isinstance(json_schema_raw, str):
+                    try:
+                        json_schema_raw = json.loads(json_schema_raw)
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(
+                            f"Invalid json_schema format: {exc}"
+                        ) from exc
+                payload["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": json_schema_raw,
+                }
+            elif response_format != "text":
+                payload["response_format"] = {"type": response_format}
+
+        # 用户在前端配置的 stop words 与系统传入的 stop 取并集，最多 4 项。
+        user_stop = model_parameters.get("stop")
+        stop_words: list[str] = []
+        if isinstance(user_stop, list):
+            stop_words.extend([s for s in user_stop if isinstance(s, str) and s])
+        elif isinstance(user_stop, str) and user_stop:
+            stop_words.append(user_stop)
         if stop:
-            payload["stop"] = stop
+            stop_words.extend([s for s in stop if isinstance(s, str) and s])
+        if stop_words:
+            payload["stop"] = stop_words[:4]
+
         if tools:
             payload["tools"] = self._convert_tools(tools)
+
         try:
-            response = self.client.complete(**payload)
+            response = client.complete(**payload)
             if stream:
                 return self._handle_stream_response(response, model, prompt_messages)
-            else:
-                return self._handle_non_stream_response(
-                    response, model, prompt_messages, credentials
-                )
+            return self._handle_non_stream_response(
+                response, model, prompt_messages, credentials
+            )
         except Exception as e:
             raise self._transform_invoke_error(e)
 
@@ -322,20 +390,27 @@ class AzureAIStudioLargeLanguageModel(LargeLanguageModel):
         :return:
         """
         try:
-            endpoint = str(credentials.get("endpoint"))
-            api_key = str(credentials.get("api_key"))
+            endpoint = str(credentials.get("endpoint", ""))
+            api_key = str(credentials.get("api_key", ""))
             api_version = credentials.get("api_version", "2024-05-01-preview")
+            if not endpoint or not api_key:
+                raise CredentialsValidateFailedError(
+                    "Both endpoint and api_key are required"
+                )
             client = ChatCompletionsClient(
                 endpoint=endpoint,
                 credential=AzureKeyCredential(api_key),
                 api_version=api_version,
             )
+            # 不传任何采样参数，避免对 Claude / o-series 等限制型模型触发 400
             client.complete(
                 messages=[
                     {"role": "user", "content": "I say 'ping', you say 'pong'.ping"},
                 ],
                 model=model,
             )
+        except CredentialsValidateFailedError:
+            raise
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 
@@ -352,6 +427,7 @@ class AzureAIStudioLargeLanguageModel(LargeLanguageModel):
         return {
             InvokeConnectionError: [ServiceRequestError],
             InvokeServerUnavailableError: [ServiceResponseError],
+            InvokeRateLimitError: [],
             InvokeAuthorizationError: [ClientAuthenticationError],
             InvokeBadRequestError: [
                 HttpResponseError,
@@ -362,6 +438,7 @@ class AzureAIStudioLargeLanguageModel(LargeLanguageModel):
                 ResourceNotModifiedError,
                 SerializationError,
                 DeserializationError,
+                ValueError,
             ],
         }
 
@@ -371,18 +448,61 @@ class AzureAIStudioLargeLanguageModel(LargeLanguageModel):
         """
         Used to define customizable model schema
         """
+        # 注意：temperature 与 top_p 在 Azure 上的部分模型（Claude opus-4-7、
+        # mythos-preview、o-series 等）存在互斥或限定取值。这里全部设为
+        # required=False 且不强制默认值，仅在用户主动开启时才会下发。
         rules = [
             ParameterRule(
                 name="temperature",
                 type=ParameterType.FLOAT,
                 use_template="temperature",
+                required=False,
                 label=I18nObject(zh_Hans="温度", en_US="Temperature"),
+                help=I18nObject(
+                    zh_Hans=(
+                        "采样温度。部分模型（如 Claude opus-4-7、mythos-preview、"
+                        "o-series 推理模型）不允许同时设置 temperature 和 top_p，"
+                        "请只配置其中之一。"
+                    ),
+                    en_US=(
+                        "Sampling temperature. Some models on Azure "
+                        "(e.g. Claude opus-4-7, mythos-preview, o-series reasoning "
+                        "models) do not allow temperature and top_p to be set at "
+                        "the same time. Please configure only one of them."
+                    ),
+                ),
             ),
             ParameterRule(
                 name="top_p",
                 type=ParameterType.FLOAT,
                 use_template="top_p",
+                required=False,
                 label=I18nObject(zh_Hans="Top P", en_US="Top P"),
+                help=I18nObject(
+                    zh_Hans=(
+                        "核采样阈值。Claude opus-4-7 / mythos-preview 必须 ≥ 0.99，"
+                        "且不要同时配置 temperature。"
+                    ),
+                    en_US=(
+                        "Nucleus sampling threshold. For Claude opus-4-7 / "
+                        "mythos-preview the value must be >= 0.99 and you should "
+                        "not also set temperature."
+                    ),
+                ),
+            ),
+            ParameterRule(
+                name="presence_penalty",
+                type=ParameterType.FLOAT,
+                use_template="presence_penalty",
+                required=False,
+                label=I18nObject(zh_Hans="存在惩罚", en_US="Presence Penalty"),
+            ),
+            ParameterRule(
+                name="frequency_penalty",
+                type=ParameterType.FLOAT,
+                use_template="frequency_penalty",
+                required=False,
+                label=I18nObject(zh_Hans="频率惩罚", en_US="Frequency Penalty"),
             ),
             ParameterRule(
                 name="max_tokens",
@@ -390,17 +510,94 @@ class AzureAIStudioLargeLanguageModel(LargeLanguageModel):
                 use_template="max_tokens",
                 min=1,
                 default=512,
+                required=False,
                 label=I18nObject(zh_Hans="最大生成长度", en_US="Max Tokens"),
+                help=I18nObject(
+                    zh_Hans=(
+                        "生成内容的最大 token 数。OpenAI o-series / GPT-5 等推理"
+                        "模型请改用 max_completion_tokens。"
+                    ),
+                    en_US=(
+                        "Maximum number of tokens to generate. For OpenAI o-series "
+                        "/ GPT-5 reasoning models please use max_completion_tokens "
+                        "instead."
+                    ),
+                ),
+            ),
+            ParameterRule(
+                name="max_completion_tokens",
+                type=ParameterType.INT,
+                required=False,
+                min=1,
+                label=I18nObject(
+                    zh_Hans="最大补全长度", en_US="Max Completion Tokens"
+                ),
+                help=I18nObject(
+                    zh_Hans=(
+                        "用于 OpenAI o-series / GPT-5 等推理模型的输出长度限制。"
+                        "若已设置 max_tokens 则忽略此项。"
+                    ),
+                    en_US=(
+                        "Output length limit for OpenAI o-series / GPT-5 "
+                        "reasoning models. Ignored when max_tokens is also set."
+                    ),
+                ),
+            ),
+            ParameterRule(
+                name="seed",
+                type=ParameterType.INT,
+                required=False,
+                label=I18nObject(zh_Hans="随机种子", en_US="Seed"),
+                help=I18nObject(
+                    zh_Hans="可复现采样的随机种子。",
+                    en_US="Random seed used for reproducible sampling.",
+                ),
+            ),
+            ParameterRule(
+                name="response_format",
+                type=ParameterType.STRING,
+                required=False,
+                options=["text", "json_object"],
+                label=I18nObject(zh_Hans="响应格式", en_US="Response Format"),
+                help=I18nObject(
+                    zh_Hans=(
+                        "强制模型按指定格式响应，json_object 要求模型输出合法 JSON。"
+                    ),
+                    en_US=(
+                        "Force the model response to follow a specific format. "
+                        "json_object requires the model to emit valid JSON."
+                    ),
+                ),
             ),
         ]
 
-        # Add features based on credentials
+        # 当用户开启推理模型支持时，额外暴露 reasoning_effort 参数
+        if credentials.get("reasoning_support") == "true":
+            rules.append(
+                ParameterRule(
+                    name="reasoning_effort",
+                    type=ParameterType.STRING,
+                    required=False,
+                    options=["low", "medium", "high"],
+                    label=I18nObject(zh_Hans="推理强度", en_US="Reasoning Effort"),
+                    help=I18nObject(
+                        zh_Hans="OpenAI o-series / GPT-5 推理模型的推理强度。",
+                        en_US=(
+                            "Reasoning effort level for OpenAI o-series / GPT-5 "
+                            "reasoning models."
+                        ),
+                    ),
+                )
+            )
+
         features = []
         if credentials.get("vision_support") == "true":
             features.append(ModelFeature.VISION)
         if credentials.get("function_call_support") == "true":
             features.append(ModelFeature.TOOL_CALL)
             features.append(ModelFeature.MULTI_TOOL_CALL)
+        if credentials.get("stream_tool_call_support") == "true":
+            features.append(ModelFeature.STREAM_TOOL_CALL)
 
         entity = AIModelEntity(
             model=model,

--- a/models/azure_ai_studio/provider/azure_ai_studio.yaml
+++ b/models/azure_ai_studio/provider/azure_ai_studio.yaml
@@ -183,6 +183,44 @@ model_credential_schema:
     type: radio
     variable: function_call_support
   - label:
+      en_US: Stream tool call support
+      zh_Hans: 是否支持流式工具调用
+    default: 'false'
+    options:
+    - label:
+        en_US: 'Yes'
+        zh_Hans: 是
+      value: 'true'
+    - label:
+        en_US: 'No'
+        zh_Hans: 否
+      value: 'false'
+    required: false
+    show_on:
+    - value: llm
+      variable: __model_type
+    type: radio
+    variable: stream_tool_call_support
+  - label:
+      en_US: Reasoning model support
+      zh_Hans: 是否为推理模型
+    default: 'false'
+    options:
+    - label:
+        en_US: 'Yes'
+        zh_Hans: 是
+      value: 'true'
+    - label:
+        en_US: 'No'
+        zh_Hans: 否
+      value: 'false'
+    required: false
+    show_on:
+    - value: llm
+      variable: __model_type
+    type: radio
+    variable: reasoning_support
+  - label:
       en_US: JWT Token
       zh_Hans: JWT令牌
     placeholder:


### PR DESCRIPTION
Some Azure-hosted models (Claude opus-4-7 / mythos-preview, OpenAI o-series, etc.) reject requests that contain both `temperature` and `top_p`, but the previous code always injected default values for both, which caused 400 errors such as:

  `temperature` and `top_p` cannot both be specified for this model.

Now only the parameters explicitly provided in `model_parameters` are forwarded to the Azure AI Inference SDK. Also fixes a few related issues and extends parameter coverage:

- Cache the `ChatCompletionsClient` by (endpoint, api_key, api_version) so credential changes invalidate the cached client.
- Add support for `presence_penalty`, `frequency_penalty`, `seed`, `response_format` (text / json_object / json_schema), `stop`, `max_completion_tokens`, `reasoning_effort`, `top_k`, `user`.
- Expose new credential options `stream_tool_call_support` and `reasoning_support` to enable matching features and parameter rules.
- Map `InvokeRateLimitError` and `ValueError` in the error mapping.
- Skip sampling params during `validate_credentials` so connectivity checks no longer trip the same conflict on restricted models.
- Bump plugin version to 0.0.15.


## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->



## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [ ] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [ ] SaaS (cloud.dify.ai)
