### PR TITLE
feat(tongyi): add tool-call support for DeepSeek-V3 series models

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.1.41
+version: 0.1.42
 created_at: "2024-12-10T16:13:50.29298939+08:00"

--- a/models/tongyi/models/llm/deepseek-v3.1.yaml
+++ b/models/tongyi/models/llm/deepseek-v3.1.yaml
@@ -5,6 +5,9 @@ label:
 model_type: llm
 features:
   - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 131072

--- a/models/tongyi/models/llm/deepseek-v3.2-exp.yaml
+++ b/models/tongyi/models/llm/deepseek-v3.2-exp.yaml
@@ -5,6 +5,9 @@ label:
 model_type: llm
 features:
   - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 131072

--- a/models/tongyi/models/llm/deepseek-v3.2.yaml
+++ b/models/tongyi/models/llm/deepseek-v3.2.yaml
@@ -5,6 +5,9 @@ label:
 model_type: llm
 features:
   - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 131072

--- a/models/tongyi/models/llm/deepseek-v3.yaml
+++ b/models/tongyi/models/llm/deepseek-v3.yaml
@@ -5,6 +5,9 @@ label:
 model_type: llm
 features:
   - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
 model_properties:
   mode: chat
   context_size: 64000


### PR DESCRIPTION
## Summary

- Add `tool-call` feature declarations (including multi-tool-call and stream-tool-call where supported) to `deepseek-v3`, `deepseek-v3.1`, `deepseek-v3.2`, and `deepseek-v3.2-exp` model YAML files.
- DashScope API already supports function calling for these models, but the corresponding feature flags were not declared, which prevented tool usage in Dify agent workflows.

Closes #3002

## Reference

- DeepSeek Function Calling docs: https://api-docs.deepseek.com/guides/function_calling

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| Agent could not trigger tool calls (`tool used: Null`) | Tool call feature enabled for DeepSeek models |