### PR TITLE
perf(tongyi/stt): detect audio type from magic bytes

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.1.41
+version: 0.1.42
 created_at: "2024-12-10T16:13:50.29298939+08:00"

--- a/models/tongyi/models/speech2text/speech2text.py
+++ b/models/tongyi/models/speech2text/speech2text.py
@@ -3,12 +3,41 @@ import tempfile
 import uuid
 from typing import IO, Optional
 
-from dashscope.audio.asr import *
+from dashscope.audio.asr import Recognition
 from dify_plugin import OAICompatSpeech2TextModel
 from models._common import get_ws_base_address
 from pydub import AudioSegment
 
 from ..constant import BURY_POINT_HEADER
+
+_AUDIO_MAGIC = [
+    (0, b"fLaC", "flac"),
+    (0, b"ID3", "mp3"),
+    (0, b"OggS", "ogg"),
+    (0, b"\x1a\x45\xdf\xa3", "webm"),
+    (4, b"ftyp", "m4a"),
+    (0, b"#!AMR", "amr"),
+]
+_RIFF_SUBTYPE = {(8, b"WAVE"): "wav", (8, b"AVI "): "avi"}
+_AUDIO_FORMATS_FALLBACK = [
+    "wav",
+    "mp3",
+    "webm",
+    "ogg",
+    "m4a",
+    "flac",
+    "opus",
+    "aac",
+    "amr",
+    "flv",
+    "mkv",
+    "mov",
+    "mp4",
+    "mpeg",
+    "avi",
+    "wma",
+    "wmv",
+]
 
 
 class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
@@ -16,7 +45,9 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
     Model class for Tongyi Speech to text model.
     """
 
-    def _invoke(self, model: str, credentials: dict, file: IO[bytes], user: Optional[str] = None) -> str:
+    def _invoke(
+        self, model: str, credentials: dict, file: IO[bytes], user: Optional[str] = None
+    ) -> str:
         """
         Invoke speech2text model
 
@@ -30,12 +61,11 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
         try:
             ws_base_address = get_ws_base_address(credentials)
             file.seek(0)
-            audio = AudioSegment.from_file(file)
-            sample_rate = audio.frame_rate
-            file.seek(0)
             audio_format = self.get_audio_type(file)
-            if audio_format == 'unknown':
+            if audio_format == "unknown":
                 raise ValueError("Unsupported audio format")
+            audio = AudioSegment.from_file(file, format=audio_format)
+            sample_rate = audio.frame_rate
             file.seek(0)
             file_path = self.write_bytes_to_temp_file(file, audio_format)
             recognition = Recognition(
@@ -52,23 +82,21 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
             )
             sentence_list = result.get_sentence()
             if sentence_list is None:
-                return ''
+                return ""
             else:
                 sentence_ans = []
                 for sentence in sentence_list:
-                    sentence_ans.append(sentence['text'])
+                    sentence_ans.append(sentence["text"])
                 return "\n".join(sentence_ans)
         except Exception as ex:
-            raise ValueError(
-                f"[TongyiSpeech2TextModel] {ex}"
-            ) from ex
+            raise ValueError(f"[TongyiSpeech2TextModel] {ex}") from ex
         finally:
             if file_path and os.path.exists(file_path):
                 try:
                     os.remove(file_path)
                 except OSError:
                     pass
-        
+
     def write_bytes_to_temp_file(self, file: IO[bytes], file_extension: str) -> str:
         temp_dir = tempfile.gettempdir()
         file_path = os.path.join(temp_dir, f"{uuid.uuid4()}_audio.{file_extension}")
@@ -79,21 +107,33 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
             temp_file.write(file_content)
         return file_path
 
-    def get_audio_type(self,file_obj: IO[bytes]) -> str:
+    def get_audio_type(self, file_obj: IO[bytes]) -> str:
         current_position = file_obj.tell()
         file_obj.seek(0)
-        audio_formats = ['aac','amr','avi','flac','flv','m4a','mkv','mov','mp3','mp4','mpeg','ogg','opus','wav','webm','wma','wmv']
-        detected_format = 'unknown'
-        for format_name in audio_formats:
-            try:
-                file_obj.seek(0)
-                AudioSegment.from_file(file_obj, format=format_name)
-                detected_format = format_name
-                break
-            except Exception:
-                continue
-        file_obj.seek(current_position)
-        return detected_format
-    
+        try:
+            header = file_obj.read(12)
+            if len(header) >= 12 and header[0:4] == b"RIFF":
+                for (offset, signature), format_name in _RIFF_SUBTYPE.items():
+                    if header[offset : offset + len(signature)] == signature:
+                        return format_name
+            for offset, signature, format_name in _AUDIO_MAGIC:
+                if (
+                    len(header) >= offset + len(signature)
+                    and header[offset : offset + len(signature)] == signature
+                ):
+                    return format_name
+            detected_format = "unknown"
+            for format_name in _AUDIO_FORMATS_FALLBACK:
+                try:
+                    file_obj.seek(0)
+                    AudioSegment.from_file(file_obj, format=format_name)
+                    detected_format = format_name
+                    break
+                except Exception:
+                    continue
+            return detected_format
+        finally:
+            file_obj.seek(current_position)
+
     def validate_credentials(self, model: str, credentials: dict) -> None:
         return super().validate_credentials(model, credentials)

--- a/models/tongyi/tests/test_speech2text.py
+++ b/models/tongyi/tests/test_speech2text.py
@@ -1,0 +1,65 @@
+import os
+import sys
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models.speech2text.speech2text import TongyiSpeech2TextModel
+
+
+def _model() -> TongyiSpeech2TextModel:
+    return TongyiSpeech2TextModel(model_schemas=MagicMock())
+
+
+def _named_bytes(data: bytes, name: str) -> BytesIO:
+    file_obj = BytesIO(data)
+    file_obj.name = name
+    return file_obj
+
+
+def test_get_audio_type_prefers_magic_bytes_without_decoding() -> None:
+    file_obj = _named_bytes(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 16, "temp.mp3")
+    file_obj.seek(5)
+
+    with patch(
+        "models.speech2text.speech2text.AudioSegment.from_file",
+        side_effect=AssertionError("magic-byte detection should not decode audio"),
+    ) as decode_mock:
+        assert _model().get_audio_type(file_obj) == "wav"
+
+    decode_mock.assert_not_called()
+    assert file_obj.tell() == 5
+
+
+def test_get_audio_type_uses_magic_bytes_before_misleading_filename() -> None:
+    file_obj = _named_bytes(b"ID3\x04\x00\x00\x00\x00\x00\x21" + b"\x00" * 16, "upload.wav")
+
+    with patch(
+        "models.speech2text.speech2text.AudioSegment.from_file",
+        side_effect=AssertionError("magic-byte detection should not decode audio"),
+    ):
+        assert _model().get_audio_type(file_obj) == "mp3"
+
+
+def test_invoke_reuses_detected_audio_format_for_decoding() -> None:
+    file_obj = _named_bytes(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 16, "upload.mp3")
+    audio = MagicMock(frame_rate=16000)
+    result = MagicMock()
+    result.get_sentence.return_value = [{"text": "hello"}]
+    recognition = MagicMock()
+    recognition.call.return_value = result
+
+    with patch("models.speech2text.speech2text.AudioSegment.from_file", return_value=audio) as decode_mock:
+        with patch("models.speech2text.speech2text.Recognition", return_value=recognition):
+            assert (
+                _model()._invoke(
+                    model="paraformer-realtime-v1",
+                    credentials={"dashscope_api_key": "test-key"},
+                    file=file_obj,
+                )
+                == "hello"
+            )
+
+    decode_mock.assert_called_once()
+    assert decode_mock.call_args.kwargs["format"] == "wav"


### PR DESCRIPTION
## Summary

Improve Tongyi STT audio format detection by checking common file signatures before falling back to `pydub` decoder probing.

This avoids trying every supported format through ffmpeg when the uploaded bytes already identify the container (for example RIFF/WAV or ID3/MP3), and it also avoids trusting misleading upload filenames when the bytes say otherwise.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

N/A — STT backend change only.

| Before | After |
| ------ | ----- |
| `get_audio_type()` probes formats by repeatedly decoding with `AudioSegment.from_file()` | Known formats are returned from magic bytes without invoking the decoder |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — unchanged in this PR; the existing Tongyi plugin constraint is kept as-is.

## Testing

- [x] Local deployment — Dify plugin daemon version: 0.6.0
- [ ] SaaS (cloud.dify.ai)

Commands run locally:

```bash
cd models/tongyi
uv run --python 3.12 --frozen --with pytest pytest -q tests/test_speech2text.py
uv run --with ruff ruff check models/speech2text/speech2text.py tests/test_speech2text.py
```

Result: the new STT unit tests pass (`2 passed`) and ruff reports no issues.

I also attempted the full Tongyi plugin live test suite with a local Dify CLI and DashScope credentials. It ran most tests successfully but is not a reliable local gate because several existing live LLM cases failed due external model/account conditions (free-tier exhaustion) or plugin startup timeout; this change only touches STT audio type detection and adds isolated unit coverage for it.
