### PR TITLE
fix(azure_openai): prompt caching misses

### DIFF
--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.54
+version: 0.0.55

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -359,7 +359,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         if stop:
             extra_model_kwargs["stop"] = stop
         if user:
-            extra_model_kwargs["user"] = user
+            extra_model_kwargs["safety_identifier"] = user
         if stream:
             extra_model_kwargs["stream_options"] = {"include_usage": True}
         prompt_messages = self._clear_illegal_prompt_messages(
@@ -477,7 +477,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
         # Handle the user identifier
         if user:
-            responses_params["user"] = user
+            responses_params["safety_identifier"] = user
 
         # stop sequences are not supported by gpt-5 reasoning models
         if stop and not is_reasoning_model:


### PR DESCRIPTION
## Summary
Fix #3007

* fix(azure_openai): replace deprecated "user" parameter with "safety_identifier" to prevent cache routing issue
<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->



## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        | <img width="1337" height="195" alt="image" src="https://github.com/user-attachments/assets/92cf7685-5477-4ee7-9617-d1cbd0b877f4" />|


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.9.2 <!-- e.g. 1.2.0 -->
- [ ] SaaS (cloud.dify.ai)
