### PR TITLE
fix(deepseek): allow reasoner 64k output tokens

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.27
+version: 0.0.28
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/deepseek-reasoner.yaml
+++ b/models/aihubmix/models/llm/deepseek-reasoner.yaml
@@ -11,7 +11,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     min: 1
-    max: 8192
+    max: 65536
     default: 4096
 pricing:
   input: "0.60"

--- a/models/cometapi/manifest.yaml
+++ b/models/cometapi/manifest.yaml
@@ -1,4 +1,4 @@
-version: 1.0.5
+version: 1.0.6
 type: plugin
 author: langgenius
 name: cometapi

--- a/models/cometapi/models/llm/deepseek/deepseek-reasoner.yaml
+++ b/models/cometapi/models/llm/deepseek/deepseek-reasoner.yaml
@@ -15,7 +15,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     min: 1
-    max: 8192
+    max: 65536
     default: 4096
   - name: response_format
     label:

--- a/models/deerapi/manifest.yaml
+++ b/models/deerapi/manifest.yaml
@@ -1,4 +1,4 @@
-version: 1.0.5
+version: 1.0.6
 type: plugin
 author: langgenius
 name: deerapi

--- a/models/deerapi/models/llm/deepseek/deepseek-reasoner.yaml
+++ b/models/deerapi/models/llm/deepseek/deepseek-reasoner.yaml
@@ -15,7 +15,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     min: 1
-    max: 8192
+    max: 65536
     default: 4096
   - name: response_format
     label:


### PR DESCRIPTION
## Summary
- raise `deepseek-reasoner` `max_tokens` to 65536 for AIHubMix, CometAPI, and DeerAPI configs
- keep defaults unchanged while allowing the larger output limit

Fixes #2887

## Testing
- `uv run --with pyyaml python - <<PY ...` loaded all changed YAML files and verified `max_tokens.max == 65536` and defaults remain `4096`.