### PR TITLE
fix(vertex-ai): count only text content for token usage

### DIFF
--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -1016,7 +1016,7 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
         ai_prompt = "\n\nmodel:"
         content = message.content
         if isinstance(content, list):
-            content = "".join((c.data for c in content if c.type != PromptMessageContentType.IMAGE))
+            content = "".join((c.data for c in content if c.type == PromptMessageContentType.TEXT))
         if isinstance(message, UserPromptMessage):
             message_text = f"{human_prompt} {content}"
         elif isinstance(message, AssistantPromptMessage):


### PR DESCRIPTION
## Summary
- exclude non-text multimodal payloads from Vertex AI local token estimation
- prevent document/PDF base64 data from inflating token usage

Fixes #2896

## Testing
- `uv run python -m py_compile models/vertex_ai/models/llm/llm.py`
- Ran a small smoke test confirming token-count input construction keeps only text payloads.