### PR TITLE
fix(tongyi): preserve detected vision model flag

### DIFF
--- a/models/tongyi/models/text_embedding/text_embedding.py
+++ b/models/tongyi/models/text_embedding/text_embedding.py
@@ -214,7 +214,8 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                         vision_models[model] = True
             except Exception:
                 pass
-            vision_models[model] = False
+            if model not in vision_models:
+                vision_models[model] = False
         return vision_models[model]
 
     def _calc_response_usage(self, model: str, credentials: dict, tokens: int) -> EmbeddingUsage:


### PR DESCRIPTION
## Summary
- avoid overwriting a detected Tongyi vision embedding model with `False`
- keep the negative cache behavior for missing/invalid YAML configs

Fixes #3006

## Testing
- `uv run python -m py_compile models/tongyi/models/text_embedding/text_embedding.py`