### PR TITLE
feat(zhipuai): add glm-5 series and new flash variants

### DIFF
--- a/models/zhipuai/manifest.yaml
+++ b/models/zhipuai/manifest.yaml
@@ -1,5 +1,5 @@
 type: plugin
-version: 0.0.27
+version: 0.0.28
 author: langgenius
 name: zhipuai
 created_at: "2024-09-20T00:13:50.29298939-04:00"

--- a/models/zhipuai/manifest.yaml
+++ b/models/zhipuai/manifest.yaml
@@ -1,9 +1,9 @@
 type: plugin
-version: 0.0.26
+version: 0.0.27
 author: langgenius
 name: zhipuai
-created_at: '2024-09-20T00:13:50.29298939-04:00'
-description: 
+created_at: "2024-09-20T00:13:50.29298939-04:00"
+description:
   en_US: ZHIPU AI
   zh_Hans: 智谱 AI
 icon: icon_s_en.svg

--- a/models/zhipuai/models/llm/_position.yaml
+++ b/models/zhipuai/models/llm/_position.yaml
@@ -1,4 +1,10 @@
+- glm-5.1
+- glm-5v-turbo
+- glm-5-turbo
+- glm-5
 - glm-4.7
+- glm-4.7-flash
+- glm-4.7-flashx
 - glm-4.6
 - glm-4.5
 - glm-4.5-x

--- a/models/zhipuai/models/llm/glm-4.6v-flash.yaml
+++ b/models/zhipuai/models/llm/glm-4.6v-flash.yaml
@@ -1,0 +1,51 @@
+model: glm-4.6v-flash
+label:
+  en_US: glm-4.6v-flash
+model_type: llm
+model_properties:
+  mode: chat
+  context_size: 131072
+features:
+  - vision
+  - video
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+parameter_rules:
+  - name: web_search
+    type: boolean
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    default: false
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑“自行判断”是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0"
+  output: "0"
+  unit: "0.001"
+  currency: RMB

--- a/models/zhipuai/models/llm/glm-4.6v-flashx.yaml
+++ b/models/zhipuai/models/llm/glm-4.6v-flashx.yaml
@@ -1,0 +1,51 @@
+model: glm-4.6v-flashx
+label:
+  en_US: glm-4.6v-flashx
+model_type: llm
+model_properties:
+  mode: chat
+  context_size: 131072
+features:
+  - vision
+  - video
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+parameter_rules:
+  - name: web_search
+    type: boolean
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    default: false
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑“自行判断”是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0.00015"
+  output: "0.0015"
+  unit: "0.001"
+  currency: RMB

--- a/models/zhipuai/models/llm/glm-4.7-flash.yaml
+++ b/models/zhipuai/models/llm/glm-4.7-flash.yaml
@@ -1,0 +1,48 @@
+model: glm-4.7-flash
+label:
+  en_US: glm-4.7-flash
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 204800
+parameter_rules:
+  - name: web_search
+    type: boolean
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    default: false
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑“自行判断”是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0"
+  output: "0"
+  unit: "0.001"
+  currency: RMB

--- a/models/zhipuai/models/llm/glm-4.7-flashx.yaml
+++ b/models/zhipuai/models/llm/glm-4.7-flashx.yaml
@@ -1,0 +1,48 @@
+model: glm-4.7-flashx
+label:
+  en_US: glm-4.7-flashx
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 204800
+parameter_rules:
+  - name: web_search
+    type: boolean
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    default: false
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑“自行判断”是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0.0005"
+  output: "0.003"
+  unit: "0.001"
+  currency: RMB

--- a/models/zhipuai/models/llm/glm-4.7.yaml
+++ b/models/zhipuai/models/llm/glm-4.7.yaml
@@ -70,7 +70,7 @@ parameter_rules:
       - text
       - json_object
 pricing:
-  input: '0.002'
-  output: '0.008'
-  unit: '0.001'
+  input: "0.002"
+  output: "0.008"
+  unit: "0.001"
   currency: RMB

--- a/models/zhipuai/models/llm/glm-5-turbo.yaml
+++ b/models/zhipuai/models/llm/glm-5-turbo.yaml
@@ -1,0 +1,48 @@
+model: glm-5-turbo
+label:
+  en_US: glm-5-turbo
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 204800
+parameter_rules:
+  - name: web_search
+    type: boolean
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    default: false
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑“自行判断”是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0.005"
+  output: "0.022"
+  unit: "0.001"
+  currency: RMB

--- a/models/zhipuai/models/llm/glm-5.1.yaml
+++ b/models/zhipuai/models/llm/glm-5.1.yaml
@@ -1,0 +1,48 @@
+model: glm-5.1
+label:
+  en_US: glm-5.1
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 204800
+parameter_rules:
+  - name: web_search
+    type: boolean
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    default: false
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑“自行判断”是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0.006"
+  output: "0.024"
+  unit: "0.001"
+  currency: RMB

--- a/models/zhipuai/models/llm/glm-5.yaml
+++ b/models/zhipuai/models/llm/glm-5.yaml
@@ -1,0 +1,48 @@
+model: glm-5
+label:
+  en_US: glm-5
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 204800
+parameter_rules:
+  - name: web_search
+    type: boolean
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    default: false
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑“自行判断”是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0.004"
+  output: "0.018"
+  unit: "0.001"
+  currency: RMB

--- a/models/zhipuai/models/llm/glm-5v-turbo.yaml
+++ b/models/zhipuai/models/llm/glm-5v-turbo.yaml
@@ -10,7 +10,6 @@ features:
   - video
   - agent-thought
   - multi-tool-call
-  - agent-thought
   - stream-tool-call
 parameter_rules:
   - name: web_search

--- a/models/zhipuai/models/llm/glm-5v-turbo.yaml
+++ b/models/zhipuai/models/llm/glm-5v-turbo.yaml
@@ -1,0 +1,51 @@
+model: glm-5v-turbo
+label:
+  en_US: glm-5v-turbo
+model_type: llm
+model_properties:
+  mode: chat
+  context_size: 204800
+features:
+  - vision
+  - video
+  - agent-thought
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+parameter_rules:
+  - name: web_search
+    type: boolean
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    default: false
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑“自行判断”是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0.005"
+  output: "0.022"
+  unit: "0.001"
+  currency: RMB

--- a/models/zhipuai/models/llm/llm.py
+++ b/models/zhipuai/models/llm/llm.py
@@ -35,6 +35,9 @@ viso_models = [
     "glm-4v-flash",
     "glm-4.1v-thinking-flash",
     "glm-4.1v-thinking-flashx",
+    "glm-4.6v-flash",
+    "glm-4.6v-flashx",
+    "glm-5v-turbo",
 ]
 
 TOKEN_BEGIN_OF_BOX = "<|begin_of_box|>"


### PR DESCRIPTION
## Summary

Add new ZhipuAI LLM models and enable vision capabilities for recent variants.

## New Models

| Model | Type | Features |
|---|---|---|
| glm-5 | Chat | multi-tool-call, agent-thought, stream-tool-call |
| glm-5.1 | Chat | multi-tool-call, agent-thought, stream-tool-call |
| glm-5-turbo | Chat | multi-tool-call, agent-thought, stream-tool-call |
| glm-5v-turbo | Chat (Vision) | vision, multi-tool-call, agent-thought, stream-tool-call |
| glm-4.7-flash | Chat | multi-tool-call, agent-thought, stream-tool-call |
| glm-4.7-flashx | Chat | multi-tool-call, agent-thought, stream-tool-call |
| glm-4.6v-flash | Chat (Vision) | vision, video, multi-tool-call, agent-thought, stream-tool-call |
| glm-4.6v-flashx | Chat (Vision) | vision, video, multi-tool-call, agent-thought, stream-tool-call |


## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|      |   

    |
-->

| Before | After |
| ------ | ----- |
|   <img width="809" height="1228" alt="image" src="https://github.com/user-attachments/assets/2ae8138f-a253-4ab8-b22e-b0b0406b9f89" />     |   <img width="868" height="1318" alt="image" src="https://github.com/user-attachments/assets/0aeb64a6-3b6c-49b5-a22f-0ab7ca12ded7" />    |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [x] SaaS (cloud.dify.ai)
