### PR TITLE
feat(tongyi/stt): isolate recognition in subprocess

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.1.42
+version: 0.1.43
 created_at: "2024-12-10T16:13:50.29298939+08:00"

--- a/models/tongyi/models/speech2text/_stt_worker.py
+++ b/models/tongyi/models/speech2text/_stt_worker.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        args = json.loads(sys.stdin.read())
+    except Exception as ex:
+        print(json.dumps({"status": "err", "data": f"parse args: {ex}"}))
+        return 2
+
+    try:
+        from dashscope.audio.asr import Recognition
+    except Exception as ex:
+        print(json.dumps({"status": "err", "data": f"import dashscope: {ex}"}))
+        return 3
+
+    try:
+        recognition = Recognition(
+            model=args["model"],
+            format=args["audio_format"],
+            sample_rate=args["sample_rate"],
+            callback=None,
+        )
+        result = recognition.call(
+            file=args["file_path"],
+            headers=args.get("headers") or {},
+            api_key=args["api_key"],
+            base_address=args.get("base_address"),
+        )
+        sentences = result.get_sentence()
+        if sentences is None:
+            normalized = []
+        else:
+            normalized = [
+                sentence if isinstance(sentence, dict) else {"text": str(sentence)}
+                for sentence in sentences
+            ]
+        print(json.dumps({"status": "ok", "data": normalized}))
+        return 0
+    except Exception as ex:
+        print(json.dumps({"status": "err", "data": f"{type(ex).__name__}: {ex}"}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/tongyi/models/speech2text/_stt_worker.py
+++ b/models/tongyi/models/speech2text/_stt_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import sys
 
@@ -12,32 +13,44 @@ def main() -> int:
         return 2
 
     try:
-        from dashscope.audio.asr import Recognition
+        with contextlib.redirect_stdout(sys.stderr):
+            from dashscope.audio.asr import Recognition
     except Exception as ex:
         print(json.dumps({"status": "err", "data": f"import dashscope: {ex}"}))
         return 3
 
     try:
-        recognition = Recognition(
-            model=args["model"],
-            format=args["audio_format"],
-            sample_rate=args["sample_rate"],
-            callback=None,
-        )
-        result = recognition.call(
-            file=args["file_path"],
-            headers=args.get("headers") or {},
-            api_key=args["api_key"],
-            base_address=args.get("base_address"),
-        )
+        with contextlib.redirect_stdout(sys.stderr):
+            recognition = Recognition(
+                model=args["model"],
+                format=args["audio_format"],
+                sample_rate=args["sample_rate"],
+                callback=None,
+            )
+            result = recognition.call(
+                file=args["file_path"],
+                headers=args.get("headers") or {},
+                api_key=args["api_key"],
+                base_address=args.get("base_address"),
+            )
+        status_code = getattr(result, "status_code", 200)
+        if status_code != 200:
+            message = getattr(result, "message", None) or "Unknown DashScope error"
+            print(
+                json.dumps(
+                    {
+                        "status": "err",
+                        "data": f"DashScope error: {message} ({status_code})",
+                    }
+                )
+            )
+            return 0
+
         sentences = result.get_sentence()
-        if sentences is None:
-            normalized = []
-        else:
-            normalized = [
-                sentence if isinstance(sentence, dict) else {"text": str(sentence)}
-                for sentence in sentences
-            ]
+        normalized = [
+            sentence if isinstance(sentence, dict) else {"text": str(sentence)}
+            for sentence in (sentences or [])
+        ]
         print(json.dumps({"status": "ok", "data": normalized}))
         return 0
     except Exception as ex:

--- a/models/tongyi/models/speech2text/speech2text.py
+++ b/models/tongyi/models/speech2text/speech2text.py
@@ -44,8 +44,14 @@ _AUDIO_FORMATS_FALLBACK = [
 ]
 _WORKER_SCRIPT_PATH = str(Path(__file__).resolve().parent / "_stt_worker.py")
 _SUBPROCESS_ENV = "TONGYI_STT_SUBPROCESS"
+_SUBPROCESS_TRUE_VALUES = {"1", "true", "yes", "on"}
 _RECOGNITION_TIMEOUT_ENV = "TONGYI_STT_RECOGNITION_TIMEOUT"
 _DEFAULT_RECOGNITION_TIMEOUT = 120
+
+
+def _is_subprocess_enabled() -> bool:
+    value = os.getenv(_SUBPROCESS_ENV)
+    return value is not None and value.strip().lower() in _SUBPROCESS_TRUE_VALUES
 
 
 def _get_recognition_timeout() -> int:
@@ -152,7 +158,7 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
             file_path = self.write_bytes_to_temp_file(file, audio_format)
             api_key = credentials["dashscope_api_key"]
 
-            if os.getenv(_SUBPROCESS_ENV):
+            if _is_subprocess_enabled():
                 headers = dict(BURY_POINT_HEADER) if BURY_POINT_HEADER else {}
                 status, data = _run_recognition_in_subprocess(
                     file_path,

--- a/models/tongyi/models/speech2text/speech2text.py
+++ b/models/tongyi/models/speech2text/speech2text.py
@@ -81,13 +81,13 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
                 base_address=ws_base_address,
             )
             sentence_list = result.get_sentence()
-            if sentence_list is None:
+            if not sentence_list:
                 return ""
-            else:
-                sentence_ans = []
-                for sentence in sentence_list:
-                    sentence_ans.append(sentence["text"])
-                return "\n".join(sentence_ans)
+            sentence_ans = [
+                sentence.get("text", "") if isinstance(sentence, dict) else str(sentence)
+                for sentence in sentence_list
+            ]
+            return "\n".join(sentence_ans)
         except Exception as ex:
             raise ValueError(f"[TongyiSpeech2TextModel] {ex}") from ex
         finally:

--- a/models/tongyi/models/speech2text/speech2text.py
+++ b/models/tongyi/models/speech2text/speech2text.py
@@ -1,7 +1,11 @@
+import json
 import os
+import subprocess
+import sys
 import tempfile
 import uuid
-from typing import IO, Optional
+from pathlib import Path
+from typing import IO, Any, Optional, Tuple
 
 from dashscope.audio.asr import Recognition
 from dify_plugin import OAICompatSpeech2TextModel
@@ -38,6 +42,84 @@ _AUDIO_FORMATS_FALLBACK = [
     "wma",
     "wmv",
 ]
+_WORKER_SCRIPT_PATH = str(Path(__file__).resolve().parent / "_stt_worker.py")
+_SUBPROCESS_ENV = "TONGYI_STT_SUBPROCESS"
+_RECOGNITION_TIMEOUT_ENV = "TONGYI_STT_RECOGNITION_TIMEOUT"
+_DEFAULT_RECOGNITION_TIMEOUT = 120
+
+
+def _get_recognition_timeout() -> int:
+    value = os.getenv(_RECOGNITION_TIMEOUT_ENV)
+    if not value:
+        return _DEFAULT_RECOGNITION_TIMEOUT
+    try:
+        seconds = int(value)
+    except (TypeError, ValueError):
+        return _DEFAULT_RECOGNITION_TIMEOUT
+    return seconds if seconds > 0 else _DEFAULT_RECOGNITION_TIMEOUT
+
+
+def _run_recognition_in_subprocess(
+    file_path: str,
+    model: str,
+    audio_format: str,
+    sample_rate: int,
+    api_key: str,
+    base_address: Optional[str],
+    headers: dict,
+    timeout: Optional[int] = None,
+) -> Tuple[str, Any]:
+    if timeout is None:
+        timeout = _get_recognition_timeout()
+
+    args_json = json.dumps(
+        {
+            "file_path": file_path,
+            "model": model,
+            "audio_format": audio_format,
+            "sample_rate": sample_rate,
+            "api_key": api_key,
+            "base_address": base_address,
+            "headers": headers or {},
+        }
+    )
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, _WORKER_SCRIPT_PATH],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception as ex:
+        return ("err", f"spawn worker: {ex}")
+
+    try:
+        out, err = proc.communicate(input=args_json.encode(), timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.communicate(timeout=5)
+        except Exception:
+            pass
+        return ("err", "speech recognition timed out")
+    except Exception as ex:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        return ("err", f"communicate: {ex}")
+
+    if proc.returncode != 0:
+        err_tail = (err.decode("utf-8", errors="replace") or out.decode("utf-8", errors="replace"))[
+            -500:
+        ]
+        return ("err", f"worker exit {proc.returncode}: {err_tail}")
+
+    try:
+        result = json.loads(out.decode("utf-8").strip() or "{}")
+    except Exception as ex:
+        return ("err", f"parse result: {ex}; out={out[:200]!r}")
+    return (result.get("status", "err"), result.get("data"))
 
 
 class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
@@ -68,19 +150,37 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
             sample_rate = audio.frame_rate
             file.seek(0)
             file_path = self.write_bytes_to_temp_file(file, audio_format)
-            recognition = Recognition(
-                model=str(model),
-                format=str(audio_format),
-                sample_rate=int(sample_rate),
-                callback=None,
-            )
-            result = recognition.call(
-                file=file_path,
-                headers=BURY_POINT_HEADER,
-                api_key=credentials["dashscope_api_key"],
-                base_address=ws_base_address,
-            )
-            sentence_list = result.get_sentence()
+            api_key = credentials["dashscope_api_key"]
+
+            if os.getenv(_SUBPROCESS_ENV):
+                headers = dict(BURY_POINT_HEADER) if BURY_POINT_HEADER else {}
+                status, data = _run_recognition_in_subprocess(
+                    file_path,
+                    str(model),
+                    audio_format,
+                    int(sample_rate),
+                    api_key,
+                    ws_base_address,
+                    headers,
+                )
+                if status == "err":
+                    raise ValueError(data)
+                sentence_list = data
+            else:
+                recognition = Recognition(
+                    model=str(model),
+                    format=str(audio_format),
+                    sample_rate=int(sample_rate),
+                    callback=None,
+                )
+                result = recognition.call(
+                    file=file_path,
+                    headers=BURY_POINT_HEADER,
+                    api_key=api_key,
+                    base_address=ws_base_address,
+                )
+                sentence_list = result.get_sentence()
+
             if not sentence_list:
                 return ""
             sentence_ans = [

--- a/models/tongyi/models/speech2text/speech2text.py
+++ b/models/tongyi/models/speech2text/speech2text.py
@@ -170,7 +170,7 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
                     headers,
                 )
                 if status == "err":
-                    raise ValueError(data)
+                    raise ValueError(data or "Unknown error in STT worker subprocess")
                 sentence_list = data
             else:
                 recognition = Recognition(

--- a/models/tongyi/tests/test_speech2text.py
+++ b/models/tongyi/tests/test_speech2text.py
@@ -63,3 +63,23 @@ def test_invoke_reuses_detected_audio_format_for_decoding() -> None:
 
     decode_mock.assert_called_once()
     assert decode_mock.call_args.kwargs["format"] == "wav"
+
+
+def test_invoke_normalizes_non_dict_sentences() -> None:
+    file_obj = _named_bytes(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 16, "upload.wav")
+    audio = MagicMock(frame_rate=16000)
+    result = MagicMock()
+    result.get_sentence.return_value = ["hello", {"text": "world"}]
+    recognition = MagicMock()
+    recognition.call.return_value = result
+
+    with patch("models.speech2text.speech2text.AudioSegment.from_file", return_value=audio):
+        with patch("models.speech2text.speech2text.Recognition", return_value=recognition):
+            assert (
+                _model()._invoke(
+                    model="paraformer-realtime-v1",
+                    credentials={"dashscope_api_key": "test-key"},
+                    file=file_obj,
+                )
+                == "hello\nworld"
+            )

--- a/models/tongyi/tests/test_speech2text.py
+++ b/models/tongyi/tests/test_speech2text.py
@@ -18,6 +18,10 @@ def _named_bytes(data: bytes, name: str) -> BytesIO:
     return file_obj
 
 
+def _wav_file() -> BytesIO:
+    return _named_bytes(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 16, "audio.wav")
+
+
 def test_get_audio_type_prefers_magic_bytes_without_decoding() -> None:
     file_obj = _named_bytes(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 16, "temp.mp3")
     file_obj.seek(5)
@@ -83,3 +87,68 @@ def test_invoke_normalizes_non_dict_sentences() -> None:
                 )
                 == "hello\nworld"
             )
+
+
+def test_invoke_uses_subprocess_when_env_set() -> None:
+    from models.speech2text import speech2text as st2
+
+    audio = MagicMock(frame_rate=16000)
+    with patch.dict(os.environ, {"TONGYI_STT_SUBPROCESS": "1"}):
+        with patch("models.speech2text.speech2text.AudioSegment.from_file", return_value=audio):
+            with patch(
+                "models.speech2text.speech2text._run_recognition_in_subprocess",
+                return_value=("ok", [{"text": "hello"}, {"text": "world"}]),
+            ) as run_mock:
+                result = _model()._invoke(
+                    model="paraformer-realtime-v1",
+                    credentials={"dashscope_api_key": "test-key"},
+                    file=_wav_file(),
+                )
+
+    assert result == "hello\nworld"
+    run_mock.assert_called_once()
+    _, _, audio_format, sample_rate, api_key, _, headers = run_mock.call_args.args
+    assert audio_format == "wav"
+    assert sample_rate == 16000
+    assert api_key == "test-key"
+    assert headers == dict(st2.BURY_POINT_HEADER)
+    assert headers is not st2.BURY_POINT_HEADER
+
+
+def test_invoke_raises_when_subprocess_returns_error() -> None:
+    audio = MagicMock(frame_rate=16000)
+    with patch.dict(os.environ, {"TONGYI_STT_SUBPROCESS": "1"}):
+        with patch("models.speech2text.speech2text.AudioSegment.from_file", return_value=audio):
+            with patch(
+                "models.speech2text.speech2text._run_recognition_in_subprocess",
+                return_value=("err", "recognition timeout"),
+            ):
+                try:
+                    _model()._invoke(
+                        model="paraformer-realtime-v1",
+                        credentials={"dashscope_api_key": "test-key"},
+                        file=_wav_file(),
+                    )
+                except ValueError as exc:
+                    assert "recognition timeout" in str(exc)
+                else:
+                    raise AssertionError("expected subprocess error to raise ValueError")
+
+
+def test_run_recognition_in_subprocess_returns_error_for_missing_file() -> None:
+    from models.speech2text import speech2text as st2
+
+    status, data = st2._run_recognition_in_subprocess(
+        file_path="/missing/audio.wav",
+        model="paraformer-realtime-v1",
+        audio_format="wav",
+        sample_rate=16000,
+        api_key="test-key",
+        base_address=None,
+        headers={},
+        timeout=30,
+    )
+
+    assert status == "err"
+    assert isinstance(data, str)
+    assert data

--- a/models/tongyi/tests/test_speech2text.py
+++ b/models/tongyi/tests/test_speech2text.py
@@ -1,6 +1,7 @@
+import json
 import os
 import sys
-from io import BytesIO
+from io import BytesIO, StringIO
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -20,6 +21,30 @@ def _named_bytes(data: bytes, name: str) -> BytesIO:
 
 def _wav_file() -> BytesIO:
     return _named_bytes(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 16, "audio.wav")
+
+
+def _run_worker_main(monkeypatch, payload: dict) -> tuple[int, str, str]:
+    from models.speech2text import _stt_worker
+
+    stdout = StringIO()
+    stderr = StringIO()
+    monkeypatch.setattr(sys, "stdin", StringIO(json.dumps(payload)))
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    return _stt_worker.main(), stdout.getvalue(), stderr.getvalue()
+
+
+def _worker_payload() -> dict:
+    return {
+        "file_path": "/tmp/audio.wav",
+        "model": "paraformer-realtime-v1",
+        "audio_format": "wav",
+        "sample_rate": 16000,
+        "api_key": "test-key",
+        "base_address": None,
+        "headers": {},
+    }
 
 
 def test_get_audio_type_prefers_magic_bytes_without_decoding() -> None:
@@ -176,3 +201,58 @@ def test_run_recognition_in_subprocess_returns_error_for_missing_file() -> None:
     assert status == "err"
     assert isinstance(data, str)
     assert data
+
+
+def test_worker_keeps_library_stdout_out_of_json(monkeypatch) -> None:
+    import dashscope.audio.asr as asr
+
+    class FakeResult:
+        status_code = 200
+
+        def get_sentence(self):
+            return [{"text": "hello"}]
+
+    class FakeRecognition:
+        def __init__(self, **kwargs):
+            pass
+
+        def call(self, **kwargs):
+            print("dashscope library log")
+            return FakeResult()
+
+    monkeypatch.setattr(asr, "Recognition", FakeRecognition)
+
+    exit_code, stdout, stderr = _run_worker_main(monkeypatch, _worker_payload())
+
+    assert exit_code == 0
+    assert json.loads(stdout) == {"status": "ok", "data": [{"text": "hello"}]}
+    assert "dashscope library log" not in stdout
+    assert "dashscope library log" in stderr
+
+
+def test_worker_returns_dashscope_status_error(monkeypatch) -> None:
+    import dashscope.audio.asr as asr
+
+    class FakeResult:
+        status_code = 400
+        message = "invalid audio"
+
+        def get_sentence(self):
+            raise AssertionError("API errors should be returned before reading sentences")
+
+    class FakeRecognition:
+        def __init__(self, **kwargs):
+            pass
+
+        def call(self, **kwargs):
+            return FakeResult()
+
+    monkeypatch.setattr(asr, "Recognition", FakeRecognition)
+
+    exit_code, stdout, stderr = _run_worker_main(monkeypatch, _worker_payload())
+    data = json.loads(stdout)
+
+    assert exit_code == 0
+    assert data["status"] == "err"
+    assert "DashScope error: invalid audio (400)" == data["data"]
+    assert stderr == ""

--- a/models/tongyi/tests/test_speech2text.py
+++ b/models/tongyi/tests/test_speech2text.py
@@ -115,6 +115,30 @@ def test_invoke_uses_subprocess_when_env_set() -> None:
     assert headers is not st2.BURY_POINT_HEADER
 
 
+def test_invoke_does_not_use_subprocess_when_env_is_zero() -> None:
+    audio = MagicMock(frame_rate=16000)
+    result = MagicMock()
+    result.get_sentence.return_value = [{"text": "hello"}]
+    recognition = MagicMock()
+    recognition.call.return_value = result
+
+    with patch.dict(os.environ, {"TONGYI_STT_SUBPROCESS": "0"}):
+        with patch("models.speech2text.speech2text.AudioSegment.from_file", return_value=audio):
+            with patch("models.speech2text.speech2text.Recognition", return_value=recognition):
+                with patch(
+                    "models.speech2text.speech2text._run_recognition_in_subprocess",
+                    side_effect=AssertionError("subprocess path should stay disabled"),
+                ) as run_mock:
+                    result_text = _model()._invoke(
+                        model="paraformer-realtime-v1",
+                        credentials={"dashscope_api_key": "test-key"},
+                        file=_wav_file(),
+                    )
+
+    assert result_text == "hello"
+    run_mock.assert_not_called()
+
+
 def test_invoke_raises_when_subprocess_returns_error() -> None:
     audio = MagicMock(frame_rate=16000)
     with patch.dict(os.environ, {"TONGYI_STT_SUBPROCESS": "1"}):


### PR DESCRIPTION
## Summary

Improve Tongyi STT robustness by isolating DashScope `Recognition.call()` behind an optional subprocess path. This gives the plugin a bounded worker process for recognition calls and adds safer sentence normalization.

Notes:
- The subprocess path is currently opt-in via `TONGYI_STT_SUBPROCESS=1|true|yes|on`.
- `TONGYI_STT_SUBPROCESS=0` stays disabled.
- Recognition timeout can be configured with `TONGYI_STT_RECOGNITION_TIMEOUT` and defaults to 120 seconds.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (speech2text recognition runtime isolation)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`)

## Testing

- [x] `cd models/tongyi && uv run --python /Users/zeninexu/.local/bin/python3.12 pytest tests/test_speech2text.py -q` — 8 passed
- [x] Packaged a clean `git archive HEAD:models/tongyi` source with Dify Plugin CLI 0.6.0 and confirmed `_stt_worker.py` is included in the package
- [x] Local PluginRunner smoke test verified the plugin can spawn the STT worker subprocess and communicate via stdin/stdout
- [ ] Local deployment — Dify version: not tested
- [ ] SaaS (cloud.dify.ai)
