### PR TITLE
chore: Update OpenRouter model list

### DIFF
--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -26,5 +26,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.0.50
+version: 0.0.51
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/openrouter/models/llm/_position.yaml
+++ b/models/openrouter/models/llm/_position.yaml
@@ -41,7 +41,11 @@
 - mistralai/mixtral-8x22b-instruct
 - qwen/qwen-2.5-72b-instruct
 - qwen/qwen3-max
+- qwen/qwen3.6-max-preview
 - qwen/qwen3.6-plus
+- qwen/qwen3.6-flash
+- qwen/qwen3.6-35b-a3b
+- qwen/qwen3.6-27b
 - deepseek/deepseek-v4-pro
 - deepseek/deepseek-v4-flash
 - deepseek/deepseek-chat

--- a/models/openrouter/models/llm/deepseek-v4-flash.yaml
+++ b/models/openrouter/models/llm/deepseek-v4-flash.yaml
@@ -4,7 +4,6 @@ label:
 model_type: llm
 features:
   - agent-thought
-  - vision
   - multi-tool-call
   - stream-tool-call
 model_properties:

--- a/models/openrouter/models/llm/deepseek-v4-pro.yaml
+++ b/models/openrouter/models/llm/deepseek-v4-pro.yaml
@@ -4,7 +4,6 @@ label:
 model_type: llm
 features:
   - agent-thought
-  - vision
   - multi-tool-call
   - stream-tool-call
 model_properties:

--- a/models/openrouter/models/llm/qwen3.6-27b.yaml
+++ b/models/openrouter/models/llm/qwen3.6-27b.yaml
@@ -1,6 +1,6 @@
-model: qwen/qwen3.6-plus
+model: qwen/qwen3.6-27b
 label:
-  en_US: qwen3.6-plus
+  en_US: qwen3.6-27b
 model_type: llm
 features:
   - agent-thought
@@ -11,7 +11,7 @@ features:
   - video
 model_properties:
   mode: chat
-  context_size: 1000000
+  context_size: 262144
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -21,7 +21,20 @@ parameter_rules:
     use_template: max_tokens
     default: 4096
     min: 1
-    max: 65536
+    max: 81920
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: frequency_penalty
+    use_template: frequency_penalty
+    min: -2.0
+    max: 2.0
   - name: response_format
     label:
       zh_Hans: 回复格式
@@ -58,7 +71,7 @@ parameter_rules:
       en_US: Whether to hide the thought process.
     required: false
 pricing:
-  input: "0.325"
-  output: "1.95"
+  input: "0.32"
+  output: "3.2"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/qwen3.6-27b.yaml
+++ b/models/openrouter/models/llm/qwen3.6-27b.yaml
@@ -21,7 +21,7 @@ parameter_rules:
     use_template: max_tokens
     default: 4096
     min: 1
-    max: 81920
+    max: 65536
   - name: top_k
     label:
       zh_Hans: 取样数量

--- a/models/openrouter/models/llm/qwen3.6-35b-a3b.yaml
+++ b/models/openrouter/models/llm/qwen3.6-35b-a3b.yaml
@@ -15,21 +15,18 @@ model_properties:
 parameter_rules:
   - name: temperature
     use_template: temperature
-    default: 1
   - name: top_p
     use_template: top_p
-    default: 0.95
   - name: max_tokens
     use_template: max_tokens
     default: 4096
     min: 1
-    max: 262144
+    max: 65536
   - name: top_k
     label:
       zh_Hans: 取样数量
       en_US: Top k
     type: int
-    default: 20
     help:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.

--- a/models/openrouter/models/llm/qwen3.6-35b-a3b.yaml
+++ b/models/openrouter/models/llm/qwen3.6-35b-a3b.yaml
@@ -1,6 +1,6 @@
-model: qwen/qwen3.6-plus
+model: qwen/qwen3.6-35b-a3b
 label:
-  en_US: qwen3.6-plus
+  en_US: qwen3.6-35b-a3b
 model_type: llm
 features:
   - agent-thought
@@ -11,17 +11,33 @@ features:
   - video
 model_properties:
   mode: chat
-  context_size: 1000000
+  context_size: 262144
 parameter_rules:
   - name: temperature
     use_template: temperature
+    default: 1
   - name: top_p
     use_template: top_p
+    default: 0.95
   - name: max_tokens
     use_template: max_tokens
     default: 4096
     min: 1
-    max: 65536
+    max: 262144
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    default: 20
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: frequency_penalty
+    use_template: frequency_penalty
+    min: -2.0
+    max: 2.0
   - name: response_format
     label:
       zh_Hans: 回复格式
@@ -58,7 +74,7 @@ parameter_rules:
       en_US: Whether to hide the thought process.
     required: false
 pricing:
-  input: "0.325"
-  output: "1.95"
+  input: "0.15"
+  output: "1"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/qwen3.6-flash.yaml
+++ b/models/openrouter/models/llm/qwen3.6-flash.yaml
@@ -1,6 +1,6 @@
-model: qwen/qwen3.6-plus
+model: qwen/qwen3.6-flash
 label:
-  en_US: qwen3.6-plus
+  en_US: qwen3.6-flash
 model_type: llm
 features:
   - agent-thought
@@ -58,7 +58,7 @@ parameter_rules:
       en_US: Whether to hide the thought process.
     required: false
 pricing:
-  input: "0.325"
-  output: "1.95"
+  input: "0.25"
+  output: "1.5"
   unit: "0.000001"
   currency: USD

--- a/models/openrouter/models/llm/qwen3.6-max-preview.yaml
+++ b/models/openrouter/models/llm/qwen3.6-max-preview.yaml
@@ -1,17 +1,15 @@
-model: qwen/qwen3.6-plus
+model: qwen/qwen3.6-max-preview
 label:
-  en_US: qwen3.6-plus
+  en_US: qwen3.6-max-preview
 model_type: llm
 features:
   - agent-thought
   - tool-call
   - multi-tool-call
   - stream-tool-call
-  - vision
-  - video
 model_properties:
   mode: chat
-  context_size: 1000000
+  context_size: 262144
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -58,7 +56,7 @@ parameter_rules:
       en_US: Whether to hide the thought process.
     required: false
 pricing:
-  input: "0.325"
-  output: "1.95"
+  input: "1.04"
+  output: "6.24"
   unit: "0.000001"
   currency: USD


### PR DESCRIPTION
## Summary

- Add the current OpenRouter Qwen 3.6 models from the OpenRouter model list: qwen3.6-flash, qwen3.6-35b-a3b, qwen3.6-max-preview, and qwen3.6-27b.
- Update qwen3.6-plus pricing/capabilities and add JSON schema support.
- Remove vision support from DeepSeek V4 Pro and Flash because OpenRouter currently reports them as text-only, which prevents image inputs from being routed to unsupported endpoints.
- Bump the OpenRouter plugin version to 0.0.51.

## Validation

- `python` YAML/model-position validation for listed OpenRouter LLM entries.
- `uv run pytest tests/test_endpoint_url_config.py -q`
- `git diff --check`