### PR TITLE
feat(mimo): add Token Plan subscription support

### DIFF
--- a/models/mimo/manifest.yaml
+++ b/models/mimo/manifest.yaml
@@ -1,8 +1,8 @@
 author: langgenius
 created_at: '2025-12-17T14:56:23.054168583+08:00'
 description:
-  en_US: Models provided by Xiaomi MiMo, such as mimo-v2.5-pro, mimo-v2.5, mimo-v2-flash.
-  zh_Hans: Xiaomi MiMo 提供的模型，例如 mimo-v2.5-pro、mimo-v2.5、mimo-v2-flash。
+  en_US: Models provided by Xiaomi MiMo, such as mimo-v2.5-pro, mimo-v2.5, mimo-v2-flash. Supports Token Plan subscription.
+  zh_Hans: Xiaomi MiMo 提供的模型，例如 mimo-v2.5-pro、mimo-v2.5、mimo-v2-flash。支持 Token Plan 订阅计划。
 icon: icon_s_en.png
 label:
   en_US: Xiaomi MiMo
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/mimo/models/llm/llm.py
+++ b/models/mimo/models/llm/llm.py
@@ -30,5 +30,6 @@ class MimoLargeLanguageModel(OAICompatLargeLanguageModel):
 
     @staticmethod
     def _add_custom_parameters(credentials: dict) -> None:
-        credentials.setdefault("endpoint_url", "https://api.xiaomimimo.com/v1")
+        if not credentials.get("endpoint_url"):
+            credentials["endpoint_url"] = "https://api.xiaomimimo.com/v1"
         credentials["mode"] = LLMMode.CHAT.value

--- a/models/mimo/models/llm/llm.py
+++ b/models/mimo/models/llm/llm.py
@@ -30,5 +30,5 @@ class MimoLargeLanguageModel(OAICompatLargeLanguageModel):
 
     @staticmethod
     def _add_custom_parameters(credentials: dict) -> None:
-        credentials["endpoint_url"] = "https://api.xiaomimimo.com/v1"
+        credentials.setdefault("endpoint_url", "https://api.xiaomimimo.com/v1")
         credentials["mode"] = LLMMode.CHAT.value

--- a/models/mimo/provider/mimo.yaml
+++ b/models/mimo/provider/mimo.yaml
@@ -2,8 +2,8 @@ background: '#faf7f5'
 configurate_methods:
 - predefined-model
 description:
-  en_US: Models provided by Xiaomi MiMo, such as mimo-v2.5-pro, mimo-v2.5, mimo-v2-flash.
-  zh_Hans: Xiaomi MiMo 提供的模型，例如 mimo-v2.5-pro、mimo-v2.5、mimo-v2-flash。
+  en_US: Models provided by Xiaomi MiMo, such as mimo-v2.5-pro, mimo-v2.5, mimo-v2-flash. Supports Token Plan subscription.
+  zh_Hans: Xiaomi MiMo 提供的模型，例如 mimo-v2.5-pro、mimo-v2.5、mimo-v2-flash。支持 Token Plan 订阅计划。
 extra:
   python:
     model_sources:
@@ -33,20 +33,37 @@ provider_credential_schema:
   - label:
       en_US: API Key
     placeholder:
-      en_US: Enter your API Key
-      zh_Hans: 在此输入您的 API Key
+      en_US: Enter your API Key (sk-xxx for pay-per-use, tp-xxx for Token Plan)
+      zh_Hans: 输入 API Key（按量付费 sk-xxx，Token Plan 订阅 tp-xxx）
     required: true
     type: secret-input
     variable: api_key
   - label:
-      en_US: Custom API endpoint URL
-      zh_Hans: 自定义 API endpoint 地址
+      en_US: API Endpoint
+      zh_Hans: API 接入地址
     placeholder:
-      en_US: Base URL, e.g. https://api.xiaomimimo.com/v1
-      zh_Hans: Base URL, e.g. https://api.xiaomimimo.com/v1
+      en_US: Select or enter Base URL
+      zh_Hans: 选择或输入 Base URL
     required: false
-    type: text-input
-    default: "https://api.xiaomimimo.com/v1"
+    type: select
+    default: https://api.xiaomimimo.com/v1
+    options:
+    - value: https://api.xiaomimimo.com/v1
+      label:
+        en_US: Default (Pay-per-use)
+        zh_Hans: 默认（按量付费）
+    - value: https://token-plan-cn.xiaomimimo.com/v1
+      label:
+        en_US: Token Plan - China
+        zh_Hans: Token Plan - 中国集群
+    - value: https://token-plan-sgp.xiaomimimo.com/v1
+      label:
+        en_US: Token Plan - Singapore
+        zh_Hans: Token Plan - 新加坡集群
+    - value: https://token-plan-ams.xiaomimimo.com/v1
+      label:
+        en_US: Token Plan - Europe
+        zh_Hans: Token Plan - 欧洲集群
     variable: endpoint_url
 supported_model_types:
 - llm


### PR DESCRIPTION
## Summary

Add Xiaomi MiMo Token Plan subscription support. Users can now select Token Plan cluster endpoints directly from a dropdown instead of manually entering URLs.

- Change `endpoint_url` from hardcoded `credentials["endpoint_url"] = ...` to `credentials.setdefault()`, allowing user-configured Token Plan URLs to take effect
- Replace `text-input` with `select` dropdown for endpoint selection, providing 4 options:
  - Default (Pay-per-use): `https://api.xiaomimimo.com/v1`
  - Token Plan - China: `https://token-plan-cn.xiaomimimo.com/v1`
  - Token Plan - Singapore: `https://token-plan-sgp.xiaomimimo.com/v1`
  - Token Plan - Europe: `https://token-plan-ams.xiaomimimo.com/v1`
- Update API Key placeholder to indicate `sk-xxx` (pay-per-use) vs `tp-xxx` (Token Plan)

Ref: https://platform.xiaomimimo.com/docs/zh-CN/tokenplan/quick-access

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| text-input field for endpoint URL, hardcoded override in code | Select dropdown with 4 endpoint options (Default + 3 Token Plan clusters) |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

## Testing

- [x] Local deployment — Dify version: 1.x
- [ ] SaaS (cloud.dify.ai)