### PR TITLE
feat(siliconflow): deprecate legacy models and add Qwen3.6-27B

### DIFF
--- a/models/siliconflow/manifest.yaml
+++ b/models/siliconflow/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.52
+version: 0.0.53
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/siliconflow/models/llm/_position.yaml
+++ b/models/siliconflow/models/llm/_position.yaml
@@ -24,6 +24,7 @@
 - deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
 - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
 - deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+- Qwen/Qwen3.6-27B
 - Qwen/Qwen3.6-35B-A3B
 - Qwen/Qwen3.5-397B-A17B
 - Qwen/Qwen3.5-122B-A10B

--- a/models/siliconflow/models/llm/glm-41v-9b-thinking.yaml
+++ b/models/siliconflow/models/llm/glm-41v-9b-thinking.yaml
@@ -48,7 +48,8 @@ parameter_rules:
     options:
       - text
 pricing:
-  input: '0'
-  output: '0'
-  unit: '0'
+  input: "0"
+  output: "0"
+  unit: "0"
   currency: RMB
+deprecated: true

--- a/models/siliconflow/models/llm/glm46.yaml
+++ b/models/siliconflow/models/llm/glm46.yaml
@@ -70,7 +70,8 @@ parameter_rules:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
 pricing:
-  input: '3.5'
-  output: '14'
-  unit: '0.000001'
+  input: "3.5"
+  output: "14"
+  unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/models/siliconflow/models/llm/glm46v.yaml
+++ b/models/siliconflow/models/llm/glm46v.yaml
@@ -71,7 +71,8 @@ parameter_rules:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
 pricing:
-  input: '1'
-  output: '3'
-  unit: '0.000001'
+  input: "1"
+  output: "3"
+  unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/models/siliconflow/models/llm/kimi-k2-instruct-pro.yaml
+++ b/models/siliconflow/models/llm/kimi-k2-instruct-pro.yaml
@@ -33,3 +33,4 @@ pricing:
   output: "16"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/models/siliconflow/models/llm/kimi-k2-instruct.yaml
+++ b/models/siliconflow/models/llm/kimi-k2-instruct.yaml
@@ -33,3 +33,4 @@ pricing:
   output: "16"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/models/siliconflow/models/llm/kimi-k2-thinking-pro.yaml
+++ b/models/siliconflow/models/llm/kimi-k2-thinking-pro.yaml
@@ -48,3 +48,4 @@ pricing:
   output: "16"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/models/siliconflow/models/llm/kimi-k2-thinking.yaml
+++ b/models/siliconflow/models/llm/kimi-k2-thinking.yaml
@@ -48,3 +48,4 @@ pricing:
   output: "16"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/models/siliconflow/models/llm/qwen2.5-14b-instruct.yaml
+++ b/models/siliconflow/models/llm/qwen2.5-14b-instruct.yaml
@@ -45,7 +45,8 @@ parameter_rules:
       - text
       - json_object
 pricing:
-  input: '0.7'
-  output: '0.7'
-  unit: '0.000001'
+  input: "0.7"
+  output: "0.7"
+  unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/models/siliconflow/models/llm/qwen3.6-27b.yaml
+++ b/models/siliconflow/models/llm/qwen3.6-27b.yaml
@@ -34,7 +34,7 @@ parameter_rules:
       zh_Hans: 是否开启思考模式。
       en_US: Whether to enable thinking mode.
 pricing:
-  input: "0.4"
-  output: "3.2"
+  input: "0.6"
+  output: "4.8"
   unit: "0.000001"
   currency: RMB

--- a/models/siliconflow/models/llm/qwen3.6-27b.yaml
+++ b/models/siliconflow/models/llm/qwen3.6-27b.yaml
@@ -1,6 +1,6 @@
-model: Qwen/Qwen3.6-27B
+model: Qwen/Qwen3.6-35B-A3B
 label:
-  en_US: Qwen/Qwen3.6-27B
+  en_US: Qwen/Qwen3.6-35B-A3B
 model_type: llm
 features:
   - agent-thought
@@ -34,7 +34,7 @@ parameter_rules:
       zh_Hans: 是否开启思考模式。
       en_US: Whether to enable thinking mode.
 pricing:
-  input: "0.6"
-  output: "4.8"
+  input: "0.4"
+  output: "3.2"
   unit: "0.000001"
   currency: RMB

--- a/models/siliconflow/models/llm/qwen3.6-27b.yaml
+++ b/models/siliconflow/models/llm/qwen3.6-27b.yaml
@@ -1,6 +1,6 @@
-model: Qwen/Qwen3.6-35B-A3B
+model: Qwen/Qwen3.6-27B
 label:
-  en_US: Qwen/Qwen3.6-35B-A3B
+  en_US: Qwen/Qwen3.6-27B
 model_type: llm
 features:
   - agent-thought

--- a/models/siliconflow/models/llm/qwen3.6-35b-a3b.yaml
+++ b/models/siliconflow/models/llm/qwen3.6-35b-a3b.yaml
@@ -1,6 +1,6 @@
-model: Qwen/Qwen3.6-27B
+model: Qwen/Qwen3.6-35B-A3B
 label:
-  en_US: Qwen/Qwen3.6-27B
+  en_US: Qwen/Qwen3.6-35B-A3B
 model_type: llm
 features:
   - agent-thought
@@ -34,7 +34,7 @@ parameter_rules:
       zh_Hans: 是否开启思考模式。
       en_US: Whether to enable thinking mode.
 pricing:
-  input: "0.6"
-  output: "4.8"
+  input: "0.4"
+  output: "3.2"
   unit: "0.000001"
   currency: RMB


### PR DESCRIPTION
Mark glm-41v-9b-thinking, glm46, glm46v, kimi-k2-instruct(-pro), kimi-k2-thinking(-pro), and qwen2.5-14b-instruct as deprecated. Replace Qwen3.6-35B-A3B with Qwen3.6-27B and update pricing.

According to the document: https://docs.siliconflow.cn/cn/release-notes/overview#2026-05-08

## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->



## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|    <img width="774" height="1162" alt="image" src="https://github.com/user-attachments/assets/3947d4dc-a5ad-4275-9267-1ceac69f4faf" />    |   <img width="802" height="1184" alt="image" src="https://github.com/user-attachments/assets/43955a48-ca65-40de-a07b-4ee61de53197" /> |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [x] SaaS (cloud.dify.ai)
