### PR TITLE
fix(anthropic): handle custom API URL headers

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.13
+version: 0.3.14

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -1099,7 +1099,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             credentials_kwargs["base_url"] = api_url.rstrip("/")
             # Spoof the User-Agent if using a third-party proxy (non-official API)
             if "api.anthropic.com" not in api_url:
-                kwargs["default_headers"] = {"User-Agent": "python-httpx"}
+                credentials_kwargs["default_headers"] = {"User-Agent": "python-httpx"}
 
         return credentials_kwargs
 


### PR DESCRIPTION
## Summary

- fix Anthropic credential kwargs construction for custom API URLs
- bump the Anthropic plugin version to 0.3.14

## Root Cause

When a custom `anthropic_api_url` is configured and it does not point to `api.anthropic.com`, the Anthropic provider tries to set `default_headers` on an undefined local variable named `kwargs`. This raises `NameError: name 'kwargs' is not defined` during credential validation before the client can be created.

The SDK accepts `default_headers` as part of `Anthropic(...)`, so the header should be added to the existing `credentials_kwargs` mapping that is passed into the client constructor.

## Validation

```bash
cd models/anthropic
uv run --python /opt/homebrew/bin/python3.12 python - <<'PY'
from models.llm.llm import AnthropicLargeLanguageModel

kwargs = AnthropicLargeLanguageModel()._to_credential_kwargs({
    "anthropic_api_key": "test-api-key",
    "anthropic_api_url": "https://litellm.example.com/",
})
assert kwargs["base_url"] == "https://litellm.example.com"
assert kwargs["default_headers"] == {"User-Agent": "python-httpx"}
print("custom API URL credential kwargs ok")
PY
```
