### PR TITLE
feat(openai_api_compatible): forward VIDEO/AUDIO/DOCUMENT content to upstream models

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.48
+version: 0.0.49
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -15,11 +15,17 @@ from dify_plugin.entities.model import (
 )
 from dify_plugin.entities.model.llm import LLMMode, LLMResult
 from dify_plugin.entities.model.message import (
+    AudioPromptMessageContent,
+    DocumentPromptMessageContent,
+    ImagePromptMessageContent,
     PromptMessage,
+    PromptMessageContentType,
     PromptMessageRole,
     PromptMessageTool,
     SystemPromptMessage,
     AssistantPromptMessage,
+    UserPromptMessage,
+    VideoPromptMessageContent,
 )
 from dify_plugin.errors.model import CredentialsValidateFailedError, InvokeError
 from dify_plugin.interfaces.model.openai_compatible.llm import OAICompatLargeLanguageModel
@@ -315,7 +321,18 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                     required=False,
                 )
             )
-        
+
+        # Register VIDEO/AUDIO/DOCUMENT features when the corresponding credential is enabled.
+        # Without these on entity.features, Dify host filters out non-image attachments
+        # before they reach _convert_prompt_message_to_dict, causing silent drop.
+        for credential_key, feature in (
+            ("video_support", ModelFeature.VIDEO),
+            ("audio_support", ModelFeature.AUDIO),
+            ("document_support", ModelFeature.DOCUMENT),
+        ):
+            if credentials.get(credential_key, "no_support") == "support" and feature not in entity.features:
+                entity.features.append(feature)
+
         return entity
 
     @classmethod
@@ -345,6 +362,66 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             # Only update if changed
             if new_content != p.content:
                 p.content = new_content
+
+    def _convert_prompt_message_to_dict(
+        self, message: PromptMessage, credentials: Optional[dict] = None
+    ) -> dict:
+        # The base SDK implementation only handles TEXT and IMAGE content for user
+        # messages, silently dropping VIDEO / AUDIO / DOCUMENT. Extend it so the same
+        # OpenAI-compatible request shape carries the additional modalities. The
+        # encoding follows what LiteLLM and OpenAI-compatible aggregators accept:
+        #   - VIDEO/AUDIO: image_url with a data URI (mime_type carried in the URI),
+        #     which providers like Vertex Gemini convert into inline_data.
+        #   - DOCUMENT: the OpenAI Files-compatible "file" part with file_data set
+        #     to the data URI.
+        if isinstance(message, UserPromptMessage) and isinstance(message.content, list):
+            sub_messages: list[dict] = []
+            for c in message.content:
+                if c.type == PromptMessageContentType.TEXT:
+                    sub_messages.append({"type": "text", "text": c.data})
+                elif c.type == PromptMessageContentType.IMAGE:
+                    image_c: ImagePromptMessageContent = c
+                    sub_messages.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": image_c.data,
+                                "detail": image_c.detail.value,
+                            },
+                        }
+                    )
+                elif c.type == PromptMessageContentType.VIDEO:
+                    video_c: VideoPromptMessageContent = c
+                    sub_messages.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": video_c.data},
+                        }
+                    )
+                elif c.type == PromptMessageContentType.AUDIO:
+                    audio_c: AudioPromptMessageContent = c
+                    sub_messages.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": audio_c.data},
+                        }
+                    )
+                elif c.type == PromptMessageContentType.DOCUMENT:
+                    doc_c: DocumentPromptMessageContent = c
+                    sub_messages.append(
+                        {
+                            "type": "file",
+                            "file": {
+                                "file_data": doc_c.data,
+                                "filename": doc_c.filename or "document",
+                            },
+                        }
+                    )
+            message_dict: dict = {"role": "user", "content": sub_messages}
+            if message.name:
+                message_dict["name"] = message.name
+            return message_dict
+        return super()._convert_prompt_message_to_dict(message, credentials)
 
     def _invoke(
         self,

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -345,9 +345,86 @@ model_credential_schema:
       label:
         zh_Hans: 视觉支持
         en_US: Vision Support
+        ja_JP: 画像入力対応
       type: select
       required: false
       default: no_support
+      help:
+        en_US: Whether the model can accept image input. Covers IMAGE content only; enable video_support / audio_support / document_support independently for other modalities.
+        zh_Hans: 模型是否支持图像输入。仅覆盖 IMAGE 类型内容；视频/音频/文档请分别启用对应的开关。
+        ja_JP: モデルが画像入力を受け付けるかどうか。IMAGE タイプのみを対象。動画・音声・文書はそれぞれ独立した設定で有効化してください。
+      options:
+        - value: support
+          label:
+            en_US: Support
+            zh_Hans: 支持
+        - value: no_support
+          label:
+            en_US: Not Support
+            zh_Hans: 不支持
+    - variable: video_support
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        zh_Hans: 视频支持
+        en_US: Video Support
+        ja_JP: 動画入力対応
+      type: select
+      required: false
+      default: no_support
+      help:
+        en_US: Whether the model can accept video input. Covers VIDEO content only; independent from vision_support.
+        zh_Hans: 模型是否支持视频输入。仅覆盖 VIDEO 类型内容；与视觉支持相互独立。
+        ja_JP: モデルが動画入力を受け付けるかどうか。VIDEO タイプのみを対象。画像入力対応とは独立した設定です。
+      options:
+        - value: support
+          label:
+            en_US: Support
+            zh_Hans: 支持
+        - value: no_support
+          label:
+            en_US: Not Support
+            zh_Hans: 不支持
+    - variable: audio_support
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        zh_Hans: 音频支持
+        en_US: Audio Support
+        ja_JP: 音声入力対応
+      type: select
+      required: false
+      default: no_support
+      help:
+        en_US: Whether the model can accept audio input. Covers AUDIO content only; independent from vision_support.
+        zh_Hans: 模型是否支持音频输入。仅覆盖 AUDIO 类型内容；与视觉支持相互独立。
+        ja_JP: モデルが音声入力を受け付けるかどうか。AUDIO タイプのみを対象。画像入力対応とは独立した設定です。
+      options:
+        - value: support
+          label:
+            en_US: Support
+            zh_Hans: 支持
+        - value: no_support
+          label:
+            en_US: Not Support
+            zh_Hans: 不支持
+    - variable: document_support
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        zh_Hans: 文档支持
+        en_US: Document Support
+        ja_JP: 文書入力対応
+      type: select
+      required: false
+      default: no_support
+      help:
+        en_US: Whether the model can accept document input such as PDF. Covers DOCUMENT content only; independent from vision_support.
+        zh_Hans: 模型是否支持文档输入（如 PDF）。仅覆盖 DOCUMENT 类型内容；与视觉支持相互独立。
+        ja_JP: モデルが PDF などの文書入力を受け付けるかどうか。DOCUMENT タイプのみを対象。画像入力対応とは独立した設定です。
       options:
         - value: support
           label:


### PR DESCRIPTION
## Related Issues or Context

Resolves #3089.
Supersedes the partial attempt in #2806 (which only touched README and the provider YAML without changing the message-conversion path). Also addresses the long-standing requests #2127, #2807 and #2160.

## This PR contains Changes to *LLM Models Plugin*

- [x] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)

### What changed

1. `provider/openai_api_compatible.yaml`
   - Adds three new credentials `video_support`, `audio_support`, `document_support` (same shape as `vision_support`, default `no_support`).
   - Adds `help:` text to all four `*_support` credentials clarifying that each one covers a single `PromptMessageContentType` and they are independent. This avoids confusion with the LLM node's "Vision" toggle in Dify host which gates all multimodal types collectively.
   - Adds `ja_JP` label / help entries to the four `*_support` credentials.

2. `models/llm/llm.py`
   - In `get_customizable_model_schema`, registers `ModelFeature.VIDEO/AUDIO/DOCUMENT` when the corresponding credential is `support`. Without this, Dify host strips the corresponding file types from `sys.files` before they reach the plugin.
   - Overrides `_convert_prompt_message_to_dict` to extend the SDK's TEXT/IMAGE-only branches with:
     - `VIDEO` → `image_url` part with a `data:video/<mime>;base64,...` data URI.
     - `AUDIO` → `image_url` part with a `data:audio/<mime>;base64,...` data URI.
     - `DOCUMENT` → OpenAI Files-compatible `file` part with `file_data` set to the data URI.

   The `image_url`-with-data-URI shape is what LiteLLM dispatches into Vertex Gemini's `inline_data` for non-image modalities, so the same plugin works for image / video / audio without provider-specific code. `input_audio` and `video_url` types were tested and silently dropped by LiteLLM's Gemini route, so they are not used.

3. `manifest.yaml`
   - Version bump 0.0.27 → 0.1.0 (MINOR, backwards-compatible feature addition).

### Backwards compatibility

All new credentials default to `no_support`. Existing deployments continue to behave exactly as before; only users who explicitly enable the new credentials see additional `ModelFeature` flags on their model entity. The override of `_convert_prompt_message_to_dict` only changes behaviour for `UserPromptMessage` content lists that contain VIDEO/AUDIO/DOCUMENT entries — anything else delegates to `super()`.

## Version Control

- [x] I have Bumped Up the Version in Manifest.yaml (0.0.27 → 0.1.0)

## Dify Plugin SDK Version

- [x] `requirements.txt` already pins `dify_plugin==0.7.0`, which is the first release that ships `VideoPromptMessageContent`, `AudioPromptMessageContent` and `ModelFeature.{VIDEO,AUDIO,DOCUMENT}`.

## Environment Verification

### Local Deployment Environment

- [x] Dify Version: 1.x (Self Hosted, Docker). Tested end-to-end against **Gemini 2.5 Flash** via a LiteLLM 1.83.14 proxy, on a Chatflow with the LLM node "Vision" toggle on:
  - **Image** (jpeg) → analysed correctly.
  - **Video** (mp4, ~7 MB) → analysed correctly.
  - **Audio** (mpeg) → analysed correctly.
  - **PDF** (5 pages) → analysed correctly.
  - Text-only chat → unchanged behaviour.

  Verified the outbound HTTP payload by inspecting LiteLLM Logs: each attachment lands in `messages[].content` as the expected `image_url` / `file` part with a `data:` URI.

### SaaS Environment

- [ ] Not tested on cloud.dify.ai for this change.
