### PR TITLE
fix(openai-compatible): support embedding encoding format

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.49
+version: 0.0.50
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/text_embedding/text_embedding.py
+++ b/models/openai_api_compatible/models/text_embedding/text_embedding.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Literal, Mapping, Optional, Union
+from typing import Mapping, Optional, Union
 import ipaddress
 import json
 import re
@@ -8,23 +8,38 @@ from urllib.parse import urlparse
 import requests
 import tiktoken
 
+from typing import Literal
+from typing import List, Union, Dict, Any
 from openai import OpenAI
 from openai._types import NOT_GIVEN, NotGiven
 from openai.types.chat import ChatCompletionMessageParam
 from openai.types.create_embedding_response import CreateEmbeddingResponse
 
-from dify_plugin.entities.model import AIModelEntity, EmbeddingInputType, I18nObject, ModelFeature
-from dify_plugin.entities.model.text_embedding import TextEmbeddingResult, EmbeddingUsage
+from dify_plugin.entities.model import (
+    AIModelEntity,
+    EmbeddingInputType,
+    I18nObject,
+    ModelFeature,
+)
+from dify_plugin.entities.model.text_embedding import (
+    TextEmbeddingResult,
+    EmbeddingUsage,
+)
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,
     InvokeError,
     InvokeServerUnavailableError,
 )
-from dify_plugin.interfaces.model.openai_compatible.text_embedding import OAICompatEmbeddingModel
-from dify_plugin.entities.model.text_embedding import MultiModalContentType
+from dify_plugin.interfaces.model.openai_compatible.text_embedding import (
+    OAICompatEmbeddingModel,
+)
+from dify_plugin.entities.model.text_embedding import (
+    MultiModalContent,
+    MultiModalContentType,
+)
+
 
 logger = logging.getLogger(__name__)
-
 
 def _get_encoding_format(credentials: Mapping[str, Any]) -> Literal["float"] | None:
     encoding_format = credentials.get("encoding_format")
@@ -32,14 +47,13 @@ def _get_encoding_format(credentials: Mapping[str, Any]) -> Literal["float"] | N
         return encoding_format
     return None
 
-
 def create_chat_embeddings(
     client: OpenAI,
     *,
-    # messages: list[ChatCompletionMessageParam],
+    #messages: list[ChatCompletionMessageParam],
     messages: List[ChatCompletionMessageParam],
     model: str,
-    # encoding_format: Literal["base64", "float"] | NotGiven = NOT_GIVEN,
+    #encoding_format: Literal["base64", "float"] | NotGiven = NOT_GIVEN,
     encoding_format: Union[Literal["base64", "float"], NotGiven] = NOT_GIVEN,
     continue_final_message: bool = False,
     add_special_tokens: bool = False,
@@ -59,7 +73,6 @@ def create_chat_embeddings(
             "add_special_tokens": add_special_tokens,
         },
     )
-
 
 class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
     def get_customizable_model_schema(
@@ -126,6 +139,10 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
         if prefix:
             processed_inputs = self._add_prefix_to_inputs(processed_inputs, prefix)
 
+        # Get context size and max chunks from credentials or model properties
+        context_size = self._get_context_size(model, credentials)
+        max_chunks = self._get_max_chunks(model, credentials)
+
         # Truncate long texts (similar to Tongyi's approach)
         inputs = []
         for input_data in processed_inputs:
@@ -136,16 +153,16 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                     if content.get("type") == "text":
                         text_parts.append(content.get("text", ""))
                     elif content.get("type") == "image_url":
-                        # text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
+                        #text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
                         text_parts.append(f"Image:{content.get('image_url', {}).get('url', '')}")
                 text = " ".join(text_parts) if text_parts else ""
             else:
                 text = input_data if isinstance(input_data, str) else str(input_data)
 
             # Check token count and truncate if necessary
-            # num_tokens = self._get_num_tokens_by_gpt2(text)
-            # if num_tokens >= context_size:
-            # Truncate to fit within context size
+            #num_tokens = self._get_num_tokens_by_gpt2(text)
+            #if num_tokens >= context_size:
+                # Truncate to fit within context size
             #    cutoff = int(len(text) * (context_size / num_tokens))
             #    text = text[0:cutoff]
 
@@ -210,7 +227,10 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 for i in range(0, len(text_inputs), max_chunks):
                     batch = text_inputs[i : i + max_chunks]
 
-                    payload: dict[str, Any] = {"model": endpoint_model_name, "input": batch}
+                    payload: dict[str, Any] = {
+                        "model": endpoint_model_name,
+                        "input": batch,
+                    }
 
                     if encoding_format:
                         payload["encoding_format"] = encoding_format
@@ -221,7 +241,10 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                     )
 
                     response = requests.post(
-                        f"{endpoint_url}/embeddings", headers=headers, json=payload, timeout=60
+                        f"{endpoint_url}/embeddings",
+                        headers=headers,
+                        json=payload,
+                        timeout=60,
                     )
 
                     if response.status_code != 200:
@@ -324,10 +347,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 response = create_chat_embeddings(
                     client,
                     messages=[
-                        {
-                            "role": "system",
-                            "content": [{"type": "text", "text": default_instruction}],
-                        },
+                        {"role": "system", "content": [{"type": "text", "text": default_instruction}]},
                         {"role": "user", "content": [{"type": "text", "text": prompt}]},
                         {"role": "assistant", "content": [{"type": "text", "text": ""}]},
                     ],
@@ -337,21 +357,15 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                     add_special_tokens=True,
                 )
             elif input_type == 1:
-                image_url = prompt[len("Image:") :]
+                image_url = prompt[len("Image:"):]
                 response = create_chat_embeddings(
                     client,
                     messages=[
-                        {
-                            "role": "system",
-                            "content": [{"type": "text", "text": default_instruction}],
-                        },
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "image_url", "image_url": {"url": image_url}},
-                                {"type": "text", "text": ""},
-                            ],
-                        },
+                        {"role": "system", "content": [{"type": "text", "text": default_instruction}]},
+                        {"role": "user", "content": [
+                            {"type": "image_url", "image_url": {"url": image_url}},
+                            {"type": "text", "text": ""},
+                        ]},
                         {"role": "assistant", "content": [{"type": "text", "text": ""}]},
                     ],
                     model=model,
@@ -364,24 +378,18 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 text_parts = []
                 for item in prompt_list:
                     if item.startswith("Image:"):
-                        image_url = item[len("Image:") :]
+                        image_url = item[len("Image:"):]
                     elif item:
                         text_parts.append(item)
                 text = " ".join(text_parts)
                 response = create_chat_embeddings(
                     client,
                     messages=[
-                        {
-                            "role": "system",
-                            "content": [{"type": "text", "text": default_instruction}],
-                        },
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "image_url", "image_url": {"url": image_url}},
-                                {"type": "text", "text": text},
-                            ],
-                        },
+                        {"role": "system", "content": [{"type": "text", "text": default_instruction}]},
+                        {"role": "user", "content": [
+                            {"type": "image_url", "image_url": {"url": image_url}},
+                            {"type": "text", "text": text},
+                        ]},
                         {"role": "assistant", "content": [{"type": "text", "text": ""}]},
                     ],
                     model=model,
@@ -402,7 +410,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
             if "currency" in usage:
                 currency = usage.get("currency", "USD")
 
-        return (batched_embeddings, used_tokens, total_price, unit_price, price_unit, currency)
+        return batched_embeddings, used_tokens, total_price, unit_price, price_unit, currency
 
     def _process_input(self, text: str, vision_enabled: bool) -> Union[str, list]:
         """
@@ -493,7 +501,40 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
             try:
                 ip = ipaddress.ip_address(hostname)
                 # Check if it's private, loopback, link-local, or reserved
-                if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                if (
+                    ip.is_private
+                    or ip.is_loopback
+                    or ip.is_link_local
+                    or ip.is_reserved
+                ):
+                    logger.warning(f"Blocked private IP URL: {url[:50]}...")
+                    return ""
+            except ValueError:
+                # Not an IP address, it's a hostname - allow it
+                pass
+
+            return url
+        except Exception as e:
+            logger.warning(f"URL validation failed: {e}")
+            return ""
+
+            # Block localhost
+            if hostname in ("localhost", "127.0.0.1", "::1"):
+                logger.warning(f"Blocked localhost URL: {url[:50]}...")
+                return ""
+
+            # Block private IP ranges
+            import ipaddress
+
+            try:
+                ip = ipaddress.ip_address(hostname)
+                # Check if it's private, loopback, link-local, or reserved
+                if (
+                    ip.is_private
+                    or ip.is_loopback
+                    or ip.is_link_local
+                    or ip.is_reserved
+                ):
                     logger.warning(f"Blocked private IP URL: {url[:50]}...")
                     return ""
             except ValueError:
@@ -588,10 +629,10 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 return "bmp"
             else:
                 # Default to jpeg if unknown
-                # return "jpeg"
+                #return "jpeg"
                 return ""
         except Exception:
-            # return "jpeg"
+            #return "jpeg"
             return ""
 
     def _contains_ip(self, text):
@@ -604,7 +645,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
         Returns:
             bool: True if a valid IP address is found, False otherwise
         """
-        ip_pattern = r"\b(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
+        ip_pattern = r'\b(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b'
 
         return bool(re.search(ip_pattern, text))
 
@@ -692,7 +733,9 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
             return len(encoding.encode(text))
         except Exception:
             # Fallback to character count or a default if tiktoken fails
-            return len(text) // 4  # Rough estimate if tiktoken is not available or fails
+            return (
+                len(text) // 4
+            )  # Rough estimate if tiktoken is not available or fails
 
     def _invoke_multimodal(
         self,
@@ -716,24 +759,30 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                     if content.get("type") == "text":
                         text_parts.append(content.get("text", ""))
                     elif content.get("type") == "image_url":
-                        # text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
+                        #text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
                         text_parts.append(f"Image:{content.get('image_url', {}).get('url', '')}")
                 texts.append(" ".join(text_parts) if text_parts else "")
             elif input_data.content_type == MultiModalContentType.TEXT:
-                input = {"text": input_data.content}
+                input = {
+                    "text": input_data.content
+                }
                 input_str = json.dumps(input, ensure_ascii=False)
                 texts.append(input_str)
             elif input_data.content_type == MultiModalContentType.IMAGE:
                 image_format = self._detect_image_format_from_base64(input_data.content)
-                if len(image_format) > 0:
+                if len(image_format)>0:
                     input = {
                         "image": "data:image/" + image_format + ";base64," + input_data.content
                     }
                 else:
-                    input = {"image": "data:image" + ";base64," + input_data.content}
+                    input = {
+                        "image": "data:image" + ";base64," + input_data.content
+                    }
                 input_str = json.dumps(input, ensure_ascii=False)
                 texts.append(input_str)
             else:
-                texts.append(input_data if isinstance(input_data, str) else str(input_data))
+                texts.append(
+                    input_data if isinstance(input_data, str) else str(input_data)
+                )
 
         return self._invoke(model, credentials, texts, user, input_type)

--- a/models/openai_api_compatible/models/text_embedding/text_embedding.py
+++ b/models/openai_api_compatible/models/text_embedding/text_embedding.py
@@ -26,7 +26,7 @@ from dify_plugin.entities.model.text_embedding import MultiModalContentType
 logger = logging.getLogger(__name__)
 
 
-def _get_encoding_format(credentials: Mapping | dict) -> Literal["float"] | None:
+def _get_encoding_format(credentials: Mapping[str, Any]) -> Literal["float"] | None:
     encoding_format = credentials.get("encoding_format")
     if encoding_format == "float":
         return encoding_format
@@ -205,12 +205,13 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 }
                 text_embeddings = []
 
+                encoding_format = _get_encoding_format(credentials)
+
                 for i in range(0, len(text_inputs), max_chunks):
                     batch = text_inputs[i : i + max_chunks]
 
                     payload: dict[str, Any] = {"model": endpoint_model_name, "input": batch}
 
-                    encoding_format = _get_encoding_format(credentials)
                     if encoding_format:
                         payload["encoding_format"] = encoding_format
 

--- a/models/openai_api_compatible/models/text_embedding/text_embedding.py
+++ b/models/openai_api_compatible/models/text_embedding/text_embedding.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Union
+from typing import Any, List, Literal, Mapping, Optional, Union
 import ipaddress
 import json
 import re
@@ -8,42 +8,38 @@ from urllib.parse import urlparse
 import requests
 import tiktoken
 
-from typing import Literal
-from typing import List, Union, Dict, Any
 from openai import OpenAI
 from openai._types import NOT_GIVEN, NotGiven
 from openai.types.chat import ChatCompletionMessageParam
 from openai.types.create_embedding_response import CreateEmbeddingResponse
 
-from dify_plugin.entities.model import (
-    AIModelEntity,
-    EmbeddingInputType,
-    I18nObject,
-    ModelFeature,
+from dify_plugin.entities.model import AIModelEntity, EmbeddingInputType, I18nObject, ModelFeature
+from dify_plugin.entities.model.text_embedding import TextEmbeddingResult, EmbeddingUsage
+from dify_plugin.errors.model import (
+    CredentialsValidateFailedError,
+    InvokeError,
+    InvokeServerUnavailableError,
 )
-from dify_plugin.entities.model.text_embedding import (
-    TextEmbeddingResult,
-    EmbeddingUsage,
-)
-from dify_plugin.errors.model import InvokeError, InvokeServerUnavailableError
-from dify_plugin.interfaces.model.openai_compatible.text_embedding import (
-    OAICompatEmbeddingModel,
-)
-from dify_plugin.entities.model.text_embedding import (
-    MultiModalContent,
-    MultiModalContentType,
-)
-
+from dify_plugin.interfaces.model.openai_compatible.text_embedding import OAICompatEmbeddingModel
+from dify_plugin.entities.model.text_embedding import MultiModalContentType
 
 logger = logging.getLogger(__name__)
+
+
+def _get_encoding_format(credentials: Mapping | dict) -> Literal["float"] | None:
+    encoding_format = credentials.get("encoding_format")
+    if encoding_format == "float":
+        return encoding_format
+    return None
+
 
 def create_chat_embeddings(
     client: OpenAI,
     *,
-    #messages: list[ChatCompletionMessageParam],
+    # messages: list[ChatCompletionMessageParam],
     messages: List[ChatCompletionMessageParam],
     model: str,
-    #encoding_format: Literal["base64", "float"] | NotGiven = NOT_GIVEN,
+    # encoding_format: Literal["base64", "float"] | NotGiven = NOT_GIVEN,
     encoding_format: Union[Literal["base64", "float"], NotGiven] = NOT_GIVEN,
     continue_final_message: bool = False,
     add_special_tokens: bool = False,
@@ -63,6 +59,7 @@ def create_chat_embeddings(
             "add_special_tokens": add_special_tokens,
         },
     )
+
 
 class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
     def get_customizable_model_schema(
@@ -85,6 +82,14 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 entity.features.append(ModelFeature.VISION)
 
         return entity
+
+    def validate_credentials(self, model: str, credentials: dict) -> None:
+        try:
+            self._invoke(model=model, credentials=credentials, texts=["ping"])
+        except CredentialsValidateFailedError:
+            raise
+        except Exception as ex:
+            raise CredentialsValidateFailedError(str(ex)) from ex
 
     def _invoke(
         self,
@@ -121,10 +126,6 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
         if prefix:
             processed_inputs = self._add_prefix_to_inputs(processed_inputs, prefix)
 
-        # Get context size and max chunks from credentials or model properties
-        context_size = self._get_context_size(model, credentials)
-        max_chunks = self._get_max_chunks(model, credentials)
-
         # Truncate long texts (similar to Tongyi's approach)
         inputs = []
         for input_data in processed_inputs:
@@ -135,16 +136,16 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                     if content.get("type") == "text":
                         text_parts.append(content.get("text", ""))
                     elif content.get("type") == "image_url":
-                        #text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
+                        # text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
                         text_parts.append(f"Image:{content.get('image_url', {}).get('url', '')}")
                 text = " ".join(text_parts) if text_parts else ""
             else:
                 text = input_data if isinstance(input_data, str) else str(input_data)
 
             # Check token count and truncate if necessary
-            #num_tokens = self._get_num_tokens_by_gpt2(text)
-            #if num_tokens >= context_size:
-                # Truncate to fit within context size
+            # num_tokens = self._get_num_tokens_by_gpt2(text)
+            # if num_tokens >= context_size:
+            # Truncate to fit within context size
             #    cutoff = int(len(text) * (context_size / num_tokens))
             #    text = text[0:cutoff]
 
@@ -207,12 +208,9 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 for i in range(0, len(text_inputs), max_chunks):
                     batch = text_inputs[i : i + max_chunks]
 
-                    payload: dict[str, Any] = {
-                        "model": endpoint_model_name,
-                        "input": batch,
-                    }
+                    payload: dict[str, Any] = {"model": endpoint_model_name, "input": batch}
 
-                    encoding_format = credentials.get("encoding_format")
+                    encoding_format = _get_encoding_format(credentials)
                     if encoding_format:
                         payload["encoding_format"] = encoding_format
 
@@ -222,10 +220,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                     )
 
                     response = requests.post(
-                        f"{endpoint_url}/embeddings",
-                        headers=headers,
-                        json=payload,
-                        timeout=60,
+                        f"{endpoint_url}/embeddings", headers=headers, json=payload, timeout=60
                     )
 
                     if response.status_code != 200:
@@ -328,7 +323,10 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 response = create_chat_embeddings(
                     client,
                     messages=[
-                        {"role": "system", "content": [{"type": "text", "text": default_instruction}]},
+                        {
+                            "role": "system",
+                            "content": [{"type": "text", "text": default_instruction}],
+                        },
                         {"role": "user", "content": [{"type": "text", "text": prompt}]},
                         {"role": "assistant", "content": [{"type": "text", "text": ""}]},
                     ],
@@ -338,15 +336,21 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                     add_special_tokens=True,
                 )
             elif input_type == 1:
-                image_url = prompt[len("Image:"):]
+                image_url = prompt[len("Image:") :]
                 response = create_chat_embeddings(
                     client,
                     messages=[
-                        {"role": "system", "content": [{"type": "text", "text": default_instruction}]},
-                        {"role": "user", "content": [
-                            {"type": "image_url", "image_url": {"url": image_url}},
-                            {"type": "text", "text": ""},
-                        ]},
+                        {
+                            "role": "system",
+                            "content": [{"type": "text", "text": default_instruction}],
+                        },
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "image_url", "image_url": {"url": image_url}},
+                                {"type": "text", "text": ""},
+                            ],
+                        },
                         {"role": "assistant", "content": [{"type": "text", "text": ""}]},
                     ],
                     model=model,
@@ -359,18 +363,24 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 text_parts = []
                 for item in prompt_list:
                     if item.startswith("Image:"):
-                        image_url = item[len("Image:"):]
+                        image_url = item[len("Image:") :]
                     elif item:
                         text_parts.append(item)
                 text = " ".join(text_parts)
                 response = create_chat_embeddings(
                     client,
                     messages=[
-                        {"role": "system", "content": [{"type": "text", "text": default_instruction}]},
-                        {"role": "user", "content": [
-                            {"type": "image_url", "image_url": {"url": image_url}},
-                            {"type": "text", "text": text},
-                        ]},
+                        {
+                            "role": "system",
+                            "content": [{"type": "text", "text": default_instruction}],
+                        },
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "image_url", "image_url": {"url": image_url}},
+                                {"type": "text", "text": text},
+                            ],
+                        },
                         {"role": "assistant", "content": [{"type": "text", "text": ""}]},
                     ],
                     model=model,
@@ -391,7 +401,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
             if "currency" in usage:
                 currency = usage.get("currency", "USD")
 
-        return batched_embeddings, used_tokens, total_price, unit_price, price_unit, currency
+        return (batched_embeddings, used_tokens, total_price, unit_price, price_unit, currency)
 
     def _process_input(self, text: str, vision_enabled: bool) -> Union[str, list]:
         """
@@ -482,40 +492,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
             try:
                 ip = ipaddress.ip_address(hostname)
                 # Check if it's private, loopback, link-local, or reserved
-                if (
-                    ip.is_private
-                    or ip.is_loopback
-                    or ip.is_link_local
-                    or ip.is_reserved
-                ):
-                    logger.warning(f"Blocked private IP URL: {url[:50]}...")
-                    return ""
-            except ValueError:
-                # Not an IP address, it's a hostname - allow it
-                pass
-
-            return url
-        except Exception as e:
-            logger.warning(f"URL validation failed: {e}")
-            return ""
-
-            # Block localhost
-            if hostname in ("localhost", "127.0.0.1", "::1"):
-                logger.warning(f"Blocked localhost URL: {url[:50]}...")
-                return ""
-
-            # Block private IP ranges
-            import ipaddress
-
-            try:
-                ip = ipaddress.ip_address(hostname)
-                # Check if it's private, loopback, link-local, or reserved
-                if (
-                    ip.is_private
-                    or ip.is_loopback
-                    or ip.is_link_local
-                    or ip.is_reserved
-                ):
+                if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
                     logger.warning(f"Blocked private IP URL: {url[:50]}...")
                     return ""
             except ValueError:
@@ -610,10 +587,10 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                 return "bmp"
             else:
                 # Default to jpeg if unknown
-                #return "jpeg"
+                # return "jpeg"
                 return ""
         except Exception:
-            #return "jpeg"
+            # return "jpeg"
             return ""
 
     def _contains_ip(self, text):
@@ -626,7 +603,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
         Returns:
             bool: True if a valid IP address is found, False otherwise
         """
-        ip_pattern = r'\b(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b'
+        ip_pattern = r"\b(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
 
         return bool(re.search(ip_pattern, text))
 
@@ -714,9 +691,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
             return len(encoding.encode(text))
         except Exception:
             # Fallback to character count or a default if tiktoken fails
-            return (
-                len(text) // 4
-            )  # Rough estimate if tiktoken is not available or fails
+            return len(text) // 4  # Rough estimate if tiktoken is not available or fails
 
     def _invoke_multimodal(
         self,
@@ -740,30 +715,24 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                     if content.get("type") == "text":
                         text_parts.append(content.get("text", ""))
                     elif content.get("type") == "image_url":
-                        #text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
+                        # text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
                         text_parts.append(f"Image:{content.get('image_url', {}).get('url', '')}")
                 texts.append(" ".join(text_parts) if text_parts else "")
             elif input_data.content_type == MultiModalContentType.TEXT:
-                input = {
-                    "text": input_data.content
-                }
+                input = {"text": input_data.content}
                 input_str = json.dumps(input, ensure_ascii=False)
                 texts.append(input_str)
             elif input_data.content_type == MultiModalContentType.IMAGE:
                 image_format = self._detect_image_format_from_base64(input_data.content)
-                if len(image_format)>0:
+                if len(image_format) > 0:
                     input = {
                         "image": "data:image/" + image_format + ";base64," + input_data.content
                     }
                 else:
-                    input = {
-                        "image": "data:image" + ";base64," + input_data.content
-                    }
+                    input = {"image": "data:image" + ";base64," + input_data.content}
                 input_str = json.dumps(input, ensure_ascii=False)
                 texts.append(input_str)
             else:
-                texts.append(
-                    input_data if isinstance(input_data, str) else str(input_data)
-                )
+                texts.append(input_data if isinstance(input_data, str) else str(input_data))
 
         return self._invoke(model, credentials, texts, user, input_type)

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -162,6 +162,28 @@ model_credential_schema:
       placeholder:
         zh_Hans: 在此输入您的模型上下文长度
         en_US: Enter your Model context size
+    - variable: encoding_format
+      label:
+        zh_Hans: Embedding encoding format
+        en_US: Embedding encoding format
+      required: false
+      show_on:
+        - variable: __model_type
+          value: text-embedding
+      type: select
+      default: not_set
+      options:
+        - value: not_set
+          label:
+            zh_Hans: Not set
+            en_US: Not set
+        - value: float
+          label:
+            zh_Hans: float
+            en_US: float
+      help:
+        zh_Hans: Set this to float for strict OpenAI-compatible gateways such as LiteLLM that require an explicit embedding encoding_format.
+        en_US: Set this to float for strict OpenAI-compatible gateways such as LiteLLM that require an explicit embedding encoding_format.
     - variable: vision_support
       show_on:
         - variable: __model_type

--- a/models/openai_api_compatible/tests/test_text_embedding.py
+++ b/models/openai_api_compatible/tests/test_text_embedding.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+
+from models.text_embedding.text_embedding import OpenAITextEmbeddingModel
+
+
+def _successful_embedding_response() -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "data": [{"embedding": [0.1, 0.2, 0.3]}],
+        "usage": {"total_tokens": 3},
+    }
+    return response
+
+
+def _credentials(**overrides):
+    credentials = {
+        "endpoint_url": "https://litellm.example.com/v1",
+        "endpoint_model_name": "Qwen3-Embedding-8B",
+        "api_key": "test-key",
+        "context_size": "4096",
+        "max_chunks": "8",
+    }
+    credentials.update(overrides)
+    return credentials
+
+
+@patch("models.text_embedding.text_embedding.requests.post")
+def test_text_embedding_sends_configured_encoding_format(mock_post):
+    mock_post.return_value = _successful_embedding_response()
+    model = OpenAITextEmbeddingModel(model_schemas=[])
+
+    result = model._invoke(
+        model="display-name", credentials=_credentials(encoding_format="float"), texts=["ping"]
+    )
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload == {"model": "Qwen3-Embedding-8B", "input": ["ping"], "encoding_format": "float"}
+    assert result.embeddings == [[0.1, 0.2, 0.3]]
+
+
+@patch("models.text_embedding.text_embedding.requests.post")
+def test_text_embedding_omits_unset_encoding_format(mock_post):
+    mock_post.return_value = _successful_embedding_response()
+    model = OpenAITextEmbeddingModel(model_schemas=[])
+
+    model._invoke(
+        model="display-name", credentials=_credentials(encoding_format="not_set"), texts=["ping"]
+    )
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload == {"model": "Qwen3-Embedding-8B", "input": ["ping"]}
+
+
+@patch("models.text_embedding.text_embedding.requests.post")
+def test_text_embedding_validate_credentials_uses_runtime_payload_shape(mock_post):
+    mock_post.return_value = _successful_embedding_response()
+    model = OpenAITextEmbeddingModel(model_schemas=[])
+
+    model.validate_credentials(
+        model="display-name", credentials=_credentials(encoding_format="float")
+    )
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload == {"model": "Qwen3-Embedding-8B", "input": ["ping"], "encoding_format": "float"}


### PR DESCRIPTION
## Summary

Related to langgenius/dify#35784.
close https://github.com/langgenius/dify-official-plugins/pull/3092
The OpenAI-compatible text embedding plugin overrides the SDK embedding request path, so credential validation was still using a different payload shape from runtime embedding calls. Strict OpenAI-compatible gateways such as LiteLLM can reject that validation request when embedding-specific fields are missing or malformed.

This change adds an optional text-embedding-only `encoding_format` credential and routes credential validation through the same runtime embedding path. When set to `float`, embedding requests include `encoding_format: "float"`; when left as `not_set`, the plugin preserves the existing behavior and omits the field.

Only `float` is exposed because Dify stores embeddings as float vectors. `base64` would require a separate decode path before Dify can consume the result.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Review follow-up

- [x] Addressed Gemini's type precision feedback with `Mapping[str, Any]`.
- [x] Addressed Gemini's request-construction feedback by resolving `encoding_format` once before building embedding requests.

## Screenshots / Videos

N/A. This is a provider compatibility fix covered by unit tests.

| Before | After |
| ------ | ----- |
| Strict LiteLLM-compatible embedding validation can reject the OpenAI-compatible provider request. | Users can set `encoding_format` to `float`, and validation uses the runtime embedding request path. |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user -> assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [x] Parsed `models/openai_api_compatible/manifest.yaml` and `provider/openai_api_compatible.yaml` with PyYAML
- [x] `uv run --project models/openai_api_compatible --group dev black --check models/openai_api_compatible/models/text_embedding/text_embedding.py models/openai_api_compatible/tests/test_text_embedding.py -C -l 100`
- [x] `uv run --project models/openai_api_compatible --group dev ruff check models/openai_api_compatible/models/text_embedding/text_embedding.py models/openai_api_compatible/tests/test_text_embedding.py`
- [x] `uv run --project models/openai_api_compatible --frozen --with pytest pytest models/openai_api_compatible/tests`
- [x] GitHub checks: `detect-changes`, `test (models/openai_api_compatible)`, `Check Complete`

Local result: 26 passed, 2 warnings from existing dependencies.
