### PR TITLE
fix(azure_openai): handle None tool.description in _num_tokens_for_tools

### DIFF
--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -1452,7 +1452,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             num_tokens += len(encoding.encode("name"))
             num_tokens += len(encoding.encode(tool.name))
             num_tokens += len(encoding.encode("description"))
-            num_tokens += len(encoding.encode(tool.description))
+            num_tokens += len(encoding.encode(tool.description or ""))
             parameters = tool.parameters
             num_tokens += len(encoding.encode("parameters"))
             if "title" in parameters:


### PR DESCRIPTION
## Bug Description

`_num_tokens_for_tools()` in the Azure OpenAI plugin crashes with a `TypeError` when `tool.description` is `None`:

```
TypeError: can only concatenate str (not "NoneType") to str
```

The error is wrapped by the plugin SDK as:
```json
{"error_type": "InvokeError", "message": "[models] Error: can only concatenate str (not \"NoneType\") to str"}
```

## Root Cause

In `models/azure_openai/models/llm/llm.py`, line 1455:
```python
num_tokens += len(encoding.encode(tool.description))  # crashes when None
```

`PromptMessageTool.description` is typed as `str` but can be `None` in practice when:
1. An OpenAPI-based custom tool provider has endpoints with a `summary` but no `description` field
2. The tool provider chain (`ApiToolBundle.summary` → `ToolDescription.llm` → `PromptMessageTool.description`) can produce `None` at several points

## Fix

Add a `or ""` fallback — consistent with line 472 which **already** guards against this exact case:
```python
num_tokens += len(encoding.encode(tool.description or ""))
```

## Impact

This bug blocks **all** agent invocations that use custom API tools with missing descriptions. It affects versions 0.0.49+.

## How to Reproduce

1. Create an OpenAPI tool provider with endpoints that have `summary` but no `description` (or `description: ""`)
2. Create an Agent that uses these tools
3. Invoke the agent → immediate crash before any tool is called

## Related

The same pattern exists in `dify-plugin-sdks` (`openai_compatible/llm.py` lines 466, 897) — a separate PR will be submitted there.