### PR TITLE
fix(openai-compatible): preserve non-stream reasoning content

### DIFF
--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -1,4 +1,3 @@
-import json
 import re
 from contextlib import suppress
 from typing import Mapping, Optional, Union, Generator, List
@@ -62,7 +61,7 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             # delta without reasoning/content should just close the block
             if len(reasoning_piece) == 0 and len(content_piece) == 0:
                 is_reasoning = False
-                output += f"\n</think>"
+                output += "\n</think>"
             # sometimes reasoning_piece is not empty and content_piece is not empty. but if content_piece is not empty, then we should not close the think block
             if len(content_piece) > 0:
                 is_reasoning = False
@@ -71,6 +70,15 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             output += content_piece
 
         return output, is_reasoning
+
+    @staticmethod
+    def _wrap_non_stream_reasoning_content(message: dict, content: str) -> str:
+        reasoning_piece = message.get("reasoning") or message.get("reasoning_content")
+        if not reasoning_piece:
+            return content
+        if content.startswith("<think>"):
+            return content
+        return f"<think>\n{reasoning_piece}\n</think>{content or ''}"
 
     # Timeout for validation requests: (connect_timeout, read_timeout) in seconds
     _VALIDATE_TIMEOUT = (10, 300)
@@ -605,11 +613,14 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         prompt_messages: list[PromptMessage],
     ) -> LLMResult:
         """
-        Handle non-streaming chat responses that omit `message.content` when returning tool calls.
+        Handle non-streaming chat responses that need OpenAI-compatible normalization.
 
         Some OpenAI-compatible gateways, including LiteLLM-backed Azure deployments, may
         legitimately return tool calls without a `content` field. The SDK base class indexes
         `message["content"]` directly, which raises `KeyError('content')` in that case.
+        vLLM/SGLang-compatible reasoning models can also return thinking traces in
+        `message.reasoning` or `message.reasoning_content`, while the final answer remains in
+        `message.content`.
         """
         response_json: dict = response.json()
         completion_type = LLMMode.value_of(credentials["mode"])
@@ -633,6 +644,8 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                 response_content = ""
             else:
                 response_content = str(raw_content)
+
+            response_content = self._wrap_non_stream_reasoning_content(message, response_content)
 
             if function_calling_type == "tool_call":
                 tool_calls = message.get("tool_calls")

--- a/models/openai_api_compatible/tests/test_handle_response.py
+++ b/models/openai_api_compatible/tests/test_handle_response.py
@@ -1,9 +1,32 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from dify_plugin.errors.model import InvokeError
 from dify_plugin.entities.model.message import SystemPromptMessage, UserPromptMessage
 
 from models.llm.llm import OpenAILargeLanguageModel
+
+
+def _chat_response(message: dict) -> Mock:
+    response = Mock()
+    response.json.return_value = {
+        "id": "chatcmpl-test",
+        "model": "Qwen3.5-27B",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": message,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 11,
+            "completion_tokens": 31,
+            "total_tokens": 42,
+        },
+    }
+    return response
 
 
 def test_handle_generate_response_accepts_tool_calls_without_content_key():
@@ -94,6 +117,108 @@ def test_handle_generate_response_normalizes_null_content():
     assert result.message.content == ""
     assert result.message.tool_calls
     assert result.message.tool_calls[0].function.name == "lookup"
+
+
+@pytest.mark.parametrize(
+    ("reasoning_key", "reasoning_value"),
+    [
+        ("reasoning", "vLLM reasoning trace"),
+        ("reasoning_content", "legacy reasoning trace"),
+    ],
+)
+def test_handle_generate_response_wraps_non_stream_reasoning_fields(
+    reasoning_key: str, reasoning_value: str
+):
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    result = model._handle_generate_response(
+        model="Qwen3.5-27B",
+        credentials={"mode": "chat"},
+        response=_chat_response(
+            {
+                "role": "assistant",
+                "content": "final answer",
+                reasoning_key: reasoning_value,
+            }
+        ),
+        prompt_messages=[UserPromptMessage(content="test")],
+    )
+
+    assert result.message.content == f"<think>\n{reasoning_value}\n</think>final answer"
+    assert result.usage.prompt_tokens == 11
+    assert result.usage.completion_tokens == 31
+
+
+def test_handle_generate_response_keeps_existing_think_content_when_reasoning_field_is_present():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    result = model._handle_generate_response(
+        model="Qwen3.5-27B",
+        credentials={"mode": "chat"},
+        response=_chat_response(
+            {
+                "role": "assistant",
+                "content": "<think>\ninline reasoning\n</think>\nfinal answer",
+                "reasoning": "separate reasoning",
+            }
+        ),
+        prompt_messages=[UserPromptMessage(content="test")],
+    )
+
+    assert result.message.content == "<think>\ninline reasoning\n</think>\nfinal answer"
+
+
+def test_handle_generate_response_preserves_tool_calls_with_non_stream_reasoning():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    result = model._handle_generate_response(
+        model="Qwen3.5-27B",
+        credentials={"mode": "chat", "function_calling_type": "tool_call"},
+        response=_chat_response(
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning": "need to call a tool",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "search_docs",
+                            "arguments": "{\"query\":\"Qwen reasoning\"}",
+                        },
+                    }
+                ],
+            }
+        ),
+        prompt_messages=[UserPromptMessage(content="test")],
+    )
+
+    assert result.message.content == "<think>\nneed to call a tool\n</think>"
+    assert result.message.tool_calls
+    assert result.message.tool_calls[0].function.name == "search_docs"
+    assert result.message.tool_calls[0].function.arguments == "{\"query\":\"Qwen reasoning\"}"
+
+
+def test_filter_thinking_result_removes_wrapped_non_stream_reasoning():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    result = model._handle_generate_response(
+        model="Qwen3.5-27B",
+        credentials={"mode": "chat"},
+        response=_chat_response(
+            {
+                "role": "assistant",
+                "content": "final answer",
+                "reasoning": "hidden reasoning",
+            }
+        ),
+        prompt_messages=[UserPromptMessage(content="test")],
+    )
+
+    filtered_result = model._filter_thinking_result(result)
+
+    assert filtered_result.message.content == "final answer"
 
 
 def test_handle_generate_response_counts_all_prompt_messages_when_usage_missing():


### PR DESCRIPTION
## Summary

Related to #2945.

The OpenAI-compatible streaming path already normalizes both `delta.reasoning` and `delta.reasoning_content` into Dify's `<think>...</think>` format. The non-streaming chat response path still only used `message.content`, so vLLM/SGLang-style responses that put the reasoning trace in `message.reasoning` dropped that trace before Dify could render or filter it.

This PR applies the same normalization to non-streaming chat responses:
- wraps `message.reasoning` and `message.reasoning_content` before the final answer
- leaves content that already starts with `<think>` unchanged to avoid double wrapping
- keeps existing tool call extraction and usage handling unchanged
- keeps existing thinking-disabled filtering behavior working after the response is wrapped

This is separate from the earlier streaming fix in #2741 and the `extensions/openai_compatible` endpoint fix in #2676; it covers the model plugin's non-streaming `choices[].message` handler.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

N/A. This is a response-normalization fix covered by unit and package tests.

| Before | After |
| ------ | ----- |
| Non-streaming responses with `message.reasoning` only surfaced `message.content`. | Reasoning is preserved as `<think>...</think>` before the final answer, matching the streaming path. |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Message flow (system messages, user -> assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.5.0` is declared in `pyproject.toml` and locked in `uv.lock`

Note: this PR bumps `openai_api_compatible` to `0.0.51` because open PRs #3091 and #3092 already use the pending `0.0.50` bump for the same plugin.

## Testing

- [x] `uv run --project models/openai_api_compatible --frozen --with pytest pytest models/openai_api_compatible/tests`
- [x] `uv run --project models/openai_api_compatible --frozen python -m py_compile models/openai_api_compatible/models/llm/llm.py models/openai_api_compatible/tests/test_handle_response.py`
- [x] `uv run --with requests --with dify_plugin python .scripts/toolkit/uploader/upload-package.py -d models/openai_api_compatible -t dummy-token --plugin-daemon-path .scripts/dify-plugin-windows-amd64.exe -u https://marketplace.dify.ai -f --test`
- [x] `.\.scripts\dify-plugin-windows-amd64.exe plugin package models/openai_api_compatible --output_path test-openai-api-compatible-package.difypkg`
- [x] Unpacked the generated package and ran `uv run --frozen --with pytest pytest`
- [ ] Local deployment - Dify version:
- [ ] SaaS (cloud.dify.ai)

Local result: 28 passed, 2 warnings from existing dependencies.