### PR TITLE
feat: add configurable docs field name for rerank API

### DIFF
--- a/models/openai_api_compatible/models/rerank/rerank.py
+++ b/models/openai_api_compatible/models/rerank/rerank.py
@@ -102,10 +102,11 @@ class OpenAIRerankModel(OAICompatRerankModel):
 
         # Simple string format for text-only mode
         # Use `top_n if top_n is not None else len(docs)` to correctly handle top_n=0
+        docs_field = credentials.get("docs_field_name", "documents")
         payload = {
             "model": endpoint_model_name,
             "query": query,
-            "documents": docs,
+            docs_field: docs,
             "top_n": top_n if top_n is not None else len(docs),
         }
 

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -213,6 +213,28 @@ model_credential_schema:
           label:
             en_US: Not Support
             zh_Hans: 不支持
+    - variable: docs_field_name
+      show_on:
+        - variable: __model_type
+          value: rerank
+      label:
+        zh_Hans: 文档字段名
+        en_US: Documents field name
+      type: select
+      required: false
+      default: documents
+      help:
+        en_US: Some APIs use 'docs' instead of 'documents' for the rerank request field.
+        zh_Hans: 部分 API 使用 docs 作为 rerank 请求的文档字段名，而非 documents。
+      options:
+        - value: documents
+          label:
+            en_US: documents (default)
+            zh_Hans: documents（默认）
+        - value: docs
+          label:
+            en_US: docs
+            zh_Hans: docs
     - variable: max_tokens_to_sample
       label:
         zh_Hans: 最大 token 上限


### PR DESCRIPTION
## Summary

Some rerank APIs (e.g., custom model proxies) use `docs` instead of `documents` as the request field name. This causes a 500 error when validating credentials.

This PR adds a configurable `docs_field_name` option for rerank models, allowing users to choose between `documents` (default) and `docs`.

## Changes

- `models/rerank/rerank.py`: Read `docs_field_name` from credentials to determine the field name
- `provider/openai_api_compatible.yaml`: Add dropdown selector for rerank models in the UI

## Testing

Tested with a rerank service that expects `docs` field:
- Before: 500 Server Error
- After: 200 OK with correct rerank results