### PR TITLE
Ollama: optional Bearer token for auth-fronted deployments

### DIFF
--- a/models/ollama/manifest.yaml
+++ b/models/ollama/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.5
+version: 0.2.0

--- a/models/ollama/models/llm/llm.py
+++ b/models/ollama/models/llm/llm.py
@@ -178,6 +178,9 @@ class OllamaLargeLanguageModel(LargeLanguageModel):
         :return: full response or stream response chunk generator result
         """
         headers = {"Content-Type": "application/json"}
+        api_key = credentials.get("api_key")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         endpoint_url = credentials["base_url"]
         if not endpoint_url.endswith("/"):
             endpoint_url += "/"

--- a/models/ollama/models/rerank/rerank.py
+++ b/models/ollama/models/rerank/rerank.py
@@ -57,6 +57,9 @@ class OllamaRerankModel(RerankModel):
             return RerankResult(model=model, docs=[])
 
         headers = {"Content-Type": "application/json"}
+        api_key = credentials.get("api_key")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         endpoint_url = credentials.get("base_url", "").rstrip("/")
         if not endpoint_url.endswith("/rerank"):
             endpoint_url = endpoint_url + "/api/rerank"

--- a/models/ollama/models/text_embedding/text_embedding.py
+++ b/models/ollama/models/text_embedding/text_embedding.py
@@ -58,6 +58,9 @@ class OllamaEmbeddingModel(TextEmbeddingModel):
         :return: embeddings result
         """
         headers = {"Content-Type": "application/json"}
+        api_key = credentials.get("api_key")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         endpoint_url = credentials.get("base_url", "")
         if endpoint_url and not endpoint_url.endswith("/"):
             endpoint_url += "/"

--- a/models/ollama/provider/ollama.yaml
+++ b/models/ollama/provider/ollama.yaml
@@ -31,6 +31,15 @@ model_credential_schema:
     required: true
     type: text-input
     variable: base_url
+  - label:
+      en_US: API Key (optional)
+      zh_Hans: API 密钥（可选）
+    placeholder:
+      en_US: Bearer token sent as Authorization header. Leave blank for unauthenticated Ollama deployments.
+      zh_Hans: 作为 Authorization 标头发送的 Bearer 令牌。如果 Ollama 没有身份验证，请留空。
+    required: false
+    type: secret-input
+    variable: api_key
   - default: chat
     label:
       en_US: Completion mode


### PR DESCRIPTION
Adds an optional `api_key` field to the Ollama provider. When set, the plugin sends `Authorization: Bearer <api_key>` on every request to the configured base URL; when empty nothing changes.

Motivation is that Ollama has no built-in auth, so anyone sharing an Ollama instance across services or exposing it beyond a single host ends up putting a reverse proxy in front. As soon as that proxy authenticates, this plugin breaks because there's nowhere to enter the token. Dropping a LangChain or generic OpenAI-compat provider in between is a lot of surface for what's really "send one extra header."

Change is roughly 15 lines across four files:

- `provider/ollama.yaml` adds the `api_key` credential as `secret-input`, `required: false`, with placeholder text explaining the use case
- `models/llm/llm.py`, `models/text_embedding/text_embedding.py`, `models/rerank/rerank.py` read `credentials.get("api_key")` and inject the Authorization header when set

Backwards-compatible. Every existing config keeps working since the field defaults to absent. Encryption at rest comes for free from Dify's existing `secret-input` handling (PKCS1_OAEP).

Tested locally against an Ollama instance fronted by a Bearer-auth proxy: empty api_key 401s as expected, correct token validates, wrong token 401s. Same for chat, embedding and rerank. Also confirmed the unauthenticated path against a direct Ollama still works.

One design note — i kept the header name hardcoded to `Authorization: Bearer` since that's the dominant convention. Could parameterize for `X-API-Key`-style proxies later if there's demand, felt like a separate PR.

Manifest bumped to 0.2.0 in my fork, adjust as you like.
