### PR TITLE
fix(tongyi): align DeepSeek model metadata

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.1.44
+version: 0.1.45
 created_at: "2024-12-10T16:13:50.29298939+08:00"

--- a/models/tongyi/models/llm/deepseek-v3.1.yaml
+++ b/models/tongyi/models/llm/deepseek-v3.1.yaml
@@ -59,6 +59,15 @@ parameter_rules:
     required: false
     options:
       - text
+  - name: enable_search
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑"自行判断"是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
   - name: enable_thinking
     required: false
     type: boolean
@@ -83,5 +92,4 @@ pricing:
   output: "0.012"
   unit: "0.001"
   currency: RMB
-
 

--- a/models/tongyi/models/llm/deepseek-v3.2-exp.yaml
+++ b/models/tongyi/models/llm/deepseek-v3.2-exp.yaml
@@ -59,6 +59,15 @@ parameter_rules:
     required: false
     options:
       - text
+  - name: enable_search
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑"自行判断"是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
   - name: enable_thinking
     required: false
     type: boolean
@@ -83,5 +92,4 @@ pricing:
   output: "0.003"
   unit: "0.001"
   currency: RMB
-
 

--- a/models/tongyi/models/llm/deepseek-v3.2.yaml
+++ b/models/tongyi/models/llm/deepseek-v3.2.yaml
@@ -59,6 +59,15 @@ parameter_rules:
     required: false
     options:
       - text
+  - name: enable_search
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑"自行判断"是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
   - name: enable_thinking
     required: false
     type: boolean

--- a/models/tongyi/models/llm/deepseek-v4-flash.yaml
+++ b/models/tongyi/models/llm/deepseek-v4-flash.yaml
@@ -14,7 +14,7 @@ model_properties:
 parameter_rules:
   - name: temperature
     use_template: temperature
-    default: 0.6
+    default: 1.0
   - name: max_tokens
     use_template: max_tokens
     type: int
@@ -26,7 +26,7 @@ parameter_rules:
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
   - name: top_p
     use_template: top_p
-    default: 0.95
+    default: 1.0
   - name: top_k
     label:
       zh_Hans: 取样数量
@@ -36,16 +36,6 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: repetition_penalty
-    required: false
-    type: float
-    default: 1.0
-    label:
-      zh_Hans: 重复惩罚
-      en_US: Repetition penalty
-    help:
-      zh_Hans: 用于控制模型生成时的重复度。提高 repetition_penalty 时可以降低模型生成的重复度。1.0 表示不做惩罚。
-      en_US: Used to control the repeatability when generating models. Increasing repetition_penalty can reduce the duplication of model generation. 1.0 means no punishment.
   - name: frequency_penalty
     use_template: frequency_penalty
   - name: response_format
@@ -59,10 +49,19 @@ parameter_rules:
     required: false
     options:
       - text
+  - name: enable_search
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑"自行判断"是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
   - name: enable_thinking
     required: false
     type: boolean
-    default: false
+    default: true
     label:
       zh_Hans: 思考模式
       en_US: Thinking mode

--- a/models/tongyi/models/llm/deepseek-v4-pro.yaml
+++ b/models/tongyi/models/llm/deepseek-v4-pro.yaml
@@ -14,7 +14,7 @@ model_properties:
 parameter_rules:
   - name: temperature
     use_template: temperature
-    default: 0.6
+    default: 1.0
   - name: max_tokens
     use_template: max_tokens
     type: int
@@ -26,7 +26,7 @@ parameter_rules:
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
   - name: top_p
     use_template: top_p
-    default: 0.95
+    default: 1.0
   - name: top_k
     label:
       zh_Hans: 取样数量
@@ -36,16 +36,6 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: repetition_penalty
-    required: false
-    type: float
-    default: 1.0
-    label:
-      zh_Hans: 重复惩罚
-      en_US: Repetition penalty
-    help:
-      zh_Hans: 用于控制模型生成时的重复度。提高 repetition_penalty 时可以降低模型生成的重复度。1.0 表示不做惩罚。
-      en_US: Used to control the repeatability when generating models. Increasing repetition_penalty can reduce the duplication of model generation. 1.0 means no punishment.
   - name: frequency_penalty
     use_template: frequency_penalty
   - name: response_format
@@ -59,10 +49,19 @@ parameter_rules:
     required: false
     options:
       - text
+  - name: enable_search
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑"自行判断"是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
   - name: enable_thinking
     required: false
     type: boolean
-    default: false
+    default: true
     label:
       zh_Hans: 思考模式
       en_US: Thinking mode

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -231,8 +231,8 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             "qwen3.5-flash", "qwen3.5-flash-2026-02-23",
             # GLM series (default: thinking ENABLED - must explicitly disable)
             "glm-5.1", "glm-5", "glm-4.7", "glm-4.6", "glm-4.5", "glm-4.5-air",
-            # DeepSeek series (default: thinking disabled)
-            "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v3.2", "deepseek-v3.2-exp", "deepseek-v3.1",
+            # DeepSeek V3 series (default: thinking disabled)
+            "deepseek-v3.2", "deepseek-v3.2-exp", "deepseek-v3.1",
         }
         if model in thinking_capable_models and "enable_thinking" not in model_parameters:
             model_parameters["enable_thinking"] = False
@@ -272,14 +272,23 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             model == "kimi-k2.5" and model_parameters.get("enable_thinking", False)
         ) or model == "kimi-k2-thinking"
 
-        # Qwen3 business edition (Thinking Mode), Qwen3 open-source edition (excluding coder, max, and 3.5 variants), QwQ, QVQ, Kimi, and GLM thinking models only supports streaming output.
+        thinking_deepseek_v4 = (
+            model in ("deepseek-v4-pro", "deepseek-v4-flash")
+            and model_parameters.get("enable_thinking", True)
+        )
+
+        # Thinking-mode models that need streamed responses so reasoning_content is preserved.
         # Note: qwen3-coder-xx, qwen3-max-xx, and qwen3.5-xx models support non-streaming output.
         # Note: qwen3-coder-xx, qwen3-max-xx, and qwen3.5-xx models support non-streaming output.
         qwen3_requires_stream = model.startswith("qwen3-") and not model.startswith(
             ("qwen3-coder", "qwen3-max", "qwen3.5-")
         )
         common_force_condition = (
-            thinking_business_qwen3 or qwen3_requires_stream or thinking_kimi or thinking_glm
+            thinking_business_qwen3
+            or qwen3_requires_stream
+            or thinking_kimi
+            or thinking_glm
+            or thinking_deepseek_v4
         )
         if common_force_condition or model.startswith(("qwq-", "qvq-")):
             stream = True


### PR DESCRIPTION
## Summary

Fixes #3106

Align Tongyi DeepSeek model metadata with upstream model information:

- keep DeepSeek V4 thinking mode enabled by default
- force streaming for DeepSeek V4 thinking mode so reasoning_content is preserved
- align DeepSeek V4 temperature and top_p defaults with upstream values
- remove unsupported repetition_penalty from the new DeepSeek V4 model configs
- restore enable_search for DeepSeek models where provider web search is supported
- bump Tongyi plugin version from 0.1.44 to 0.1.45

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

N/A - metadata-only LLM plugin fix.

| Before | After |
| ------ | ----- |
| DeepSeek V4 metadata disabled thinking mode by default and hid provider-supported web search. | DeepSeek metadata now matches upstream defaults, preserves V4 reasoning output, and exposes web search where supported. |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — existing Tongyi dependency metadata is unchanged in this PR.

## Testing

- [ ] Local deployment — Dify version: N/A, not run for metadata-only fix
- [ ] SaaS (cloud.dify.ai)

Additional checks run locally:

- `python3 -m py_compile models/tongyi/models/llm/llm.py`
- YAML metadata assertions for DeepSeek model defaults, enable_search, enable_thinking, V4 force-streaming logic, and Tongyi version bump
- `git diff --check HEAD~1 HEAD`
