### PR TITLE
fix: strip all thinking blocks from assistant history, not just the first

### DIFF
--- a/models/lemonade/manifest.yaml
+++ b/models/lemonade/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: "langgenius"
 name: "lemonade"

--- a/models/lemonade/models/llm/llm.py
+++ b/models/lemonade/models/llm/llm.py
@@ -129,7 +129,7 @@ def validate_lemonade_credentials(credentials: dict, model: str = None) -> None:
 
 class LemonadeLargeLanguageModel(OAICompatLargeLanguageModel):
     # Pre-compiled regex for better performance
-    _THINK_PATTERN = re.compile(r"^<think>.*?</think>\s*", re.DOTALL)
+    _THINK_PATTERN = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
     def get_customizable_model_schema(
         self, model: str, credentials: Mapping | dict
@@ -202,11 +202,11 @@ class LemonadeLargeLanguageModel(OAICompatLargeLanguageModel):
             if not isinstance(p.content, str):
                 continue
             # Quick check to avoid regex if not needed
-            if not p.content.startswith("<think>"):
+            if "<think>" not in p.content:
                 continue
 
             # Only perform regex substitution when necessary
-            new_content = cls._THINK_PATTERN.sub("", p.content, count=1)
+            new_content = cls._THINK_PATTERN.sub("", p.content)
             # Only update if changed
             if new_content != p.content:
                 p.content = new_content

--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.50
+version: 0.0.51
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -35,7 +35,7 @@ from openai import OpenAI
 
 class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
     # Pre-compiled regex for better performance
-    _THINK_PATTERN = re.compile(r"^<think>.*?</think>\s*", re.DOTALL)
+    _THINK_PATTERN = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
     # Models that require max_completion_tokens (OpenAI Responses API family)
     _NEEDS_MAX_COMPLETION_TOKENS_PATTERN = re.compile(r"^(o1|o3|gpt-5)", re.IGNORECASE)
 
@@ -354,11 +354,11 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             if not isinstance(p.content, str):
                 continue
             # Quick check to avoid regex if not needed
-            if not p.content.startswith("<think>"):
+            if "<think>" not in p.content:
                 continue
 
             # Only perform regex substitution when necessary
-            new_content = cls._THINK_PATTERN.sub("", p.content, count=1)
+            new_content = cls._THINK_PATTERN.sub("", p.content)
             # Only update if changed
             if new_content != p.content:
                 p.content = new_content
@@ -548,8 +548,8 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         """Filter thinking content from non-streaming result"""
         if result.message and result.message.content:
             content = result.message.content
-            if isinstance(content, str) and content.startswith("<think>"):
-                filtered_content = self._THINK_PATTERN.sub("", content, count=1)
+            if isinstance(content, str) and "<think>" in content:
+                filtered_content = self._THINK_PATTERN.sub("", content)
                 if filtered_content != content:
                     result.message.content = filtered_content
         return result


### PR DESCRIPTION
## Problem

Fixes #3000

When a reasoning-enabled model is used in an Agent app, one user request may trigger multiple LLM calls (e.g., planning/tool-selection, then post-tool final-answer). Each call can produce a `<think>...</think>` block.

The OpenAI-API-compatible and Lemonade model providers only stripped the **first leading** thinking block from assistant messages before sending history back to the model. Later thinking blocks remained in history and were fed back into subsequent turns, causing:

- Repeated/duplicated reasoning content across turns
- Reasoning leakage into visible conversation history
- Prompt bloat and higher latency
- Timeouts in long agent runs

## Root Cause

Two issues in `_THINK_PATTERN` and its usage:

1. **Regex anchored with `^`**: `r"^<think>.*?</think>\s*"` only matches thinking blocks at the start of the string, missing blocks that appear after other content
2. **`count=1` in `sub()`**: Only the first match is removed, leaving subsequent thinking blocks intact
3. **`startswith` early exit**: Messages containing `<think>` in the middle (not at the start) were skipped entirely

## Fix

- Remove `^` anchor from `_THINK_PATTERN` regex so thinking blocks are matched anywhere in the string
- Remove `count=1` from `re.sub()` calls to strip ALL thinking blocks, not just the first
- Change `p.content.startswith("<think>")` to `"<think>" in p.content` so messages with thinking blocks in the middle are also processed

## Consistency

This aligns with the existing implementations in the DeepSeek, Moonshot, and Volcengine MAAS providers, which already strip all thinking blocks using `r"<think>(.*?)</think>"` without anchoring or count limits.

## Files Changed

- `models/openai_api_compatible/models/llm/llm.py` — regex, early exit, and both `sub()` calls
- `models/lemonade/models/llm/llm.py` — same three fixes

## Backwards Compatibility

Fully backwards compatible. For messages with a single leading thinking block (the common case today), behavior is identical. The fix only changes behavior for the previously broken case of multiple or non-leading thinking blocks.

## Testing

- Verified regex pattern `r"<think>.*?</think>\s*"` correctly matches all thinking blocks in a string
- Verified `re.sub()` without `count` removes all occurrences
- Confirmed consistency with DeepSeek/Moonshot/Volcengine implementations