### PR TITLE
fix(openrouter): deprecate legacy grok models, add grok 4.3 and mimo v2.5

### DIFF
--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -26,5 +26,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.0.51
+version: 0.0.52
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/openrouter/models/llm/_position.yaml
+++ b/models/openrouter/models/llm/_position.yaml
@@ -56,13 +56,12 @@
 - deepseek/deepseek-r1-distill-llama-70b
 - deepseek/deepseek-r1-distill-qwen-32b
 - moonshotai/kimi-k2-0905
+- xiaomi/mimo-v2.5-pro
+- xiaomi/mimo-v2.5
 - xiaomi/mimo-v2-omni
 - xiaomi/mimo-v2-pro
+- x-ai/grok-4.3
 - x-ai/grok-4.20
 - x-ai/grok-4.20-multi-agent
-- x-ai/grok-4.1-fast
-- x-ai/grok-4-fast
-- x-ai/grok-3-beta
-- x-ai/grok-3-mini-beta
 - z-ai/glm-5.1
 - z-ai/glm-5v-turbo

--- a/models/openrouter/models/llm/grok-3-beta.yaml
+++ b/models/openrouter/models/llm/grok-3-beta.yaml
@@ -44,3 +44,4 @@ pricing:
   output: "15"
   unit: "0.000001"
   currency: USD
+deprecated: true

--- a/models/openrouter/models/llm/grok-3-mini-beta.yaml
+++ b/models/openrouter/models/llm/grok-3-mini-beta.yaml
@@ -67,3 +67,4 @@ pricing:
   output: "0.5"
   unit: "0.000001"
   currency: USD
+deprecated: true

--- a/models/openrouter/models/llm/grok-4-fast.yaml
+++ b/models/openrouter/models/llm/grok-4-fast.yaml
@@ -81,3 +81,4 @@ pricing:
   output: "0.5"
   unit: "0.000001"
   currency: USD
+deprecated: true

--- a/models/openrouter/models/llm/grok-4.1-fast.yaml
+++ b/models/openrouter/models/llm/grok-4.1-fast.yaml
@@ -81,3 +81,4 @@ pricing:
   output: "0"
   unit: "0.000001"
   currency: USD
+deprecated: true

--- a/models/openrouter/models/llm/grok-4.3.yaml
+++ b/models/openrouter/models/llm/grok-4.3.yaml
@@ -1,0 +1,66 @@
+model: x-ai/grok-4.3
+label:
+  en_US: Grok 4.3
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+  - name: enable_thinking
+    label:
+      zh_Hans: 开启思考模式
+      en_US: Enable thinking mode
+    type: boolean
+    default: true
+    help:
+      zh_Hans: 是否开启默认思考模式
+      en_US: Whether to enable the default thinking mode
+    required: false
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理程度
+      en_US: Reasoning Effort
+    type: string
+    help:
+      zh_Hans: 指定模型推理的难度
+      en_US: specifying the difficulty of the model's reasoning
+    required: false
+    options:
+      - high
+      - medium
+      - low
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: true
+    help:
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
+pricing:
+  input: "1.25"
+  output: "2.5"
+  unit: "0.000001"
+  currency: USD

--- a/models/openrouter/models/llm/mimo-v2.5-pro.yaml
+++ b/models/openrouter/models/llm/mimo-v2.5-pro.yaml
@@ -1,0 +1,29 @@
+model: xiaomi/mimo-v2.5-pro
+label:
+  en_US: MiMo-V2.5-Pro
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "1.00"
+  output: "3.00"
+  unit: "0.000001"
+  currency: USD

--- a/models/openrouter/models/llm/mimo-v2.5.yaml
+++ b/models/openrouter/models/llm/mimo-v2.5.yaml
@@ -1,0 +1,32 @@
+model: xiaomi/mimo-v2.5
+label:
+  en_US: MiMo-V2.5
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+  - vision
+  - audio
+  - video
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0.4"
+  output: "2.00"
+  unit: "0.000001"
+  currency: USD


### PR DESCRIPTION
## Summary

- Added grok-4.3, mimo-v2.5, mimo-v2.5-pro model definitions
- Removed legacy grok entries (grok-4.1-fast, grok-4-fast, grok-3-beta, grok-3-mini-beta)

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->



## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |   <img width="1552" height="1244" alt="image" src="https://github.com/user-attachments/assets/825bcff0-53b9-427c-9f46-71c98dd8c688" />    |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [ ] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [x] SaaS (cloud.dify.ai)
