### PR TITLE
feat(apitemplate): add cloud_storage param and return post_actions for create_pdf_from_html

### DIFF
--- a/tools/apitemplate/manifest.yaml
+++ b/tools/apitemplate/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: langgenius
 name: apitemplate

--- a/tools/apitemplate/tools/create_pdf_from_html.py
+++ b/tools/apitemplate/tools/create_pdf_from_html.py
@@ -18,6 +18,7 @@ class CreatePdfFromHtmlTool(Tool):
             css_styles = tool_parameters.get("css_styles", "").strip()
             template_data_str = tool_parameters.get("template_data", "").strip()
             filename = tool_parameters.get("filename", "").strip()
+            cloud_storage = tool_parameters.get("cloud_storage")
             
             # Validate required parameters
             if not html_body:
@@ -55,6 +56,17 @@ class CreatePdfFromHtmlTool(Tool):
                 if not filename.endswith('.pdf'):
                     filename += '.pdf'
                 params["filename"] = filename
+            
+            # Add cloud_storage flag if explicitly provided
+            # The API expects an integer (1 = upload to CDN, 0 = skip CDN upload)
+            if cloud_storage is not None and cloud_storage != "":
+                try:
+                    params["cloud_storage"] = int(cloud_storage)
+                except (TypeError, ValueError):
+                    yield self.create_text_message(
+                        "Invalid cloud_storage value. Expected '1' or '0'."
+                    )
+                    return
             
             # Build request body
             request_body = {
@@ -100,21 +112,29 @@ class CreatePdfFromHtmlTool(Tool):
             download_url = result.get("download_url", "")
             total_pages = result.get("total_pages", 0)
             transaction_ref = result.get("transaction_ref", "")
+            post_actions = result.get("post_actions") or []
             
             # Create success response
             summary = f"PDF generated successfully from HTML! {total_pages} pages created."
             if filename:
                 summary += f" Filename: {filename}"
+            if post_actions:
+                summary += f" {len(post_actions)} post action(s) executed."
             
             yield self.create_text_message(summary)
-            yield self.create_json_message({
+            
+            response_payload = {
                 "status": "success",
                 "download_url": download_url,
                 "total_pages": total_pages,
                 "transaction_ref": transaction_ref,
                 "filename": filename if filename else f"{transaction_ref}.pdf",
                 "source": "html"
-            })
+            }
+            if post_actions:
+                response_payload["post_actions"] = post_actions
+            
+            yield self.create_json_message(response_payload)
             
         except requests.exceptions.RequestException as e:
             yield self.create_text_message(f"Network error: {str(e)}")

--- a/tools/apitemplate/tools/create_pdf_from_html.yaml
+++ b/tools/apitemplate/tools/create_pdf_from_html.yaml
@@ -90,6 +90,40 @@ parameters:
     llm_description: "Optional custom filename for the PDF. If not provided, a UUID will be used. Must end with '.pdf'. Example: 'report_123.pdf'"
     form: llm
 
+  - name: cloud_storage
+    type: select
+    required: false
+    default: "1"
+    label:
+      en_US: "Cloud Storage"
+      ja_JP: "クラウドストレージ"
+      zh_Hans: "云存储"
+      pt_BR: "Armazenamento em Nuvem"
+      zh_Hant: "雲端儲存"
+    human_description:
+      en_US: "Whether to upload the generated PDF to APITemplate.io's CDN. Set to 0 if you have configured a Post Action to upload to your own S3 bucket."
+      ja_JP: "生成された PDF を APITemplate.io の CDN にアップロードするかどうか。Post Action で独自の S3 にアップロードするように構成している場合は 0 に設定します。"
+      zh_Hans: "是否将生成的 PDF 上传到 APITemplate.io 的 CDN。如果您已配置 Post Action 上传到您自己的 S3 存储桶，请设置为 0。"
+      pt_BR: "Se deve enviar o PDF gerado para o CDN do APITemplate.io. Defina como 0 se você configurou uma Post Action para enviar para seu próprio bucket S3."
+      zh_Hant: "是否將生成的 PDF 上傳到 APITemplate.io 的 CDN。如果您已設定 Post Action 上傳到您自己的 S3 儲存桶，請設定為 0。"
+    llm_description: "Controls whether the generated PDF is uploaded to APITemplate.io's storage CDN. Use '1' (default) to upload to the CDN, or '0' to skip the CDN upload (useful when using a Post Action to upload to your own S3 bucket)."
+    options:
+      - value: "1"
+        label:
+          en_US: "Upload to CDN (default)"
+          ja_JP: "CDN にアップロード（デフォルト）"
+          zh_Hans: "上传到 CDN（默认）"
+          pt_BR: "Enviar para o CDN (padrão)"
+          zh_Hant: "上傳到 CDN（預設）"
+      - value: "0"
+        label:
+          en_US: "Skip CDN upload"
+          ja_JP: "CDN アップロードをスキップ"
+          zh_Hans: "跳过 CDN 上传"
+          pt_BR: "Pular envio para o CDN"
+          zh_Hant: "略過 CDN 上傳"
+    form: form
+
 extra:
   python:
     source: tools/create_pdf_from_html.py 


### PR DESCRIPTION
## Summary
feat(apitemplate): add cloud_storage param and surface post_actions in create_pdf_from_html

- Add optional `cloud_storage` select parameter (1=upload to CDN, 0=skip)
  to /v2/create-pdf-from-html, letting users disable CDN upload when
  routing the output to their own S3/R2/Azure via Post Actions.
- Include `post_actions` from the API response in the JSON output and
  mention the count in the human-readable summary, so downstream nodes
  can inspect per-action status (action, name, bucket, status, file).



## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin


## Version

- [ ] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing
- [x] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [ ] SaaS (cloud.dify.ai)
