### PR TITLE
feat(azure_openai): add native web search support (#3110)

### DIFF
--- a/models/azure_openai/README.md
+++ b/models/azure_openai/README.md
@@ -4,6 +4,21 @@ Azure OpenAI Service is a cloud-based platform that provides access to advanced 
 ## Configure
 Once the plugin is installed, configure your Azure OpenAI Service Model by providing the Model Type, Deployment Name, API Endpoint URL, Authentication Method, and the Base Model. The API Version is optional when your endpoint already uses the Azure OpenAI `v1` path, for example `https://<resource>.openai.azure.com/openai/v1/`.
 
+### Web Search (Azure native)
+
+This plugin supports Azure OpenAI native Web Search for models that use the Responses API path in this provider.
+
+Available model parameters:
+- **Enable Web Search** (`enable_web_search`): Enables `tools: [{"type": "web_search"}]`.
+- **Web Search Country** (`web_search_user_country`): Optional ISO 3166-1 alpha-2 country code (for example, `US`, `JP`).
+- **Allowed Domains** (`web_search_allowed_domains`): Optional allowlist of domains (comma/newline-separated).
+- **Include Source Metadata** (`web_search_include_sources`): Optional opt-in flag to request `include=["web_search_call.action.sources"]`.
+
+Notes:
+- Web Search is controlled by Azure subscription settings and can be blocked by admins.
+- Grounding with Bing terms, privacy, and pricing apply.
+- If your endpoint/API version does not support Web Search for the selected model, Azure will return an API error.
+
 ### Authentication Methods
 
 This plugin supports two authentication methods:

--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.55
+version: 0.0.56

--- a/models/azure_openai/models/constants.py
+++ b/models/azure_openai/models/constants.py
@@ -3889,7 +3889,9 @@ def _apply_web_search_rules_to_responses_models() -> None:
         if not uses_responses_api(base_model.base_model_name):
             continue
 
-        parameter_rules = base_model.entity.parameter_rules or []
+        if base_model.entity.parameter_rules is None:
+            base_model.entity.parameter_rules = []
+        parameter_rules = base_model.entity.parameter_rules
         existing_rule_names = {rule.name for rule in parameter_rules}
         for rule in _web_search_parameter_rules():
             if rule.name not in existing_rule_names:

--- a/models/azure_openai/models/constants.py
+++ b/models/azure_openai/models/constants.py
@@ -27,6 +27,23 @@ AZURE_DEFAULT_PARAM_SEED_HELP = I18nObject(
 )
 
 
+def uses_responses_api(base_model_name: str) -> bool:
+    """
+    Determine if the model should use the Responses API.
+
+    1. Models with "codex" in the base name
+    2. gpt-5.x models (excluding chat and codex variants which use different APIs)
+    """
+    return (
+        "codex" in base_model_name
+        or (
+            base_model_name.startswith("gpt-5")
+            and "chat" not in base_model_name
+            and "codex" not in base_model_name
+        )
+    )
+
+
 def _get_max_tokens(default: int, min_val: int, max_val: int) -> ParameterRule:
     rule = ParameterRule(
         name="max_tokens",
@@ -58,6 +75,56 @@ class AzureBaseModel(BaseModel):
     # per base model without modifying the invocation logic.
     # NOTE: Currently, this field is only used in the Speech-to-Text (STT) model implementation.
     extra_invoke_params: dict[str, Any] = {}
+
+
+def _web_search_parameter_rules() -> list[ParameterRule]:
+    return [
+        ParameterRule(
+            name="enable_web_search",
+            label=I18nObject(zh_Hans="启用 Web 搜索", en_US="Enable Web Search"),
+            type="boolean",
+            help=I18nObject(
+                zh_Hans="启用 Azure OpenAI Responses API 原生 web_search 工具。",
+                en_US="Enable the native web_search tool in Azure OpenAI Responses API.",
+            ),
+            required=False,
+            default=False,
+        ),
+        ParameterRule(
+            name="web_search_user_country",
+            label=I18nObject(zh_Hans="搜索国家/地区", en_US="Web Search Country"),
+            type="string",
+            help=I18nObject(
+                zh_Hans="可选，两位 ISO 国家/地区代码（例如 US、JP）。",
+                en_US="Optional two-letter ISO country code (for example, US or JP).",
+            ),
+            required=False,
+        ),
+        ParameterRule(
+            name="web_search_allowed_domains",
+            label=I18nObject(zh_Hans="允许域名", en_US="Allowed Domains"),
+            type="text",
+            help=I18nObject(
+                zh_Hans="可选，允许搜索的域名列表。支持逗号或换行分隔。",
+                en_US="Optional allowlist of domains for web search. Use commas or new lines as separators.",
+            ),
+            required=False,
+        ),
+        ParameterRule(
+            name="web_search_include_sources",
+            label=I18nObject(zh_Hans="包含来源元数据", en_US="Include Source Metadata"),
+            type="boolean",
+            help=I18nObject(
+                zh_Hans="启用后会请求返回 web_search_call.action.sources，以便在响应中包含搜索来源信息（如 URL 和标题）。",
+                en_US=(
+                    'When enabled, the request includes include=["web_search_call.action.sources"], '
+                    "which asks Azure to return web search source metadata (for example URL/title)."
+                ),
+            ),
+            required=False,
+            default=False,
+        ),
+    ]
 
 
 LLM_BASE_MODELS = [
@@ -3815,6 +3882,23 @@ LLM_BASE_MODELS = [
         ),
     ),
 ]
+
+
+def _apply_web_search_rules_to_responses_models() -> None:
+    for base_model in LLM_BASE_MODELS:
+        if not uses_responses_api(base_model.base_model_name):
+            continue
+
+        parameter_rules = base_model.entity.parameter_rules or []
+        existing_rule_names = {rule.name for rule in parameter_rules}
+        for rule in _web_search_parameter_rules():
+            if rule.name not in existing_rule_names:
+                parameter_rules.append(rule)
+
+
+_apply_web_search_rules_to_responses_models()
+
+
 EMBEDDING_BASE_MODELS = [
     AzureBaseModel(
         base_model_name="text-embedding-ada-002",

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -4,8 +4,10 @@ import io
 import json
 import logging
 import math
+import re
 from collections.abc import Generator, Sequence
 from typing import Any, Optional, Union, cast
+from urllib.parse import urlparse
 
 import tiktoken
 from PIL import Image
@@ -44,7 +46,7 @@ from openai.types.chat.chat_completion_chunk import ChoiceDelta, ChoiceDeltaTool
 from openai.types.responses import ResponseStreamEvent, Response
 
 from ..common import _CommonAzureOpenAI
-from ..constants import LLM_BASE_MODELS
+from ..constants import LLM_BASE_MODELS, uses_responses_api
 
 logger = logging.getLogger(__name__)
 
@@ -452,9 +454,13 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         elif "max_completion_tokens" in model_parameters:
             responses_params["max_output_tokens"] = model_parameters["max_completion_tokens"]
 
-        # Handle tools in the Responses API format
+        web_search_tool, include_web_search_sources = self._extract_web_search_configuration(
+            model_parameters
+        )
+        response_tools = []
+
+        # Handle function tools in the Responses API format.
         if tools:
-            responses_params["tools"] = []
             for tool in tools:
                 # Ensure parameters are valid JSON objects
                 parameters = tool.parameters
@@ -472,8 +478,23 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                     "description": tool.description or "",
                     "parameters": parameters
                 }
-                responses_params["tools"].append(tool_dict)
+                response_tools.append(tool_dict)
+
+        if web_search_tool:
+            response_tools.append(web_search_tool)
+
+        if response_tools:
+            responses_params["tools"] = response_tools
             responses_params["tool_choice"] = "auto"
+
+        if include_web_search_sources and web_search_tool:
+            include_fields = responses_params.get("include")
+            if not isinstance(include_fields, list):
+                include_fields = []
+            include_item = "web_search_call.action.sources"
+            if include_item not in include_fields:
+                include_fields.append(include_item)
+            responses_params["include"] = include_fields
 
         # Handle the user identifier
         if user:
@@ -543,6 +564,80 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             return self._handle_responses_response(
                 model, credentials, response, prompt_messages, tools
             )
+
+    @staticmethod
+    def _extract_web_search_configuration(
+        model_parameters: dict,
+    ) -> tuple[Optional[dict[str, Any]], bool]:
+        enable_web_search = model_parameters.pop("enable_web_search", False)
+        include_sources = model_parameters.pop("web_search_include_sources", False)
+        country = model_parameters.pop("web_search_user_country", None)
+        allowed_domains = model_parameters.pop("web_search_allowed_domains", None)
+
+        if not enable_web_search:
+            return None, False
+
+        web_search_tool: dict[str, Any] = {"type": "web_search"}
+
+        if country is not None:
+            normalized_country = str(country).strip().upper()
+            if normalized_country:
+                if not re.fullmatch(r"[A-Z]{2}", normalized_country):
+                    raise ValueError(
+                        "web_search_user_country must be a 2-letter ISO country code."
+                    )
+                web_search_tool["user_location"] = {
+                    "type": "approximate",
+                    "country": normalized_country,
+                }
+
+        normalized_domains = AzureOpenAILargeLanguageModel._normalize_allowed_domains(
+            allowed_domains
+        )
+        if normalized_domains:
+            web_search_tool["filters"] = {"allowed_domains": normalized_domains}
+
+        return web_search_tool, include_sources
+
+    @staticmethod
+    def _normalize_allowed_domains(raw_domains: Any) -> list[str]:
+        if raw_domains is None:
+            return []
+
+        if isinstance(raw_domains, str):
+            candidates = re.split(r"[\s,\n\r]+", raw_domains)
+        elif isinstance(raw_domains, Sequence):
+            candidates = [str(item) for item in raw_domains]
+        else:
+            candidates = [str(raw_domains)]
+
+        normalized_domains: list[str] = []
+        seen_domains: set[str] = set()
+
+        for candidate in candidates:
+            token = candidate.strip()
+            if not token:
+                continue
+
+            parsed = urlparse(token if "://" in token else f"https://{token}")
+            host = parsed.netloc or parsed.path
+            host = host.strip().lower().rstrip(".")
+            if ":" in host:
+                host = host.split(":", 1)[0]
+
+            if not host:
+                continue
+            if not re.fullmatch(r"[a-z0-9.-]+", host):
+                raise ValueError(f"Invalid domain in web_search_allowed_domains: {token}")
+
+            if host not in seen_domains:
+                seen_domains.add(host)
+                normalized_domains.append(host)
+
+        if len(normalized_domains) > 100:
+            raise ValueError("web_search_allowed_domains can contain at most 100 domains.")
+
+        return normalized_domains
 
     def _convert_prompt_messages_to_responses_input(
         self, prompt_messages: list[PromptMessage]
@@ -1572,20 +1667,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
     @staticmethod
     def _uses_responses_api(base_model_name: str) -> bool:
-        """
-        Determine if the model should use the Responses API.
-
-        1. Models with "codex" in the base name
-        2. gpt-5.x models (excluding chat and codex variants which use different APIs)
-        """
-        return (
-            "codex" in base_model_name
-            or (
-                base_model_name.startswith("gpt-5")
-                and "chat" not in base_model_name
-                and "codex" not in base_model_name
-            )
-        )
+        return uses_responses_api(base_model_name)
 
     @staticmethod
     def _adapt_schema_for_structured_outputs(schema: dict) -> dict:

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -620,7 +620,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                 continue
 
             parsed = urlparse(token if "://" in token else f"https://{token}")
-            host = parsed.netloc or parsed.path
+            host = parsed.netloc
             host = host.strip().lower().rstrip(".")
             if ":" in host:
                 host = host.split(":", 1)[0]

--- a/models/azure_openai/tests/test_llm.py
+++ b/models/azure_openai/tests/test_llm.py
@@ -10,6 +10,7 @@ Covers regression cases found in:
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
@@ -18,11 +19,13 @@ if str(ROOT_DIR) not in sys.path:
 from dify_plugin.entities.model.message import (
     DocumentPromptMessageContent,
     ImagePromptMessageContent,
+    PromptMessageTool,
     SystemPromptMessage,
     TextPromptMessageContent,
     UserPromptMessage,
 )
 from models.llm.llm import AzureOpenAILargeLanguageModel
+from models.constants import LLM_BASE_MODELS, uses_responses_api
 
 
 def make_llm() -> AzureOpenAILargeLanguageModel:
@@ -58,6 +61,23 @@ class TestUsesResponsesApi(unittest.TestCase):
 
     def test_o1_does_not_use_responses_api(self):
         self.assertFalse(AzureOpenAILargeLanguageModel._uses_responses_api("o1"))
+
+
+class TestWebSearchParameterRules(unittest.TestCase):
+    def test_web_search_rules_added_to_responses_models_only(self):
+        for model in LLM_BASE_MODELS:
+            rule_names = {rule.name for rule in model.entity.parameter_rules or []}
+            has_web_search_rules = "enable_web_search" in rule_names
+            if uses_responses_api(model.base_model_name):
+                self.assertTrue(
+                    has_web_search_rules,
+                    f"Expected web search rules for {model.base_model_name}",
+                )
+            else:
+                self.assertFalse(
+                    has_web_search_rules,
+                    f"Did not expect web search rules for {model.base_model_name}",
+                )
 
 
 class TestConvertPromptMessagesToResponsesInput(unittest.TestCase):
@@ -249,6 +269,128 @@ class TestConvertPromptMessagesToResponsesInput(unittest.TestCase):
         self.assertIn("knowledge", result[0]["content"])
         self.assertEqual(result[1]["role"], "user")
         self.assertEqual(result[1]["content"], "What is X?")
+
+
+class TestWebSearchConfiguration(unittest.TestCase):
+    def test_extract_web_search_configuration(self):
+        params = {
+            "enable_web_search": True,
+            "web_search_user_country": "jp",
+            "web_search_allowed_domains": "https://example.com/path\nfoo.bar,EXAMPLE.com",
+            "web_search_include_sources": True,
+        }
+
+        tool, include_sources = (
+            AzureOpenAILargeLanguageModel._extract_web_search_configuration(params)
+        )
+
+        self.assertTrue(include_sources)
+        self.assertEqual(tool["type"], "web_search")
+        self.assertEqual(tool["user_location"]["country"], "JP")
+        self.assertEqual(
+            tool["filters"]["allowed_domains"],
+            ["example.com", "foo.bar"],
+        )
+        self.assertEqual(params, {})
+
+    def test_invalid_country_raises(self):
+        with self.assertRaises(ValueError):
+            AzureOpenAILargeLanguageModel._extract_web_search_configuration(
+                {
+                    "enable_web_search": True,
+                    "web_search_user_country": "JPN",
+                }
+            )
+
+
+class TestResponsesPayloadWithWebSearch(unittest.TestCase):
+    def setUp(self):
+        self.llm = make_llm()
+        self.llm._get_base_model_name = MagicMock(return_value="gpt-5")
+        self.mock_client = MagicMock()
+        self.mock_response = MagicMock()
+        self.mock_client.responses.create.return_value = self.mock_response
+        self.llm._create_client = MagicMock(return_value=self.mock_client)
+        self.llm._handle_responses_response = MagicMock(return_value="ok")
+        self.llm._handle_responses_stream_response = MagicMock(return_value=iter(()))
+
+    def _invoke(self, model_parameters: dict, tools=None):
+        prompt_messages = [UserPromptMessage(content="hello")]
+        return self.llm._chat_generate_with_responses(
+            model="deployment-name",
+            credentials={"base_model_name": "gpt-5"},
+            prompt_messages=prompt_messages,
+            model_parameters=model_parameters,
+            tools=tools,
+            stream=False,
+        )
+
+    def test_function_tools_only_keeps_existing_behavior(self):
+        tool = PromptMessageTool(
+            name="tool_a",
+            description="tool a",
+            parameters={"type": "object", "properties": {}},
+        )
+        self._invoke({}, tools=[tool])
+
+        kwargs = self.mock_client.responses.create.call_args.kwargs
+        self.assertEqual(kwargs["tools"][0]["type"], "function")
+        self.assertEqual(kwargs["tools"][0]["name"], "tool_a")
+        self.assertEqual(kwargs["tool_choice"], "auto")
+
+    def test_web_search_only(self):
+        self._invoke(
+            {
+                "enable_web_search": True,
+            }
+        )
+
+        kwargs = self.mock_client.responses.create.call_args.kwargs
+        self.assertEqual(kwargs["tools"], [{"type": "web_search"}])
+        self.assertEqual(kwargs["tool_choice"], "auto")
+
+    def test_web_search_and_function_tools_are_merged(self):
+        tool = PromptMessageTool(
+            name="tool_a",
+            description="tool a",
+            parameters={"type": "object", "properties": {}},
+        )
+        self._invoke(
+            {
+                "enable_web_search": True,
+            },
+            tools=[tool],
+        )
+
+        kwargs = self.mock_client.responses.create.call_args.kwargs
+        self.assertEqual(len(kwargs["tools"]), 2)
+        self.assertEqual(kwargs["tools"][0]["type"], "function")
+        self.assertEqual(kwargs["tools"][1]["type"], "web_search")
+
+    def test_web_search_country_domains_and_include(self):
+        self._invoke(
+            {
+                "enable_web_search": True,
+                "web_search_user_country": "us",
+                "web_search_allowed_domains": "a.com, https://b.com/path",
+                "web_search_include_sources": True,
+            }
+        )
+
+        kwargs = self.mock_client.responses.create.call_args.kwargs
+        web_search_tool = kwargs["tools"][0]
+        self.assertEqual(web_search_tool["user_location"]["country"], "US")
+        self.assertEqual(web_search_tool["filters"]["allowed_domains"], ["a.com", "b.com"])
+        self.assertEqual(kwargs["include"], ["web_search_call.action.sources"])
+
+    def test_invalid_country_raises(self):
+        with self.assertRaises(ValueError):
+            self._invoke(
+                {
+                    "enable_web_search": True,
+                    "web_search_user_country": "usa",
+                }
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add support for Azure OpenAI's native web search tool. Fixes #3110.


## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|<img width="385" height="463" alt="image" src="https://github.com/user-attachments/assets/7b069805-c874-4cc7-bd64-adf780e3ea4a" />|<img width="385" height="462" alt="image" src="https://github.com/user-attachments/assets/52a77e11-e93a-493a-bb8c-277a20e3c95b" /><img width="385" height="461" alt="image" src="https://github.com/user-attachments/assets/570693ff-d795-4002-afc0-226e3a60eaea" />|

<img width="1870" height="947" alt="image" src="https://github.com/user-attachments/assets/dd2d824f-1f59-48e7-a107-faef47594853" />

## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.14.1
- [ ] SaaS (cloud.dify.ai)
