### PR TITLE
perf(notion_datasource): speed up get_authorized_pages for large work…

### DIFF
--- a/datasources/notion_datasource/datasources/utils/notion_client.py
+++ b/datasources/notion_datasource/datasources/utils/notion_client.py
@@ -48,7 +48,11 @@ class NotionClient:
         }
         # Memoize parent_id lookups so the threaded resolution in
         # get_authorized_pages doesn't re-fetch the same ancestor block twice.
+        # `_parent_inflight` tracks lookups currently being resolved so that
+        # concurrent workers asking for the same block coalesce onto a single
+        # HTTP request instead of all racing past the cache miss.
         self._parent_cache: dict[str, str] = {}
+        self._parent_inflight: dict[str, threading.Event] = {}
         self._parent_cache_lock = threading.Lock()
 
     def _make_request(
@@ -523,7 +527,10 @@ class NotionClient:
                 parent_id = parent[parent_type]
             else:
                 parent_id = "root"
-        except ValueError:
+        except (ValueError, requests.exceptions.RequestException):
+            # One unresolvable item (HTTP error, malformed parent, etc.) must not
+            # abort the whole enumeration — preserve the original "skip and
+            # continue" behavior established by PR #2891.
             return None
 
         return OnlineDocumentPage(
@@ -547,35 +554,85 @@ class NotionClient:
         return max(1, min(value, _MAX_PARENT_RESOLVE_WORKERS))
 
     def notion_page_search(self, access_token: str):
-        return [item for item in self._search_all() if item.get("object") == "page"]
+        return self._search_filtered("page")
 
     def notion_database_search(self, access_token: str):
-        return [item for item in self._search_all() if item.get("object") == "database"]
+        return self._search_filtered("database")
+
+    def _search_filtered(self, object_type: str) -> list[dict[str, Any]]:
+        """Fetch only pages or only databases using the API-side object filter.
+
+        Used by the public ``notion_page_search`` / ``notion_database_search``
+        wrappers when callers ask for just one type. ``get_authorized_pages``
+        deliberately uses ``_search_all`` instead to collapse both kinds into a
+        single pass.
+        """
+        results: list[dict[str, Any]] = []
+        next_cursor: str | None = None
+        has_more = True
+        while has_more:
+            payload: dict[str, Any] = {
+                "filter": {"value": object_type, "property": "object"},
+            }
+            if next_cursor:
+                payload["start_cursor"] = next_cursor
+            data = self._make_request("post", "/search", json_data=payload) or {}
+            results.extend(data.get("results", []))
+            has_more = data.get("has_more", False)
+            next_cursor = data.get("next_cursor")
+        return results
 
     def notion_block_parent_page_id(self, access_token: str, block_id: str):
         return self._resolve_block_parent_page_id(block_id)
 
     def _resolve_block_parent_page_id(self, block_id: str) -> str:
         clean_id = block_id.replace("-", "")
-        cached = self._parent_cache.get(clean_id)
-        if cached is not None:
-            return cached
 
-        data = self._make_request("get", f"/blocks/{clean_id}", allow_status=(404,))
-        if data is None:
-            result = "root"
-        else:
-            parent = data.get("parent", {})
-            parent_type = parent.get("type")
-            if parent_type == "block_id":
-                result = self._resolve_block_parent_page_id(parent[parent_type])
-            elif parent_type == "workspace":
+        # Coordinate cache and in-flight lookups under the same lock so two
+        # workers can never both miss the cache for the same block and race to
+        # fetch it — under Notion's ~3 req/s limit those redundant requests
+        # would just amplify 429 backoff.
+        while True:
+            with self._parent_cache_lock:
+                cached = self._parent_cache.get(clean_id)
+                if cached is not None:
+                    return cached
+                event = self._parent_inflight.get(clean_id)
+                if event is None:
+                    # This thread is now responsible for fetching this id;
+                    # other threads asking for the same id will wait on `event`.
+                    event = threading.Event()
+                    self._parent_inflight[clean_id] = event
+                    break
+            # Another worker is already fetching; wait for it to finish, then
+            # re-check the cache on the next iteration.
+            event.wait()
+
+        try:
+            data = self._make_request("get", f"/blocks/{clean_id}", allow_status=(404,))
+            if data is None:
                 result = "root"
-            elif parent_type and parent_type in parent:
-                result = parent[parent_type]
             else:
-                result = "root"
+                parent = data.get("parent", {})
+                parent_type = parent.get("type")
+                if parent_type == "block_id":
+                    result = self._resolve_block_parent_page_id(parent[parent_type])
+                elif parent_type == "workspace":
+                    result = "root"
+                elif parent_type and parent_type in parent:
+                    result = parent[parent_type]
+                else:
+                    result = "root"
+        except Exception:
+            # Release waiters so they don't block forever; they will re-enter
+            # the lock above, see no cache entry, and retry on their own.
+            with self._parent_cache_lock:
+                self._parent_inflight.pop(clean_id, None)
+            event.set()
+            raise
 
         with self._parent_cache_lock:
             self._parent_cache[clean_id] = result
+            self._parent_inflight.pop(clean_id, None)
+        event.set()
         return result

--- a/datasources/notion_datasource/datasources/utils/notion_client.py
+++ b/datasources/notion_datasource/datasources/utils/notion_client.py
@@ -3,7 +3,11 @@ Notion API Client for Dify plugins
 This module provides a unified interface for interacting with the Notion API
 """
 
+import os
+import threading
 import time
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import requests
@@ -11,6 +15,8 @@ import requests
 from dify_plugin.entities.datasource import OnlineDocumentPage
 
 __TIMEOUT_SECONDS__ = 60 * 10
+_DEFAULT_PARENT_RESOLVE_WORKERS = 8
+_MAX_PARENT_RESOLVE_WORKERS = 32
 
 
 class NotionClient:
@@ -40,6 +46,10 @@ class NotionClient:
             "Notion-Version": self._API_VERSION,
             "Content-Type": "application/json",
         }
+        # Memoize parent_id lookups so the threaded resolution in
+        # get_authorized_pages doesn't re-fetch the same ancestor block twice.
+        self._parent_cache: dict[str, str] = {}
+        self._parent_cache_lock = threading.Lock()
 
     def _make_request(
         self,
@@ -48,7 +58,8 @@ class NotionClient:
         params: dict[str, Any] | None = None,
         json_data: dict[str, Any] | None = None,
         max_retries: int = 3,
-    ) -> dict[str, Any]:
+        allow_status: Iterable[int] = (),
+    ) -> dict[str, Any] | None:
         """
         Make an API request to Notion with retry logic for rate limits.
 
@@ -58,12 +69,15 @@ class NotionClient:
             params: URL parameters for GET requests
             json_data: JSON data for POST/PATCH requests
             max_retries: Maximum number of retries for rate limiting
+            allow_status: HTTP status codes that should resolve to None
+                instead of raising (e.g. {404} for optional resources).
 
         Returns:
-            Response data as dictionary
+            Response data as dictionary, or None if the response status was in allow_status.
         """
         url = f"{self._API_BASE_URL}{endpoint}"
         retries = 0
+        allow_status_set = set(allow_status)
 
         while retries <= max_retries:
             try:
@@ -82,6 +96,9 @@ class NotionClient:
                     time.sleep(retry_after)
                     retries += 1
                     continue
+
+                if response.status_code in allow_status_set:
+                    return None
 
                 response.raise_for_status()
                 return response.json()
@@ -439,145 +456,126 @@ class NotionClient:
         """
         return self.create_rich_text(content)
 
-    def get_authorized_pages(self):
-        pages = []
-        access_token = self.integration_token
-        page_results = self.notion_page_search(access_token)
-        database_results = self.notion_database_search(access_token)
-        # get page detail
-        for page_result in page_results:
-            page_id = page_result["id"]
-            page_name = "Untitled"
-            for key in page_result["properties"]:
-                if "title" in page_result["properties"][key] and page_result["properties"][key]["title"]:
-                    title_list = page_result["properties"][key]["title"]
-                    if len(title_list) > 0 and "plain_text" in title_list[0]:
-                        page_name = title_list[0]["plain_text"]
-            icon = None
-            parent = page_result["parent"]
-            parent_type = parent["type"]
-            try:
-                if parent_type == "block_id":
-                    parent_id = self.notion_block_parent_page_id(access_token, parent[parent_type])
-                elif parent_type == "workspace":
-                    parent_id = "root"
-                else:
-                    parent_id = parent[parent_type]
-            except ValueError:
-                continue
-            page = OnlineDocumentPage(
-                page_id=page_id,
-                page_name=page_name,
-                page_icon=icon,
-                parent_id=parent_id,
-                type="page",
-                last_edited_time=page_result["last_edited_time"],
-            )
-            pages.append(page)
-            # get database detail
-        for database_result in database_results:
-            page_id = database_result["id"]
-            page_name = database_result["title"][0]["plain_text"] if len(database_result["title"]) > 0 else "Untitled"
+    def get_authorized_pages(self) -> list[OnlineDocumentPage]:
+        items = self._search_all()
+        worker_count = self._resolve_worker_count()
 
-            icon = None
-            parent = database_result["parent"]
-            parent_type = parent["type"]
-            try:
-                if parent_type == "block_id":
-                    parent_id = self.notion_block_parent_page_id(access_token, parent[parent_type])
-                elif parent_type == "workspace":
-                    parent_id = "root"
-                else:
-                    parent_id = parent[parent_type]
-            except ValueError:
-                continue
-            page = OnlineDocumentPage(
-                page_id=page_id,
-                page_name=page_name,
-                page_icon=icon,
-                parent_id=parent_id,
-                type="database",
-                last_edited_time=database_result["last_edited_time"],
-            )
-            pages.append(page)
+        pages: list[OnlineDocumentPage] = []
+        if worker_count <= 1:
+            for item in items:
+                entry = self._build_page_entry(item)
+                if entry is not None:
+                    pages.append(entry)
+            return pages
+
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            for entry in executor.map(self._build_page_entry, items):
+                if entry is not None:
+                    pages.append(entry)
         return pages
 
-    def notion_page_search(self, access_token: str):
-        results = []
-        next_cursor = None
+    def _search_all(self) -> list[dict[str, Any]]:
+        """Fetch every page and database shared with the integration in one pass.
+
+        Notion's /v1/search returns both pages and databases when no object filter
+        is supplied, so combining the previous two filtered loops halves the number
+        of search round-trips required to enumerate the workspace.
+        """
+        results: list[dict[str, Any]] = []
+        next_cursor: str | None = None
         has_more = True
-
         while has_more:
-            data: dict[str, Any] = {
-                "filter": {"value": "page", "property": "object"},
-                **({"start_cursor": next_cursor} if next_cursor else {}),
-            }
-            headers = {
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {access_token}",
-                "Notion-Version": self._API_VERSION,
-            }
-
-            response = requests.post(
-                url=self._NOTION_PAGE_SEARCH, json=data, headers=headers, timeout=__TIMEOUT_SECONDS__
-            )
-            response_json = response.json()
-
-            results.extend(response_json.get("results", []))
-
-            has_more = response_json.get("has_more", False)
-            next_cursor = response_json.get("next_cursor", None)
-
+            payload: dict[str, Any] = {}
+            if next_cursor:
+                payload["start_cursor"] = next_cursor
+            data = self._make_request("post", "/search", json_data=payload) or {}
+            results.extend(data.get("results", []))
+            has_more = data.get("has_more", False)
+            next_cursor = data.get("next_cursor")
         return results
+
+    def _build_page_entry(self, item: dict[str, Any]) -> OnlineDocumentPage | None:
+        obj = item.get("object")
+        if obj == "page":
+            page_name = "Untitled"
+            for key in item.get("properties", {}):
+                prop = item["properties"][key]
+                if "title" in prop and prop["title"]:
+                    title_list = prop["title"]
+                    if len(title_list) > 0 and "plain_text" in title_list[0]:
+                        page_name = title_list[0]["plain_text"]
+            page_type = "page"
+        elif obj == "database":
+            title = item.get("title", [])
+            page_name = title[0]["plain_text"] if len(title) > 0 else "Untitled"
+            page_type = "database"
+        else:
+            return None
+
+        parent = item.get("parent", {})
+        parent_type = parent.get("type")
+        try:
+            if parent_type == "block_id":
+                parent_id = self._resolve_block_parent_page_id(parent[parent_type])
+            elif parent_type == "workspace":
+                parent_id = "root"
+            elif parent_type and parent_type in parent:
+                parent_id = parent[parent_type]
+            else:
+                parent_id = "root"
+        except ValueError:
+            return None
+
+        return OnlineDocumentPage(
+            page_id=item["id"],
+            page_name=page_name,
+            page_icon=None,
+            parent_id=parent_id,
+            type=page_type,
+            last_edited_time=item["last_edited_time"],
+        )
+
+    @staticmethod
+    def _resolve_worker_count() -> int:
+        raw = os.environ.get("NOTION_PARENT_RESOLVE_WORKERS")
+        if not raw:
+            return _DEFAULT_PARENT_RESOLVE_WORKERS
+        try:
+            value = int(raw)
+        except ValueError:
+            return _DEFAULT_PARENT_RESOLVE_WORKERS
+        return max(1, min(value, _MAX_PARENT_RESOLVE_WORKERS))
+
+    def notion_page_search(self, access_token: str):
+        return [item for item in self._search_all() if item.get("object") == "page"]
 
     def notion_database_search(self, access_token: str):
-        results = []
-        next_cursor = None
-        has_more = True
-
-        while has_more:
-            data: dict[str, Any] = {
-                "filter": {"value": "database", "property": "object"},
-                **({"start_cursor": next_cursor} if next_cursor else {}),
-            }
-            headers = {
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {access_token}",
-                "Notion-Version": self._API_VERSION,
-            }
-            response = requests.post(
-                url=self._NOTION_PAGE_SEARCH, json=data, headers=headers, timeout=__TIMEOUT_SECONDS__
-            )
-            response_json = response.json()
-
-            results.extend(response_json.get("results", []))
-
-            has_more = response_json.get("has_more", False)
-            next_cursor = response_json.get("next_cursor", None)
-
-        return results
+        return [item for item in self._search_all() if item.get("object") == "database"]
 
     def notion_block_parent_page_id(self, access_token: str, block_id: str):
-        headers = {
-            "Authorization": f"Bearer {access_token}",
-            "Notion-Version": self._API_VERSION,
-        }
-        response = requests.get(
-            url=f"{self._NOTION_BLOCK_SEARCH}/{block_id}", headers=headers, timeout=__TIMEOUT_SECONDS__
-        )
-        if response.status_code == 404:
-            # Treat inaccessible parent as a root-level item.
-            return "root"
-        if response.status_code != 200:
-            try:
-                response_json = response.json()
-                message = response_json.get("message", "unknown error")
-            except requests.exceptions.JSONDecodeError:
-                message = response.text or "unknown error"
-            raise ValueError(f"Error fetching block parent page ID: {message}")
-        response_json = response.json()
-        parent = response_json["parent"]
-        parent_type = parent["type"]
-        if parent_type == "block_id":
-            return self.notion_block_parent_page_id(access_token, parent[parent_type])
-        return parent[parent_type]
+        return self._resolve_block_parent_page_id(block_id)
+
+    def _resolve_block_parent_page_id(self, block_id: str) -> str:
+        clean_id = block_id.replace("-", "")
+        cached = self._parent_cache.get(clean_id)
+        if cached is not None:
+            return cached
+
+        data = self._make_request("get", f"/blocks/{clean_id}", allow_status=(404,))
+        if data is None:
+            result = "root"
+        else:
+            parent = data.get("parent", {})
+            parent_type = parent.get("type")
+            if parent_type == "block_id":
+                result = self._resolve_block_parent_page_id(parent[parent_type])
+            elif parent_type == "workspace":
+                result = "root"
+            elif parent_type and parent_type in parent:
+                result = parent[parent_type]
+            else:
+                result = "root"
+
+        with self._parent_cache_lock:
+            self._parent_cache[clean_id] = result
+        return result

--- a/datasources/notion_datasource/manifest.yaml
+++ b/datasources/notion_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.20
+version: 0.1.21
 type: plugin
 author: langgenius
 name: notion_datasource


### PR DESCRIPTION
## Summary

Fixes #3170.

`langgenius/notion_datasource@0.1.18` cannot enumerate pages on Notion workspaces with more than ~1k shared items. `get_authorized_pages()` runs three phases serially (search pages, search databases, resolve every parent block — with recursion and no cache), which routinely exceeds the plugin-daemon SSE deadline (`PLUGIN_MAX_EXECUTION_TIMEOUT`, default 600s) and the request is `killed by timeout`.

This PR rewrites the hot path without changing the external behavior:

- **Parallel + memoized parent resolution.** Resolve `block_id` parents in a `ThreadPoolExecutor` (size configurable via the env var `NOTION_PARENT_RESOLVE_WORKERS`, default `8`, clamped to `[1, 32]`). Results are memoized in a thread-safe `dict` so sibling pages that share an ancestor don't re-issue the same HTTP request.
- **Single `/v1/search` loop.** The previous two filtered loops (one for `object="page"`, one for `object="database"`) are replaced with a single un-filtered pass; items are dispatched by `object` type. Halves the number of search round-trips.
- **Unified retries.** The three direct `requests.post/get` call sites are routed through `_make_request`, which already handles 429 / transient 5xx with backoff. `_make_request` gains an `allow_status` parameter so the existing "404 on a parent block → treat as root" behavior is preserved without re-introducing a direct request.

Backwards compatibility:

- `notion_page_search`, `notion_database_search`, `notion_block_parent_page_id` are kept as thin wrappers delegating to the new internals, so any external caller keeps working.
- `OnlineDocumentPage` field values are unchanged. The only observable difference is the ordering of the returned list (parallel completion order rather than insertion order), which downstream code does not rely on.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

This PR is an internal performance fix with no observable UI change.
Before/After behavior is shown below as plugin-daemon log excerpts.

Before — request killed by the 600s SSE deadline:

```text
plugin_daemon | ERROR ... PluginDaemonInternalServerError error="killed by timeout"
plugin_daemon | HTTP request POST /plugin/<tenant>/dispatch/datasource/get_online_document_pages
              | status=200 latency_ms=600003
api           | ERROR Exception on /console/api/notion/pre-import/pages
              |   httpcore.ReadTimeout: timed out
              |   httpx.ReadTimeout: timed out
```

After — same workspace, same credential, completes well inside the deadline:

```text
plugin_daemon | HTTP request POST /plugin/<tenant>/dispatch/datasource/get_online_document_pages
              | status=200 latency_ms=63151   # ← 63 s, no timeout
```

## LLM Plugin Checklist

Not applicable — this is a datasource plugin.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (`0.1.18` → `0.1.19`, **not** the one under `meta`)
- [x] `dify_plugin>=0.5.0` is declared in `pyproject.toml` and locked in `uv.lock`

A note on the template wording: the template suggests the literal range `dify_plugin>=0.3.0,<0.6.0`, but adding an upper bound of `<0.6.0` makes the lock unsatisfiable in this plugin — `dify_plugin` 0.5.x pins `werkzeug<3.1.dev0`, while this plugin already required `werkzeug>=3.1.7` before this PR. The current spec (`>=0.5.0`, no upper bound) matches the convention used by ~all other datasource plugins in this repo (confluence, dropbox, github, gitlab, onedrive, sharepoint, etc.). `uv.lock` is left as-is on `upstream/main`.

Patch-level bump rationale:
- public API of the plugin is unchanged
- no new `manifest.yaml` capabilities or `provider/notion_datasource.yaml` fields
- purely an internal performance/reliability fix

## Testing

- [x] Local deployment — Dify version: 1.14.1 (self-hosted Docker, plugin-daemon `0.6.0-local`)

Verified manually against a multi-thousand-item Notion workspace that was previously hitting the 600s SSE deadline. After this change the same enumeration completes in ~60 seconds end to end with the default worker count. No regressions observed on a small (< 100 items) workspace.

## Configuration

| Variable | Default | Range | Effect |
|---|---|---|---|
| `NOTION_PARENT_RESOLVE_WORKERS` | `8` | `1–32` (out-of-range values fall back / are clamped) | Worker count for the parallel parent-block resolution. `1` reproduces the old serial behavior. Increase cautiously — Notion's public rate limit is roughly 3 req/s and exceeding it just amplifies 429 backoff. |
