### PR TITLE
fix(openai): correct stale pricing for gpt-4o family and gpt-5.x pro/5.5

### DIFF
--- a/models/openai/manifest.yaml
+++ b/models/openai/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.4.0
+version: 0.4.1
 type: plugin
 author: "langgenius"
 name: "openai"

--- a/models/openai/models/llm/chatgpt-4o-latest.yaml
+++ b/models/openai/models/llm/chatgpt-4o-latest.yaml
@@ -38,7 +38,7 @@ parameter_rules:
       - text
       - json_object
 pricing:
-  input: '2.50'
-  output: '10.00'
+  input: '5.00'
+  output: '15.00'
   unit: '0.000001'
   currency: USD

--- a/models/openai/models/llm/gpt-4o-audio-preview-2025-06-03.yaml
+++ b/models/openai/models/llm/gpt-4o-audio-preview-2025-06-03.yaml
@@ -38,7 +38,7 @@ parameter_rules:
       - text
       - json_object
 pricing:
-  input: '5.00'
-  output: '15.00'
+  input: '2.50'
+  output: '10.00'
   unit: '0.000001'
   currency: USD

--- a/models/openai/models/llm/gpt-4o-audio-preview.yaml
+++ b/models/openai/models/llm/gpt-4o-audio-preview.yaml
@@ -38,7 +38,7 @@ parameter_rules:
       - text
       - json_object
 pricing:
-  input: '5.00'
-  output: '15.00'
+  input: '2.50'
+  output: '10.00'
   unit: '0.000001'
   currency: USD

--- a/models/openai/models/llm/gpt-4o.yaml
+++ b/models/openai/models/llm/gpt-4o.yaml
@@ -41,7 +41,7 @@ parameter_rules:
   - name: json_schema
     use_template: json_schema
 pricing:
-  input: '5.00'
-  output: '15.00'
+  input: '2.50'
+  output: '10.00'
   unit: '0.000001'
   currency: USD

--- a/models/openai/models/llm/gpt-5.4-pro.yaml
+++ b/models/openai/models/llm/gpt-5.4-pro.yaml
@@ -87,6 +87,6 @@ parameter_rules:
       - flex
 pricing:
   input: '30.00'
-  output: '135.00'
+  output: '180.00'
   unit: '0.000001'
   currency: USD

--- a/models/openai/models/llm/gpt-5.5-pro.yaml
+++ b/models/openai/models/llm/gpt-5.5-pro.yaml
@@ -86,7 +86,7 @@ parameter_rules:
       - default
       - flex
 pricing:
-  input: '15.00'
-  output: '90.00'
+  input: '30.00'
+  output: '180.00'
   unit: '0.000001'
   currency: USD

--- a/models/openai/models/llm/gpt-5.5.yaml
+++ b/models/openai/models/llm/gpt-5.5.yaml
@@ -87,6 +87,6 @@ parameter_rules:
       - flex
 pricing:
   input: '5.00'
-  output: '22.50'
+  output: '30.00'
   unit: '0.000001'
   currency: USD


### PR DESCRIPTION
## Summary

Several models in the OpenAI provider have stale or incorrect pricing in their YAMLs. The most impactful is the `gpt-4o` ↔ `chatgpt-4o-latest` swap that has been live since the v1.0.0 plugin migration — anyone using Dify's usage stats for `gpt-4o` has been billed against double the actual rate. This PR corrects 7 YAMLs against OpenAI's current official pricing.

All values verified against https://developers.openai.com/api/docs/pricing (the current official OpenAI pricing page) and https://platform.openai.com/docs/models.

## Pricing corrections

| File | Before (in/out) | After (in/out) | Notes |
|---|---|---|---|
| `models/openai/models/llm/gpt-4o.yaml` | 5.00 / 15.00 | **2.50 / 10.00** | Post Aug 6 2024 standard rate; matches Azure plugin's `gpt-4o` |
| `models/openai/models/llm/chatgpt-4o-latest.yaml` | 2.50 / 10.00 | **5.00 / 15.00** | `chat-latest` (ChatGPT model) is priced higher than `gpt-4o`; values look swapped with above |
| `models/openai/models/llm/gpt-4o-audio-preview.yaml` | 5.00 / 15.00 | **2.50 / 10.00** | Text I/O matches `gpt-4o`; audio I/O is metered separately |
| `models/openai/models/llm/gpt-4o-audio-preview-2025-06-03.yaml` | 5.00 / 15.00 | **2.50 / 10.00** | Same |
| `models/openai/models/llm/gpt-5.5.yaml` | 5.00 / 22.50 | 5.00 / **30.00** | Output rate per OpenAI pricing page |
| `models/openai/models/llm/gpt-5.5-pro.yaml` | 15.00 / 90.00 | **30.00 / 180.00** | Pro tier matches `gpt-5.4-pro` structure |
| `models/openai/models/llm/gpt-5.4-pro.yaml` | 30.00 / 135.00 | 30.00 / **180.00** | Output rate per OpenAI pricing page |

The latter three were introduced in #2981 (merged 2026-04-26) which added the GPT-5.5 family; the values appear to have been estimated before final pricing was published.

## Why this matters

`gpt-4o` is one of the most widely used models on Dify. The current `5.00 / 15.00` configuration causes Dify's cost-estimation UI and token-spend dashboards to display **2× the actual OpenAI bill**. The reverse is true for `chatgpt-4o-latest` (showing 50% of the actual cost). This has been quietly wrong since the v1.0.0 plugin migration (Feb 2025).

## This PR contains Changes to *Non-Plugin*

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*

- [ ] I have Run Comprehensive Tests Relevant to My Changes

## This PR contains Changes to *LLM Models Plugin*

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
- [x] My Changes Affect Token Consumption Metrics
- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
- [x] Other Changes (Add New Models, Fix Model Parameters etc.)

YAML pricing fields only — no runtime/behavior changes. Token consumption metrics shown in the Dify UI and exposed via APIs will now reflect actual OpenAI billing for affected models.

## Version Control

- [x] I have Bumped Up the Version in Manifest.yaml (`models/openai/manifest.yaml`: 0.4.0 → 0.4.1, PATCH for backwards-compatible fix)

## Dify Plugin SDK Version

- [x] I have Ensured `dify_plugin>=0.3.0,<0.6.0` is in requirements.txt (no SDK changes in this PR)

## Environment Verification

### SaaS Environment
- [x] Pricing values cross-referenced against OpenAI's official pricing page; YAML-only change with no runtime behavior modified. Following the pattern of the merged precedent #2674 (`fix(gemini): update pricing configuration for Gemini models`) which made an analogous pricing-only YAML correction.