### PR TITLE
fix(anthropic): update claude-3-5-haiku-20241022 pricing to current rates

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.14
+version: 0.3.15

--- a/models/anthropic/models/llm/claude-3-5-haiku-20241022.yaml
+++ b/models/anthropic/models/llm/claude-3-5-haiku-20241022.yaml
@@ -92,7 +92,7 @@ parameter_rules:
       zh_Hans: 启用工具结果的提示缓存。
       en_US: Enable prompt caching for tool results.
 pricing:
-  input: '1.00'
-  output: '5.00'
+  input: '0.80'
+  output: '4.00'
   unit: '0.000001'
   currency: USD


### PR DESCRIPTION
## Summary

`models/anthropic/models/llm/claude-3-5-haiku-20241022.yaml` still carries the launch-era price of `$1 / $5` per MTok. Anthropic's official pricing page now lists Claude Haiku 3.5 at `$0.80 / $4` per MTok (the model is retired on the first-party API but remains available on Bedrock and Vertex AI at the current rate).

Source: https://platform.claude.com/docs/en/about-claude/pricing — "Model pricing" table.

## Pricing correction

| File | Before (in/out) | After (in/out) |
|---|---|---|
| `models/anthropic/models/llm/claude-3-5-haiku-20241022.yaml` | 1.00 / 5.00 | **0.80 / 4.00** |

## This PR contains Changes to *Non-Plugin*

- [ ] Documentation
- [ ] Other

## This PR contains Changes to *Non-LLM Models Plugin*

- [ ] I have Run Comprehensive Tests Relevant to My Changes

## This PR contains Changes to *LLM Models Plugin*

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
- [x] My Changes Affect Token Consumption Metrics
- [ ] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
- [x] Other Changes (Add New Models, Fix Model Parameters etc.)

YAML pricing field only — no runtime/behavior change.

## Version Control

- [x] I have Bumped Up the Version in Manifest.yaml (`models/anthropic/manifest.yaml`: 0.3.14 → 0.3.15, PATCH for backwards-compatible fix)

## Dify Plugin SDK Version

- [x] No SDK changes in this PR.

## Environment Verification

### SaaS Environment
- [x] Pricing values cross-referenced against Anthropic's official pricing page. YAML-only change with no runtime behavior modified. Same pattern as the merged precedent #2674 (`fix(gemini): update pricing configuration for Gemini models`).