### PR TITLE
fix(vertex_ai): build typed Gemini tool schemas

### DIFF
--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.53
+version: 0.0.54

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -460,8 +460,17 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
 
     @classmethod
     def _convert_tool_parameter_schema(cls, schema: Mapping[str, Any]) -> types.Schema:
+        raw_type = schema.get("type")
+        if not raw_type:
+            if "properties" in schema:
+                raw_type = "object"
+            elif "items" in schema:
+                raw_type = "array"
+            else:
+                raw_type = "string"
+
         schema_type, nullable = cls._convert_json_schema_type_to_genai_type(
-            schema.get("type", "string")
+            raw_type
         )
         schema_kwargs: dict[str, Any] = {"type": schema_type}
 
@@ -473,7 +482,7 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
         if enum_values and isinstance(enum_values, list):
             schema_kwargs["enum"] = [str(value) for value in enum_values]
 
-        if nullable:
+        if nullable or schema.get("nullable") is True:
             schema_kwargs["nullable"] = True
 
         if schema_type == types.Type.OBJECT:

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -436,6 +436,72 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
         text = "".join((self._convert_one_message_to_text(message) for message in messages))
         return text.rstrip()
 
+    @staticmethod
+    def _convert_json_schema_type_to_genai_type(raw_type: Any) -> tuple[types.Type, bool]:
+        nullable = False
+        if isinstance(raw_type, list):
+            type_candidates = [item for item in raw_type if item != "null"]
+            nullable = len(type_candidates) != len(raw_type)
+            raw_type = type_candidates[0] if type_candidates else "string"
+
+        type_name = str(raw_type or "string").upper()
+        if type_name == "SELECT":
+            type_name = "STRING"
+
+        type_map = {
+            "ARRAY": types.Type.ARRAY,
+            "BOOLEAN": types.Type.BOOLEAN,
+            "INTEGER": types.Type.INTEGER,
+            "NUMBER": types.Type.NUMBER,
+            "OBJECT": types.Type.OBJECT,
+            "STRING": types.Type.STRING,
+        }
+        return type_map.get(type_name, types.Type.STRING), nullable
+
+    @classmethod
+    def _convert_tool_parameter_schema(cls, schema: Mapping[str, Any]) -> types.Schema:
+        schema_type, nullable = cls._convert_json_schema_type_to_genai_type(
+            schema.get("type", "string")
+        )
+        schema_kwargs: dict[str, Any] = {"type": schema_type}
+
+        description = schema.get("description")
+        if isinstance(description, str) and description:
+            schema_kwargs["description"] = description
+
+        enum_values = schema.get("enum")
+        if enum_values and isinstance(enum_values, list):
+            schema_kwargs["enum"] = [str(value) for value in enum_values]
+
+        if nullable:
+            schema_kwargs["nullable"] = True
+
+        if schema_type == types.Type.OBJECT:
+            raw_properties = schema.get("properties", {})
+            if isinstance(raw_properties, Mapping):
+                properties = {
+                    key: cls._convert_tool_parameter_schema(value)
+                    for key, value in raw_properties.items()
+                    if isinstance(key, str) and isinstance(value, Mapping)
+                }
+                if properties:
+                    schema_kwargs["properties"] = properties
+
+            required_params = schema.get("required")
+            if (
+                required_params
+                and isinstance(required_params, list)
+                and all(isinstance(item, str) for item in required_params)
+            ):
+                schema_kwargs["required"] = required_params
+
+        if schema_type == types.Type.ARRAY:
+            raw_items = schema.get("items")
+            if isinstance(raw_items, Mapping):
+                schema_kwargs["items"] = cls._convert_tool_parameter_schema(raw_items)
+
+        return types.Schema(**schema_kwargs)
+
     def _convert_tools_to_genai_tool(self, tools: list[PromptMessageTool]) -> types.Tool:
         """
         Convert tool messages to genai tools
@@ -445,52 +511,28 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
         """
         tool_declarations = []
         for tool_config in tools:
-            properties_for_schema = {}
-
-            # tool_config.parameters is guaranteed to be a dict by the Pydantic model
             parameters_input_dict = tool_config.parameters
             raw_properties = parameters_input_dict.get("properties", {})
+            properties = (
+                {
+                    key: value
+                    for key, value in raw_properties.items()
+                    if isinstance(key, str) and isinstance(value, Mapping)
+                }
+                if isinstance(raw_properties, Mapping)
+                else {}
+            )
+            parameters = (
+                self._convert_tool_parameter_schema(parameters_input_dict)
+                if properties
+                else None
+            )
 
-            if isinstance(raw_properties, dict):
-                for key, value_schema in raw_properties.items():
-                    if not isinstance(value_schema, dict):
-                        # Property schema must be a dictionary
-                        continue
-
-                    raw_type_str = str(value_schema.get("type", "string")).upper()
-                    # Map "SELECT" to "STRING" for GenAI SDK compatibility
-                    final_type_for_prop = "STRING" if raw_type_str == "SELECT" else raw_type_str
-
-                    prop_details = {
-                        "type": final_type_for_prop,
-                        "description": value_schema.get("description", ""),
-                    }
-
-                    enum_values = value_schema.get("enum")
-                    # Add enum only if it's a non-empty list (OpenAPI recommendation)
-                    if enum_values and isinstance(enum_values, list):
-                        prop_details["enum"] = enum_values
-
-                    properties_for_schema[key] = prop_details
-
-            # Schema for the 'parameters' object of the function declaration
-            parameters_schema_for_declaration = {
-                "type": "OBJECT",
-                "properties": properties_for_schema,
-            }
-
-            required_params = parameters_input_dict.get("required")
-            # Add required only if it's a non-empty list of strings (OpenAPI recommendation)
-            if required_params and isinstance(required_params, list) and all(
-                isinstance(item, str) for item in required_params):
-                parameters_schema_for_declaration["required"] = required_params
-
-            # Create function declaration dict for GenAI SDK
-            function_declaration = {
-                "name": tool_config.name,
-                "description": tool_config.description or "",
-                "parameters": parameters_schema_for_declaration
-            }
+            function_declaration = types.FunctionDeclaration(
+                name=tool_config.name,
+                description=tool_config.description or "",
+                parameters=parameters,
+            )
             tool_declarations.append(function_declaration)
 
         return types.Tool(function_declarations=tool_declarations) if tool_declarations else None

--- a/models/vertex_ai/models/tests/test_llm_tool_schema.py
+++ b/models/vertex_ai/models/tests/test_llm_tool_schema.py
@@ -1,0 +1,73 @@
+import os
+import sys
+
+from dify_plugin.entities.model.message import PromptMessageTool
+from google.genai import types
+
+try:
+    from models.llm.llm import VertexAiLargeLanguageModel
+except ImportError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    from models.llm.llm import VertexAiLargeLanguageModel
+
+
+def test_empty_tool_parameters_are_omitted():
+    llm = VertexAiLargeLanguageModel([])
+    tool = PromptMessageTool(
+        name="ping",
+        description="Ping an external service",
+        parameters={"type": "object", "properties": {}},
+    )
+
+    genai_tool = llm._convert_tools_to_genai_tool([tool])
+
+    declaration = genai_tool.function_declarations[0]
+    assert isinstance(declaration, types.FunctionDeclaration)
+    assert declaration.parameters is None
+
+
+def test_tool_parameters_are_typed_genai_schema_objects():
+    llm = VertexAiLargeLanguageModel([])
+    tool = PromptMessageTool(
+        name="search",
+        description="Search documents",
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+                "limit": {"type": "integer", "description": "Maximum results"},
+                "mode": {"type": "select", "enum": ["fast", "full"]},
+                "filters": {
+                    "type": "object",
+                    "properties": {
+                        "archived": {"type": "boolean"},
+                    },
+                    "required": ["archived"],
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+            "required": ["query"],
+        },
+    )
+
+    genai_tool = llm._convert_tools_to_genai_tool([tool])
+
+    parameters = genai_tool.function_declarations[0].parameters
+    assert isinstance(parameters, types.Schema)
+    assert parameters.type == types.Type.OBJECT
+    assert parameters.required == ["query"]
+    assert parameters.properties["query"].type == types.Type.STRING
+    assert parameters.properties["limit"].type == types.Type.INTEGER
+    assert parameters.properties["mode"].type == types.Type.STRING
+    assert parameters.properties["mode"].enum == ["fast", "full"]
+    assert parameters.properties["filters"].type == types.Type.OBJECT
+    assert parameters.properties["filters"].required == ["archived"]
+    assert (
+        parameters.properties["filters"].properties["archived"].type
+        == types.Type.BOOLEAN
+    )
+    assert parameters.properties["tags"].type == types.Type.ARRAY
+    assert parameters.properties["tags"].items.type == types.Type.STRING

--- a/models/vertex_ai/models/tests/test_llm_tool_schema.py
+++ b/models/vertex_ai/models/tests/test_llm_tool_schema.py
@@ -48,6 +48,8 @@ def test_tool_parameters_are_typed_genai_schema_objects():
                     "type": "array",
                     "items": {"type": "string"},
                 },
+                "note": {"type": "string", "nullable": True},
+                "optional_count": {"type": ["integer", "null"]},
             },
             "required": ["query"],
         },
@@ -71,3 +73,36 @@ def test_tool_parameters_are_typed_genai_schema_objects():
     )
     assert parameters.properties["tags"].type == types.Type.ARRAY
     assert parameters.properties["tags"].items.type == types.Type.STRING
+    assert parameters.properties["note"].nullable is True
+    assert parameters.properties["optional_count"].type == types.Type.INTEGER
+    assert parameters.properties["optional_count"].nullable is True
+
+
+def test_tool_parameters_infer_missing_schema_types():
+    llm = VertexAiLargeLanguageModel([])
+    tool = PromptMessageTool(
+        name="search",
+        description="Search documents",
+        parameters={
+            "properties": {
+                "filters": {
+                    "properties": {
+                        "labels": {
+                            "items": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        },
+    )
+
+    genai_tool = llm._convert_tools_to_genai_tool([tool])
+
+    parameters = genai_tool.function_declarations[0].parameters
+    assert parameters.type == types.Type.OBJECT
+    assert parameters.properties["filters"].type == types.Type.OBJECT
+    assert parameters.properties["filters"].properties["labels"].type == types.Type.ARRAY
+    assert (
+        parameters.properties["filters"].properties["labels"].items.type
+        == types.Type.STRING
+    )


### PR DESCRIPTION
## What changed

Fixes #3173.

- Builds Vertex AI Gemini function declarations with `google.genai.types.FunctionDeclaration` and `types.Schema` instead of raw dicts.
- Omits `parameters` for tools with no declared properties, so Gemini 3.x does not receive an empty `OBJECT` schema.
- Keeps existing type handling for string/select, integer, number, boolean, object, array, enum, required, and nullable schemas.

## Tests

- `uv run --with pytest pytest models/tests/test_llm_tool_schema.py`
- `uv run --with ruff ruff check models/tests/test_llm_tool_schema.py`