### PR TITLE
fix(tongyi): align Qwen3-VL thinking defaults

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.1.45
+version: 0.1.46
 created_at: "2024-12-10T16:13:50.29298939+08:00"

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -222,8 +222,9 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             "qwen-plus-latest", "qwen-plus-2025-04-28",
             "qwen-turbo-latest", "qwen-turbo-2025-04-28",
             "qwen-flash", "qwen-flash-2025-07-28",
-            # Qwen3 Max series (default: thinking disabled)
+            # Qwen3 Max and VL Plus/Flash series (default: thinking disabled, but explicit False ensures consistency)
             "qwen3-max-2026-01-23", "qwen3-max-preview",
+            "qwen3-vl-plus", "qwen3-vl-plus-2025-09-23", "qwen3-vl-flash",
             # Qwen3.5/3.6 series (default: thinking ENABLED - must explicitly disable)
             "qwen3.6-plus", "qwen3.6-plus-2026-04-02",
             "qwen3.6-flash", "qwen3.6-flash-2026-04-16",
@@ -258,6 +259,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             "qwen-turbo-2025-04-28",
             "qwen-flash", "qwen-flash-2025-07-28",
             "qwen3-max-2026-01-23", "qwen3-max-preview",
+            "qwen3-vl-plus", "qwen3-vl-plus-2025-09-23", "qwen3-vl-flash",
             "qwen3.6-plus", "qwen3.6-plus-2026-04-02",
             "qwen3.5-plus", "qwen3.5-plus-2026-02-15",
             "qwen3.5-flash", "qwen3.5-flash-2026-02-23",
@@ -278,10 +280,9 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         )
 
         # Thinking-mode models that need streamed responses so reasoning_content is preserved.
-        # Note: qwen3-coder-xx, qwen3-max-xx, and qwen3.5-xx models support non-streaming output.
-        # Note: qwen3-coder-xx, qwen3-max-xx, and qwen3.5-xx models support non-streaming output.
+        # Note: qwen3-coder-xx, qwen3-max-xx, qwen3-vl-plus/flash, and qwen3.5-xx models support non-streaming output.
         qwen3_requires_stream = model.startswith("qwen3-") and not model.startswith(
-            ("qwen3-coder", "qwen3-max", "qwen3.5-")
+            ("qwen3-coder", "qwen3-max", "qwen3-vl-plus", "qwen3-vl-flash", "qwen3.5-")
         )
         common_force_condition = (
             thinking_business_qwen3
@@ -292,7 +293,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         )
         if common_force_condition or model.startswith(("qwq-", "qvq-")):
             stream = True
-        # Qwen3 business edition (Thinking Mode), Qwen3 open-source edition (excluding coder and max variants), QwQ, QVQ, Kimi, and GLM thinking models only supports incremental_output set to True.
+        # Qwen3 business edition (Thinking Mode), Qwen3 open-source edition (excluding coder, max, and VL Plus/Flash variants), QwQ, QVQ, Kimi, and GLM thinking models only supports incremental_output set to True.
         if common_force_condition or model.startswith(("qwq-", "qvq-")):
             incremental_output = True
 

--- a/models/tongyi/models/llm/qwen3-vl-flash.yaml
+++ b/models/tongyi/models/llm/qwen3-vl-flash.yaml
@@ -70,6 +70,28 @@ parameter_rules:
     help:
       zh_Hans: 用于控制模型生成时的重复度。提高 repetition_penalty 时可以降低模型生成的重复度。1.0 表示不做惩罚。
       en_US: Used to control the repeatability when generating models. Increasing repetition_penalty can reduce the duplication of model generation. 1.0 means no punishment.
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking mode
+    help:
+      zh_Hans: 是否开启思考模式。
+      en_US: Whether to enable thinking mode.
+  - name: thinking_budget
+    required: false
+    type: int
+    default: 512
+    min: 1
+    max: 8192
+    label:
+      zh_Hans: 思考长度限制
+      en_US: Thinking budget
+    help:
+      zh_Hans: 思考过程的最大长度，只在思考模式为 true 时生效。
+      en_US: The maximum length of the thinking process, only effective when thinking mode is true.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/models/tongyi/models/llm/qwen3-vl-plus-2025-09-23.yaml
+++ b/models/tongyi/models/llm/qwen3-vl-plus-2025-09-23.yaml
@@ -71,7 +71,7 @@ parameter_rules:
   - name: enable_thinking
     required: false
     type: boolean
-    default: true
+    default: false
     label:
       zh_Hans: 思考模式
       en_US: Thinking mode

--- a/models/tongyi/models/llm/qwen3-vl-plus.yaml
+++ b/models/tongyi/models/llm/qwen3-vl-plus.yaml
@@ -71,7 +71,7 @@ parameter_rules:
   - name: enable_thinking
     required: false
     type: boolean
-    default: true
+    default: false
     label:
       zh_Hans: 思考模式
       en_US: Thinking mode

--- a/models/tongyi/tests/test_llm_qwen3_vl_hybrid_thinking.py
+++ b/models/tongyi/tests/test_llm_qwen3_vl_hybrid_thinking.py
@@ -1,0 +1,73 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dify_plugin.entities.model import ModelFeature
+from dify_plugin.entities.model.message import UserPromptMessage
+
+from models.llm.llm import TongyiLargeLanguageModel
+
+
+QWEN3_VL_HYBRID_THINKING_MODELS = [
+    "qwen3-vl-plus",
+    "qwen3-vl-plus-2025-09-23",
+    "qwen3-vl-flash",
+]
+
+
+def _model() -> TongyiLargeLanguageModel:
+    model = TongyiLargeLanguageModel(model_schemas=MagicMock())
+    model.get_model_mode = MagicMock(return_value="chat")
+    model.get_model_schema = MagicMock(
+        return_value=SimpleNamespace(features=[ModelFeature.VISION])
+    )
+    model._handle_generate_response = MagicMock(return_value="non-stream-result")
+    model._handle_generate_stream_response = MagicMock(return_value=iter(["stream-result"]))
+    return model
+
+
+def _invoke(model_name: str, model_parameters: dict, stream: bool = False):
+    model = _model()
+    with patch("models.llm.llm.MultiModalConversation.call", return_value=MagicMock()) as call:
+        result = model._generate(
+            model=model_name,
+            credentials={"dashscope_api_key": "test-key"},
+            prompt_messages=[UserPromptMessage(content="hello")],
+            model_parameters=model_parameters,
+            stream=stream,
+        )
+    return call.call_args.kwargs, result
+
+
+def test_qwen3_vl_hybrid_models_default_to_non_thinking_in_yaml() -> None:
+    models_dir = Path(__file__).parent.parent / "models" / "llm"
+    for model_name in QWEN3_VL_HYBRID_THINKING_MODELS:
+        data = yaml.safe_load((models_dir / f"{model_name}.yaml").read_text())
+        enable_thinking_rule = next(
+            rule for rule in data["parameter_rules"] if rule["name"] == "enable_thinking"
+        )
+        assert enable_thinking_rule["default"] is False
+
+
+def test_qwen3_vl_hybrid_models_do_not_force_streaming_when_thinking_is_omitted() -> None:
+    for model_name in QWEN3_VL_HYBRID_THINKING_MODELS:
+        kwargs, result = _invoke(model_name, {})
+        assert kwargs["stream"] is False
+        assert kwargs["incremental_output"] is False
+        assert kwargs["enable_thinking"] is False
+        assert result == "non-stream-result"
+
+
+def test_qwen3_vl_hybrid_models_force_streaming_when_thinking_is_enabled() -> None:
+    for model_name in QWEN3_VL_HYBRID_THINKING_MODELS:
+        kwargs, result = _invoke(model_name, {"enable_thinking": True})
+        assert kwargs["stream"] is True
+        assert kwargs["incremental_output"] is True
+        assert kwargs["enable_thinking"] is True
+        assert list(result) == ["stream-result"]


### PR DESCRIPTION
## Summary

This PR aligns Tongyi Qwen3-VL Plus/Flash thinking-mode defaults and streaming behavior with Alibaba Cloud DashScope documentation.

- Set `enable_thinking` default to `false` for `qwen3-vl-plus` and `qwen3-vl-plus-2025-09-23`
- Add `enable_thinking` and `thinking_budget` parameters for `qwen3-vl-flash`
- Explicitly send `enable_thinking=false` for Qwen3-VL Plus/Flash models when the parameter is omitted
- Do not force Qwen3-VL Plus/Flash into streaming mode unless thinking mode is explicitly enabled
- Add regression tests for omitted and explicitly enabled thinking mode

## Background

Alibaba Cloud documents `qwen3-vl-plus` and `qwen3-vl-flash` as hybrid thinking models:

- They support `enable_thinking` to enable or disable thinking mode.
- `qwen3-vl-plus` and `qwen3-vl-flash` default to `enable_thinking=false`.
- Streaming is recommended when thinking mode is enabled, but non-thinking mode supports non-streaming output.

References:

- https://help.aliyun.com/zh/dashscope/developer-reference/qwen-vl-plus/
- https://help.aliyun.com/zh/model-studio/user-guide/qvq

## Problem

The Tongyi plugin previously forced Qwen3-VL Plus/Flash models into the streaming path through the blanket `qwen3_requires_stream` condition.

Before this change, a non-streaming call without explicit thinking mode could still be routed as streaming. For example, a real API probe for `qwen3-vl-flash` showed:

```text
stream_arg=false
enable_thinking=omit
result_kind=stream
chunks=3
```

## Behavior after this change

For Qwen3-VL Plus/Flash models:

- omitted `enable_thinking` -> explicitly sent as `false`
- `enable_thinking=false` -> non-streaming requests stay non-streaming
- `enable_thinking=true` -> streaming/incremental output is forced to preserve reasoning content

## Validation

```bash
cd models/tongyi
uv run pytest tests/test_llm_qwen3_vl_hybrid_thinking.py -q
```

```text
3 passed
```

```bash
cd models/tongyi
uv run pytest tests/test_speech2text.py tests/test_llm_qwen3_vl_hybrid_thinking.py -q
```

```text
13 passed, 3 warnings
```

The global pre-commit gate also ran the isolated Tongyi plugin check successfully during commit:

```text
global pre-commit checks passed
```

## Notes

This is a correctness fix for model parameter defaults and streaming behavior. It does not claim to fix a reproduced production CPU issue, although avoiding unnecessary streaming-path handling may reduce overhead for non-thinking calls.
