### PR TITLE
feat(openai): attach Dify app_id as request metadata (opt-in)

### DIFF
--- a/models/openai/manifest.yaml
+++ b/models/openai/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.4.1
+version: 0.4.2
 type: plugin
 author: "langgenius"
 name: "openai"

--- a/models/openai/manifest.yaml
+++ b/models/openai/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.4.2
+version: 0.4.3
 type: plugin
 author: "langgenius"
 name: "openai"

--- a/models/openai/models/llm/_metadata.py
+++ b/models/openai/models/llm/_metadata.py
@@ -13,12 +13,15 @@ Unlike Bedrock or Vertex, OpenAI does not document a character pattern
 restriction on metadata values, so ``normalize_metadata_value`` only
 enforces string coercion and the 512-character length cap.
 
-This plugin deliberately does NOT set ``store=true``. Whether stored
-completions are retained — and therefore whether this metadata appears
-in the dashboard — is governed by the account-level Stored Completions
-setting, which the terminus owner controls. Setting ``store`` from the
-plugin would change persistence behavior as a side effect of an
-observability opt-in, which is out of scope for this feature.
+The OpenAI API only accepts ``metadata`` when ``store`` is true — it
+rejects the request with ``BadRequestError: The 'metadata' parameter is
+only allowed when 'store' is enabled.`` otherwise. Enabling this feature
+therefore inherently requires ``store=true``, so
+``apply_dify_metadata_if_enabled`` sets it alongside the metadata. This
+means requests and responses are persisted to Stored Completions on the
+OpenAI account; the credential's help text documents that storage
+behavior. An explicit ``store`` value already present on the request is
+respected rather than overwritten.
 """
 
 from __future__ import annotations
@@ -67,8 +70,11 @@ def apply_dify_metadata_if_enabled(target: dict, credentials: dict) -> None:
     """Inject Dify metadata into ``target`` when opt-in credential is set.
 
     Reads ``credentials['enable_request_metadata']``; when ``"enabled"``,
-    resolves the current Dify session's ``app_id`` (best-effort) and sets
-    ``target['metadata']`` to the built dict, if one is produced.
+    resolves the current Dify session's ``app_id`` (best-effort), sets
+    ``target['metadata']`` to the built dict (if one is produced), and sets
+    ``target['store'] = True`` — the API only accepts ``metadata`` when
+    ``store`` is enabled. An explicit ``store`` value already on ``target``
+    is left untouched.
 
     Session lookup failures are swallowed silently: metadata attachment is
     telemetry, and must never break generation if the SDK is missing or
@@ -99,3 +105,7 @@ def apply_dify_metadata_if_enabled(target: dict, credentials: dict) -> None:
         target["metadata"] = {**existing, **metadata}
     else:
         target["metadata"] = metadata
+    # The API only accepts metadata when store=true. Don't overwrite an
+    # explicit store value already set by the caller.
+    if "store" not in target:
+        target["store"] = True

--- a/models/openai/models/llm/_metadata.py
+++ b/models/openai/models/llm/_metadata.py
@@ -23,12 +23,12 @@ observability opt-in, which is out of scope for this feature.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 _MAX_VALUE_LENGTH = 512
 
 
-def normalize_metadata_value(s: str) -> str:
+def normalize_metadata_value(s: Any) -> str:
     """Normalize an arbitrary value into an OpenAI metadata value.
 
     Coerces non-string input via ``str()`` so that, e.g., a numeric ``0``
@@ -44,14 +44,16 @@ def normalize_metadata_value(s: str) -> str:
     return s[:_MAX_VALUE_LENGTH]
 
 
-def build_dify_metadata(app_id: Optional[str]) -> Optional[dict[str, str]]:
+def build_dify_metadata(app_id: Any) -> Optional[dict[str, str]]:
     """Build the Dify metadata dict for an OpenAI request, or return ``None``.
 
     Returns ``None`` if ``app_id`` is ``None`` or an empty string, so the
-    caller can skip attaching metadata entirely. Otherwise, returns a dict
-    with ``dify_app_id`` (normalized) and a static ``dify_source`` marker.
+    caller can skip attaching metadata entirely. Other falsy values (e.g.
+    numeric ``0``) are coerced by ``normalize_metadata_value`` and pass
+    through. Otherwise, returns a dict with ``dify_app_id`` (normalized)
+    and a static ``dify_source`` marker.
     """
-    if not app_id:
+    if app_id is None or app_id == "":
         return None
     return {
         "dify_app_id": normalize_metadata_value(app_id),
@@ -85,5 +87,11 @@ def apply_dify_metadata_if_enabled(target: dict, credentials: dict) -> None:
         pass
 
     metadata = build_dify_metadata(app_id)
-    if metadata is not None:
+    if metadata is None:
+        return
+    existing = target.get("metadata")
+    if isinstance(existing, dict):
+        # Preserve any caller-supplied metadata; only fill in Dify keys.
+        existing.update(metadata)
+    else:
         target["metadata"] = metadata

--- a/models/openai/models/llm/_metadata.py
+++ b/models/openai/models/llm/_metadata.py
@@ -37,6 +37,8 @@ def normalize_metadata_value(s: Any) -> str:
     character-pattern restriction, so no character substitution is
     performed.
     """
+    if s is None:
+        return ""
     if not isinstance(s, str):
         s = str(s)
     if not s:
@@ -92,6 +94,8 @@ def apply_dify_metadata_if_enabled(target: dict, credentials: dict) -> None:
     existing = target.get("metadata")
     if isinstance(existing, dict):
         # Preserve any caller-supplied metadata; only fill in Dify keys.
-        existing.update(metadata)
+        # Build a new dict rather than mutating in place, so a caller-shared
+        # reference is never modified as a side effect of telemetry opt-in.
+        target["metadata"] = {**existing, **metadata}
     else:
         target["metadata"] = metadata

--- a/models/openai/models/llm/_metadata.py
+++ b/models/openai/models/llm/_metadata.py
@@ -1,0 +1,89 @@
+"""Helpers for attaching Dify metadata to OpenAI chat/responses requests.
+
+OpenAI's ``chat.completions.create`` and ``responses.create`` accept a
+``metadata`` field (a string-to-string map) that — when the account has
+Stored Completions enabled — surfaces in the Usage Dashboard, enabling
+per-app filtering. Constraints, from the OpenAI API reference:
+
+  Set of 16 key-value pairs that can be attached to an object. Keys are
+  strings with a maximum length of 64 characters. Values are strings with
+  a maximum length of 512 characters.
+
+Unlike Bedrock or Vertex, OpenAI does not document a character pattern
+restriction on metadata values, so ``normalize_metadata_value`` only
+enforces string coercion and the 512-character length cap.
+
+This plugin deliberately does NOT set ``store=true``. Whether stored
+completions are retained — and therefore whether this metadata appears
+in the dashboard — is governed by the account-level Stored Completions
+setting, which the terminus owner controls. Setting ``store`` from the
+plugin would change persistence behavior as a side effect of an
+observability opt-in, which is out of scope for this feature.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+_MAX_VALUE_LENGTH = 512
+
+
+def normalize_metadata_value(s: str) -> str:
+    """Normalize an arbitrary value into an OpenAI metadata value.
+
+    Coerces non-string input via ``str()`` so that, e.g., a numeric ``0``
+    becomes ``"0"`` rather than being silently dropped by the empty-check,
+    then truncates to 512 characters. OpenAI does not document a
+    character-pattern restriction, so no character substitution is
+    performed.
+    """
+    if not isinstance(s, str):
+        s = str(s)
+    if not s:
+        return ""
+    return s[:_MAX_VALUE_LENGTH]
+
+
+def build_dify_metadata(app_id: Optional[str]) -> Optional[dict[str, str]]:
+    """Build the Dify metadata dict for an OpenAI request, or return ``None``.
+
+    Returns ``None`` if ``app_id`` is ``None`` or an empty string, so the
+    caller can skip attaching metadata entirely. Otherwise, returns a dict
+    with ``dify_app_id`` (normalized) and a static ``dify_source`` marker.
+    """
+    if not app_id:
+        return None
+    return {
+        "dify_app_id": normalize_metadata_value(app_id),
+        "dify_source": "dify",
+    }
+
+
+def apply_dify_metadata_if_enabled(target: dict, credentials: dict) -> None:
+    """Inject Dify metadata into ``target`` when opt-in credential is set.
+
+    Reads ``credentials['enable_request_metadata']``; when ``"enabled"``,
+    resolves the current Dify session's ``app_id`` (best-effort) and sets
+    ``target['metadata']`` to the built dict, if one is produced.
+
+    Session lookup failures are swallowed silently: metadata attachment is
+    telemetry, and must never break generation if the SDK is missing or
+    the session context is not initialized.
+    """
+    if credentials.get("enable_request_metadata") != "enabled":
+        return
+
+    app_id: Optional[str] = None
+    try:
+        from dify_plugin import get_current_session
+
+        session = get_current_session()
+        if session is not None:
+            app_id = getattr(session, "app_id", None)
+    except Exception:
+        # Best-effort telemetry: never break generation.
+        pass
+
+    metadata = build_dify_metadata(app_id)
+    if metadata is not None:
+        target["metadata"] = metadata

--- a/models/openai/models/llm/llm.py
+++ b/models/openai/models/llm/llm.py
@@ -771,6 +771,14 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         if stream:
             extra_model_kwargs["stream_options"] = {"include_usage": True}
 
+        # Optional: attach Dify app_id as OpenAI request metadata. Default
+        # disabled; opt-in via the enable_request_metadata credential. Whether
+        # this surfaces in the Usage Dashboard depends on the account's
+        # Stored Completions setting — the plugin does not set store=true.
+        from ._metadata import apply_dify_metadata_if_enabled
+
+        apply_dify_metadata_if_enabled(extra_model_kwargs, credentials)
+
         # clear illegal prompt messages
         prompt_messages = self._clear_illegal_prompt_messages(model, prompt_messages)
 
@@ -832,6 +840,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         self,
         model_parameters: dict,
         user: Optional[str] = None,
+        credentials: Optional[dict] = None,
     ) -> dict:
         """
         Convert model_parameters to Responses API compatible params.
@@ -882,6 +891,14 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
 
         if user:
             params["user"] = user
+
+        # Optional: attach Dify app_id as OpenAI request metadata. Default
+        # disabled; opt-in via the enable_request_metadata credential. See
+        # _metadata.py for the rationale on not setting store=true.
+        if credentials is not None:
+            from ._metadata import apply_dify_metadata_if_enabled
+
+            apply_dify_metadata_if_enabled(params, credentials)
 
         return params
 
@@ -971,7 +988,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         Invoke model using the Responses API (non-streaming).
         Used for models like o3-pro that only support responses.create.
         """
-        response_params = self._build_responses_api_params(model_parameters, user)
+        response_params = self._build_responses_api_params(model_parameters, user, credentials)
 
         input_items = self._convert_prompt_messages_to_responses_input(prompt_messages, tools)
         api_tools = self._build_responses_api_tools(tools)
@@ -1039,7 +1056,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         """
         Invoke model using the Responses API with streaming.
         """
-        response_params = self._build_responses_api_params(model_parameters, user)
+        response_params = self._build_responses_api_params(model_parameters, user, credentials)
 
         input_items = self._convert_prompt_messages_to_responses_input(prompt_messages, tools)
         api_tools = self._build_responses_api_tools(tools)

--- a/models/openai/models/llm/llm.py
+++ b/models/openai/models/llm/llm.py
@@ -772,9 +772,10 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             extra_model_kwargs["stream_options"] = {"include_usage": True}
 
         # Optional: attach Dify app_id as OpenAI request metadata. Default
-        # disabled; opt-in via the enable_request_metadata credential. Whether
-        # this surfaces in the Usage Dashboard depends on the account's
-        # Stored Completions setting — the plugin does not set store=true.
+        # disabled; opt-in via the enable_request_metadata credential. When
+        # enabled, store=true is set alongside the metadata (the API only
+        # accepts metadata when store is enabled), persisting the request to
+        # Stored Completions on the OpenAI account.
         from ._metadata import apply_dify_metadata_if_enabled
 
         apply_dify_metadata_if_enabled(extra_model_kwargs, credentials)
@@ -893,8 +894,9 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             params["user"] = user
 
         # Optional: attach Dify app_id as OpenAI request metadata. Default
-        # disabled; opt-in via the enable_request_metadata credential. See
-        # _metadata.py for the rationale on not setting store=true.
+        # disabled; opt-in via the enable_request_metadata credential. When
+        # enabled, store=true is set alongside the metadata — see _metadata.py
+        # for why the API requires it.
         if credentials is not None:
             from ._metadata import apply_dify_metadata_if_enabled
 

--- a/models/openai/provider/openai.yaml
+++ b/models/openai/provider/openai.yaml
@@ -95,8 +95,8 @@ model_credential_schema:
             zh_Hans: 已禁用
             en_US: Disabled
       help:
-        zh_Hans: 启用后，将在 OpenAI Chat Completions 和 Responses API 调用中将 dify_app_id 和 dify_source 作为 metadata 附加，从而支持按应用过滤 Usage Dashboard。元数据是否在 Dashboard 中可见取决于 OpenAI 账户的 Stored Completions 设置，本插件不会设置 store=true。默认禁用。
-        en_US: When enabled, attaches dify_app_id and dify_source as metadata on OpenAI Chat Completions and Responses API calls, enabling per-app filtering in the Usage Dashboard. Whether the metadata is visible in the dashboard depends on the OpenAI account's Stored Completions setting; this plugin does not set store=true. Default disabled.
+        zh_Hans: 启用后，在 chat.completions.create 和 responses.create 调用中附加 dify_app_id 和 dify_source 作为 metadata，同时设置 store=true 以便 metadata 被记录到 Stored Completions（OpenAI API 要求：仅当 store 为 true 时才接受 metadata）。这意味着请求和响应会保存在您的 OpenAI 账户。可见性由您的 OpenAI Stored Completions 设置控制。默认禁用。
+        en_US: "When enabled, attaches dify_app_id and dify_source as metadata on both chat.completions.create and responses.create, AND sets store=true so the metadata is recorded in Stored Completions (required by OpenAI API: metadata is only accepted when store is true). This means requests and responses are persisted on your OpenAI account; visibility is governed by your OpenAI Stored Completions setting. Default disabled. See: https://platform.openai.com/docs/api-reference/chat/create#chat-create-store"
 provider_credential_schema:
   credential_form_schemas:
     - variable: openai_api_key
@@ -170,8 +170,8 @@ provider_credential_schema:
             zh_Hans: 已禁用
             en_US: Disabled
       help:
-        zh_Hans: 启用后，将在 OpenAI Chat Completions 和 Responses API 调用中将 dify_app_id 和 dify_source 作为 metadata 附加，从而支持按应用过滤 Usage Dashboard。元数据是否在 Dashboard 中可见取决于 OpenAI 账户的 Stored Completions 设置，本插件不会设置 store=true。默认禁用。
-        en_US: When enabled, attaches dify_app_id and dify_source as metadata on OpenAI Chat Completions and Responses API calls, enabling per-app filtering in the Usage Dashboard. Whether the metadata is visible in the dashboard depends on the OpenAI account's Stored Completions setting; this plugin does not set store=true. Default disabled.
+        zh_Hans: 启用后，在 chat.completions.create 和 responses.create 调用中附加 dify_app_id 和 dify_source 作为 metadata，同时设置 store=true 以便 metadata 被记录到 Stored Completions（OpenAI API 要求：仅当 store 为 true 时才接受 metadata）。这意味着请求和响应会保存在您的 OpenAI 账户。可见性由您的 OpenAI Stored Completions 设置控制。默认禁用。
+        en_US: "When enabled, attaches dify_app_id and dify_source as metadata on both chat.completions.create and responses.create, AND sets store=true so the metadata is recorded in Stored Completions (required by OpenAI API: metadata is only accepted when store is true). This means requests and responses are persisted on your OpenAI account; visibility is governed by your OpenAI Stored Completions setting. Default disabled. See: https://platform.openai.com/docs/api-reference/chat/create#chat-create-store"
 models:
   llm:
     predefined:

--- a/models/openai/provider/openai.yaml
+++ b/models/openai/provider/openai.yaml
@@ -78,6 +78,25 @@ model_credential_schema:
       help:
         zh_Hans: 选择该模型使用的 API 协议。Chat Completions 适用于大多数模型，Responses API 适用于 o3-pro、gpt-5.4 等模型。
         en_US: Select the API protocol for this model. Use Chat Completions for most models, Responses API for models like o3-pro and gpt-5.4.
+    - variable: enable_request_metadata
+      label:
+        zh_Hans: 启用请求元数据（可选）
+        en_US: Enable request metadata (optional)
+      type: select
+      required: false
+      default: disabled
+      options:
+        - value: enabled
+          label:
+            zh_Hans: 已启用
+            en_US: Enabled
+        - value: disabled
+          label:
+            zh_Hans: 已禁用
+            en_US: Disabled
+      help:
+        zh_Hans: 启用后，将在 OpenAI Chat Completions 和 Responses API 调用中将 dify_app_id 和 dify_source 作为 metadata 附加，从而支持按应用过滤 Usage Dashboard。元数据是否在 Dashboard 中可见取决于 OpenAI 账户的 Stored Completions 设置，本插件不会设置 store=true。默认禁用。
+        en_US: When enabled, attaches dify_app_id and dify_source as metadata on OpenAI Chat Completions and Responses API calls, enabling per-app filtering in the Usage Dashboard. Whether the metadata is visible in the dashboard depends on the OpenAI account's Stored Completions setting; this plugin does not set store=true. Default disabled.
 provider_credential_schema:
   credential_form_schemas:
     - variable: openai_api_key
@@ -134,6 +153,25 @@ provider_credential_schema:
       help:
         zh_Hans: 选择该 Provider 使用的 API 协议。Chat Completions 适用于大多数模型，Responses API 适用于 o3-pro、gpt-5 等模型。
         en_US: Select the API protocol for this provider. Use Chat Completions for most models, Responses API for models like o3-pro and gpt-5.
+    - variable: enable_request_metadata
+      label:
+        zh_Hans: 启用请求元数据（可选）
+        en_US: Enable request metadata (optional)
+      type: select
+      required: false
+      default: disabled
+      options:
+        - value: enabled
+          label:
+            zh_Hans: 已启用
+            en_US: Enabled
+        - value: disabled
+          label:
+            zh_Hans: 已禁用
+            en_US: Disabled
+      help:
+        zh_Hans: 启用后，将在 OpenAI Chat Completions 和 Responses API 调用中将 dify_app_id 和 dify_source 作为 metadata 附加，从而支持按应用过滤 Usage Dashboard。元数据是否在 Dashboard 中可见取决于 OpenAI 账户的 Stored Completions 设置，本插件不会设置 store=true。默认禁用。
+        en_US: When enabled, attaches dify_app_id and dify_source as metadata on OpenAI Chat Completions and Responses API calls, enabling per-app filtering in the Usage Dashboard. Whether the metadata is visible in the dashboard depends on the OpenAI account's Stored Completions setting; this plugin does not set store=true. Default disabled.
 models:
   llm:
     predefined:

--- a/models/openai/pyproject.toml
+++ b/models/openai/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin @ git+https://github.com/ryuta-kobayashi-ug/dify-plugin-sdks.git@feat/pass-session-to-model-plugins",
     "httpx>=0.28.1",
     "numpy>=2.4.6",
     "openai>=2.38.0",
@@ -17,4 +17,10 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=8.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/models/openai/tests/test_metadata.py
+++ b/models/openai/tests/test_metadata.py
@@ -47,6 +47,13 @@ def test_build_dify_metadata_returns_none_for_empty():
     assert build_dify_metadata("") is None
 
 
+def test_build_dify_metadata_keeps_non_string_falsy():
+    # build_dify_metadata only rejects None and "" — other falsy values
+    # such as numeric 0 are coerced by normalize_metadata_value.
+    metadata = build_dify_metadata(0)
+    assert metadata == {"dify_app_id": "0", "dify_source": "dify"}
+
+
 def test_build_dify_metadata_includes_source_marker():
     metadata = build_dify_metadata("550e8400-e29b-41d4-a716-446655440000")
     assert metadata is not None
@@ -83,3 +90,32 @@ def test_apply_silent_on_session_lookup_failure():
     target: dict = {}
     apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
     assert "metadata" not in target
+
+
+class _FakeSession:
+    app_id = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_apply_merges_with_existing_metadata(monkeypatch):
+    # When the target already carries a metadata dict (e.g. caller-supplied
+    # values), Dify keys must merge into it rather than replace it wholesale.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    target: dict = {"metadata": {"user_supplied": "value"}}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert target["metadata"]["user_supplied"] == "value"
+    assert target["metadata"]["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert target["metadata"]["dify_source"] == "dify"
+
+
+def test_apply_replaces_non_dict_metadata(monkeypatch):
+    # If existing metadata is somehow not a dict, Dify keys take over rather
+    # than blow up — telemetry is best-effort.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    target: dict = {"metadata": "unexpected-string"}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert isinstance(target["metadata"], dict)
+    assert target["metadata"]["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"

--- a/models/openai/tests/test_metadata.py
+++ b/models/openai/tests/test_metadata.py
@@ -138,5 +138,39 @@ def test_apply_does_not_mutate_existing_metadata(monkeypatch):
     assert target["metadata"]["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
 
 
+def test_apply_sets_store_true(monkeypatch):
+    # The API only accepts metadata when store=true, so applying the metadata
+    # must also enable store.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert target["store"] is True
+
+
+def test_apply_preserves_explicit_store(monkeypatch):
+    # An explicit store value set by the caller must be respected, not
+    # overwritten — even when it is False.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    target: dict = {"store": False}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert target["store"] is False
+    assert target["metadata"]["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_apply_disabled_does_not_touch_store():
+    # When the feature is disabled or unset, store must not be touched.
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "disabled"})
+    assert "store" not in target
+
+    target_unset: dict = {}
+    apply_dify_metadata_if_enabled(target_unset, {})
+    assert "store" not in target_unset
+
+
 def test_normalize_none_returns_empty():
     assert normalize_metadata_value(None) == ""

--- a/models/openai/tests/test_metadata.py
+++ b/models/openai/tests/test_metadata.py
@@ -119,3 +119,24 @@ def test_apply_replaces_non_dict_metadata(monkeypatch):
     apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
     assert isinstance(target["metadata"], dict)
     assert target["metadata"]["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_apply_does_not_mutate_existing_metadata(monkeypatch):
+    # The merge must not mutate the caller's dict in place: a shared reference
+    # must never be modified as a side effect of telemetry opt-in.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    original = {"existing_key": "existing_value"}
+    target: dict = {"metadata": original}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    # The original dict is left untouched.
+    assert original == {"existing_key": "existing_value"}
+    # target carries a new, merged dict.
+    assert target["metadata"] is not original
+    assert target["metadata"]["existing_key"] == "existing_value"
+    assert target["metadata"]["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_normalize_none_returns_empty():
+    assert normalize_metadata_value(None) == ""

--- a/models/openai/tests/test_metadata.py
+++ b/models/openai/tests/test_metadata.py
@@ -1,0 +1,85 @@
+from models.llm._metadata import (
+    apply_dify_metadata_if_enabled,
+    build_dify_metadata,
+    normalize_metadata_value,
+)
+
+
+def test_normalize_uuid_passthrough():
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    assert normalize_metadata_value(uuid) == uuid
+
+
+def test_normalize_preserves_punctuation_and_unicode():
+    # OpenAI does not document a character pattern restriction; values are
+    # only length-bounded. Brackets, slashes, and non-ASCII pass through.
+    assert normalize_metadata_value("a[b]c") == "a[b]c"
+    assert normalize_metadata_value("日本語") == "日本語"
+
+
+def test_normalize_preserves_mixed_case():
+    assert normalize_metadata_value("FOO-Bar") == "FOO-Bar"
+
+
+def test_normalize_truncates_at_512_chars():
+    long_input = "a" * 600
+    result = normalize_metadata_value(long_input)
+    assert len(result) == 512
+    assert result == "a" * 512
+
+
+def test_normalize_empty_string():
+    assert normalize_metadata_value("") == ""
+
+
+def test_normalize_coerces_non_string_input():
+    # Non-string inputs should be stringified before validation, so a
+    # numeric 0 (falsy) does not get dropped by the empty-check.
+    assert normalize_metadata_value(0) == "0"
+    assert normalize_metadata_value(123) == "123"
+
+
+def test_build_dify_metadata_returns_none_for_none():
+    assert build_dify_metadata(None) is None
+
+
+def test_build_dify_metadata_returns_none_for_empty():
+    assert build_dify_metadata("") is None
+
+
+def test_build_dify_metadata_includes_source_marker():
+    metadata = build_dify_metadata("550e8400-e29b-41d4-a716-446655440000")
+    assert metadata is not None
+    assert metadata["dify_source"] == "dify"
+
+
+def test_build_dify_metadata_normalizes_app_id_length():
+    metadata = build_dify_metadata("x" * 1000)
+    assert metadata is not None
+    assert len(metadata["dify_app_id"]) == 512
+
+
+def test_build_dify_metadata_uuid_passthrough():
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    metadata = build_dify_metadata(uuid)
+    assert metadata == {"dify_app_id": uuid, "dify_source": "dify"}
+
+
+def test_apply_no_op_when_credential_missing():
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {})
+    assert target == {}
+
+
+def test_apply_no_op_when_credential_disabled():
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "disabled"})
+    assert target == {}
+
+
+def test_apply_silent_on_session_lookup_failure():
+    # Without a Dify session context, get_current_session raises; the
+    # helper must swallow that and leave target unchanged.
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert "metadata" not in target

--- a/models/openai/uv.lock
+++ b/models/openai/uv.lock
@@ -172,9 +172,14 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", git = "https://github.com/ryuta-kobayashi-ug/dify-plugin-sdks.git?rev=feat%2Fpass-session-to-model-plugins" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "openai", specifier = ">=2.38.0" },
@@ -183,12 +188,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=8.0.0" }]
 
 [[package]]
 name = "dify-plugin"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/ryuta-kobayashi-ug/dify-plugin-sdks.git?rev=feat%2Fpass-session-to-model-plugins#ba8243c68235761f711e46ebf9a3500cff3f4b93" }
 dependencies = [
     { name = "dpkt" },
     { name = "flask" },
@@ -203,10 +208,6 @@ dependencies = [
     { name = "tiktoken" },
     { name = "werkzeug" },
     { name = "yarl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
 ]
 
 [[package]]
@@ -405,6 +406,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -752,6 +762,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -965,6 +984,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds opt-in support for attaching the Dify `app_id` as OpenAI request metadata, so usage on the OpenAI Usage Dashboard can be filtered per Dify app.

When the new `enable_request_metadata` credential is set to `enabled`, the plugin reads `app_id` from the current Dify session (via `get_current_session()` from the SDK) and attaches `{dify_app_id, dify_source}` as the `metadata` field on both `chat.completions.create` and `responses.create`. The default is `disabled`, so behavior is unchanged unless the operator opts in.

This is the OpenAI counterpart of the same feature already shipped for Vertex AI (#3168) and Bedrock (#3201). The responsibility split mirrors those plugins:

| Plugin   | What the plugin attaches              | What the operator must enable      |
| -------- | ------------------------------------- | ---------------------------------- |
| Vertex AI| labels on `generateContent`           | BigQuery billing export            |
| Bedrock  | `requestMetadata` on Converse         | CloudWatch invocation logging      |
| OpenAI   | `metadata` on Chat / Responses        | Stored Completions on the OpenAI account — *the plugin enables `store=true` automatically* |

### Design note: `store` is set to `true` alongside metadata

E2E verification against a live OpenAI account showed the API **rejects `metadata` when `store` is false**:

```
BadRequestError: The 'metadata' parameter is only allowed when 'store' is enabled.
```

Enabling the metadata feature therefore inherently requires `store=true`. The plugin makes this explicit: `apply_dify_metadata_if_enabled` sets `store=true` alongside the metadata (a non-destructive merge that respects an explicit `store` value already on the request). This means requests and responses are persisted to **Stored Completions** on the OpenAI account when the operator opts in. The credential's help text in `provider/openai.yaml` documents this storage behavior in both English and Simplified Chinese, and links to the OpenAI `store` reference.

Bedrock (#3201) and Vertex AI (#3168) do not have this constraint, so their plugins remain unchanged.

Related:
- langgenius/dify#35772
- langgenius/dify-plugin-sdks#311
- langgenius/dify-plugin-sdks#313 (SDK branch this plugin currently pins)
- #3168 (Vertex AI counterpart)
- #3201 (Bedrock counterpart)

> [!NOTE]
> **Draft / dependency.** `pyproject.toml` temporarily pins `dify_plugin` to the fork branch `ryuta-kobayashi-ug/dify-plugin-sdks@feat/pass-session-to-model-plugins` because it carries the `get_current_session()` API used here (langgenius/dify-plugin-sdks#313). The pin will revert to a versioned `dify_plugin` spec once that SDK change merges and a release ships.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| _Usage Dashboard rows are anonymous; per-app filtering is impossible._ | _With opt-in enabled, the plugin sets `store=true` and attaches `dify_app_id` and `dify_source`, so requests are recorded to Stored Completions and can be filtered per app._ |

End-to-end screenshots will be added once the dependent SDK change (#313) ships and a Dify deployment can be exercised against a live OpenAI account with Stored Completions enabled.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.) — request metadata for billing/observability
- [ ] New models / model parameter fixes

</details>

The change is additive and behind a credential that defaults to `disabled`. No existing message flow, tool, multimodal, structured-output, or token-accounting code path is altered. Only `_chat_generate` and `_build_responses_api_params` gain a one-line opt-in hook that mutates the request kwargs immediately before the OpenAI client call.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (`0.4.1` → `0.4.3`)
- [x] `dify_plugin` declared in `pyproject.toml` and locked in `uv.lock` (currently pinned to the SDK branch carrying #313 — see Draft note above)

## Testing

- [x] Unit tests — `uv run pytest tests/` (22 passed): covers normalization (UUID passthrough, punctuation, mixed case, non-ASCII, 512-char truncation, empty string, non-string coercion), `build_dify_metadata` (None / empty / source marker / UUID passthrough / length normalization), and `apply_dify_metadata_if_enabled` (no-op on missing or `disabled` credential, silent on session-lookup failure, non-destructive metadata merge, and the new `store=true` behavior: sets `store=true` on opt-in, preserves an explicit caller-supplied `store`, and never touches `store` when disabled).
- [ ] Local deployment — Dify version: pending (blocked on SDK #313 release; will retest after the pin is reverted)
- [ ] SaaS (cloud.dify.ai)

