### PR TITLE
chore: bump official plugin versions batch 1

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.38
+version: 0.0.39
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/datasources/aws_s3_storage/manifest.yaml
+++ b/datasources/aws_s3_storage/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.3.10
+version: 0.3.11
 type: plugin
 author: langgenius
 name: aws_s3_storage

--- a/datasources/azure_blob/manifest.yaml
+++ b/datasources/azure_blob/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.13
+version: 0.2.14
 type: plugin
 author: langgenius
 name: azure_blob_datasource

--- a/datasources/box_datasource/manifest.yaml
+++ b/datasources/box_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.6
+version: 0.1.7
 type: plugin
 author: langgenius
 name: box_datasource

--- a/datasources/brightdata_datasource/manifest.yaml
+++ b/datasources/brightdata_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.9
+version: 0.1.10
 type: plugin
 author: langgenius
 name: brightdata_datasource

--- a/datasources/confluence_datasource/manifest.yaml
+++ b/datasources/confluence_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.8
+version: 0.2.9
 type: plugin
 author: langgenius
 name: confluence_datasource

--- a/datasources/dropbox_datasource/manifest.yaml
+++ b/datasources/dropbox_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.7
+version: 0.2.8
 type: plugin
 author: langgenius
 name: dropbox_datasource

--- a/datasources/firecrawl_datasource/manifest.yaml
+++ b/datasources/firecrawl_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.10
+version: 0.2.11
 type: plugin
 author: langgenius
 name: firecrawl_datasource

--- a/datasources/github/manifest.yaml
+++ b/datasources/github/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.4.6
+version: 0.4.7
 type: plugin
 author: langgenius
 name: github_datasource

--- a/datasources/gitlab_datasource/manifest.yaml
+++ b/datasources/gitlab_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.3.10
+version: 0.3.11
 type: plugin
 author: langgenius
 name: gitlab_datasource

--- a/datasources/google_cloud_storage/manifest.yaml
+++ b/datasources/google_cloud_storage/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.12
+version: 0.2.13
 type: plugin
 author: langgenius
 name: google_cloud_storage

--- a/datasources/google_drive/manifest.yaml
+++ b/datasources/google_drive/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.12
+version: 0.1.13
 type: plugin
 author: langgenius
 name: google_drive

--- a/datasources/jina_datasource/manifest.yaml
+++ b/datasources/jina_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.9
+version: 0.0.10
 type: plugin
 author: langgenius
 name: jina_datasource

--- a/datasources/notion_datasource/manifest.yaml
+++ b/datasources/notion_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.19
+version: 0.1.20
 type: plugin
 author: langgenius
 name: notion_datasource

--- a/datasources/onedrive/manifest.yaml
+++ b/datasources/onedrive/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.10
+version: 0.1.11
 type: plugin
 author: langgenius
 name: onedrive_datasource

--- a/datasources/sharepoint_datasource/manifest.yaml
+++ b/datasources/sharepoint_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.8
+version: 0.2.9
 type: plugin
 author: langgenius
 name: sharepoint_datasource

--- a/datasources/tavily_datasource/manifest.yaml
+++ b/datasources/tavily_datasource/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.9
+version: 0.1.10
 type: plugin
 author: langgenius
 name: tavily_datasource

--- a/datasources/tencent_cos_storage/manifest.yaml
+++ b/datasources/tencent_cos_storage/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.3.8
+version: 0.3.9
 type: plugin
 author: langgenius
 name: tencent_cos_storage

--- a/extensions/aws_bedrock_knowledge_base/manifest.yaml
+++ b/extensions/aws_bedrock_knowledge_base/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: langgenius
 name: aws_bedrock_knowledge_base

--- a/extensions/badapple/manifest.yaml
+++ b/extensions/badapple/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 description:
   en_US: Why not play Bad Apple with Dify?

--- a/extensions/llamacloud/manifest.yaml
+++ b/extensions/llamacloud/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: llamacloud

--- a/extensions/oaicompat_dify_model/manifest.yaml
+++ b/extensions/oaicompat_dify_model/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.9
+version: 0.0.10
 type: plugin
 author: langgenius
 name: oaicompat_dify_model

--- a/extensions/openai_compatible/manifest.yaml
+++ b/extensions/openai_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.14
+version: 0.0.15
 type: plugin
 author: "langgenius"
 name: "oaicompat_dify_app"

--- a/extensions/slack_bot/manifest.yaml
+++ b/extensions/slack_bot/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 type: plugin
 author: langgenius
 name: slack-bot

--- a/extensions/wecom_bot/manifest.yaml
+++ b/extensions/wecom_bot/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: wecom-bot

--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.30
+version: 0.0.31
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.16
+version: 0.3.17

--- a/models/azure_ai_studio/manifest.yaml
+++ b/models/azure_ai_studio/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.17
+version: 0.0.18

--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.57
+version: 0.0.58

--- a/models/baichuan/manifest.yaml
+++ b/models/baichuan/manifest.yaml
@@ -23,4 +23,4 @@ resource:
   memory: 268435456
   permission: {}
 type: plugin
-version: 0.0.10
+version: 0.0.11

--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.67
+version: 0.0.68
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/chatglm/manifest.yaml
+++ b/models/chatglm/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/cohere/manifest.yaml
+++ b/models/cohere/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.13
+version: 0.0.14

--- a/models/cometapi/manifest.yaml
+++ b/models/cometapi/manifest.yaml
@@ -1,4 +1,4 @@
-version: 1.0.7
+version: 1.0.8
 type: plugin
 author: langgenius
 name: cometapi

--- a/models/deepseek/manifest.yaml
+++ b/models/deepseek/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.16
+version: 0.0.17

--- a/models/deerapi/manifest.yaml
+++ b/models/deerapi/manifest.yaml
@@ -1,4 +1,4 @@
-version: 1.0.7
+version: 1.0.8
 type: plugin
 author: langgenius
 name: deerapi

--- a/models/fireworks/manifest.yaml
+++ b/models/fireworks/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/models/fishaudio/manifest.yaml
+++ b/models/fishaudio/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: "langgenius"
 name: "fishaudio"

--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.8.2
+version: 0.8.3

--- a/models/gitee_ai/manifest.yaml
+++ b/models/gitee_ai/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.8
+version: 0.1.9

--- a/models/gmicloud/manifest.yaml
+++ b/models/gmicloud/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: gmicloud

--- a/models/gpustack/manifest.yaml
+++ b/models/gpustack/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.13
+version: 0.0.14

--- a/models/groq/manifest.yaml
+++ b/models/groq/manifest.yaml
@@ -36,4 +36,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.16
+version: 0.0.17

--- a/models/huaweicloud_maas/manifest.yaml
+++ b/models/huaweicloud_maas/manifest.yaml
@@ -26,5 +26,5 @@ resource:
       enabled: true
       llm: true
 type: plugin
-version: 0.0.19
+version: 0.0.20
 created_at: 2025-06-04T12:32:17.824356+08:00

--- a/models/huaweicloud_maas_hk/manifest.yaml
+++ b/models/huaweicloud_maas_hk/manifest.yaml
@@ -26,5 +26,5 @@ resource:
       enabled: true
       llm: true
 type: plugin
-version: 0.0.5
+version: 0.0.6
 created_at: 2025-11-08T12:32:17.824356+08:00

--- a/models/huggingface_hub/manifest.yaml
+++ b/models/huggingface_hub/manifest.yaml
@@ -26,4 +26,4 @@ resource:
     tool:
       enabled: false
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/models/huggingface_tei/manifest.yaml
+++ b/models/huggingface_tei/manifest.yaml
@@ -27,4 +27,4 @@ resource:
     tool:
       enabled: false
 type: plugin
-version: 0.1.7
+version: 0.1.8

--- a/models/hunyuan/manifest.yaml
+++ b/models/hunyuan/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.11
+version: 0.0.12

--- a/models/jina/manifest.yaml
+++ b/models/jina/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.21
+version: 0.0.22
 type: plugin
 author: "langgenius"
 name: "jina"

--- a/models/lemonade/manifest.yaml
+++ b/models/lemonade/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 type: plugin
 author: "langgenius"
 name: "lemonade"


### PR DESCRIPTION
## Summary

Related to #3206.

Bumps the top-level `version` in 50 official plugin manifests for the recovery version bump plan. This PR only changes manifest versions and does not modify dependency files.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] Dependency files are intentionally unchanged in this PR

## Testing

- [x] `git diff --check`
- [x] Verified the diff only changes top-level `version` lines in this batch
- [ ] Local deployment
- [ ] SaaS

<details>
<summary>Plugins in this batch</summary>

- `agent-strategies/cot_agent`: `0.0.38` -> `0.0.39`
- `datasources/aws_s3_storage`: `0.3.10` -> `0.3.11`
- `datasources/azure_blob`: `0.2.13` -> `0.2.14`
- `datasources/box_datasource`: `0.1.6` -> `0.1.7`
- `datasources/brightdata_datasource`: `0.1.9` -> `0.1.10`
- `datasources/confluence_datasource`: `0.2.8` -> `0.2.9`
- `datasources/dropbox_datasource`: `0.2.7` -> `0.2.8`
- `datasources/firecrawl_datasource`: `0.2.10` -> `0.2.11`
- `datasources/github`: `0.4.6` -> `0.4.7`
- `datasources/gitlab_datasource`: `0.3.10` -> `0.3.11`
- `datasources/google_cloud_storage`: `0.2.12` -> `0.2.13`
- `datasources/google_drive`: `0.1.12` -> `0.1.13`
- `datasources/jina_datasource`: `0.0.9` -> `0.0.10`
- `datasources/notion_datasource`: `0.1.19` -> `0.1.20`
- `datasources/onedrive`: `0.1.10` -> `0.1.11`
- `datasources/sharepoint_datasource`: `0.2.8` -> `0.2.9`
- `datasources/tavily_datasource`: `0.1.9` -> `0.1.10`
- `datasources/tencent_cos_storage`: `0.3.8` -> `0.3.9`
- `extensions/aws_bedrock_knowledge_base`: `0.0.8` -> `0.0.9`
- `extensions/badapple`: `0.0.5` -> `0.0.6`
- `extensions/llamacloud`: `0.0.6` -> `0.0.7`
- `extensions/oaicompat_dify_model`: `0.0.9` -> `0.0.10`
- `extensions/openai_compatible`: `0.0.14` -> `0.0.15`
- `extensions/slack_bot`: `0.0.10` -> `0.0.11`
- `extensions/wecom_bot`: `0.0.5` -> `0.0.6`
- `models/aihubmix`: `0.0.30` -> `0.0.31`
- `models/anthropic`: `0.3.16` -> `0.3.17`
- `models/azure_ai_studio`: `0.0.17` -> `0.0.18`
- `models/azure_openai`: `0.0.57` -> `0.0.58`
- `models/baichuan`: `0.0.10` -> `0.0.11`
- `models/bedrock`: `0.0.67` -> `0.0.68`
- `models/chatglm`: `0.0.6` -> `0.0.7`
- `models/cohere`: `0.0.13` -> `0.0.14`
- `models/cometapi`: `1.0.7` -> `1.0.8`
- `models/deepseek`: `0.0.16` -> `0.0.17`
- `models/deerapi`: `1.0.7` -> `1.0.8`
- `models/fireworks`: `0.0.8` -> `0.0.9`
- `models/fishaudio`: `0.0.8` -> `0.0.9`
- `models/gemini`: `0.8.2` -> `0.8.3`
- `models/gitee_ai`: `0.1.8` -> `0.1.9`
- `models/gmicloud`: `0.0.7` -> `0.0.8`
- `models/gpustack`: `0.0.13` -> `0.0.14`
- `models/groq`: `0.0.16` -> `0.0.17`
- `models/huaweicloud_maas`: `0.0.19` -> `0.0.20`
- `models/huaweicloud_maas_hk`: `0.0.5` -> `0.0.6`
- `models/huggingface_hub`: `0.0.9` -> `0.0.10`
- `models/huggingface_tei`: `0.1.7` -> `0.1.8`
- `models/hunyuan`: `0.0.11` -> `0.0.12`
- `models/jina`: `0.0.21` -> `0.0.22`
- `models/lemonade`: `0.0.10` -> `0.0.11`

</details>
