### PR TITLE
chore: bump official plugin versions batch 2

### DIFF
--- a/models/leptonai/manifest.yaml
+++ b/models/leptonai/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/longcat/manifest.yaml
+++ b/models/longcat/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/models/mimo/manifest.yaml
+++ b/models/mimo/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/minimax/manifest.yaml
+++ b/models/minimax/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.19
+version: 0.0.20

--- a/models/mistralai/manifest.yaml
+++ b/models/mistralai/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/models/nomic/manifest.yaml
+++ b/models/nomic/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/models/nvidia/manifest.yaml
+++ b/models/nvidia/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/models/nvidia_nim/manifest.yaml
+++ b/models/nvidia_nim/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/models/oci/manifest.yaml
+++ b/models/oci/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.15
+version: 0.0.16
 type: plugin
 author: langgenius
 privacy: PRIVACY.md

--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -26,5 +26,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.0.53
+version: 0.0.54
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/sambanova/manifest.yaml
+++ b/models/sambanova/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.4
+version: 0.1.5
 type: plugin
 author: langgenius
 name: sambanova

--- a/models/tencent/manifest.yaml
+++ b/models/tencent/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/models/upstage/manifest.yaml
+++ b/models/upstage/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.10
+version: 0.0.11

--- a/models/volcengine/manifest.yaml
+++ b/models/volcengine/manifest.yaml
@@ -32,4 +32,4 @@ resource:
       text_embedding: false
       tts: false
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/wenxin/manifest.yaml
+++ b/models/wenxin/manifest.yaml
@@ -24,4 +24,4 @@ resource:
   memory: 268435456
   permission: {}
 type: plugin
-version: 0.1.6
+version: 0.1.7

--- a/models/x/manifest.yaml
+++ b/models/x/manifest.yaml
@@ -35,4 +35,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.20
+version: 0.0.21

--- a/models/zhinao/manifest.yaml
+++ b/models/zhinao/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/models/zhipuai/manifest.yaml
+++ b/models/zhipuai/manifest.yaml
@@ -1,5 +1,5 @@
 type: plugin
-version: 0.0.29
+version: 0.0.30
 author: langgenius
 name: zhipuai
 created_at: "2024-09-20T00:13:50.29298939-04:00"

--- a/tools/aihubmix_image/manifest.yaml
+++ b/tools/aihubmix_image/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.1
+version: 0.1.2
 type: plugin
 author: langgenius
 name: aihubmix-image

--- a/tools/aliyuque/manifest.yaml
+++ b/tools/aliyuque/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - productivity
 - search
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/alphavantage/manifest.yaml
+++ b/tools/alphavantage/manifest.yaml
@@ -37,4 +37,4 @@ resource:
 tags:
 - finance
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/apitemplate/manifest.yaml
+++ b/tools/apitemplate/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: apitemplate

--- a/tools/arxiv/manifest.yaml
+++ b/tools/arxiv/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 tags:
 - search

--- a/tools/attio/manifest.yaml
+++ b/tools/attio/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: attio


### PR DESCRIPTION
## Summary

Related to #3206.

Bumps the top-level `version` in 24 official plugin manifests for batch 2 of the recovery version bump plan.
Skips 26 plugins whose versions have already been bumped on `main`, so this PR does not apply an additional bump to them.
This PR only changes manifest versions and does not modify dependency files.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] Dependency files are intentionally unchanged in this PR

## Testing

- [x] `git diff --check`
- [x] Verified the diff only changes top-level `version` lines in this batch
- [ ] Local deployment
- [ ] SaaS

<details>
<summary>Plugins bumped in this PR</summary>

- `models/leptonai`: `0.0.6` -> `0.0.7`
- `models/longcat`: `0.0.7` -> `0.0.8`
- `models/mimo`: `0.0.6` -> `0.0.7`
- `models/minimax`: `0.0.19` -> `0.0.20`
- `models/mistralai`: `0.0.8` -> `0.0.9`
- `models/nomic`: `0.0.8` -> `0.0.9`
- `models/nvidia`: `0.0.7` -> `0.0.8`
- `models/nvidia_nim`: `0.0.7` -> `0.0.8`
- `models/oci`: `0.0.15` -> `0.0.16`
- `models/openrouter`: `0.0.53` -> `0.0.54`
- `models/sambanova`: `0.1.4` -> `0.1.5`
- `models/tencent`: `0.0.8` -> `0.0.9`
- `models/upstage`: `0.0.10` -> `0.0.11`
- `models/volcengine`: `0.0.6` -> `0.0.7`
- `models/wenxin`: `0.1.6` -> `0.1.7`
- `models/x`: `0.0.20` -> `0.0.21`
- `models/zhinao`: `0.0.6` -> `0.0.7`
- `models/zhipuai`: `0.0.29` -> `0.0.30`
- `tools/aihubmix_image`: `0.1.1` -> `0.1.2`
- `tools/aliyuque`: `0.0.6` -> `0.0.7`
- `tools/alphavantage`: `0.0.6` -> `0.0.7`
- `tools/apitemplate`: `0.0.6` -> `0.0.7`
- `tools/arxiv`: `0.0.6` -> `0.0.7`
- `tools/attio`: `0.0.5` -> `0.0.6`

</details>

<details>
<summary>Plugins already bumped on main and skipped</summary>

- `models/llama_api`: base `0.0.7`, main `0.0.8`, previous PR target `0.0.8`
- `models/localai`: base `0.0.7`, main `0.0.8`, previous PR target `0.0.8`
- `models/mixedbread`: base `0.0.8`, main `0.0.9`, previous PR target `0.0.9`
- `models/modelscope`: base `0.0.14`, main `0.0.15`, previous PR target `0.0.15`
- `models/moonshot`: base `0.1.6`, main `0.1.7`, previous PR target `0.1.7`
- `models/novita`: base `0.0.9`, main `0.0.10`, previous PR target `0.0.10`
- `models/ollama`: base `0.2.1`, main `0.2.2`, previous PR target `0.2.2`
- `models/openai`: base `0.4.1`, main `0.4.2`, previous PR target `0.4.2`
- `models/openai_api_compatible`: base `0.0.52`, main `0.0.53`, previous PR target `0.0.53`
- `models/openllm`: base `0.0.7`, main `0.0.8`, previous PR target `0.0.8`
- `models/perfxcloud`: base `0.0.10`, main `0.0.11`, previous PR target `0.0.11`
- `models/regolo`: base `0.2.4`, main `0.2.5`, previous PR target `0.2.5`
- `models/replicate`: base `0.0.7`, main `0.0.8`, previous PR target `0.0.8`
- `models/sagemaker`: base `0.0.15`, main `0.0.16`, previous PR target `0.0.16`
- `models/siliconflow`: base `0.0.54`, main `0.0.55`, previous PR target `0.0.55`
- `models/stepfun`: base `0.0.6`, main `0.0.7`, previous PR target `0.0.7`
- `models/togetherai`: base `0.0.6`, main `0.0.7`, previous PR target `0.0.7`
- `models/tongyi`: base `0.1.46`, main `0.1.47`, previous PR target `0.1.47`
- `models/triton_inference_server`: base `0.0.6`, main `0.0.7`, previous PR target `0.0.7`
- `models/vertex_ai`: base `0.0.55`, main `0.0.56`, previous PR target `0.0.56`
- `models/vessl_ai`: base `0.0.6`, main `0.0.7`, previous PR target `0.0.7`
- `models/volcengine_maas`: base `0.0.50`, main `0.0.51`, previous PR target `0.0.51`
- `models/voyage`: base `0.0.11`, main `0.0.12`, previous PR target `0.0.12`
- `models/xinference`: base `0.0.13`, main `0.0.14`, previous PR target `0.0.14`
- `models/yi`: base `0.0.6`, main `0.0.7`, previous PR target `0.0.7`
- `tools/aws`: base `0.0.24`, main `0.0.25`, previous PR target `0.0.25`

</details>
