### PR TITLE
chore: bump official plugin versions batch 3

### DIFF
--- a/tools/azure_openai_tool/manifest.yaml
+++ b/tools/azure_openai_tool/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/azuredalle/manifest.yaml
+++ b/tools/azuredalle/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/baidu_translate/manifest.yaml
+++ b/tools/baidu_translate/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/bailian_memory/manifest.yaml
+++ b/tools/bailian_memory/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: "langgenius"
 name: bailian_memory

--- a/tools/baserow/manifest.yaml
+++ b/tools/baserow/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: baserow

--- a/tools/bing/manifest.yaml
+++ b/tools/bing/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.9
+version: 0.0.10
 type: plugin
 author: "langgenius"
 name: "bing"

--- a/tools/bitbucket/manifest.yaml
+++ b/tools/bitbucket/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: langgenius
 name: bitbucket

--- a/tools/brave/manifest.yaml
+++ b/tools/brave/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
   - search
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/chart/manifest.yaml
+++ b/tools/chart/manifest.yaml
@@ -39,4 +39,4 @@ tags:
   - productivity
   - utilities
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/cogview/manifest.yaml
+++ b/tools/cogview/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - image
   - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/confluence/manifest.yaml
+++ b/tools/confluence/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: langgenius
 name: confluence

--- a/tools/crossref/manifest.yaml
+++ b/tools/crossref/manifest.yaml
@@ -35,4 +35,4 @@ resource:
 tags:
   - search
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/deepl/manifest.yaml
+++ b/tools/deepl/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.4
+version: 0.1.5
 type: plugin
 author: langgenius
 name: deepl

--- a/tools/devdocs/manifest.yaml
+++ b/tools/devdocs/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/dicom_reader/manifest.yaml
+++ b/tools/dicom_reader/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: dicom_reader

--- a/tools/did/manifest.yaml
+++ b/tools/did/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - videos
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/dify_extractor/manifest.yaml
+++ b/tools/dify_extractor/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.11
+version: 0.0.12
 type: plugin
 author: langgenius
 name: dify_extractor

--- a/tools/dingo/manifest.yaml
+++ b/tools/dingo/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.6.8
+version: 0.6.9
 type: plugin
 author: langgenius
 name: dingo

--- a/tools/dingtalk/manifest.yaml
+++ b/tools/dingtalk/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/discord/manifest.yaml
+++ b/tools/discord/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/dropbox/manifest.yaml
+++ b/tools/dropbox/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: langgenius
 name: dropbox

--- a/tools/duckduckgo/manifest.yaml
+++ b/tools/duckduckgo/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.9
+version: 0.0.10
 type: plugin
 author: "langgenius"
 name: "duckduckgo"

--- a/tools/e2b/manifest.yaml
+++ b/tools/e2b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: e2b

--- a/tools/echarts/manifest.yaml
+++ b/tools/echarts/manifest.yaml
@@ -35,4 +35,4 @@ tags:
   - productivity
   - utilities
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/email/manifest.yaml
+++ b/tools/email/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.15
+version: 0.0.16

--- a/tools/ernie_image/manifest.yaml
+++ b/tools/ernie_image/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 type: plugin
 author: langgenius
 name: ernie_image

--- a/tools/fal/manifest.yaml
+++ b/tools/fal/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - image
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/feishu/manifest.yaml
+++ b/tools/feishu/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/feishu_base/manifest.yaml
+++ b/tools/feishu_base/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/feishu_calendar/manifest.yaml
+++ b/tools/feishu_calendar/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/feishu_document/manifest.yaml
+++ b/tools/feishu_document/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/feishu_message/manifest.yaml
+++ b/tools/feishu_message/manifest.yaml
@@ -37,4 +37,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/feishu_spreadsheet/manifest.yaml
+++ b/tools/feishu_spreadsheet/manifest.yaml
@@ -37,4 +37,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/feishu_task/manifest.yaml
+++ b/tools/feishu_task/manifest.yaml
@@ -38,4 +38,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/feishu_wiki/manifest.yaml
+++ b/tools/feishu_wiki/manifest.yaml
@@ -36,4 +36,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/firecrawl/manifest.yaml
+++ b/tools/firecrawl/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - utilities
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/fishaudio/manifest.yaml
+++ b/tools/fishaudio/manifest.yaml
@@ -27,4 +27,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.13
+version: 0.0.14

--- a/tools/frontapp/manifest.yaml
+++ b/tools/frontapp/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.5
+version: 0.1.6

--- a/tools/gaode/manifest.yaml
+++ b/tools/gaode/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - travel
 - weather
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/gemini_image/manifest.yaml
+++ b/tools/gemini_image/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.1.8
+version: 0.1.9

--- a/tools/gemini_video/manifest.yaml
+++ b/tools/gemini_video/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.14
+version: 0.0.15
 type: plugin
 author: langgenius
 name: gemini_video

--- a/tools/general_chunk/manifest.yaml
+++ b/tools/general_chunk/manifest.yaml
@@ -35,4 +35,4 @@ resource:
 tags: 
   - rag
 type: plugin
-version: 0.0.12
+version: 0.0.13

--- a/tools/getimgai/manifest.yaml
+++ b/tools/getimgai/manifest.yaml
@@ -30,4 +30,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/gitee_ai/manifest.yaml
+++ b/tools/gitee_ai/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/github/manifest.yaml
+++ b/tools/github/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.3.6
+version: 0.3.7

--- a/tools/gitlab/manifest.yaml
+++ b/tools/gitlab/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 0.0.12
+version: 0.0.13

--- a/tools/gmail/manifest.yaml
+++ b/tools/gmail/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.5
+version: 0.2.6
 type: plugin
 author: langgenius
 name: dify-gmail

--- a/tools/google/manifest.yaml
+++ b/tools/google/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.4
+version: 0.1.5
 type: plugin
 author: "langgenius"
 name: "google"

--- a/tools/google_calendar/manifest.yaml
+++ b/tools/google_calendar/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.4
+version: 0.1.5


### PR DESCRIPTION
## Summary

Related to #3206.

Bumps the top-level `version` in 49 official plugin manifests for batch 3 of the recovery version bump plan.
Skips 1 plugins whose versions have already been bumped on `main`, so this PR does not apply an additional bump to them.
This PR only changes manifest versions and does not modify dependency files.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] Dependency files are intentionally unchanged in this PR

## Testing

- [x] `git diff --check`
- [x] Verified the diff only changes top-level `version` lines in this batch
- [ ] Local deployment
- [ ] SaaS

<details>
<summary>Plugins bumped in this PR</summary>

- `tools/azure_openai_tool`: `0.0.8` -> `0.0.9`
- `tools/azuredalle`: `0.0.8` -> `0.0.9`
- `tools/baidu_translate`: `0.0.7` -> `0.0.8`
- `tools/bailian_memory`: `0.0.6` -> `0.0.7`
- `tools/baserow`: `0.0.5` -> `0.0.6`
- `tools/bing`: `0.0.9` -> `0.0.10`
- `tools/bitbucket`: `0.0.8` -> `0.0.9`
- `tools/brave`: `0.0.6` -> `0.0.7`
- `tools/chart`: `0.0.6` -> `0.0.7`
- `tools/cogview`: `0.0.6` -> `0.0.7`
- `tools/confluence`: `0.0.8` -> `0.0.9`
- `tools/crossref`: `0.0.6` -> `0.0.7`
- `tools/deepl`: `0.1.4` -> `0.1.5`
- `tools/devdocs`: `0.0.6` -> `0.0.7`
- `tools/dicom_reader`: `0.0.6` -> `0.0.7`
- `tools/did`: `0.0.6` -> `0.0.7`
- `tools/dify_extractor`: `0.0.11` -> `0.0.12`
- `tools/dingo`: `0.6.8` -> `0.6.9`
- `tools/dingtalk`: `0.0.8` -> `0.0.9`
- `tools/discord`: `0.0.6` -> `0.0.7`
- `tools/dropbox`: `0.0.4` -> `0.0.5`
- `tools/duckduckgo`: `0.0.9` -> `0.0.10`
- `tools/e2b`: `0.0.6` -> `0.0.7`
- `tools/echarts`: `0.0.5` -> `0.0.6`
- `tools/email`: `0.0.15` -> `0.0.16`
- `tools/ernie_image`: `0.0.2` -> `0.0.3`
- `tools/fal`: `0.0.7` -> `0.0.8`
- `tools/feishu`: `0.0.5` -> `0.0.6`
- `tools/feishu_base`: `0.0.5` -> `0.0.6`
- `tools/feishu_calendar`: `0.0.5` -> `0.0.6`
- `tools/feishu_document`: `0.0.5` -> `0.0.6`
- `tools/feishu_message`: `0.0.5` -> `0.0.6`
- `tools/feishu_spreadsheet`: `0.0.5` -> `0.0.6`
- `tools/feishu_task`: `0.0.5` -> `0.0.6`
- `tools/feishu_wiki`: `0.0.5` -> `0.0.6`
- `tools/firecrawl`: `0.0.8` -> `0.0.9`
- `tools/fishaudio`: `0.0.13` -> `0.0.14`
- `tools/frontapp`: `0.1.5` -> `0.1.6`
- `tools/gaode`: `0.0.7` -> `0.0.8`
- `tools/gemini_image`: `0.1.8` -> `0.1.9`
- `tools/gemini_video`: `0.0.14` -> `0.0.15`
- `tools/general_chunk`: `0.0.12` -> `0.0.13`
- `tools/getimgai`: `0.0.6` -> `0.0.7`
- `tools/gitee_ai`: `0.0.7` -> `0.0.8`
- `tools/github`: `0.3.6` -> `0.3.7`
- `tools/gitlab`: `0.0.12` -> `0.0.13`
- `tools/gmail`: `0.2.5` -> `0.2.6`
- `tools/google`: `0.1.4` -> `0.1.5`
- `tools/google_calendar`: `0.1.4` -> `0.1.5`

</details>

<details>
<summary>Plugins already bumped on main and skipped</summary>

- `tools/comfyui`: base `0.3.9`, main `0.3.10`, previous PR target `0.3.10`

</details>
