### PR TITLE
chore: bump official plugin versions batch 4

### DIFF
--- a/tools/google_contacts/manifest.yaml
+++ b/tools/google_contacts/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.4
+version: 0.1.5

--- a/tools/google_tasks/manifest.yaml
+++ b/tools/google_tasks/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.4
+version: 0.1.5

--- a/tools/google_translate/manifest.yaml
+++ b/tools/google_translate/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/gpustack/manifest.yaml
+++ b/tools/gpustack/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: gpustack_tools

--- a/tools/hackernews/manifest.yaml
+++ b/tools/hackernews/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.4
+version: 0.1.5

--- a/tools/hap/manifest.yaml
+++ b/tools/hap/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
   - productivity
 type: plugin
-version: 0.1.4
+version: 0.1.5

--- a/tools/hubspot/manifest.yaml
+++ b/tools/hubspot/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: hubspot

--- a/tools/jiandaoyun/manifest.yaml
+++ b/tools/jiandaoyun/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: jiandaoyun

--- a/tools/jina/manifest.yaml
+++ b/tools/jina/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - search
 - productivity
 type: plugin
-version: 0.0.12
+version: 0.0.13

--- a/tools/jira/manifest.yaml
+++ b/tools/jira/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: langgenius
 name: jira

--- a/tools/json_process/manifest.yaml
+++ b/tools/json_process/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/judge0ce/manifest.yaml
+++ b/tools/judge0ce/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - utilities
 - other
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/lark_base/manifest.yaml
+++ b/tools/lark_base/manifest.yaml
@@ -36,4 +36,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/lark_calendar/manifest.yaml
+++ b/tools/lark_calendar/manifest.yaml
@@ -38,4 +38,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/lark_document/manifest.yaml
+++ b/tools/lark_document/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/lark_message_and_group/manifest.yaml
+++ b/tools/lark_message_and_group/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/lark_spreadsheet/manifest.yaml
+++ b/tools/lark_spreadsheet/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/lark_task/manifest.yaml
+++ b/tools/lark_task/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/lark_wiki/manifest.yaml
+++ b/tools/lark_wiki/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - social
 - productivity
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/linear/manifest.yaml
+++ b/tools/linear/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: linear

--- a/tools/llama_parse/manifest.yaml
+++ b/tools/llama_parse/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 tags:
   - utilities

--- a/tools/maths/manifest.yaml
+++ b/tools/maths/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - utilities
 - productivity
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/microsoft_excel_365/manifest.yaml
+++ b/tools/microsoft_excel_365/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.1.5
+version: 0.1.6

--- a/tools/microsoft_todo/manifest.yaml
+++ b/tools/microsoft_todo/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: microsoft_todo

--- a/tools/mineru/manifest.yaml
+++ b/tools/mineru/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.5.5
+version: 0.5.6
 type: plugin
 author: langgenius
 name: mineru

--- a/tools/minimax_tts/manifest.yaml
+++ b/tools/minimax_tts/manifest.yaml
@@ -29,4 +29,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/tools/monday/manifest.yaml
+++ b/tools/monday/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: monday

--- a/tools/neo4j/manifest.yaml
+++ b/tools/neo4j/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: neo4j

--- a/tools/nextcloud/manifest.yaml
+++ b/tools/nextcloud/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.4
+version: 0.1.5
 type: plugin
 author: langgenius
 name: nextcloud

--- a/tools/nocodb/manifest.yaml
+++ b/tools/nocodb/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.6
+version: 0.0.7
 type: plugin
 author: langgenius
 name: nocodb

--- a/tools/nominatim/manifest.yaml
+++ b/tools/nominatim/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - search
 - utilities
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/notion/manifest.yaml
+++ b/tools/notion/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.9
+version: 0.0.10
 type: plugin
 author: langgenius
 name: notion

--- a/tools/novitaai/manifest.yaml
+++ b/tools/novitaai/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/onebot/manifest.yaml
+++ b/tools/onebot/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/onedrive/manifest.yaml
+++ b/tools/onedrive/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: onedrive

--- a/tools/openai/manifest.yaml
+++ b/tools/openai/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.1.8
+version: 0.1.9

--- a/tools/openweather/manifest.yaml
+++ b/tools/openweather/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - weather
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/oracle_ai_db/manifest.yaml
+++ b/tools/oracle_ai_db/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: oracle_ai_db

--- a/tools/outlook/manifest.yaml
+++ b/tools/outlook/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.4
+version: 0.2.5
 type: plugin
 author: langgenius
 name: outlook

--- a/tools/paddleocr/manifest.yaml
+++ b/tools/paddleocr/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.5
+version: 0.2.6
 type: plugin
 author: langgenius
 name: paddleocr

--- a/tools/parent_child_chunk/manifest.yaml
+++ b/tools/parent_child_chunk/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 type: plugin
 author: langgenius
 name: parentchild_chunker

--- a/tools/perplexity/manifest.yaml
+++ b/tools/perplexity/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
 - search
 type: plugin
-version: 1.0.5
+version: 1.0.6

--- a/tools/plivo_sms/manifest.yaml
+++ b/tools/plivo_sms/manifest.yaml
@@ -28,4 +28,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/plivo_verify/manifest.yaml
+++ b/tools/plivo_verify/manifest.yaml
@@ -28,4 +28,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/podcast_generator/manifest.yaml
+++ b/tools/podcast_generator/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/tools/pubmed/manifest.yaml
+++ b/tools/pubmed/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - medical
 - search
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/pushover/manifest.yaml
+++ b/tools/pushover/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: pushover

--- a/tools/qa_chunk/manifest.yaml
+++ b/tools/qa_chunk/manifest.yaml
@@ -36,4 +36,4 @@ tags:
   - utilities
   - rag
 type: plugin
-version: 0.0.12
+version: 0.0.13

--- a/tools/qrcode/manifest.yaml
+++ b/tools/qrcode/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.5
+version: 0.1.6

--- a/tools/rapidapi/manifest.yaml
+++ b/tools/rapidapi/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - news
 type: plugin
-version: 0.0.7
+version: 0.0.8


### PR DESCRIPTION
## Summary

Related to #3206.

Bumps the top-level `version` in 50 official plugin manifests for batch 4 of the recovery version bump plan.
This PR only changes manifest versions and does not modify dependency files.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] Dependency files are intentionally unchanged in this PR

## Testing

- [x] `git diff --check`
- [x] Verified the diff only changes top-level `version` lines in this batch
- [ ] Local deployment
- [ ] SaaS

<details>
<summary>Plugins bumped in this PR</summary>

- `tools/google_contacts`: `0.1.4` -> `0.1.5`
- `tools/google_tasks`: `0.1.4` -> `0.1.5`
- `tools/google_translate`: `0.0.7` -> `0.0.8`
- `tools/gpustack`: `0.0.7` -> `0.0.8`
- `tools/hackernews`: `0.1.4` -> `0.1.5`
- `tools/hap`: `0.1.4` -> `0.1.5`
- `tools/hubspot`: `0.0.7` -> `0.0.8`
- `tools/jiandaoyun`: `0.0.7` -> `0.0.8`
- `tools/jina`: `0.0.12` -> `0.0.13`
- `tools/jira`: `0.0.8` -> `0.0.9`
- `tools/json_process`: `0.0.6` -> `0.0.7`
- `tools/judge0ce`: `0.0.6` -> `0.0.7`
- `tools/lark_base`: `0.0.5` -> `0.0.6`
- `tools/lark_calendar`: `0.0.5` -> `0.0.6`
- `tools/lark_document`: `0.0.5` -> `0.0.6`
- `tools/lark_message_and_group`: `0.0.5` -> `0.0.6`
- `tools/lark_spreadsheet`: `0.0.5` -> `0.0.6`
- `tools/lark_task`: `0.0.5` -> `0.0.6`
- `tools/lark_wiki`: `0.0.5` -> `0.0.6`
- `tools/linear`: `0.0.6` -> `0.0.7`
- `tools/llama_parse`: `0.0.7` -> `0.0.8`
- `tools/maths`: `0.0.7` -> `0.0.8`
- `tools/microsoft_excel_365`: `0.1.5` -> `0.1.6`
- `tools/microsoft_todo`: `0.0.5` -> `0.0.6`
- `tools/mineru`: `0.5.5` -> `0.5.6`
- `tools/minimax_tts`: `0.0.5` -> `0.0.6`
- `tools/monday`: `0.0.5` -> `0.0.6`
- `tools/neo4j`: `0.0.5` -> `0.0.6`
- `tools/nextcloud`: `0.1.4` -> `0.1.5`
- `tools/nocodb`: `0.0.6` -> `0.0.7`
- `tools/nominatim`: `0.0.7` -> `0.0.8`
- `tools/notion`: `0.0.9` -> `0.0.10`
- `tools/novitaai`: `0.0.8` -> `0.0.9`
- `tools/onebot`: `0.0.6` -> `0.0.7`
- `tools/onedrive`: `0.0.5` -> `0.0.6`
- `tools/openai`: `0.1.8` -> `0.1.9`
- `tools/openweather`: `0.0.7` -> `0.0.8`
- `tools/oracle_ai_db`: `0.0.7` -> `0.0.8`
- `tools/outlook`: `0.2.4` -> `0.2.5`
- `tools/paddleocr`: `0.2.5` -> `0.2.6`
- `tools/parent_child_chunk`: `0.0.12` -> `0.0.13`
- `tools/perplexity`: `1.0.5` -> `1.0.6`
- `tools/plivo_sms`: `0.0.6` -> `0.0.7`
- `tools/plivo_verify`: `0.0.6` -> `0.0.7`
- `tools/podcast_generator`: `0.0.9` -> `0.0.10`
- `tools/pubmed`: `0.0.7` -> `0.0.8`
- `tools/pushover`: `0.0.5` -> `0.0.6`
- `tools/qa_chunk`: `0.0.12` -> `0.0.13`
- `tools/qrcode`: `0.1.5` -> `0.1.6`
- `tools/rapidapi`: `0.0.7` -> `0.0.8`

</details>
