### PR TITLE
chore: bump official plugin versions batch 5

### DIFF
--- a/tools/regex/manifest.yaml
+++ b/tools/regex/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - utilities
 - productivity
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/salesforce/manifest.yaml
+++ b/tools/salesforce/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: salesforce

--- a/tools/searchapi/manifest.yaml
+++ b/tools/searchapi/manifest.yaml
@@ -42,4 +42,4 @@ tags:
   - news
   - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/searxng/manifest.yaml
+++ b/tools/searxng/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - productivity
 type: plugin
-version: 0.0.11
+version: 0.0.12

--- a/tools/seltz/manifest.yaml
+++ b/tools/seltz/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: "langgenius"
 name: "seltz"

--- a/tools/serper/manifest.yaml
+++ b/tools/serper/manifest.yaml
@@ -37,4 +37,4 @@ resource:
 tags:
   - search
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/siliconflow/manifest.yaml
+++ b/tools/siliconflow/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
   - image
 type: plugin
-version: 0.0.11
+version: 0.0.12

--- a/tools/slack/manifest.yaml
+++ b/tools/slack/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/slidespeak/manifest.yaml
+++ b/tools/slidespeak/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       enabled: true
 tags: []
 type: plugin
-version: 1.0.4
+version: 1.0.5

--- a/tools/smartsheet/manifest.yaml
+++ b/tools/smartsheet/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: smartsheet

--- a/tools/snowflake/manifest.yaml
+++ b/tools/snowflake/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: snowflake_sql

--- a/tools/somark/manifest.yaml
+++ b/tools/somark/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.1.1
 created_at: '2026-01-30T03:17:37.000000000Z'
 type: plugin
 author: langgenius

--- a/tools/spark/manifest.yaml
+++ b/tools/spark/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/spider/manifest.yaml
+++ b/tools/spider/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - search
 - utilities
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/spotify/manifest.yaml
+++ b/tools/spotify/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.4
+version: 0.1.5

--- a/tools/sqlite/manifest.yaml
+++ b/tools/sqlite/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: sqlite

--- a/tools/stability/manifest.yaml
+++ b/tools/stability/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/stablediffusion/manifest.yaml
+++ b/tools/stablediffusion/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - image
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/stackexchange/manifest.yaml
+++ b/tools/stackexchange/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - search
 - utilities
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/stepfun/manifest.yaml
+++ b/tools/stepfun/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/supabase/manifest.yaml
+++ b/tools/supabase/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.4
+version: 0.1.5
 type: plugin
 author: langgenius
 name: supabase

--- a/tools/tavily/manifest.yaml
+++ b/tools/tavily/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - search
 type: plugin
-version: 0.1.8
+version: 0.1.9

--- a/tools/telegraph/manifest.yaml
+++ b/tools/telegraph/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.9
+version: 0.0.10
 type: plugin
 author: langgenius
 name: telegraph

--- a/tools/tianditu/manifest.yaml
+++ b/tools/tianditu/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - utilities
 - travel
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/todoist/manifest.yaml
+++ b/tools/todoist/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: todoist

--- a/tools/transcript/manifest.yaml
+++ b/tools/transcript/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
 - videos
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/trello/manifest.yaml
+++ b/tools/trello/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/twilio/manifest.yaml
+++ b/tools/twilio/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/twitter/manifest.yaml
+++ b/tools/twitter/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.4
+version: 0.1.5

--- a/tools/unstructured/manifest.yaml
+++ b/tools/unstructured/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 author: langgenius
 name: unstructured

--- a/tools/vanna/manifest.yaml
+++ b/tools/vanna/manifest.yaml
@@ -33,4 +33,4 @@ tags:
 - utilities
 - productivity
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/vectorizer/manifest.yaml
+++ b/tools/vectorizer/manifest.yaml
@@ -34,4 +34,4 @@ tags:
   - productivity
   - image
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/websearch/manifest.yaml
+++ b/tools/websearch/manifest.yaml
@@ -38,4 +38,4 @@ tags:
 - news
 - productivity
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/wecom/manifest.yaml
+++ b/tools/wecom/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/tools/whatsapp-bot/manifest.yaml
+++ b/tools/whatsapp-bot/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.5
+version: 0.0.6
 type: plugin
 author: langgenius
 name: whatsapp-bot

--- a/tools/wikipedia/manifest.yaml
+++ b/tools/wikipedia/manifest.yaml
@@ -35,4 +35,4 @@ resource:
 tags:
 - social
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/wolframalpha/manifest.yaml
+++ b/tools/wolframalpha/manifest.yaml
@@ -34,4 +34,4 @@ tags:
 - productivity
 - utilities
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/yahoo/manifest.yaml
+++ b/tools/yahoo/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - business
 - finance
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/tools/youtube/manifest.yaml
+++ b/tools/youtube/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - videos
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/zhipuai/manifest.yaml
+++ b/tools/zhipuai/manifest.yaml
@@ -33,4 +33,4 @@ tags:
   - image
   - videos
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/zoom/manifest.yaml
+++ b/tools/zoom/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 0.1.5
+version: 0.1.6

--- a/triggers/airtable_trigger/manifest.yaml
+++ b/triggers/airtable_trigger/manifest.yaml
@@ -38,4 +38,4 @@ tags:
 - productivity
 - utilities
 type: plugin
-version: 1.0.4
+version: 1.0.5

--- a/triggers/google_drive_trigger/manifest.yaml
+++ b/triggers/google_drive_trigger/manifest.yaml
@@ -30,4 +30,4 @@ resource:
       size: 1048576
       enabled: true
 type: plugin
-version: 1.3.4
+version: 1.3.5

--- a/triggers/lark_trigger/manifest.yaml
+++ b/triggers/lark_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.7
+version: 0.0.8


### PR DESCRIPTION
## Summary

Related to #3206.

Bumps the top-level `version` in 44 official plugin manifests for batch 5 of the recovery version bump plan.
Skips 6 plugins whose versions have already been bumped on `main`, so this PR does not apply an additional bump to them.
This PR only changes manifest versions and does not modify dependency files.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] Dependency files are intentionally unchanged in this PR

## Testing

- [x] `git diff --check`
- [x] Verified the diff only changes top-level `version` lines in this batch
- [ ] Local deployment
- [ ] SaaS

<details>
<summary>Plugins bumped in this PR</summary>

- `tools/regex`: `0.0.7` -> `0.0.8`
- `tools/salesforce`: `0.0.5` -> `0.0.6`
- `tools/searchapi`: `0.0.6` -> `0.0.7`
- `tools/searxng`: `0.0.11` -> `0.0.12`
- `tools/seltz`: `0.0.7` -> `0.0.8`
- `tools/serper`: `0.0.6` -> `0.0.7`
- `tools/siliconflow`: `0.0.11` -> `0.0.12`
- `tools/slack`: `0.0.8` -> `0.0.9`
- `tools/slidespeak`: `1.0.4` -> `1.0.5`
- `tools/smartsheet`: `0.0.5` -> `0.0.6`
- `tools/snowflake`: `0.0.5` -> `0.0.6`
- `tools/somark`: `0.1.0` -> `0.1.1`
- `tools/spark`: `0.0.6` -> `0.0.7`
- `tools/spider`: `0.0.8` -> `0.0.9`
- `tools/spotify`: `0.1.4` -> `0.1.5`
- `tools/sqlite`: `0.0.5` -> `0.0.6`
- `tools/stability`: `0.0.6` -> `0.0.7`
- `tools/stablediffusion`: `0.0.6` -> `0.0.7`
- `tools/stackexchange`: `0.0.6` -> `0.0.7`
- `tools/stepfun`: `0.0.6` -> `0.0.7`
- `tools/supabase`: `0.1.4` -> `0.1.5`
- `tools/tavily`: `0.1.8` -> `0.1.9`
- `tools/telegraph`: `0.0.9` -> `0.0.10`
- `tools/tianditu`: `0.0.6` -> `0.0.7`
- `tools/todoist`: `0.0.5` -> `0.0.6`
- `tools/transcript`: `0.0.6` -> `0.0.7`
- `tools/trello`: `0.0.6` -> `0.0.7`
- `tools/twilio`: `0.0.6` -> `0.0.7`
- `tools/twitter`: `0.1.4` -> `0.1.5`
- `tools/unstructured`: `0.0.8` -> `0.0.9`
- `tools/vanna`: `0.0.7` -> `0.0.8`
- `tools/vectorizer`: `0.0.6` -> `0.0.7`
- `tools/websearch`: `0.0.6` -> `0.0.7`
- `tools/wecom`: `0.0.9` -> `0.0.10`
- `tools/whatsapp-bot`: `0.0.5` -> `0.0.6`
- `tools/wikipedia`: `0.0.7` -> `0.0.8`
- `tools/wolframalpha`: `0.0.8` -> `0.0.9`
- `tools/yahoo`: `0.0.9` -> `0.0.10`
- `tools/youtube`: `0.0.6` -> `0.0.7`
- `tools/zhipuai`: `0.0.7` -> `0.0.8`
- `tools/zoom`: `0.1.5` -> `0.1.6`
- `triggers/airtable_trigger`: `1.0.4` -> `1.0.5`
- `triggers/google_drive_trigger`: `1.3.4` -> `1.3.5`
- `triggers/lark_trigger`: `0.0.7` -> `0.0.8`

</details>

<details>
<summary>Plugins already bumped on main and skipped</summary>

- `triggers/github_trigger`: base `1.4.6`, main `1.4.7`, previous PR target `1.4.7`
- `triggers/gmail_trigger`: base `0.0.6`, main `0.0.7`, previous PR target `0.0.7`
- `triggers/google_calendar_trigger`: base `0.0.5`, main `0.0.6`, previous PR target `0.0.6`
- `triggers/linear_trigger`: base `0.5.6`, main `0.5.7`, previous PR target `0.5.7`
- `triggers/notion_trigger`: base `0.1.4`, main `0.1.5`, previous PR target `0.1.5`
- `triggers/outlook_trigger`: base `0.1.5`, main `0.1.6`, previous PR target `0.1.6`

</details>
