### PR TITLE
chore: bump official plugin versions batch 6

### DIFF
--- a/triggers/rsshub_trigger/manifest.yaml
+++ b/triggers/rsshub_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/triggers/slack_trigger/manifest.yaml
+++ b/triggers/slack_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.2.4
+version: 0.2.5

--- a/triggers/telegram_trigger/manifest.yaml
+++ b/triggers/telegram_trigger/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.5
+version: 0.0.6

--- a/triggers/woocommerce_trigger/manifest.yaml
+++ b/triggers/woocommerce_trigger/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 1.0.4
+version: 1.0.5

--- a/triggers/zendesk_trigger/manifest.yaml
+++ b/triggers/zendesk_trigger/manifest.yaml
@@ -34,4 +34,4 @@ resource:
 tags:
 - utilities
 type: plugin
-version: 1.0.4
+version: 1.0.5


### PR DESCRIPTION
## Summary

Related to #3206.

Bumps the top-level `version` in 5 official plugin manifests for batch 6 of the recovery version bump plan.
Skips 2 plugins whose versions have already been bumped on `main`, so this PR does not apply an additional bump to them.
This PR only changes manifest versions and does not modify dependency files.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] Dependency files are intentionally unchanged in this PR

## Testing

- [x] `git diff --check`
- [x] Verified the diff only changes top-level `version` lines in this batch
- [ ] Local deployment
- [ ] SaaS

<details>
<summary>Plugins bumped in this PR</summary>

- `triggers/rsshub_trigger`: `0.0.5` -> `0.0.6`
- `triggers/slack_trigger`: `0.2.4` -> `0.2.5`
- `triggers/telegram_trigger`: `0.0.5` -> `0.0.6`
- `triggers/woocommerce_trigger`: `1.0.4` -> `1.0.5`
- `triggers/zendesk_trigger`: `1.0.4` -> `1.0.5`

</details>

<details>
<summary>Plugins already bumped on main and skipped</summary>

- `triggers/twilio_trigger`: base `0.0.4`, main `0.0.5`, previous PR target `0.0.5`
- `triggers/typeform_trigger`: base `0.1.5`, main `0.1.6`, previous PR target `0.1.6`

</details>
