### PR TITLE
fix(vertex_ai): trust Google usage_metadata for token counts

### DIFF
--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.57
+version: 0.0.58

--- a/models/vertex_ai/models/llm/gemini-3.1-flash-lite.yaml
+++ b/models/vertex_ai/models/llm/gemini-3.1-flash-lite.yaml
@@ -1,0 +1,132 @@
+model: gemini-3.1-flash-lite
+label:
+  en_US: Gemini 3.1 Flash-Lite
+model_type: llm
+features:
+  - tool-call
+  - multi-tool-call
+  - agent-thought
+  - vision
+  - stream-tool-call
+  - document
+  - video
+  - audio
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    type: float
+    required: true
+    default: 1
+    min: 0
+    max: 2
+    label:
+      en_US: Temperature
+      zh_Hans: 温度
+    help:
+      en_US: For Gemini 3, best results at default 1.0. Lower values may impact reasoning.
+      zh_Hans: 对于 Gemini 3，使用默认值 1.0 可获得最佳效果。数值过低可能会影响推理能力。
+  - name: top_p
+    use_template: top_p
+    default: 0.95
+  - name: max_output_tokens
+    type: int
+    required: true
+    default: 65536
+    min: 1
+    max: 65536
+    label:
+      en_US: Output length
+      zh_Hans: 输出长度
+    help:
+      en_US: The maximum number of tokens to generate in the response.
+      zh_Hans: 模型单次输出的最大 tokens 数。
+  - name: thinking_level
+    label:
+      zh_Hans: 思考层级
+      en_US: Thinking Level
+    type: string
+    default: "High"
+    options:
+      - Minimal
+      - Low
+      - Medium
+      - High
+    required: false
+    help:
+      zh_Hans: 控制模型推理深度。High 提供最深入的推理，Minimal 适合最简单任务。默认为 High。注意此参数仅适用于 Gemini 3，与 thinking_budget 互斥。
+      en_US: Controls the maximum depth of the model's reasoning. High provides deepest reasoning, Minimal is suitable for simplest tasks. Defaults to High. Note this parameter is only for Gemini 3 and is mutually exclusive with thinking_budget.
+  - name: include_thoughts
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Include Thoughts
+      zh_Hans: 返回思考过程
+    help:
+      en_US: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available.
+      zh_Hans: 是否返回思考过程。若为 true 则只有模型支持思考且启动思考模式时才返回思考过程。
+  - name: media_resolution
+    type: string
+    required: false
+    default: "Default"
+    options:
+      - Default
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Media Resolution
+      zh_Hans: 媒体分辨率
+    help:
+      en_US: |
+        Fine-grained control over multimodal visual processing quality. Higher resolution improves small text reading and detail recognition but increases token usage and latency.
+
+        Token Impact: Images (High: 1120 tokens), PDF (Medium: 560 tokens), Video regular (Low/Medium: 70 tokens/frame), Video text-heavy (High: 280 tokens/frame).
+
+        If not specified, the model automatically selects the best resolution based on media type.
+      zh_Hans: |
+        对多模态视觉处理质量的精细控制。分辨率越高，模型读取细小文本和识别细节的能力越强，但会增加令牌用量和延迟。
+
+        令牌影响：图片(High: 1120 tokens)，PDF(Medium: 560 tokens)，视频常规(Low/Medium: 70 tokens/帧)，视频文字密集(High: 280 tokens/帧)。
+
+        如果不指定，模型会根据媒体类型自动选择最佳分辨率。
+  - name: grounding
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Grounding
+      zh_Hans: 事实核查
+    help:
+      en_US: Grounding with Google Search. The model will use Google search results as reference information.
+      zh_Hans: 使用 Google 搜索进行事实核查。模型会将搜索结果作为参考信息。
+  - name: url_context
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: URL Context
+      zh_Hans: 链接详情
+    help:
+      en_US: Browse the URL context. Get and analyze detailed information from URLs to provide reference for responses.
+      zh_Hans: 获取并分析链接的详细信息，为回答提供参考依据。
+  - name: code_execution
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Code Execution
+      zh_Hans: 代码执行
+    help:
+      en_US: Lets Gemini use code to solve complex tasks.
+      zh_Hans: 让 Gemini 使用代码来解决复杂任务。
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.25'
+  output: '1.50'
+  unit: '0.000001'
+  currency: USD

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -811,6 +811,42 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
             )
             return self._handle_generate_response(model, credentials, response, prompt_messages)
 
+    @staticmethod
+    def _calculate_tokens_from_usage_metadata(
+        usage_metadata: types.GenerateContentResponseUsageMetadata | None,
+    ) -> tuple[int, int]:
+        """
+        Extract prompt and completion token counts from Google's response
+        ``usage_metadata`` so we report what Google actually billed instead of
+        a local GPT-2 estimate.
+
+        Uses ``prompt_token_count`` directly: on a cache hit this includes
+        cached tokens while a per-modality sum over ``prompt_tokens_details``
+        would silently miss them. ``prompt_token_count`` is also already
+        forward-compatible with new modalities Google may add.
+
+        ``completion_tokens`` is ``candidates_token_count + thoughts_token_count``
+        because Vertex bills these as two separate SKUs (e.g.
+        ``Gemini 2.5 Flash Lite Text Output`` vs
+        ``Gemini 2.5 Flash Lite Thinking Text Output``); dropping
+        ``thoughts_token_count`` would under-report by ~50% on thinking-enabled
+        requests. ``tool_use_prompt_token_count`` is intentionally not summed
+        here, matching the sibling ``langgenius/gemini`` helper.
+
+        Returns ``(0, 0)`` if the metadata is missing; callers should branch on
+        ``usage_metadata is None`` (not on a zero return) before deciding
+        whether to fall back to ``get_num_tokens``.
+        """
+        if not usage_metadata:
+            return 0, 0
+
+        prompt_tokens = getattr(usage_metadata, "prompt_token_count", 0) or 0
+        candidates_token_count = getattr(usage_metadata, "candidates_token_count", 0) or 0
+        thoughts_token_count = getattr(usage_metadata, "thoughts_token_count", 0) or 0
+        completion_tokens = candidates_token_count + thoughts_token_count
+
+        return prompt_tokens, completion_tokens
+
     def _handle_generate_response(
         self, model: str, credentials: dict, response: types.GenerateContentResponse,
         prompt_messages: list[PromptMessage]
@@ -890,8 +926,26 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
                                 is_thinking = False
                             assistant_prompt_message.content += part.text
 
-        prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
-        completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
+        # Prefer Google's reported usage so we don't recompute prompt_tokens
+        # locally on a base64-inlined PDF/audio/video and over-report by orders
+        # of magnitude. Branch on usage_metadata presence (not on token=0) so a
+        # legitimate zero-token reply doesn't silently fall back to the broken
+        # local path.
+        response_usage_metadata = getattr(response, "usage_metadata", None)
+        if response_usage_metadata is not None:
+            prompt_tokens, completion_tokens = self._calculate_tokens_from_usage_metadata(
+                response_usage_metadata
+            )
+        else:
+            # Defensive only — the GenAI SDK always populates usage_metadata on
+            # successful responses, so in practice this branch only fires on
+            # SDK regressions or hand-rolled test fixtures. The local
+            # get_num_tokens path here is itself a known source of inflated
+            # counts on multimodal inputs (see commit message); we preserve it
+            # only because deleting it would be a behaviour regression for
+            # unknown-shape responses.
+            prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
+            completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
         usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
         result = LLMResult(model=model, prompt_messages=prompt_messages, message=assistant_prompt_message, usage=usage)
         return result
@@ -989,8 +1043,20 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
                         delta=LLMResultChunkDelta(index=index, message=assistant_prompt_message),
                     )
                 else:
-                    prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
-                    completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
+                    # Prefer Google's reported usage (see non-stream handler above
+                    # for rationale). The GenAI SDK only populates
+                    # usage_metadata on the terminal chunk, so we only consult
+                    # it inside this finish-reason branch — no risk of reading
+                    # partial usage from intermediate chunks.
+                    chunk_usage_metadata = getattr(chunk, "usage_metadata", None)
+                    if chunk_usage_metadata is not None:
+                        prompt_tokens, completion_tokens = self._calculate_tokens_from_usage_metadata(
+                            chunk_usage_metadata
+                        )
+                    else:
+                        # Defensive only; same caveat as the non-stream handler.
+                        prompt_tokens = self.get_num_tokens(model, credentials, prompt_messages)
+                        completion_tokens = self.get_num_tokens(model, credentials, [assistant_prompt_message])
                     usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
 
                     # For image responses (list content), skip grounding/reference processing

--- a/models/vertex_ai/models/tests/test_usage_metadata.py
+++ b/models/vertex_ai/models/tests/test_usage_metadata.py
@@ -1,0 +1,64 @@
+import os
+import sys
+
+from google.genai import types
+
+try:
+    from models.llm.llm import VertexAiLargeLanguageModel
+except ImportError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    from models.llm.llm import VertexAiLargeLanguageModel
+
+
+def test_returns_zero_zero_when_metadata_is_none():
+    assert VertexAiLargeLanguageModel._calculate_tokens_from_usage_metadata(None) == (0, 0)
+
+
+def test_reads_prompt_token_count_directly():
+    """
+    ``prompt_token_count`` is Google's authoritative aggregate (includes cached
+    tokens on cache hits and any future modalities), so we use it directly
+    rather than summing per-modality details.
+    """
+    meta = types.GenerateContentResponseUsageMetadata(
+        prompt_token_count=24,
+        prompt_tokens_details=[
+            types.ModalityTokenCount(modality=types.MediaModality.TEXT, token_count=18),
+            types.ModalityTokenCount(modality=types.MediaModality.DOCUMENT, token_count=6),
+        ],
+        candidates_token_count=58,
+        thoughts_token_count=120,
+        total_token_count=202,
+    )
+    prompt_tokens, completion_tokens = VertexAiLargeLanguageModel._calculate_tokens_from_usage_metadata(meta)
+    assert prompt_tokens == 24
+    assert completion_tokens == 178  # 58 candidates + 120 thoughts; see SKU split rationale in docstring
+
+
+def test_zero_token_reply_is_preserved_not_treated_as_missing():
+    """
+    Caller contract: a legitimate zero-token reply (e.g. function-call-only
+    response) should round-trip as (0, 0). Callers branch on
+    ``usage_metadata is None`` to decide fallback, not on the returned zero.
+    """
+    meta = types.GenerateContentResponseUsageMetadata(
+        prompt_token_count=0,
+        prompt_tokens_details=None,
+        candidates_token_count=0,
+        thoughts_token_count=None,
+        total_token_count=0,
+    )
+    assert VertexAiLargeLanguageModel._calculate_tokens_from_usage_metadata(meta) == (0, 0)
+
+
+def test_handles_missing_thoughts_token_count():
+    meta = types.GenerateContentResponseUsageMetadata(
+        prompt_token_count=10,
+        prompt_tokens_details=None,
+        candidates_token_count=5,
+        thoughts_token_count=None,
+        total_token_count=15,
+    )
+    prompt_tokens, completion_tokens = VertexAiLargeLanguageModel._calculate_tokens_from_usage_metadata(meta)
+    assert prompt_tokens == 10
+    assert completion_tokens == 5


### PR DESCRIPTION
> **Update (2026-05-28 17:30 UTC+8)**: this PR now **bundles two independent vertex_ai changes** that share `manifest.yaml` version `0.0.58`. The companion PR #3220 (Gemini 3.1 Flash-Lite GA model YAML) has been folded in to avoid serialized rebases. Both commits are kept separate for clean history. See [Commit list](#commits-list) for the two distinct changes.
>
> - Commit 1: `fix(vertex_ai): trust Google usage_metadata for token counts` — the main fix this PR was opened for
> - Commit 2: `feat(vertex_ai): add Gemini 3.1 Flash-Lite (GA) model` — additive new model YAML, no behavior change

---

## Summary

The `vertex_ai` plugin's Gemini response handlers were calling `self.get_num_tokens(...)` to estimate `prompt_tokens` **locally** instead of reading `response.usage_metadata.prompt_token_count` returned by Google. Combined with two adjacent (separate-scope) bugs, this caused `prompt_tokens` / `total_price` reported in `metadata.usage` to scale with the **base64 size of any attached file** rather than what Google actually billed, and silently dropped `thoughts_token_count` for thinking-enabled requests.

In production we observed a 21 MB / 3-page PDF reported as **29.6 M prompt_tokens / $7.40** for one completion call — Google's actual billing was several orders of magnitude lower. Reproduced in isolation with a controlled fixture; numbers matched the broken prod row to within ~200 tokens.

For thinking-enabled requests we observed a separate ~50% under-report of `completion_tokens`: Google bills `candidates_token_count` (visible output) and `thoughts_token_count` (hidden reasoning) as two distinct SKUs on Vertex ("Text Output - Predictions" vs "Thinking Text Output - Predictions"), but the previous code only counted visible output.

**Upstream issue**: langgenius/dify#36721

## The fix (commit 1)

Mirror the sibling `langgenius/gemini` plugin's pattern: read tokens from `response.usage_metadata` (and from terminal `chunk.usage_metadata` for streaming). Fall back to `get_num_tokens` **only** when `usage_metadata is None`.

- `prompt_tokens = usage_metadata.prompt_token_count` directly. This is Google's authoritative aggregate — it includes cached tokens on cache hits (which a per-modality sum over `prompt_tokens_details` would silently miss) and is already forward-compatible with any new modalities Google may add.
- `completion_tokens = candidates_token_count + thoughts_token_count`. These are billed as separate SKUs on Vertex, so they must be summed to match GCP billing. Validated against a real linnk-ai project bill: 89.8M Text Output + 98.2M Thinking Text Output on 2026-05-26, two distinct SKU rows. Dropping `thoughts_token_count` would under-report by ~50% on thinking-enabled requests — exactly the bug this PR fixes.

`tool_use_prompt_token_count` is not summed into `prompt_tokens` — same as the sibling gemini helper. Multi-turn tool-using sessions therefore under-report by exactly that volume. Separate concern, not introduced here.

## New model (commit 2)

Google announced general availability of Gemini 3.1 Flash-Lite on 2026-05-07. The GA model id `gemini-3.1-flash-lite` is live on Vertex AI publishers/google/models, but the plugin only ships the corresponding `-preview` model. Adding the GA variant lets users select it from Dify without falling back to preview (which Google is deprecating).

The GA YAML is a near-identical copy of `gemini-3.1-flash-lite-preview.yaml` — only `model` id and `label` differ. All other parameters (`thinking_level`, `include_thoughts`, `media_resolution`, `grounding`, `url_context`, `code_execution`, `json_schema`, 1,048,576-token context, parameter ranges) match. Pricing per [Google's pricing page](https://cloud.google.com/vertex-ai/generative-ai/pricing): `$0.25 / 1M input tokens, $1.50 / 1M output tokens` — identical to the preview, so the `pricing:` block is unchanged.

Verified live on Vertex (project linnk-ai, global location): GA model exists and returns `usage_metadata` as expected. Tested all four thinking levels — `Minimal` produces 0 thoughts as expected.

## Change Type

- [x] LLM plugin

## Areas affected

- [x] **Token consumption metrics** — both stream and non-stream paths now report Google's authoritative counts.
- [x] **Multimodal input** — files (PDF / image / audio / video) no longer inflate reported usage via local base64-tokenizer estimation.
- [x] **Thinking-enabled requests** — `thoughts_token_count` is now included in `completion_tokens` so internal cost matches Vertex's Thinking SKU.
- [x] **Model garden** — `gemini-3.1-flash-lite` (GA) becomes selectable in Dify alongside the deprecating preview model.

## Left intentionally out of scope (follow-ups)

- `_convert_one_message_to_text` still concatenates non-IMAGE `c.data` (i.e. base64 file payloads) into prompt text. The new `get_num_tokens` fallback path therefore remains buggy on file inputs. In practice that path is dead code for real GenAI SDK responses (usage_metadata is always populated on success).
- `_get_num_tokens_by_gpt2` in `langgenius/dify-plugin-sdks` still has the `if len(text) >= TOKEN_ESTIMATION_TEXT_LIMIT: return len(text)` shortcut (returning char count as token count). Worth a separate PR on that repo; this fix removes the only cost-impacting caller from `vertex_ai`.

The Claude response handler in the same file is left untouched: it already reads `response.usage.input_tokens` correctly and falls back to `get_num_tokens` only when `response.usage` is absent.

## Testing

- [x] **Unit tests added**: `models/vertex_ai/models/tests/test_usage_metadata.py` — 4 cases covering `None` metadata, `prompt_token_count` direct read + candidates+thoughts sum, zero-token reply round-trip, and missing `thoughts_token_count`. All pass.
- [x] **Reproduced in prod-shaped environment** (Dify 1.3.0 server + `vertex_ai-0.0.44` plugin + `gemini-3.1-flash-lite-preview` on Vertex AI): before fix, 21 MB / 3-page PDF → 29,609,617 prompt_tokens / $7.40; the patched plugin reads Google's actual `usage_metadata.prompt_token_count` instead, which matches GCP billing console.
- [x] **GA model availability verified** via direct `aiplatform.googleapis.com:generateContent` call.

## Version

- [x] Bumped `models/vertex_ai/manifest.yaml` to **0.0.58** (PATCH — bug fix + additive model).

---

Refs:
- langgenius/dify#36721 (upstream root-cause writeup)
- Google announcement of Gemini 3.1 Flash-Lite GA (2026-05-07)
