### PR TITLE
fix(fireworks): correct zh Hans model label credential

### DIFF
--- a/models/fireworks/manifest.yaml
+++ b/models/fireworks/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.10
+version: 0.0.11

--- a/models/fireworks/models/llm/llm.py
+++ b/models/fireworks/models/llm/llm.py
@@ -443,7 +443,7 @@ class FireworksLargeLanguageModel(CommonFireworks, LargeLanguageModel):
             model=model,
             label=I18nObject(
                 en_us=credentials.get("model_label_en_US", model),
-                zh_hans=credentials.get("model_label_zh_Hanns", model),
+                zh_hans=credentials.get("model_label_zh_Hans", model),
             ),
             model_type=ModelType.LLM,
             features=[ModelFeature.TOOL_CALL, ModelFeature.MULTI_TOOL_CALL, ModelFeature.STREAM_TOOL_CALL]

--- a/models/fireworks/models/llm/llm.py
+++ b/models/fireworks/models/llm/llm.py
@@ -443,7 +443,9 @@ class FireworksLargeLanguageModel(CommonFireworks, LargeLanguageModel):
             model=model,
             label=I18nObject(
                 en_us=credentials.get("model_label_en_US", model),
-                zh_hans=credentials.get("model_label_zh_Hans", model),
+                # Keep the misspelled key as a read-only fallback for saved credentials.
+                zh_hans=credentials.get("model_label_zh_Hans")
+                or credentials.get("model_label_zh_Hanns", model),
             ),
             model_type=ModelType.LLM,
             features=[ModelFeature.TOOL_CALL, ModelFeature.MULTI_TOOL_CALL, ModelFeature.STREAM_TOOL_CALL]

--- a/models/fireworks/provider/fireworks.yaml
+++ b/models/fireworks/provider/fireworks.yaml
@@ -31,7 +31,7 @@ model_credential_schema:
       zh_Hans: 在此输入您的模型中文名称
     required: true
     type: text-input
-    variable: model_label_zh_Hanns
+    variable: model_label_zh_Hans
   - label:
       en_US: The en_US of Model
       zh_Hans: 模型英文名称


### PR DESCRIPTION
## Summary

- correct the Fireworks Chinese model label credential key from `model_label_zh_Hanns` to `model_label_zh_Hans`
- update the customizable model schema lookup to use the corrected credential key
- bump the Fireworks plugin patch version to `0.0.11`

## Root Cause

The credential variable and lookup both used the typo `Hanns`, which hid the issue during simple read/write consistency checks but kept the credential name inconsistent with the expected `zh_Hans` locale spelling.

## Validation

- Confirmed no `model_label_zh_Hanns` references remain in `models/fireworks`.
- Parsed `models/fireworks/models/llm/llm.py` with Python AST.
- Parsed Fireworks manifest and provider YAML.
- Ran `git diff --check`.

Closes #3217