### PR TITLE
feat(anthropic): add model Claude Opus 4.8

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.18
+version: 0.3.19

--- a/models/anthropic/models/llm/_position.yaml
+++ b/models/anthropic/models/llm/_position.yaml
@@ -1,3 +1,4 @@
+- claude-opus-4-8
 - claude-opus-4-7
 - claude-sonnet-4-6
 - claude-opus-4-6

--- a/models/anthropic/models/llm/claude-opus-4-8.yaml
+++ b/models/anthropic/models/llm/claude-opus-4-8.yaml
@@ -1,0 +1,149 @@
+# https://platform.claude.com/docs/en/about-claude/models/overview
+# https://platform.claude.com/docs/en/about-claude/models/migration-guide
+# https://platform.claude.com/docs/en/resources/overview
+model: claude-opus-4-8
+label:
+  en_US: claude-opus-4-8
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 自适应推理
+      en_US: Adaptive Thinking
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 启用自适应推理（adaptive thinking）。Claude Opus 4.8 仅支持 adaptive 模式，不再支持设置 thinking_budget。推理深度由 Effort 参数控制。
+      en_US: Enable adaptive thinking. Claude Opus 4.8 only supports adaptive mode; thinking_budget is no longer supported. Thinking depth is controlled by the Effort parameter.
+  - name: thinking_display
+    label:
+      zh_Hans: 推理内容展示
+      en_US: Thinking Display
+    type: string
+    default: summarized
+    required: false
+    options:
+      - omitted
+      - summarized
+    help:
+      zh_Hans: 响应中推理内容的展示方式。omitted 为官方默认值（响应中不返回 thinking 文本）；summarized 返回摘要化的推理过程，便于在前端展示思考进度。
+      en_US: How thinking content is exposed in the response. `omitted` is the official default (thinking text not returned); `summarized` returns summarized reasoning so clients can display progress.
+  - name: effort
+    label:
+      zh_Hans: 推理投入等级
+      en_US: Effort
+    type: string
+    default: high
+    required: false
+    options:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    help:
+      zh_Hans: 通过 output_config.effort 控制智能/token 消耗的权衡。xhigh 推荐用于编码与智能体场景，high 是智能敏感场景的最低建议值；low 与 medium 适合延迟或成本敏感场景。
+      en_US: Controls the intelligence vs. token cost trade-off via output_config.effort. Use `xhigh` for coding and agentic tasks; `high` is the minimum recommendation for intelligence-sensitive tasks; `low`/`medium` for latency- or cost-sensitive tasks.
+  - name: task_budget
+    label:
+      zh_Hans: 任务预算
+      en_US: Task Budget
+    type: int
+    default: 0
+    min: 0
+    max: 1000000
+    required: false
+    help:
+      zh_Hans: |
+        跨完整智能体循环（推理+工具调用+工具结果+最终输出）下发给模型的建议性 token 预算。这是"建议"（模型可见并据此自我调度），不是硬上限；真正的硬上限由 max_tokens 控制。
+        · 0（默认）：不发送该字段 → 模型看不到预算倒计时，按 max_tokens 自由发挥，适合质量优先的开放式任务。这不是"无上限"，而是"不启用预算建议"。
+        · <20000：插件会静默忽略（API 要求最小 20000，避免 400）。
+        · ≥20000：启用并自动追加 beta 头 `task-budgets-2026-03-13`；预算过紧可能导致模型潦草收尾。
+      en_US: |
+        Advisory token budget visible to the model across the full agentic loop (thinking + tool calls + tool results + final output). This is advisory — the hard per-request cap is `max_tokens`.
+        · 0 (default): field is not sent → model runs without a countdown, bounded only by `max_tokens`. Recommended for open-ended agentic tasks where quality matters more than speed. "0" means "no budget hint", NOT "unlimited".
+        · <20000: silently ignored by the plugin (API requires a minimum of 20000 and would otherwise return 400).
+        · ≥20000: enabled and the `task-budgets-2026-03-13` beta header is attached automatically. Overly tight budgets can cause the model to wrap up prematurely.
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    default: 128000
+    min: 1
+    max: 128000
+  - name: response_format
+    use_template: response_format
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
+pricing:
+  input: '5.00'
+  output: '25.00'
+  unit: '0.000001'
+  currency: USD

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -157,7 +157,10 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
     #   - assistant prefill rejected with 400
     #   - thinking content omitted by default — opt in via thinking.display=summarized
     #   - effort / task_budget delivered via output_config
-    OPUS_4_7_PLUS_MODELS: tuple[str, ...] = ("claude-opus-4-7",)
+    OPUS_4_7_PLUS_MODELS: tuple[str, ...] = (
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+    )
 
     def __init__(self, model_schemas=None):
         super().__init__(model_schemas or [])


### PR DESCRIPTION
## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

Add Claude Opus 4.8 model definition to the Anthropic provider.

Claude Opus 4.8 is Anthropic's latest and most capable model for complex reasoning, long-horizon agentic coding, and high-autonomy work.

**Key specs:**
- Model ID: `claude-opus-4-8`
- Context window: 1M tokens
- Max output: 128k tokens
- Pricing: $5 / input MTok, $25 / output MTok
- Adaptive thinking support (effort parameter: low / medium / high / xhigh / max)
- No extended thinking (adaptive only)
- Task budget support

Reference: https://platform.claude.com/docs/en/about-claude/models/overview

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
| Opus 4.7 is the latest model | Opus 4.8 added at top of model list |

## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)  — `0.3.18` → `0.3.19`
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [ ] SaaS (cloud.dify.ai)
