### PR TITLE
fix(anthropic): render markdown heading on first body line after thin…

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.19
+version: 0.3.20

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -1024,7 +1024,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 
                 if chunk.index != current_block_index:
                     if current_block_type == "thinking" and current_block_index is not None:
-                        assistant_prompt_message = AssistantPromptMessage(content="\n</think>")
+                        assistant_prompt_message = AssistantPromptMessage(content="\n</think>\n\n")
                         yield LLMResultChunk(
                             model=return_model,
                             prompt_messages=prompt_messages,
@@ -1112,7 +1112,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 )
             elif isinstance(chunk, MessageStopEvent):
                 if current_block_type == "thinking" and current_block_index is not None:
-                    assistant_prompt_message = AssistantPromptMessage(content="\n</think>")
+                    assistant_prompt_message = AssistantPromptMessage(content="\n</think>\n\n")
                     yield LLMResultChunk(
                         model=return_model,
                         prompt_messages=prompt_messages,

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -1023,7 +1023,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                                     break
                 
                 if chunk.index != current_block_index:
-                    if current_block_type == "thinking" and current_block_index is not None:
+                    if current_block_type in ("thinking", "redacted_thinking") and current_block_index is not None:
                         assistant_prompt_message = AssistantPromptMessage(content="\n</think>\n\n")
                         yield LLMResultChunk(
                             model=return_model,
@@ -1111,7 +1111,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     self._get_cache_creation_input_tokens_by_ttl(chunk.usage)
                 )
             elif isinstance(chunk, MessageStopEvent):
-                if current_block_type == "thinking" and current_block_index is not None:
+                if current_block_type in ("thinking", "redacted_thinking") and current_block_index is not None:
                     assistant_prompt_message = AssistantPromptMessage(content="\n</think>\n\n")
                     yield LLMResultChunk(
                         model=return_model,


### PR DESCRIPTION
## What this PR does

Fixes markdown rendering of the first body line after extended thinking in
streaming mode.

The closing `</think>` tag was emitted without a trailing newline, so a body
that started with a markdown heading (e.g. `## Winter is coming`) was concatenated on
the same line as `</think>` and rendered as plain text instead of a heading.
Markdown only renders `##` as a heading when it's at the start of a line.

Appending a blank line after `</think>` ensures body content always starts on
a fresh line, so headings/lists/code-blocks render correctly.

## Changes
- `models/anthropic/models/llm/llm.py`: `\n</think>` → `\n</think>\n\n` (2 spots)
- `models/anthropic/manifest.yaml`: version bump `0.3.19` → `0.3.20`
