### PR TITLE
feat(minimax): add MiniMax-M3 model support

### DIFF
--- a/models/minimax/manifest.yaml
+++ b/models/minimax/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.20
+version: 0.0.21

--- a/models/minimax/models/llm/_position.yaml
+++ b/models/minimax/models/llm/_position.yaml
@@ -1,3 +1,4 @@
+- minimax-m3
 - minimax-m1
 - minimax-m2.5
 - minimax-m2-her

--- a/models/minimax/models/llm/llm.py
+++ b/models/minimax/models/llm/llm.py
@@ -900,23 +900,19 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
         if isinstance(thinking, str):
             thinking_type = thinking.strip().lower()
-            if thinking_type in {"adaptive", "disabled"}:
-                return {"type": thinking_type}
+            if thinking_type == "adaptive":
+                return {"type": "adaptive"}
             if thinking_type in {"enabled", "true"}:
                 if request_model == "MiniMax-M3":
                     return {"type": "adaptive"}
                 return {"type": "enabled", "budget_tokens": max(1024, thinking_budget)}
-            if thinking_type in {"false", "none", "off"}:
-                if request_model == "MiniMax-M3":
-                    return {"type": "disabled"}
+            if thinking_type in {"disabled", "false", "none", "off"}:
                 return None
 
         if thinking is True:
             if request_model == "MiniMax-M3":
                 return {"type": "adaptive"}
             return {"type": "enabled", "budget_tokens": max(1024, thinking_budget)}
-        if thinking is False and request_model == "MiniMax-M3":
-            return {"type": "disabled"}
         return None
 
     def _to_credential_kwargs(self, credentials: Mapping[str, Any]) -> dict[str, Any]:

--- a/models/minimax/models/llm/llm.py
+++ b/models/minimax/models/llm/llm.py
@@ -8,12 +8,15 @@ from anthropic.types import Message
 from dify_plugin.entities.model.llm import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
+    ImagePromptMessageContent,
     PromptMessage,
+    PromptMessageContentType,
     PromptMessageTool,
     SystemPromptMessage,
     TextPromptMessageContent,
     ToolPromptMessage,
     UserPromptMessage,
+    VideoPromptMessageContent,
 )
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,
@@ -29,6 +32,7 @@ from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
 
 class MinimaxLargeLanguageModel(LargeLanguageModel):
     _MODEL_ALIASES = {
+        "minimax-m3": "MiniMax-M3",
         "minimax-m2.7": "MiniMax-M2.7",
         "minimax-m2.7-highspeed": "MiniMax-M2.7-highspeed",
         "minimax-m2.7lightning": "MiniMax-M2.7-highspeed",
@@ -108,13 +112,13 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             request_kwargs["stop_sequences"] = list(stop)
         if user:
             request_kwargs["metadata"] = {"user_id": user}
-        if thinking is True:
-            request_kwargs["thinking"] = {
-                "type": "enabled",
-                "budget_tokens": max(1024, thinking_budget),
-            }
-        elif isinstance(thinking, dict):
-            request_kwargs["thinking"] = thinking
+        thinking_payload = self._normalize_thinking_payload(
+            thinking=thinking,
+            thinking_budget=thinking_budget,
+            request_model=request_model,
+        )
+        if thinking_payload:
+            request_kwargs["thinking"] = thinking_payload
 
         for key in ("temperature", "top_p", "top_k"):
             if key in model_parameters and model_parameters[key] is not None:
@@ -198,8 +202,10 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         self, prompt_message: PromptMessage
     ) -> Optional[dict[str, Any]]:
         if isinstance(prompt_message, UserPromptMessage):
-            text = self._extract_text_content(prompt_message.content)
-            return {"role": "user", "content": [{"type": "text", "text": text}]}
+            return {
+                "role": "user",
+                "content": self._convert_user_content_blocks(prompt_message.content),
+            }
 
         if isinstance(prompt_message, AssistantPromptMessage):
             content_blocks: list[dict[str, Any]] = []
@@ -244,6 +250,72 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             }
 
         return None
+
+    def _convert_user_content_blocks(self, content: Any) -> list[dict[str, Any]]:
+        if not isinstance(content, list):
+            return [{"type": "text", "text": self._extract_text_content(content)}]
+
+        content_blocks: list[dict[str, Any]] = []
+        for item in content:
+            block = self._convert_user_content_block(item)
+            if block is not None:
+                content_blocks.append(block)
+
+        if not content_blocks:
+            return [{"type": "text", "text": ""}]
+        return content_blocks
+
+    def _convert_user_content_block(self, content: Any) -> Optional[dict[str, Any]]:
+        if isinstance(content, TextPromptMessageContent):
+            return {"type": "text", "text": content.data}
+        if isinstance(content, ImagePromptMessageContent):
+            return self._create_media_content_block("image", content.data)
+        if isinstance(content, VideoPromptMessageContent):
+            return self._create_media_content_block("video", content.data)
+
+        if isinstance(content, dict):
+            content_type = content.get("type")
+            if content_type == "text":
+                return {
+                    "type": "text",
+                    "text": str(content.get("data") or content.get("text") or ""),
+                }
+            if content_type in {"image", "image_url"}:
+                image_url = content.get("data") or content.get("url")
+                if not image_url and isinstance(content.get("image_url"), dict):
+                    image_url = content["image_url"].get("url")
+                return self._create_media_content_block("image", str(image_url or ""))
+            if content_type in {"video", "video_url"}:
+                video_url = content.get("data") or content.get("url")
+                if not video_url and isinstance(content.get("video_url"), dict):
+                    video_url = content["video_url"].get("url")
+                return self._create_media_content_block("video", str(video_url or ""))
+            return None
+
+        content_type = getattr(content, "type", None)
+        if content_type == PromptMessageContentType.TEXT:
+            return {"type": "text", "text": str(getattr(content, "data", ""))}
+        if content_type == PromptMessageContentType.IMAGE:
+            return self._create_media_content_block("image", str(getattr(content, "data", "")))
+        if content_type == PromptMessageContentType.VIDEO:
+            return self._create_media_content_block("video", str(getattr(content, "data", "")))
+        return None
+
+    def _create_media_content_block(self, block_type: str, data: str) -> Optional[dict[str, Any]]:
+        data = data.strip()
+        if not data:
+            return None
+        return {"type": block_type, "source": self._create_media_source(data)}
+
+    def _create_media_source(self, data: str) -> dict[str, Any]:
+        if data.startswith("data:") and ";base64," in data:
+            header, encoded = data.split(";base64,", 1)
+            return {
+                "type": "base64",
+                "media_type": header.removeprefix("data:"),
+                "data": encoded,
+            }
+        return {"type": "url", "url": data}
 
     def _merge_consecutive_messages(
         self, message_dicts: list[dict[str, Any]]
@@ -656,6 +728,37 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
     def _set_previous_thinking_blocks(self, thinking_blocks: list[dict[str, Any]]) -> None:
         setattr(self, "_previous_thinking_blocks", thinking_blocks)
+
+    def _normalize_thinking_payload(
+        self,
+        *,
+        thinking: Any,
+        thinking_budget: int,
+        request_model: str,
+    ) -> Optional[dict[str, Any]]:
+        if isinstance(thinking, dict):
+            return thinking
+
+        if isinstance(thinking, str):
+            thinking_type = thinking.strip().lower()
+            if thinking_type in {"adaptive", "disabled"}:
+                return {"type": thinking_type}
+            if thinking_type in {"enabled", "true"}:
+                if request_model == "MiniMax-M3":
+                    return {"type": "adaptive"}
+                return {"type": "enabled", "budget_tokens": max(1024, thinking_budget)}
+            if thinking_type in {"false", "none", "off"}:
+                if request_model == "MiniMax-M3":
+                    return {"type": "disabled"}
+                return None
+
+        if thinking is True:
+            if request_model == "MiniMax-M3":
+                return {"type": "adaptive"}
+            return {"type": "enabled", "budget_tokens": max(1024, thinking_budget)}
+        if thinking is False and request_model == "MiniMax-M3":
+            return {"type": "disabled"}
+        return None
 
     def _to_credential_kwargs(self, credentials: Mapping[str, Any]) -> dict[str, Any]:
         api_key = str(credentials.get("minimax_api_key") or "").strip()

--- a/models/minimax/models/llm/llm.py
+++ b/models/minimax/models/llm/llm.py
@@ -30,6 +30,7 @@ from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
 
 
 class MinimaxLargeLanguageModel(LargeLanguageModel):
+    _OPAQUE_ANTHROPIC_CONTENT_KEY = "minimax_anthropic_content"
     _MODEL_ALIASES = {
         "minimax-m3": "MiniMax-M3",
         "minimax-m2.7": "MiniMax-M2.7",
@@ -207,6 +208,10 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             }
 
         if isinstance(prompt_message, AssistantPromptMessage):
+            opaque_content_blocks = self._get_opaque_anthropic_content(prompt_message)
+            if prompt_message.tool_calls and opaque_content_blocks:
+                return {"role": "assistant", "content": opaque_content_blocks}
+
             content_blocks: list[dict[str, Any]] = []
 
             previous_thinking_blocks = self._get_previous_thinking_blocks()
@@ -214,6 +219,8 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 content_blocks.extend(previous_thinking_blocks)
 
             text = self._extract_text_content(prompt_message.content)
+            if prompt_message.tool_calls and previous_thinking_blocks:
+                text = self._strip_leading_thinking_text(text)
             if text:
                 content_blocks.append({"type": "text", "text": text})
 
@@ -394,6 +401,40 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             )
         return transformed_tools
 
+    def _parse_tool_arguments(self, arguments: str) -> dict[str, Any]:
+        try:
+            input_payload = json.loads(arguments or "{}")
+        except Exception:
+            return {"raw": arguments}
+        if not isinstance(input_payload, dict):
+            return {"value": input_payload}
+        return input_payload
+
+    def _get_opaque_anthropic_content(
+        self, prompt_message: AssistantPromptMessage
+    ) -> list[dict[str, Any]]:
+        opaque_body = prompt_message.opaque_body
+        if not isinstance(opaque_body, dict):
+            return []
+        raw_content = opaque_body.get(self._OPAQUE_ANTHROPIC_CONTENT_KEY)
+        if not isinstance(raw_content, list):
+            return []
+
+        content_blocks: list[dict[str, Any]] = []
+        for block in raw_content:
+            if isinstance(block, dict):
+                content_blocks.append(block)
+        return content_blocks
+
+    def _strip_leading_thinking_text(self, text: str) -> str:
+        if not text.startswith("<think>"):
+            return text
+        end_tag = "</think>"
+        end_index = text.find(end_tag)
+        if end_index < 0:
+            return text
+        return text[end_index + len(end_tag) :].lstrip("\n")
+
     def _handle_chat_generate_response(
         self,
         model: str,
@@ -405,6 +446,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         text_chunks: list[str] = []
         tool_calls: list[AssistantPromptMessage.ToolCall] = []
         thinking_blocks: list[dict[str, Any]] = []
+        response_content_blocks: list[dict[str, Any]] = []
 
         for block in response.content:
             block_type = getattr(block, "type", "")
@@ -412,22 +454,33 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 text = getattr(block, "text", "")
                 if text:
                     text_chunks.append(text)
+                    response_content_blocks.append({"type": "text", "text": text})
             elif block_type == "thinking":
                 thinking_text = getattr(block, "thinking", "")
                 if thinking_text:
-                    thinking_blocks.append(
-                        {
-                            "type": "thinking",
-                            "thinking": thinking_text,
-                            "signature": getattr(block, "signature", ""),
-                        }
-                    )
+                    thinking_block = {
+                        "type": "thinking",
+                        "thinking": thinking_text,
+                        "signature": getattr(block, "signature", ""),
+                    }
+                    thinking_blocks.append(thinking_block)
+                    response_content_blocks.append(thinking_block)
             elif block_type == "redacted_thinking":
-                thinking_blocks.append({"type": "redacted_thinking"})
+                thinking_block = {"type": "redacted_thinking"}
+                thinking_blocks.append(thinking_block)
+                response_content_blocks.append(thinking_block)
             elif block_type == "tool_use":
                 input_payload = getattr(block, "input", {}) or {}
                 if not isinstance(input_payload, dict):
                     input_payload = {"value": input_payload}
+                response_content_blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": getattr(block, "id", ""),
+                        "name": getattr(block, "name", ""),
+                        "input": input_payload,
+                    }
+                )
                 tool_calls.append(
                     AssistantPromptMessage.ToolCall(
                         id=getattr(block, "id", ""),
@@ -461,7 +514,15 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         # 添加正常文本内容
         assistant_text += "".join(text_chunks)
 
-        assistant_message = AssistantPromptMessage(content=assistant_text, tool_calls=tool_calls)
+        opaque_body = None
+        if response_content_blocks:
+            opaque_body = {self._OPAQUE_ANTHROPIC_CONTENT_KEY: response_content_blocks}
+
+        assistant_message = AssistantPromptMessage(
+            content=assistant_text,
+            tool_calls=tool_calls,
+            opaque_body=opaque_body,
+        )
 
         prompt_tokens = int(getattr(response.usage, "input_tokens", 0) or 0)
         completion_tokens = int(getattr(response.usage, "output_tokens", 0) or 0)
@@ -507,9 +568,58 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         finish_reason: Optional[str] = None
         streamed_text: list[str] = []
         streamed_tool_calls: dict[str, AssistantPromptMessage.ToolCall] = {}
+        streamed_tool_input_buffers: dict[str, str] = {}
+        streamed_tool_input_fallbacks: dict[str, str] = {}
+        streamed_content_blocks: dict[str, dict[str, Any]] = {}
+        streamed_thinking_blocks: dict[str, dict[str, Any]] = {}
         current_thinking_blocks: list[dict[str, Any]] = []
         emitted_final = False
         is_reasoning_started = 0  # 0 not started, 1 started, 2 ended
+
+        def close_reasoning_chunk(index: int = 0) -> Optional[LLMResultChunk]:
+            nonlocal is_reasoning_started
+            if is_reasoning_started != 1:
+                return None
+            is_reasoning_started = 2
+            return LLMResultChunk(
+                model=model,
+                prompt_messages=prompt_messages,
+                delta=LLMResultChunkDelta(
+                    index=index,
+                    message=AssistantPromptMessage(content="\n</think>\n"),
+                ),
+            )
+
+        def finalize_tool_calls() -> list[AssistantPromptMessage.ToolCall]:
+            final_tool_calls: list[AssistantPromptMessage.ToolCall] = []
+            for index in sorted(
+                streamed_tool_calls,
+                key=lambda value: (0, int(value)) if value.isdigit() else (1, value),
+            ):
+                tool_call = streamed_tool_calls[index]
+                arguments = (
+                    streamed_tool_input_buffers.get(index)
+                    or streamed_tool_input_fallbacks.get(index)
+                    or "{}"
+                )
+                tool_call.function.arguments = arguments
+                content_block = streamed_content_blocks.get(index)
+                if content_block is not None and content_block.get("type") == "tool_use":
+                    content_block["input"] = self._parse_tool_arguments(arguments)
+                final_tool_calls.append(tool_call)
+            return final_tool_calls
+
+        def build_opaque_body() -> Optional[dict[str, Any]]:
+            if not streamed_content_blocks:
+                return None
+            content_blocks = [
+                streamed_content_blocks[index]
+                for index in sorted(
+                    streamed_content_blocks,
+                    key=lambda value: (0, int(value)) if value.isdigit() else (1, value),
+                )
+            ]
+            return {self._OPAQUE_ANTHROPIC_CONTENT_KEY: content_blocks}
 
         for event in response:
             event_type = getattr(event, "type", "")
@@ -522,17 +632,27 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
             if event_type == "content_block_start":
                 block = getattr(event, "content_block", None)
+                index = str(getattr(event, "index", len(streamed_content_blocks)))
                 if getattr(block, "type", "") == "tool_use":
-                    index = str(getattr(event, "index", len(streamed_tool_calls)))
+                    closing_chunk = close_reasoning_chunk(int(index) if index.isdigit() else 0)
+                    if closing_chunk is not None:
+                        yield closing_chunk
                     input_payload = getattr(block, "input", {}) or {}
                     if not isinstance(input_payload, dict):
                         input_payload = {"value": input_payload}
+                    streamed_tool_input_fallbacks[index] = json.dumps(input_payload)
+                    streamed_content_blocks[index] = {
+                        "type": "tool_use",
+                        "id": getattr(block, "id", index),
+                        "name": getattr(block, "name", ""),
+                        "input": input_payload,
+                    }
                     streamed_tool_calls[index] = AssistantPromptMessage.ToolCall(
                         id=getattr(block, "id", index),
                         type="function",
                         function=AssistantPromptMessage.ToolCall.ToolCallFunction(
                             name=getattr(block, "name", ""),
-                            arguments=json.dumps(input_payload),
+                            arguments="",
                         ),
                     )
                 elif getattr(block, "type", "") == "thinking":
@@ -547,15 +667,23 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                             ),
                         )
                         is_reasoning_started = 1
-                    current_thinking_blocks.append(
-                        {
-                            "type": "thinking",
-                            "thinking": "",
-                            "signature": getattr(block, "signature", ""),
-                        }
-                    )
+                    thinking_block = {
+                        "type": "thinking",
+                        "thinking": "",
+                        "signature": getattr(block, "signature", ""),
+                    }
+                    streamed_content_blocks[index] = thinking_block
+                    streamed_thinking_blocks[index] = thinking_block
+                    current_thinking_blocks.append(thinking_block)
                 elif getattr(block, "type", "") == "redacted_thinking":
-                    current_thinking_blocks.append({"type": "redacted_thinking"})
+                    thinking_block = {"type": "redacted_thinking"}
+                    streamed_content_blocks[index] = thinking_block
+                    current_thinking_blocks.append(thinking_block)
+                elif getattr(block, "type", "") == "text":
+                    streamed_content_blocks[index] = {
+                        "type": "text",
+                        "text": getattr(block, "text", "") or "",
+                    }
                 continue
 
             if event_type == "content_block_delta":
@@ -567,17 +695,16 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                     text = getattr(delta, "text", "")
                     if text:
                         # 如果之前在思考状态,先结束思考标签
-                        if is_reasoning_started == 1:
-                            yield LLMResultChunk(
-                                model=model,
-                                prompt_messages=prompt_messages,
-                                delta=LLMResultChunkDelta(
-                                    index=event_index,
-                                    message=AssistantPromptMessage(content="\n</think>\n"),
-                                ),
-                            )
-                            is_reasoning_started = 2
+                        closing_chunk = close_reasoning_chunk(event_index)
+                        if closing_chunk is not None:
+                            yield closing_chunk
                         streamed_text.append(text)
+                        content_block = streamed_content_blocks.setdefault(
+                            str(event_index),
+                            {"type": "text", "text": ""},
+                        )
+                        if content_block.get("type") == "text":
+                            content_block["text"] = str(content_block.get("text", "")) + text
                         yield LLMResultChunk(
                             model=model,
                             prompt_messages=prompt_messages,
@@ -589,16 +716,19 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 elif delta_type == "thinking_delta":
                     thinking = getattr(delta, "thinking", "")
                     if thinking:
-                        if not current_thinking_blocks or current_thinking_blocks[-1].get("type") != "thinking":
-                            current_thinking_blocks.append(
-                                {
-                                    "type": "thinking",
-                                    "thinking": "",
-                                    "signature": "",
-                                }
-                            )
-                        prev = str(current_thinking_blocks[-1].get("thinking", ""))
-                        current_thinking_blocks[-1]["thinking"] = prev + thinking
+                        index = str(event_index)
+                        thinking_block = streamed_thinking_blocks.get(index)
+                        if thinking_block is None:
+                            thinking_block = {
+                                "type": "thinking",
+                                "thinking": "",
+                                "signature": "",
+                            }
+                            streamed_content_blocks[index] = thinking_block
+                            streamed_thinking_blocks[index] = thinking_block
+                            current_thinking_blocks.append(thinking_block)
+                        prev = str(thinking_block.get("thinking", ""))
+                        thinking_block["thinking"] = prev + thinking
                         # 实时输出思考内容
                         if is_reasoning_started == 0:
                             yield LLMResultChunk(
@@ -620,13 +750,21 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                         )
                 elif delta_type == "signature_delta":
                     signature = getattr(delta, "signature", "")
-                    if signature and current_thinking_blocks and current_thinking_blocks[-1].get("type") == "thinking":
-                        current_thinking_blocks[-1]["signature"] = signature
+                    thinking_block = streamed_thinking_blocks.get(str(event_index))
+                    if signature and thinking_block is not None:
+                        thinking_block["signature"] = signature
                 elif delta_type == "input_json_delta":
                     partial_json = getattr(delta, "partial_json", "")
                     if partial_json:
                         index = str(event_index)
                         if index not in streamed_tool_calls:
+                            streamed_tool_input_fallbacks[index] = "{}"
+                            streamed_content_blocks[index] = {
+                                "type": "tool_use",
+                                "id": f"tool_{index}",
+                                "name": "",
+                                "input": {},
+                            }
                             streamed_tool_calls[index] = AssistantPromptMessage.ToolCall(
                                 id=f"tool_{index}",
                                 type="function",
@@ -635,7 +773,9 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                                     arguments="",
                                 ),
                             )
-                        streamed_tool_calls[index].function.arguments += partial_json
+                        streamed_tool_input_buffers[index] = (
+                            streamed_tool_input_buffers.get(index, "") + partial_json
+                        )
                 continue
 
             if event_type == "message_delta":
@@ -647,6 +787,9 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 continue
 
             if event_type == "message_stop":
+                closing_chunk = close_reasoning_chunk(0)
+                if closing_chunk is not None:
+                    yield closing_chunk
                 assistant_text = "".join(streamed_text)
                 if input_tokens == 0:
                     input_tokens = self.get_num_tokens(
@@ -665,10 +808,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                     completion_tokens=output_tokens,
                 )
 
-                final_tool_calls = list(streamed_tool_calls.values())
-                for tool_call in final_tool_calls:
-                    if not tool_call.function.arguments:
-                        tool_call.function.arguments = "{}"
+                final_tool_calls = finalize_tool_calls()
 
                 if final_tool_calls and current_thinking_blocks:
                     self._set_previous_thinking_blocks(current_thinking_blocks)
@@ -680,7 +820,11 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                     prompt_messages=prompt_messages,
                     delta=LLMResultChunkDelta(
                         index=0,
-                        message=AssistantPromptMessage(content="", tool_calls=final_tool_calls),
+                        message=AssistantPromptMessage(
+                            content="",
+                            tool_calls=final_tool_calls,
+                            opaque_body=build_opaque_body(),
+                        ),
                         usage=usage,
                         finish_reason=finish_reason or "stop",
                     ),
@@ -688,6 +832,9 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 emitted_final = True
 
         if not emitted_final:
+            closing_chunk = close_reasoning_chunk(0)
+            if closing_chunk is not None:
+                yield closing_chunk
             assistant_text = "".join(streamed_text)
             if input_tokens == 0:
                 input_tokens = self.get_num_tokens(
@@ -706,10 +853,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 completion_tokens=output_tokens,
             )
 
-            final_tool_calls = list(streamed_tool_calls.values())
-            for tool_call in final_tool_calls:
-                if not tool_call.function.arguments:
-                    tool_call.function.arguments = "{}"
+            final_tool_calls = finalize_tool_calls()
 
             if final_tool_calls and current_thinking_blocks:
                 self._set_previous_thinking_blocks(current_thinking_blocks)
@@ -721,7 +865,11 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 prompt_messages=prompt_messages,
                 delta=LLMResultChunkDelta(
                     index=0,
-                    message=AssistantPromptMessage(content="", tool_calls=final_tool_calls),
+                    message=AssistantPromptMessage(
+                        content="",
+                        tool_calls=final_tool_calls,
+                        opaque_body=build_opaque_body(),
+                    ),
                     usage=usage,
                     finish_reason=finish_reason or "stop",
                 ),

--- a/models/minimax/models/llm/llm.py
+++ b/models/minimax/models/llm/llm.py
@@ -10,7 +10,6 @@ from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
     ImagePromptMessageContent,
     PromptMessage,
-    PromptMessageContentType,
     PromptMessageTool,
     SystemPromptMessage,
     TextPromptMessageContent,
@@ -275,30 +274,42 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
         if isinstance(content, dict):
             content_type = content.get("type")
-            if content_type == "text":
+            if self._is_content_type(content_type, "text"):
                 return {
                     "type": "text",
                     "text": str(content.get("data") or content.get("text") or ""),
                 }
-            if content_type in {"image", "image_url"}:
-                image_url = content.get("data") or content.get("url")
-                if not image_url and isinstance(content.get("image_url"), dict):
-                    image_url = content["image_url"].get("url")
+            if self._is_content_type(content_type, "image", "image_url"):
+                image_url = self._extract_media_url(content, "image_url")
                 return self._create_media_content_block("image", str(image_url or ""))
-            if content_type in {"video", "video_url"}:
-                video_url = content.get("data") or content.get("url")
-                if not video_url and isinstance(content.get("video_url"), dict):
-                    video_url = content["video_url"].get("url")
+            if self._is_content_type(content_type, "video", "video_url"):
+                video_url = self._extract_media_url(content, "video_url")
                 return self._create_media_content_block("video", str(video_url or ""))
             return None
 
         content_type = getattr(content, "type", None)
-        if content_type == PromptMessageContentType.TEXT:
+        if self._is_content_type(content_type, "text"):
             return {"type": "text", "text": str(getattr(content, "data", ""))}
-        if content_type == PromptMessageContentType.IMAGE:
+        if self._is_content_type(content_type, "image"):
             return self._create_media_content_block("image", str(getattr(content, "data", "")))
-        if content_type == PromptMessageContentType.VIDEO:
+        if self._is_content_type(content_type, "video"):
             return self._create_media_content_block("video", str(getattr(content, "data", "")))
+        return None
+
+    def _is_content_type(self, content_type: Any, *expected: str) -> bool:
+        content_type_value = getattr(content_type, "value", content_type)
+        return content_type_value in expected
+
+    def _extract_media_url(self, content: dict[str, Any], media_key: str) -> Any:
+        media_url = content.get("data") or content.get("url")
+        if media_url:
+            return media_url
+
+        media_value = content.get(media_key)
+        if isinstance(media_value, dict):
+            return media_value.get("url")
+        if isinstance(media_value, str):
+            return media_value
         return None
 
     def _create_media_content_block(self, block_type: str, data: str) -> Optional[dict[str, Any]]:

--- a/models/minimax/models/llm/minimax-m3.yaml
+++ b/models/minimax/models/llm/minimax-m3.yaml
@@ -36,11 +36,10 @@ parameter_rules:
     default: adaptive
     required: false
     help:
-      en_US: Controls deep thinking for MiniMax-M3.
-      zh_Hans: 控制 MiniMax-M3 的深度思考。
+      en_US: Enables adaptive thinking for MiniMax-M3.
+      zh_Hans: 启用 MiniMax-M3 自适应思考。
     options:
       - adaptive
-      - disabled
 # Official pricing is tiered; this flat estimate uses the standard <=512k input-token tier.
 pricing:
   input: "4.2"

--- a/models/minimax/models/llm/minimax-m3.yaml
+++ b/models/minimax/models/llm/minimax-m3.yaml
@@ -1,0 +1,49 @@
+model: minimax-m3
+label:
+  en_US: MiniMax-M3
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - video
+  - tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    min: 0
+    max: 2
+    default: 1
+  - name: top_p
+    use_template: top_p
+    min: 0
+    max: 1
+    default: 0.95
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    default: 10240
+    min: 1
+    max: 524288
+  - name: thinking
+    label:
+      en_US: Thinking Mode
+      zh_Hans: 思考模式
+    type: string
+    default: adaptive
+    required: false
+    help:
+      en_US: Controls deep thinking for MiniMax-M3.
+      zh_Hans: 控制 MiniMax-M3 的深度思考。
+    options:
+      - adaptive
+      - disabled
+# Official pricing is tiered; this flat estimate uses the standard <=512k input-token tier.
+pricing:
+  input: "4.2"
+  output: "16.8"
+  unit: "0.000001"
+  currency: RMB

--- a/models/minimax/provider/minimax.py
+++ b/models/minimax/provider/minimax.py
@@ -17,7 +17,7 @@ class MinimaxProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="minimax-m3", credentials=credentials)
+            model_instance.validate_credentials(model="minimax-m2.5", credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:

--- a/models/minimax/provider/minimax.py
+++ b/models/minimax/provider/minimax.py
@@ -17,7 +17,7 @@ class MinimaxProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="minimax-m2.5", credentials=credentials)
+            model_instance.validate_credentials(model="minimax-m3", credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:

--- a/models/minimax/provider/minimax.yaml
+++ b/models/minimax/provider/minimax.yaml
@@ -44,8 +44,8 @@ provider_credential_schema:
   - label:
       en_US: Group ID
     placeholder:
-      en_US: Required only for legacy ABAB chat, embedding, and TTS models. Leave empty for MiniMax-M2.x.
-      zh_Hans: 仅在使用 ABAB chat、Embedding、TTS 模型时需要；MiniMax-M2.x 留空即可。
+      en_US: Required only for legacy ABAB chat, embedding, and TTS models. Leave empty for MiniMax-M series.
+      zh_Hans: 仅在使用 ABAB chat、Embedding、TTS 模型时需要；MiniMax-M 系列留空即可。
     required: false
     type: text-input
     variable: minimax_group_id

--- a/models/minimax/tests/test_m3_payload.py
+++ b/models/minimax/tests/test_m3_payload.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import yaml
 from dify_plugin.entities.model.message import (
+    AssistantPromptMessage,
     ImagePromptMessageContent,
     TextPromptMessageContent,
     UserPromptMessage,
@@ -17,6 +18,14 @@ from models.llm.llm import MinimaxLargeLanguageModel  # noqa: E402
 
 def _llm() -> MinimaxLargeLanguageModel:
     return MinimaxLargeLanguageModel(model_schemas=[])
+
+
+def _event(event_type: str, **kwargs) -> SimpleNamespace:
+    return SimpleNamespace(type=event_type, **kwargs)
+
+
+def _usage(input_tokens: int = 1, output_tokens: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens)
 
 
 def test_m3_model_alias() -> None:
@@ -65,6 +74,16 @@ def test_m3_thinking_uses_adaptive_or_disabled() -> None:
         thinking_budget=1024,
         request_model="MiniMax-M3",
     ) == {"type": "adaptive"}
+    assert llm._normalize_thinking_payload(
+        thinking="enabled",
+        thinking_budget=1024,
+        request_model="MiniMax-M3",
+    ) == {"type": "adaptive"}
+    assert llm._normalize_thinking_payload(
+        thinking="false",
+        thinking_budget=1024,
+        request_model="MiniMax-M3",
+    ) == {"type": "disabled"}
 
 
 def test_m2_thinking_keeps_budget_payload() -> None:
@@ -143,6 +162,32 @@ def test_dict_media_payload_accepts_url_string_values() -> None:
     ]
 
 
+def test_dict_media_payload_accepts_nested_url_values() -> None:
+    converted = _llm()._convert_user_content_blocks(
+        [
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+            {"type": "video", "video_url": {"url": "https://example.com/video.mp4"}},
+        ]
+    )
+
+    assert converted == [
+        {
+            "type": "image",
+            "source": {
+                "type": "url",
+                "url": "https://example.com/image.png",
+            },
+        },
+        {
+            "type": "video",
+            "source": {
+                "type": "url",
+                "url": "https://example.com/video.mp4",
+            },
+        },
+    ]
+
+
 def test_object_content_type_accepts_string_values() -> None:
     converted = _llm()._convert_user_content_blocks(
         [
@@ -169,3 +214,195 @@ def test_object_content_type_accepts_string_values() -> None:
             },
         },
     ]
+
+
+def test_stream_tool_call_arguments_use_delta_buffer() -> None:
+    llm = _llm()
+    events = [
+        _event("message_start", message=SimpleNamespace(usage=_usage())),
+        _event(
+            "content_block_start",
+            index=0,
+            content_block=SimpleNamespace(type="tool_use", id="call_1", name="search", input={}),
+        ),
+        _event(
+            "content_block_delta",
+            index=0,
+            delta=SimpleNamespace(type="input_json_delta", partial_json='{"query":'),
+        ),
+        _event(
+            "content_block_delta",
+            index=0,
+            delta=SimpleNamespace(type="input_json_delta", partial_json='"m3"}'),
+        ),
+        _event(
+            "message_delta",
+            delta=SimpleNamespace(stop_reason="tool_use"),
+            usage=_usage(output_tokens=2),
+        ),
+        _event("message_stop"),
+    ]
+
+    chunks = list(
+        llm._handle_chat_generate_stream_response(
+            model="minimax-m3",
+            prompt_messages=[UserPromptMessage(content="hi")],
+            credentials={},
+            response=events,
+        )
+    )
+
+    final_message = chunks[-1].delta.message
+    assert final_message.tool_calls[0].function.arguments == '{"query":"m3"}'
+    assert final_message.opaque_body == {
+        "minimax_anthropic_content": [
+            {
+                "type": "tool_use",
+                "id": "call_1",
+                "name": "search",
+                "input": {"query": "m3"},
+            }
+        ]
+    }
+
+
+def test_stream_tool_call_keeps_input_fallback_without_delta() -> None:
+    llm = _llm()
+    events = [
+        _event("message_start", message=SimpleNamespace(usage=_usage())),
+        _event(
+            "content_block_start",
+            index=0,
+            content_block=SimpleNamespace(
+                type="tool_use",
+                id="call_1",
+                name="read",
+                input={"path": "a.txt"},
+            ),
+        ),
+        _event(
+            "message_delta",
+            delta=SimpleNamespace(stop_reason="tool_use"),
+            usage=_usage(output_tokens=2),
+        ),
+        _event("message_stop"),
+    ]
+
+    chunks = list(
+        llm._handle_chat_generate_stream_response(
+            model="minimax-m3",
+            prompt_messages=[UserPromptMessage(content="hi")],
+            credentials={},
+            response=events,
+        )
+    )
+
+    assert chunks[-1].delta.message.tool_calls[0].function.arguments == '{"path": "a.txt"}'
+
+
+def test_stream_thinking_closes_before_tool_call_without_text_delta() -> None:
+    llm = _llm()
+    events = [
+        _event("message_start", message=SimpleNamespace(usage=_usage())),
+        _event(
+            "content_block_start",
+            index=0,
+            content_block=SimpleNamespace(type="thinking", signature="sig"),
+        ),
+        _event(
+            "content_block_delta",
+            index=0,
+            delta=SimpleNamespace(type="thinking_delta", thinking="reason"),
+        ),
+        _event(
+            "content_block_start",
+            index=1,
+            content_block=SimpleNamespace(type="tool_use", id="call_1", name="search", input={}),
+        ),
+        _event(
+            "message_delta",
+            delta=SimpleNamespace(stop_reason="tool_use"),
+            usage=_usage(output_tokens=2),
+        ),
+        _event("message_stop"),
+    ]
+
+    chunks = list(
+        llm._handle_chat_generate_stream_response(
+            model="minimax-m3",
+            prompt_messages=[UserPromptMessage(content="hi")],
+            credentials={},
+            response=events,
+        )
+    )
+
+    contents = [chunk.delta.message.content for chunk in chunks]
+    assert contents[:3] == ["<think>\n", "reason", "\n</think>\n"]
+    assert contents.count("\n</think>\n") == 1
+    assert chunks[-1].delta.message.opaque_body == {
+        "minimax_anthropic_content": [
+            {"type": "thinking", "thinking": "reason", "signature": "sig"},
+            {"type": "tool_use", "id": "call_1", "name": "search", "input": {}},
+        ]
+    }
+
+
+def test_non_stream_tool_call_replays_opaque_content_without_duplicate_thinking_text() -> None:
+    llm = _llm()
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="reason", signature="sig"),
+            SimpleNamespace(type="text", text="I will call a tool."),
+            SimpleNamespace(type="tool_use", id="call_1", name="search", input={"query": "m3"}),
+        ],
+        usage=_usage(output_tokens=2),
+    )
+
+    result = llm._handle_chat_generate_response(
+        model="minimax-m3",
+        prompt_messages=[UserPromptMessage(content="hi")],
+        credentials={},
+        response=response,
+    )
+    converted = llm._convert_prompt_message_to_anthropic_message(result.message)
+
+    assert result.message.content == "<think>reason</think>\nI will call a tool."
+    assert converted == {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "reason", "signature": "sig"},
+            {"type": "text", "text": "I will call a tool."},
+            {"type": "tool_use", "id": "call_1", "name": "search", "input": {"query": "m3"}},
+        ],
+    }
+
+
+def test_previous_thinking_fallback_strips_tagged_text_on_tool_replay() -> None:
+    llm = _llm()
+    llm._set_previous_thinking_blocks(
+        [{"type": "thinking", "thinking": "reason", "signature": "sig"}]
+    )
+    message = AssistantPromptMessage(
+        content="<think>reason</think>\nI will call a tool.",
+        tool_calls=[
+            AssistantPromptMessage.ToolCall(
+                id="call_1",
+                type="function",
+                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                    name="search",
+                    arguments='{"query": "m3"}',
+                ),
+            )
+        ],
+    )
+
+    converted = llm._convert_prompt_message_to_anthropic_message(message)
+
+    assert converted == {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "reason", "signature": "sig"},
+            {"type": "text", "text": "I will call a tool."},
+            {"type": "tool_use", "id": "call_1", "name": "search", "input": {"query": "m3"}},
+        ],
+    }

--- a/models/minimax/tests/test_m3_payload.py
+++ b/models/minimax/tests/test_m3_payload.py
@@ -53,10 +53,10 @@ def test_m3_yaml_parameters_match_official_limits() -> None:
     assert rules["top_p"]["max"] == 1
     assert rules["top_p"]["default"] == 0.95
     assert rules["max_tokens"]["max"] == 524288
-    assert rules["thinking"]["options"] == ["adaptive", "disabled"]
+    assert rules["thinking"]["options"] == ["adaptive"]
 
 
-def test_m3_thinking_uses_adaptive_or_disabled() -> None:
+def test_m3_thinking_uses_adaptive_or_omits_unsupported_modes() -> None:
     llm = _llm()
 
     assert llm._normalize_thinking_payload(
@@ -68,7 +68,7 @@ def test_m3_thinking_uses_adaptive_or_disabled() -> None:
         thinking=False,
         thinking_budget=1024,
         request_model="MiniMax-M3",
-    ) == {"type": "disabled"}
+    ) is None
     assert llm._normalize_thinking_payload(
         thinking=True,
         thinking_budget=1024,
@@ -83,7 +83,12 @@ def test_m3_thinking_uses_adaptive_or_disabled() -> None:
         thinking="false",
         thinking_budget=1024,
         request_model="MiniMax-M3",
-    ) == {"type": "disabled"}
+    ) is None
+    assert llm._normalize_thinking_payload(
+        thinking="disabled",
+        thinking_budget=1024,
+        request_model="MiniMax-M3",
+    ) is None
 
 
 def test_m2_thinking_keeps_budget_payload() -> None:

--- a/models/minimax/tests/test_m3_payload.py
+++ b/models/minimax/tests/test_m3_payload.py
@@ -1,5 +1,6 @@
-from pathlib import Path
 import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import yaml
 from dify_plugin.entities.model.message import (
@@ -114,3 +115,57 @@ def test_m3_multimodal_user_message_uses_anthropic_sources() -> None:
             },
         ],
     }
+
+
+def test_dict_media_payload_accepts_url_string_values() -> None:
+    converted = _llm()._convert_user_content_blocks(
+        [
+            {"type": "image", "image_url": "https://example.com/image.png"},
+            {"type": "video_url", "video_url": "https://example.com/video.mp4"},
+        ]
+    )
+
+    assert converted == [
+        {
+            "type": "image",
+            "source": {
+                "type": "url",
+                "url": "https://example.com/image.png",
+            },
+        },
+        {
+            "type": "video",
+            "source": {
+                "type": "url",
+                "url": "https://example.com/video.mp4",
+            },
+        },
+    ]
+
+
+def test_object_content_type_accepts_string_values() -> None:
+    converted = _llm()._convert_user_content_blocks(
+        [
+            SimpleNamespace(type="text", data="What is shown?"),
+            SimpleNamespace(type="image", data="https://example.com/image.png"),
+            SimpleNamespace(type="video", data="https://example.com/video.mp4"),
+        ]
+    )
+
+    assert converted == [
+        {"type": "text", "text": "What is shown?"},
+        {
+            "type": "image",
+            "source": {
+                "type": "url",
+                "url": "https://example.com/image.png",
+            },
+        },
+        {
+            "type": "video",
+            "source": {
+                "type": "url",
+                "url": "https://example.com/video.mp4",
+            },
+        },
+    ]

--- a/models/minimax/tests/test_m3_payload.py
+++ b/models/minimax/tests/test_m3_payload.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+import sys
+
+import yaml
+from dify_plugin.entities.model.message import (
+    ImagePromptMessageContent,
+    TextPromptMessageContent,
+    UserPromptMessage,
+    VideoPromptMessageContent,
+)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models.llm.llm import MinimaxLargeLanguageModel  # noqa: E402
+
+
+def _llm() -> MinimaxLargeLanguageModel:
+    return MinimaxLargeLanguageModel(model_schemas=[])
+
+
+def test_m3_model_alias() -> None:
+    assert _llm()._resolve_model_name("minimax-m3") == "MiniMax-M3"
+
+
+def test_m3_yaml_parameters_match_official_limits() -> None:
+    model_file = Path(__file__).parent.parent / "models" / "llm" / "minimax-m3.yaml"
+    model_schema = yaml.safe_load(model_file.read_text(encoding="utf-8"))
+    rules = {rule["name"]: rule for rule in model_schema["parameter_rules"]}
+
+    assert model_schema["model"] == "minimax-m3"
+    assert model_schema["model_properties"]["context_size"] == 1000000
+    assert model_schema["features"] == [
+        "agent-thought",
+        "vision",
+        "video",
+        "tool-call",
+        "stream-tool-call",
+    ]
+    assert rules["temperature"]["min"] == 0
+    assert rules["temperature"]["max"] == 2
+    assert rules["temperature"]["default"] == 1
+    assert rules["top_p"]["min"] == 0
+    assert rules["top_p"]["max"] == 1
+    assert rules["top_p"]["default"] == 0.95
+    assert rules["max_tokens"]["max"] == 524288
+    assert rules["thinking"]["options"] == ["adaptive", "disabled"]
+
+
+def test_m3_thinking_uses_adaptive_or_disabled() -> None:
+    llm = _llm()
+
+    assert llm._normalize_thinking_payload(
+        thinking="adaptive",
+        thinking_budget=1024,
+        request_model="MiniMax-M3",
+    ) == {"type": "adaptive"}
+    assert llm._normalize_thinking_payload(
+        thinking=False,
+        thinking_budget=1024,
+        request_model="MiniMax-M3",
+    ) == {"type": "disabled"}
+    assert llm._normalize_thinking_payload(
+        thinking=True,
+        thinking_budget=1024,
+        request_model="MiniMax-M3",
+    ) == {"type": "adaptive"}
+
+
+def test_m2_thinking_keeps_budget_payload() -> None:
+    assert _llm()._normalize_thinking_payload(
+        thinking=True,
+        thinking_budget=2048,
+        request_model="MiniMax-M2.7",
+    ) == {"type": "enabled", "budget_tokens": 2048}
+
+
+def test_m3_multimodal_user_message_uses_anthropic_sources() -> None:
+    message = UserPromptMessage(
+        content=[
+            TextPromptMessageContent(data="Describe these inputs."),
+            ImagePromptMessageContent(
+                format="url",
+                url="https://example.com/image.png",
+                mime_type="image/png",
+            ),
+            VideoPromptMessageContent(
+                format="base64",
+                base64_data="AAAA",
+                mime_type="video/mp4",
+            ),
+        ]
+    )
+
+    converted = _llm()._convert_prompt_message_to_anthropic_message(message)
+
+    assert converted == {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe these inputs."},
+            {
+                "type": "image",
+                "source": {
+                    "type": "url",
+                    "url": "https://example.com/image.png",
+                },
+            },
+            {
+                "type": "video",
+                "source": {
+                    "type": "base64",
+                    "media_type": "video/mp4",
+                    "data": "AAAA",
+                },
+            },
+        ],
+    }


### PR DESCRIPTION
## Summary
Add MiniMax-M3 to the Minimax model provider.

## Changes
- Add the MiniMax-M3 predefined model schema with official context, output, sampling, thinking, vision, and video parameters.
- Map minimax-m3 to the upstream MiniMax-M3 model name.
- Normalize M3 thinking payloads and support Anthropic-compatible image/video message blocks.
- Update provider credential validation and Group ID guidance for MiniMax-M series.
- Add focused tests for schema limits, aliasing, thinking, and multimodal payloads.

## Validation
- uv run pytest tests/test_m3_payload.py
- git diff --check

Closes #3235