### PR TITLE
feat(bedrock): add OpenAI GPT-5.5 and GPT-5.4 support via bedrock-mantle endpoint

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.71
+version: 0.0.72
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -1622,6 +1622,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         """
         # Create model name mapping for individual model files
         model_name_mapping = {
+            # OpenAI GPT-5.x models (bedrock-mantle endpoint)
+            'GPT-5.5': 'gpt-5-5',
+            'GPT-5.4': 'gpt-5-4',
             # Claude models
             'Claude 4.8 Opus': 'claude-4-8-opus',
             'Claude 4.7 Opus': 'claude-4-7-opus',

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -103,6 +103,17 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         {"prefix": "ai21.jamba-1-5", "support_system_prompts": True, "support_tool_use": False},
     ]
 
+    # Models that require the bedrock-mantle endpoint with the OpenAI Responses API.
+    # These do NOT go through the standard Converse API path.
+    _BEDROCK_MANTLE_MODEL_IDS: frozenset = frozenset({
+        "openai.gpt-5.5",
+        "openai.gpt-5.4",
+    })
+
+    @staticmethod
+    def _is_bedrock_mantle_model(model_id: str) -> bool:
+        return model_id in BedrockLargeLanguageModel._BEDROCK_MANTLE_MODEL_IDS
+
     @staticmethod
     def _find_model_info(model_id):
         for model in BedrockLargeLanguageModel.CONVERSE_API_ENABLED_MODEL_INFO:
@@ -231,6 +242,16 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 logger.error(f"Failed to invoke inference profile: {str(e)}")
                 raise InvokeError(f"Failed to invoke inference profile {inference_profile_id}: {str(e)}")
         else:
+            # Check for bedrock-mantle models (GPT-5.5, GPT-5.4) before attempting Converse API.
+            # These models use a different endpoint and the OpenAI Responses API.
+            _model_name = model_parameters.get('model_name')
+            if _model_name:
+                _candidate_id = model_ids.get_model_id(model, _model_name)
+                if _candidate_id and self._is_bedrock_mantle_model(_candidate_id):
+                    return self._generate_with_responses_api(
+                        _candidate_id, credentials, prompt_messages, model_parameters, stop, stream, user
+                    )
+
             # Traditional model - try converse API first, then fall back if needed
             model_info = self._get_model_info(model, credentials, model_parameters)
             if model_info:
@@ -1741,3 +1762,207 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
         # Fallback to parent class implementation
         return super()._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+
+    # -------------------------------------------------------------------------
+    # bedrock-mantle / OpenAI Responses API path (GPT-5.5, GPT-5.4)
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html
+    # -------------------------------------------------------------------------
+
+    def _get_mantle_auth_token(self, credentials: dict) -> str:
+        """
+        Return a Bearer token for the bedrock-mantle endpoint.
+
+        - API_Key auth: use the long-term Bedrock API key directly.
+        - Access_Secret_Key / IAM_Role: generate a short-lived token via
+          aws-bedrock-token-generator (official AWS library).
+        """
+        auth_method = credentials.get("auth_method", "IAM_Role")
+        region = credentials.get("aws_region", "us-east-2")
+
+        if auth_method == "API_Key":
+            api_key = credentials.get("bedrock_api_key")
+            if not api_key:
+                raise InvokeBadRequestError("bedrock_api_key is required for API_Key auth")
+            return api_key
+
+        # IAM_Role or Access_Secret_Key: generate a short-lived bearer token.
+        try:
+            from aws_bedrock_token_generator import provide_token
+        except ImportError:
+            raise InvokeBadRequestError(
+                "aws-bedrock-token-generator is required for IAM-based authentication "
+                "with GPT-5.5/5.4. Install it with: pip install aws-bedrock-token-generator"
+            )
+
+        aws_access_key_id = credentials.get("aws_access_key_id")
+        aws_secret_access_key = credentials.get("aws_secret_access_key")
+
+        if auth_method == "Access_Secret_Key" and aws_access_key_id and aws_secret_access_key:
+            from botocore.credentials import Credentials as BotocoreCredentials
+            creds = BotocoreCredentials(
+                access_key=aws_access_key_id,
+                secret_key=aws_secret_access_key,
+            )
+            return provide_token(region=region, aws_credentials_provider=creds)
+
+        # IAM_Role: rely on the environment (instance profile, env vars, etc.)
+        return provide_token(region=region)
+
+    def _build_responses_api_input(self, prompt_messages: list[PromptMessage]) -> list[dict]:
+        """Convert Dify prompt messages to OpenAI Responses API input format."""
+        result = []
+        for message in prompt_messages:
+            if isinstance(message, SystemPromptMessage):
+                result.append({"role": "system", "content": message.content or ""})
+            elif isinstance(message, UserPromptMessage):
+                if isinstance(message.content, str):
+                    content = message.content
+                else:
+                    content = " ".join(
+                        c.data for c in message.content
+                        if c.type == PromptMessageContentType.TEXT
+                    )
+                result.append({"role": "user", "content": content})
+            elif isinstance(message, AssistantPromptMessage):
+                result.append({"role": "assistant", "content": message.content or ""})
+        return result
+
+    def _generate_with_responses_api(
+        self,
+        model_id: str,
+        credentials: dict,
+        prompt_messages: list[PromptMessage],
+        model_parameters: dict,
+        stop: Optional[list[str]] = None,
+        stream: bool = True,
+        user: Optional[str] = None,
+    ) -> Union[LLMResult, Generator]:
+        """
+        Invoke GPT-5.5 / GPT-5.4 via bedrock-mantle endpoint using the OpenAI Responses API.
+        Authentication supports API Key, Access/Secret Key, and IAM Role.
+        """
+        try:
+            from openai import OpenAI
+        except ImportError:
+            raise InvokeBadRequestError(
+                "openai package is required for GPT-5.5/5.4. "
+                "Install it with: pip install openai"
+            )
+
+        region = credentials.get("aws_region", "us-east-2")
+        token = self._get_mantle_auth_token(credentials)
+        base_url = f"https://bedrock-mantle.{region}.api.aws/openai/v1"
+
+        client = OpenAI(api_key=token, base_url=base_url)
+        input_messages = self._build_responses_api_input(prompt_messages)
+
+        params: dict = {
+            "model": model_id,
+            "input": input_messages,
+            "stream": stream,
+        }
+
+        # Map Dify parameters to Responses API parameters.
+        # Pop model_name and cross-region which are Dify/Bedrock routing params.
+        model_parameters.pop("model_name", None)
+        model_parameters.pop("cross-region", None)
+        model_parameters.pop("system_cache_checkpoint", None)
+        model_parameters.pop("latest_two_messages_cache_checkpoint", None)
+        model_parameters.pop("response_format", None)
+
+        if "max_tokens" in model_parameters:
+            params["max_output_tokens"] = model_parameters["max_tokens"]
+        if "temperature" in model_parameters:
+            params["temperature"] = model_parameters["temperature"]
+        if "top_p" in model_parameters:
+            params["top_p"] = model_parameters["top_p"]
+
+        # Store model_name for pricing calculation (use model_id as fallback).
+        credentials_for_pricing = credentials.copy()
+        if "model_parameters" not in credentials_for_pricing:
+            credentials_for_pricing["model_parameters"] = {}
+
+        try:
+            response = client.responses.create(**params)
+            if stream:
+                return self._handle_responses_api_stream(
+                    model_id, credentials_for_pricing, response, prompt_messages
+                )
+            else:
+                return self._handle_responses_api_response(
+                    model_id, credentials_for_pricing, response, prompt_messages
+                )
+        except Exception as ex:
+            raise InvokeError(str(ex))
+
+    def _handle_responses_api_response(
+        self,
+        model: str,
+        credentials: dict,
+        response,
+        prompt_messages: list[PromptMessage],
+    ) -> LLMResult:
+        """Convert a non-streaming OpenAI Responses API response to LLMResult."""
+        text = response.output_text or ""
+        usage = getattr(response, "usage", None)
+        prompt_tokens = getattr(usage, "input_tokens", 0) if usage else 0
+        completion_tokens = getattr(usage, "output_tokens", 0) if usage else 0
+        dify_usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+
+        return LLMResult(
+            model=model,
+            prompt_messages=prompt_messages,
+            message=AssistantPromptMessage(content=text),
+            usage=dify_usage,
+        )
+
+    def _handle_responses_api_stream(
+        self,
+        model: str,
+        credentials: dict,
+        stream_response,
+        prompt_messages: list[PromptMessage],
+    ) -> Generator:
+        """Convert a streaming OpenAI Responses API response to LLMResultChunk generator."""
+        index = 0
+        input_tokens = 0
+        output_tokens = 0
+
+        try:
+            for event in stream_response:
+                event_type = type(event).__name__
+
+                if event_type == "ResponseTextDeltaEvent":
+                    delta_text = getattr(event, "delta", "")
+                    if delta_text:
+                        yield LLMResultChunk(
+                            model=model,
+                            prompt_messages=prompt_messages,
+                            delta=LLMResultChunkDelta(
+                                index=index,
+                                message=AssistantPromptMessage(content=delta_text),
+                            ),
+                        )
+                        index += 1
+
+                elif event_type == "ResponseCompletedEvent":
+                    resp = getattr(event, "response", None)
+                    usage = getattr(resp, "usage", None) if resp else None
+                    if usage:
+                        input_tokens = getattr(usage, "input_tokens", 0)
+                        output_tokens = getattr(usage, "output_tokens", 0)
+                    dify_usage = self._calc_response_usage(
+                        model, credentials, input_tokens, output_tokens
+                    )
+                    yield LLMResultChunk(
+                        model=model,
+                        prompt_messages=prompt_messages,
+                        delta=LLMResultChunkDelta(
+                            index=index,
+                            message=AssistantPromptMessage(content=""),
+                            finish_reason="stop",
+                            usage=dify_usage,
+                        ),
+                    )
+        except Exception as ex:
+            raise InvokeError(str(ex))

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -1768,6 +1768,25 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
     # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html
     # -------------------------------------------------------------------------
 
+    @staticmethod
+    def _map_openai_exception(ex: Exception) -> None:
+        """Map openai SDK exceptions to the corresponding Dify invoke error types."""
+        try:
+            import openai
+            if isinstance(ex, openai.APIConnectionError):
+                raise InvokeConnectionError(str(ex))
+            elif isinstance(ex, openai.AuthenticationError):
+                raise InvokeAuthorizationError(str(ex))
+            elif isinstance(ex, openai.RateLimitError):
+                raise InvokeRateLimitError(str(ex))
+            elif isinstance(ex, openai.BadRequestError):
+                raise InvokeBadRequestError(str(ex))
+            elif isinstance(ex, openai.InternalServerError):
+                raise InvokeServerUnavailableError(str(ex))
+        except ImportError:
+            pass
+        raise InvokeError(str(ex))
+
     def _get_mantle_auth_token(self, credentials: dict) -> str:
         """
         Return a Bearer token for the bedrock-mantle endpoint.
@@ -1802,6 +1821,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             creds = BotocoreCredentials(
                 access_key=aws_access_key_id,
                 secret_key=aws_secret_access_key,
+                token=credentials.get("aws_session_token"),
             )
             return provide_token(region=region, aws_credentials_provider=creds)
 
@@ -1862,9 +1882,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             "stream": stream,
         }
 
-        # Map Dify parameters to Responses API parameters.
-        # Pop model_name and cross-region which are Dify/Bedrock routing params.
-        model_parameters.pop("model_name", None)
+        # Copy to avoid mutating the caller's dict (retry mechanisms may reuse it).
+        model_parameters = model_parameters.copy()
+        model_name = model_parameters.pop("model_name", None)
         model_parameters.pop("cross-region", None)
         model_parameters.pop("system_cache_checkpoint", None)
         model_parameters.pop("latest_two_messages_cache_checkpoint", None)
@@ -1877,10 +1897,13 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if "top_p" in model_parameters:
             params["top_p"] = model_parameters["top_p"]
 
-        # Store model_name for pricing calculation (use model_id as fallback).
+        # Store model_name for pricing calculation, deriving it from model_id if not set.
         credentials_for_pricing = credentials.copy()
-        if "model_parameters" not in credentials_for_pricing:
-            credentials_for_pricing["model_parameters"] = {}
+        resolved_model_name = model_name or ("GPT-5.5" if "gpt-5.5" in model_id else "GPT-5.4")
+        credentials_for_pricing["model_parameters"] = {
+            **credentials_for_pricing.get("model_parameters", {}),
+            "model_name": resolved_model_name,
+        }
 
         try:
             response = client.responses.create(**params)
@@ -1893,7 +1916,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     model_id, credentials_for_pricing, response, prompt_messages
                 )
         except Exception as ex:
-            raise InvokeError(str(ex))
+            self._map_openai_exception(ex)
 
     def _handle_responses_api_response(
         self,
@@ -1965,4 +1988,4 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                         ),
                     )
         except Exception as ex:
-            raise InvokeError(str(ex))
+            self._map_openai_exception(ex)

--- a/models/bedrock/models/llm/model_configurations/gpt-5-4.yaml
+++ b/models/bedrock/models/llm/model_configurations/gpt-5-4.yaml
@@ -1,0 +1,55 @@
+model: gpt-5-4
+label:
+  en_US: GPT-5.4
+icon: icon_s_en.svg
+model_type: llm
+features:
+  - vision
+model_properties:
+  mode: chat
+  context_size: 272000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    label:
+      zh_Hans: 最大token数
+      en_US: Max Tokens
+    type: int
+    default: 4096
+    min: 1
+    max: 272000
+    help:
+      zh_Hans: 停止前生成的最大令牌数。
+      en_US: The maximum number of tokens to generate before stopping.
+  - name: temperature
+    use_template: temperature
+    required: false
+    label:
+      zh_Hans: 模型温度
+      en_US: Model Temperature
+    type: float
+    default: 1
+    min: 0.0
+    max: 1.0
+    help:
+      zh_Hans: 生成内容的随机性。
+      en_US: The amount of randomness injected into the response.
+  - name: top_p
+    use_template: top_p
+    label:
+      zh_Hans: Top P
+      en_US: Top P
+    required: false
+    type: float
+    default: 0.999
+    min: 0.000
+    max: 1.000
+    help:
+      zh_Hans: 在核采样中的概率阈値。
+      en_US: The probability threshold in nucleus sampling.
+pricing:
+  input: '0.00275'
+  output: '0.0165'
+  unit: '0.001'
+  currency: USD

--- a/models/bedrock/models/llm/model_configurations/gpt-5-5.yaml
+++ b/models/bedrock/models/llm/model_configurations/gpt-5-5.yaml
@@ -1,0 +1,55 @@
+model: gpt-5-5
+label:
+  en_US: GPT-5.5
+icon: icon_s_en.svg
+model_type: llm
+features:
+  - vision
+model_properties:
+  mode: chat
+  context_size: 272000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    label:
+      zh_Hans: 最大token数
+      en_US: Max Tokens
+    type: int
+    default: 4096
+    min: 1
+    max: 272000
+    help:
+      zh_Hans: 停止前生成的最大令牌数。
+      en_US: The maximum number of tokens to generate before stopping.
+  - name: temperature
+    use_template: temperature
+    required: false
+    label:
+      zh_Hans: 模型温度
+      en_US: Model Temperature
+    type: float
+    default: 1
+    min: 0.0
+    max: 1.0
+    help:
+      zh_Hans: 生成内容的随机性。
+      en_US: The amount of randomness injected into the response.
+  - name: top_p
+    use_template: top_p
+    label:
+      zh_Hans: Top P
+      en_US: Top P
+    required: false
+    type: float
+    default: 0.999
+    min: 0.000
+    max: 1.000
+    help:
+      zh_Hans: 在核采样中的概率阈值。
+      en_US: The probability threshold in nucleus sampling.
+pricing:
+  input: '0.0055'
+  output: '0.033'
+  unit: '0.001'
+  currency: USD

--- a/models/bedrock/models/llm/model_ids.py
+++ b/models/bedrock/models/llm/model_ids.py
@@ -70,6 +70,8 @@ BEDROCK_MODEL_IDS = {
         'Qwen3 Coder 30B': 'qwen.qwen3-coder-30b-a3b-v1:0'
     },
     'openai': {
+        'GPT-5.5': 'openai.gpt-5.5',
+        'GPT-5.4': 'openai.gpt-5.4',
         'GPT OSS 120B': 'openai.gpt-oss-120b-1:0',
         'GPT OSS 20B': 'openai.gpt-oss-20b-1:0'
     }
@@ -83,7 +85,9 @@ def is_support_cross_region(model_id):
         "qwen.qwen3-coder-480b-a35b-v1:0",
         "qwen.qwen3-coder-30b-a3b-v1:0",
         "openai.gpt-oss-120b-1:0",
-        "openai.gpt-oss-20b-1:0"
+        "openai.gpt-oss-20b-1:0",
+        "openai.gpt-5.5",
+        "openai.gpt-5.4",
     ]
     return model_id not in unsupport_model_list
 

--- a/models/bedrock/models/llm/openai.yaml
+++ b/models/bedrock/models/llm/openai.yaml
@@ -9,7 +9,7 @@ features:
   - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 32768
+  context_size: 272000
 parameter_rules:
   - name: model_name
     label:
@@ -22,6 +22,8 @@ parameter_rules:
     required: true
     default: GPT OSS 20B
     options:
+      - GPT-5.5
+      - GPT-5.4
       - GPT OSS 120B
       - GPT OSS 20B
   - name: cross-region
@@ -47,7 +49,7 @@ parameter_rules:
     type: int
     default: 4096
     min: 1
-    max: 128000
+    max: 272000
     help:
       zh_Hans: 停止前生成的最大令牌数。
       en_US: The maximum number of tokens to generate before stopping.

--- a/models/bedrock/pyproject.toml
+++ b/models/bedrock/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "botocore>=1.43.13",
     "dify_plugin>=0.9.0",
     "tiktoken>=0.13.0",
+    "openai>=1.0.0",
+    "aws-bedrock-token-generator>=1.1.0",
 ]
 
 # uv run black . -C -l 100 && uv run ruff check --fix


### PR DESCRIPTION
## Summary

- Add **GPT-5.5** and **GPT-5.4** as selectable models in the Amazon Bedrock plugin
- Route these models through the `bedrock-mantle` endpoint using the **OpenAI Responses API** (separate from the existing Converse API path)
- Support all three Bedrock authentication methods: API Key, Access/Secret Key, IAM Role

## Background

GPT-5.5 and GPT-5.4 became generally available on Amazon Bedrock on June 1, 2026. Unlike existing models (GPT OSS, Claude, etc.) which use the `bedrock-runtime` endpoint and Converse API, these models require:

| | Existing models | GPT-5.5 / GPT-5.4 |
|---|---|---|
| Endpoint | `bedrock-runtime` | `bedrock-mantle` |
| API | Converse (boto3) | OpenAI Responses API |
| SDK | boto3 | openai |
| Cross-Region | Supported | **Not supported** |
| Context window | up to 128K | **272K tokens** |

## Changes

### `models/bedrock/models/llm/model_ids.py`
- Add `'GPT-5.5': 'openai.gpt-5.5'` and `'GPT-5.4': 'openai.gpt-5.4'` to the `openai` section
- Add both model IDs to `is_support_cross_region` exclusion list

### `models/bedrock/models/llm/openai.yaml`
- Add `GPT-5.5` and `GPT-5.4` to model options
- Update `context_size` from 32768 → 272000 and `max_tokens.max` from 128000 → 272000

### `models/bedrock/models/llm/llm.py`
- Add `_BEDROCK_MANTLE_MODEL_IDS` frozenset and `_is_bedrock_mantle_model()` to identify models requiring the new path
- Add early-exit routing in `_invoke()` before the Converse API path
- Add `_get_mantle_auth_token()` — obtains a Bearer token from API Key or short-lived token from IAM credentials via `aws-bedrock-token-generator`
- Add `_build_responses_api_input()` — converts Dify `PromptMessage` list to Responses API `input` format
- Add `_generate_with_responses_api()` — main invocation method
- Add `_handle_responses_api_response()` — non-streaming response handler
- Add `_handle_responses_api_stream()` — streaming response handler

### `models/bedrock/pyproject.toml`
- Add `openai>=1.0.0`
- Add `aws-bedrock-token-generator>=1.1.0` (official AWS library for generating Bearer tokens from IAM credentials)

## Known Limitations

- **Tool use**: Not supported (Responses API on Bedrock does not expose tool/function calling)
- **Image input**: Not supported in this PR (text-only for now)
- **Structured output**: Not supported
- **Cross-region inference**: Not available for GPT-5.5/5.4 per AWS documentation
- **Regional availability**: GPT-5.5 — `us-east-2` only; GPT-5.4 — `us-east-2` and `us-west-2`

## References

- [GPT-5.5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html)
- [GPT-5.4 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-54.html)
- [AWS blog: Get started with OpenAI GPT-5.5, GPT-5.4 models, and Codex on Amazon Bedrock](https://aws.amazon.com/blogs/aws/get-started-with-openai-gpt-5-5-gpt-5-4-models-and-codex-on-amazon-bedrock/)
- [aws-bedrock-token-generator (PyPI)](https://pypi.org/project/aws-bedrock-token-generator/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)