### PR TITLE
Add Firecrawl Monitor tools (create_monitor + monitor_checks)

### DIFF
--- a/tools/firecrawl/README.md
+++ b/tools/firecrawl/README.md
@@ -19,7 +19,7 @@ Navigate to **Plugins > Firecrawl > To Authorize** in Dify, and input your API K
 
 ## Tool Features
 
-The Firecrawl tool provides four actions for web crawling and scraping:
+The Firecrawl tool provides six actions for web crawling, scraping, and monitoring:
 
 ### Crawl Job
 
@@ -44,6 +44,14 @@ When using the **Map** action to generate a complete map of all URLs present on 
 Convert any URL into clean, structured data, transforming raw HTML into actionable insights.
 
 <img src="./_assets/firecrawl-05.png" width="400" />
+
+### Create Monitor
+
+Create a scheduled monitor that watches a target for changes on a recurring schedule — useful for keeping ingested data fresh by re-checking pages over time.
+
+### Monitor Checks
+
+Retrieve a monitor's details and its check results, so you can see what changed on each scheduled run and act only on the pages that changed.
 
 ## Usage
 

--- a/tools/firecrawl/manifest.yaml
+++ b/tools/firecrawl/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - utilities
 type: plugin
-version: 0.0.9
+version: 0.1.0

--- a/tools/firecrawl/manifest.yaml
+++ b/tools/firecrawl/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - utilities
 type: plugin
-version: 0.1.0
+version: 0.2.0

--- a/tools/firecrawl/provider/firecrawl.yaml
+++ b/tools/firecrawl/provider/firecrawl.yaml
@@ -42,3 +42,5 @@ tools:
   - tools/crawl.yaml
   - tools/map.yaml
   - tools/scrape.yaml
+  - tools/create_monitor.yaml
+  - tools/monitor_checks.yaml

--- a/tools/firecrawl/tools/create_monitor.py
+++ b/tools/firecrawl/tools/create_monitor.py
@@ -1,0 +1,65 @@
+from typing import Any, Generator
+from dify_plugin.entities.tool import ToolInvokeMessage
+from dify_plugin import Tool
+
+from .firecrawl_appx import FirecrawlApp, get_array_params, get_json_params
+
+
+class CreateMonitorTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        Create a Firecrawl monitor: a recurring scrape that diffs each result
+        against the last snapshot. Docs: https://docs.firecrawl.dev/features/monitors
+        """
+        app = FirecrawlApp(
+            api_key=self.runtime.credentials.get("firecrawl_api_key"), base_url=self.runtime.credentials.get("base_url")
+        )
+
+        # The simplest, well-supported target shape: scrape one or more URLs.
+        urls = get_array_params(tool_parameters, "urls") or []
+        scrape_options = get_json_params(tool_parameters, "scrapeOptions")
+        targets = []
+        for url in urls:
+            target: dict[str, Any] = {"type": "scrape", "url": url}
+            if scrape_options:
+                target["scrapeOptions"] = scrape_options
+            targets.append(target)
+
+        # Schedule: prefer a natural-language schedule, fall back to cron.
+        schedule: dict[str, Any] = {}
+        schedule_text = tool_parameters.get("scheduleText")
+        cron = tool_parameters.get("cron")
+        timezone = tool_parameters.get("timezone")
+        if schedule_text:
+            schedule["text"] = schedule_text
+        elif cron:
+            schedule["cron"] = cron
+        if timezone:
+            schedule["timezone"] = timezone
+
+        payload: dict[str, Any] = {
+            "name": tool_parameters["name"],
+            "targets": targets,
+        }
+        if schedule:
+            payload["schedule"] = schedule
+
+        goal = tool_parameters.get("goal")
+        if goal:
+            payload["goal"] = goal
+            payload["judgeEnabled"] = tool_parameters.get("judgeEnabled", True)
+
+        retention_days = tool_parameters.get("retentionDays")
+        if retention_days:
+            payload["retentionDays"] = retention_days
+
+        email = tool_parameters.get("email")
+        if email:
+            payload["notification"] = {"email": email}
+
+        webhook_url = tool_parameters.get("webhookUrl")
+        if webhook_url:
+            payload["webhook"] = {"url": webhook_url}
+
+        result = app.create_monitor(**payload)
+        yield self.create_json_message(result)

--- a/tools/firecrawl/tools/create_monitor.yaml
+++ b/tools/firecrawl/tools/create_monitor.yaml
@@ -1,0 +1,137 @@
+description:
+  human:
+    en_US: Create a Firecrawl monitor that recurringly scrapes one or more URLs
+      and diffs each result against the last snapshot to detect changes.
+    zh_Hans: 创建一个 Firecrawl 监控器，定期抓取一个或多个网址，并将每次结果与上一次快照进行对比以检测变化。
+  llm: Create a Firecrawl monitor. A monitor recurringly scrapes the given URLs on
+    a schedule and reports meaningful changes. Returns the created monitor object
+    including its id, which can be used with the Monitor Checks tool.
+extra:
+  python:
+    source: tools/create_monitor.py
+identity:
+  author: langgenius
+  label:
+    en_US: Create Monitor
+    zh_Hans: 创建监控器
+  name: create_monitor
+parameters:
+- form: llm
+  human_description:
+    en_US: A human-readable name for the monitor.
+    zh_Hans: 监控器的可读名称。
+  label:
+    en_US: Name
+    zh_Hans: 名称
+  llm_description: A human-readable name for the monitor. This is a required parameter.
+  name: name
+  required: true
+  type: string
+- form: llm
+  human_description:
+    en_US: The URLs to monitor. Use comma separated values for multiple URLs.
+    zh_Hans: 要监控的网址。多个网址使用半角逗号分隔。
+  label:
+    en_US: URLs
+    zh_Hans: 网址
+  llm_description: The URLs of the pages to monitor. Use comma separated values for
+    multiple URLs. This is a required parameter.
+  name: urls
+  placeholder:
+    en_US: Use commas to separate multiple URLs
+    zh_Hans: 多个网址使用半角逗号分隔
+  required: true
+  type: string
+- form: form
+  human_description:
+    en_US: 'Natural-language schedule, e.g. "every 30 minutes" or "daily at 9am".'
+    zh_Hans: 自然语言形式的计划，例如 “every 30 minutes” 或 “daily at 9am”。
+  label:
+    en_US: Schedule (text)
+    zh_Hans: 计划（文本）
+  name: scheduleText
+  placeholder:
+    en_US: every 30 minutes
+  type: string
+- form: form
+  human_description:
+    en_US: A cron expression for the schedule. Used only if Schedule (text) is empty.
+    zh_Hans: 计划的 cron 表达式。仅在“计划（文本）”为空时使用。
+  label:
+    en_US: Schedule (cron)
+    zh_Hans: 计划（cron）
+  name: cron
+  placeholder:
+    en_US: '*/30 * * * *'
+  type: string
+- form: form
+  human_description:
+    en_US: 'IANA timezone for the schedule, e.g. America/New_York.'
+    zh_Hans: 计划使用的 IANA 时区，例如 America/New_York。
+  label:
+    en_US: Timezone
+    zh_Hans: 时区
+  name: timezone
+  type: string
+- form: form
+  human_description:
+    en_US: Plain-language description of what changes matter. When set, the meaningful-change
+      judge is enabled.
+    zh_Hans: 用自然语言描述哪些变化是重要的。设置后将启用有意义变化的判定。
+  label:
+    en_US: Goal
+    zh_Hans: 目标
+  name: goal
+  type: string
+- form: form
+  human_description:
+    en_US: Whether to enable the meaningful-change judge. Defaults to true when a goal
+      is set.
+    zh_Hans: 是否启用有意义变化的判定。设置目标后默认为开启。
+  label:
+    en_US: Judge Enabled
+    zh_Hans: 启用判定
+  name: judgeEnabled
+  type: boolean
+  default: true
+- form: form
+  human_description:
+    en_US: Number of days to retain check snapshots (1-365).
+    zh_Hans: 保留检查快照的天数（1-365）。
+  label:
+    en_US: Retention Days
+    zh_Hans: 保留天数
+  min: 1
+  name: retentionDays
+  type: number
+- form: form
+  human_description:
+    en_US: Email address to receive change summaries.
+    zh_Hans: 接收变化摘要的电子邮件地址。
+  label:
+    en_US: Notification Email
+    zh_Hans: 通知邮箱
+  name: email
+  type: string
+- form: form
+  human_description:
+    en_US: Webhook URL to receive monitor events.
+    zh_Hans: 接收监控事件的 Webhook 网址。
+  label:
+    en_US: Webhook URL
+    zh_Hans: Webhook 网址
+  name: webhookUrl
+  type: string
+- form: form
+  human_description:
+    en_US: 'Scrape options applied to each target, as a JSON object. Example: {"formats":
+      ["markdown"], "onlyMainContent": true}'
+    zh_Hans: '应用于每个目标的抓取选项，JSON 对象。示例：{"formats": ["markdown"], "onlyMainContent": true}'
+  label:
+    en_US: Scrape Options
+    zh_Hans: 抓取选项
+  name: scrapeOptions
+  placeholder:
+    en_US: Please enter an object that can be serialized in JSON
+    zh_Hans: 请输入可以json序列化的对象
+  type: string

--- a/tools/firecrawl/tools/firecrawl_appx.py
+++ b/tools/firecrawl/tools/firecrawl_appx.py
@@ -94,6 +94,34 @@ class FirecrawlApp:
             raise HTTPError(f"Failed to cancel job {job_id} after multiple retries")
         return response
 
+    def create_monitor(self, **kwargs):
+        # v2 monitors API. Docs: https://docs.firecrawl.dev/features/monitors
+        endpoint = f"{self.base_url}/v2/monitor"
+        logger.debug(f"Sent request to {endpoint=} body={kwargs}")
+        response = self._request("POST", endpoint, kwargs)
+        if response is None:
+            raise HTTPError("Failed to create monitor after multiple retries")
+        elif response.get("success") is False:
+            raise HTTPError(f'Failed to create monitor: {response.get("error")}')
+        return response
+
+    def get_monitor(self, monitor_id: str):
+        endpoint = f"{self.base_url}/v2/monitor/{monitor_id}"
+        response = self._request("GET", endpoint)
+        if response is None:
+            raise HTTPError(f"Failed to get monitor {monitor_id} after multiple retries")
+        return response
+
+    def get_monitor_checks(self, monitor_id: str, **kwargs):
+        endpoint = f"{self.base_url}/v2/monitor/{monitor_id}/checks"
+        params = "&".join(f"{k}={v}" for k, v in kwargs.items() if v not in (None, ""))
+        if params:
+            endpoint = f"{endpoint}?{params}"
+        response = self._request("GET", endpoint)
+        if response is None:
+            raise HTTPError(f"Failed to list checks for monitor {monitor_id} after multiple retries")
+        return response
+
     def _monitor_job_status(self, job_id: str, poll_interval: int):
         while True:
             status = self.check_crawl_status(job_id)

--- a/tools/firecrawl/tools/firecrawl_appx.py
+++ b/tools/firecrawl/tools/firecrawl_appx.py
@@ -1,3 +1,4 @@
+import urllib.parse
 import json
 import logging
 import time
@@ -114,9 +115,9 @@ class FirecrawlApp:
 
     def get_monitor_checks(self, monitor_id: str, **kwargs):
         endpoint = f"{self.base_url}/v2/monitor/{monitor_id}/checks"
-        params = "&".join(f"{k}={v}" for k, v in kwargs.items() if v not in (None, ""))
-        if params:
-            endpoint = f"{endpoint}?{params}"
+        query = {k: v for k, v in kwargs.items() if v not in (None, "")}
+        if query:
+            endpoint = f"{endpoint}?{urllib.parse.urlencode(query)}"
         response = self._request("GET", endpoint)
         if response is None:
             raise HTTPError(f"Failed to list checks for monitor {monitor_id} after multiple retries")
@@ -135,7 +136,7 @@ class FirecrawlApp:
 def get_array_params(tool_parameters: dict[str, Any], key):
     param = tool_parameters.get(key)
     if param:
-        return param.split(",")
+        return [p.strip() for p in param.split(",")]
 
 
 def get_json_params(tool_parameters: dict[str, Any], key):

--- a/tools/firecrawl/tools/monitor_checks.py
+++ b/tools/firecrawl/tools/monitor_checks.py
@@ -1,0 +1,31 @@
+from typing import Any, Generator
+from dify_plugin.entities.tool import ToolInvokeMessage
+from dify_plugin import Tool
+
+from .firecrawl_appx import FirecrawlApp
+
+
+class MonitorChecksTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        List historical checks for a monitor, or fetch the monitor itself.
+        Docs: https://docs.firecrawl.dev/features/monitors
+        """
+        app = FirecrawlApp(
+            api_key=self.runtime.credentials.get("firecrawl_api_key"), base_url=self.runtime.credentials.get("base_url")
+        )
+        monitor_id = tool_parameters["monitor_id"]
+        operation = tool_parameters.get("operation", "checks")
+        if operation == "checks":
+            query = {
+                "limit": tool_parameters.get("limit"),
+                "offset": tool_parameters.get("offset"),
+                "status": tool_parameters.get("status"),
+            }
+            query = {k: v for (k, v) in query.items() if v not in (None, "")}
+            result = app.get_monitor_checks(monitor_id, **query)
+        elif operation == "get":
+            result = app.get_monitor(monitor_id)
+        else:
+            raise ValueError(f"Invalid operation: {operation}")
+        yield self.create_json_message(result)

--- a/tools/firecrawl/tools/monitor_checks.yaml
+++ b/tools/firecrawl/tools/monitor_checks.yaml
@@ -1,0 +1,99 @@
+description:
+  human:
+    en_US: List historical checks for a Firecrawl monitor, or fetch the monitor
+      itself by ID.
+    zh_Hans: 列出某个 Firecrawl 监控器的历史检查记录，或根据 ID 获取该监控器。
+  llm: List the historical checks for a Firecrawl monitor (each check is one run of
+    the monitor), or fetch the monitor configuration itself by its ID.
+extra:
+  python:
+    source: tools/monitor_checks.py
+identity:
+  author: langgenius
+  label:
+    en_US: Monitor Checks
+    zh_Hans: 监控检查
+  name: monitor_checks
+parameters:
+- form: llm
+  human_description:
+    en_US: The ID of the monitor. Returned by the Create Monitor tool.
+    zh_Hans: 监控器的 ID，由“创建监控器”工具返回。
+  label:
+    en_US: Monitor ID
+    zh_Hans: 监控器 ID
+  llm_description: The ID of the monitor, returned by the Create Monitor tool. This
+    is a required parameter.
+  name: monitor_id
+  required: true
+  type: string
+- form: llm
+  human_description:
+    en_US: choose the operation to perform. `checks` lists the monitor's check
+      history, `get` returns the monitor configuration.
+    zh_Hans: 选择要执行的操作。`checks` 列出监控检查历史，`get` 返回监控器配置。
+  label:
+    en_US: operation
+    zh_Hans: 操作
+  llm_description: choose the operation to perform. `checks` lists the monitor's
+    check history, `get` returns the monitor configuration.
+  name: operation
+  options:
+  - label:
+      en_US: list checks
+    value: checks
+  - label:
+      en_US: get monitor
+    value: get
+  required: true
+  type: select
+  default: checks
+- form: form
+  human_description:
+    en_US: Maximum number of checks to return (1-100). Only used for the list checks
+      operation.
+    zh_Hans: 返回检查记录的最大数量（1-100）。仅用于“列出检查”操作。
+  label:
+    en_US: Limit
+    zh_Hans: 数量上限
+  min: 1
+  name: limit
+  type: number
+- form: form
+  human_description:
+    en_US: Number of checks to skip. Only used for the list checks operation.
+    zh_Hans: 要跳过的检查记录数量。仅用于“列出检查”操作。
+  label:
+    en_US: Offset
+    zh_Hans: 偏移量
+  min: 0
+  name: offset
+  type: number
+- form: form
+  human_description:
+    en_US: Filter checks by status.
+    zh_Hans: 按状态筛选检查记录。
+  label:
+    en_US: Status
+    zh_Hans: 状态
+  name: status
+  options:
+  - label:
+      en_US: queued
+    value: queued
+  - label:
+      en_US: running
+    value: running
+  - label:
+      en_US: completed
+    value: completed
+  - label:
+      en_US: failed
+    value: failed
+  - label:
+      en_US: partial
+    value: partial
+  - label:
+      en_US: skipped (overlap)
+    value: skipped_overlap
+  type: select


### PR DESCRIPTION
Adds two new tools mirroring the existing tool structure — `create_monitor` and `monitor_checks` — calling the v2 monitor endpoints, registered in the provider. README updated to document them.

**Verification:** static + SDK-introspection/mocked against the real v2 SDK (`firecrawl-py 4.28.2` / `@mendable firecrawl v4`); not run against the live API. Happy to address review/CI feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)