### PR TITLE
fix(openai_api_compatible): use endpoint_model_name in multimodal embedding

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.53
+version: 0.0.54
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/text_embedding/text_embedding.py
+++ b/models/openai_api_compatible/models/text_embedding/text_embedding.py
@@ -324,6 +324,11 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
         Embed inputs containing multimodal content using vLLM chat embeddings API.
         Returns (embeddings, used_tokens, total_price, unit_price, price_unit, currency).
         """
+        # Resolve the upstream model id the same way the text-only path does, so a
+        # configured endpoint_model_name override reaches the API instead of the
+        # Dify display/registration name (which would 404 upstream).
+        endpoint_model_name = credentials.get("endpoint_model_name", "") or model
+
         client = OpenAI(api_key=api_key, base_url=endpoint_url)
 
         batched_embeddings = []
@@ -351,7 +356,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                         {"role": "user", "content": [{"type": "text", "text": prompt}]},
                         {"role": "assistant", "content": [{"type": "text", "text": ""}]},
                     ],
-                    model=model,
+                    model=endpoint_model_name,
                     encoding_format="float",
                     continue_final_message=True,
                     add_special_tokens=True,
@@ -368,7 +373,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                         ]},
                         {"role": "assistant", "content": [{"type": "text", "text": ""}]},
                     ],
-                    model=model,
+                    model=endpoint_model_name,
                     encoding_format="float",
                     continue_final_message=True,
                     add_special_tokens=True,
@@ -392,7 +397,7 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
                         ]},
                         {"role": "assistant", "content": [{"type": "text", "text": ""}]},
                     ],
-                    model=model,
+                    model=endpoint_model_name,
                     encoding_format="float",
                     continue_final_message=True,
                     add_special_tokens=True,

--- a/models/openai_api_compatible/tests/test_text_embedding.py
+++ b/models/openai_api_compatible/tests/test_text_embedding.py
@@ -63,3 +63,31 @@ def test_text_embedding_validate_credentials_uses_runtime_payload_shape(mock_pos
 
     payload = mock_post.call_args.kwargs["json"]
     assert payload == {"model": "Qwen3-Embedding-8B", "input": ["ping"], "encoding_format": "float"}
+
+
+def _chat_embedding_response() -> MagicMock:
+    response = MagicMock()
+    response.data = [MagicMock(embedding=[0.4, 0.5, 0.6])]
+    response.model_dump.return_value = {"usage": {"total_tokens": 5}}
+    return response
+
+
+@patch("models.text_embedding.text_embedding.OpenAI")
+@patch("models.text_embedding.text_embedding.create_chat_embeddings")
+def test_multimodal_embedding_sends_endpoint_model_name(mock_create, _mock_openai):
+    # Regression test for #3191: the multimodal (vision) path must send the
+    # configured endpoint_model_name upstream, not the Dify display/registration
+    # name, otherwise the upstream server returns 404.
+    mock_create.return_value = _chat_embedding_response()
+    model = OpenAITextEmbeddingModel(model_schemas=[])
+
+    result = model._invoke(
+        model="Qwen3-VL-Embedding",
+        credentials=_credentials(
+            endpoint_model_name="qwen3-vl-embedding-8b-awq", vision_support="support"
+        ),
+        texts=["https://example.com/image.png"],
+    )
+
+    assert mock_create.call_args.kwargs["model"] == "qwen3-vl-embedding-8b-awq"
+    assert result.embeddings == [[0.4, 0.5, 0.6]]


### PR DESCRIPTION
## Summary

Fixes #3191

The multimodal (vision) embedding path of the OpenAI-API-compatible provider forwarded the Dify display/registration name to the upstream API instead of the configured `endpoint_model_name`. When the registration name differed from the real upstream model id, the server returned `404 - The model ... does not exist` for multimodal embedding, even though text-only embedding worked.

**Root cause:** the text-only path resolves `endpoint_model_name = credentials.get("endpoint_model_name", "") or model`, but `_embed_multimodal_via_chat` forwarded the raw `model` arg straight to `create_chat_embeddings(model=model, ...)`.

**Fix:** resolve `endpoint_model_name` inside `_embed_multimodal_via_chat` and use it for all three input shapes (text, image-only, image+text). `TextEmbeddingResult.model` and credential validation intentionally keep using the display name, matching the text-only path.

## Change Type

- [x] LLM plugin

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [x] New models / model parameter fixes

</details>

Added a regression test (`test_multimodal_embedding_sends_endpoint_model_name`) asserting the multimodal path sends `endpoint_model_name`; all 4 tests in `tests/test_text_embedding.py` pass.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (0.0.53 -> 0.0.54)
- [x] `dify_plugin` declared in `pyproject.toml` and locked in `uv.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)