### PR TITLE
fix(openai_tool): normalize base URL and use models.list() for auth validation

### DIFF
--- a/tests/tools/openai/test_openai_tool.py
+++ b/tests/tools/openai/test_openai_tool.py
@@ -1,0 +1,163 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PLUGIN_DIR = Path("tools") / "openai"
+
+
+class FakeToolInvokeMessage:
+    pass
+
+
+class FakeToolProviderCredentialValidationError(Exception):
+    pass
+
+
+def install_dify_plugin_stubs():
+    dify_plugin_module = types.ModuleType("dify_plugin")
+
+    class FakeTool:
+        response_type = FakeToolInvokeMessage
+
+        def create_text_message(self, text):
+            return text
+
+        def create_blob_message(self, blob=None, meta=None, save_as=None):
+            return {"blob": blob, "meta": meta, "save_as": save_as}
+
+        def create_json_message(self, payload):
+            return payload
+
+    class FakeToolProvider:
+        pass
+
+    dify_plugin_module.Tool = FakeTool
+    dify_plugin_module.ToolProvider = FakeToolProvider
+
+    entities_module = types.ModuleType("dify_plugin.entities")
+    entities_tool_module = types.ModuleType("dify_plugin.entities.tool")
+    entities_tool_module.ToolInvokeMessage = FakeToolInvokeMessage
+
+    errors_module = types.ModuleType("dify_plugin.errors")
+    errors_tool_module = types.ModuleType("dify_plugin.errors.tool")
+    errors_tool_module.ToolProviderCredentialValidationError = (
+        FakeToolProviderCredentialValidationError
+    )
+
+    sys.modules["dify_plugin"] = dify_plugin_module
+    sys.modules["dify_plugin.entities"] = entities_module
+    sys.modules["dify_plugin.entities.tool"] = entities_tool_module
+    sys.modules["dify_plugin.errors"] = errors_module
+    sys.modules["dify_plugin.errors.tool"] = errors_tool_module
+
+
+install_dify_plugin_stubs()
+
+
+def load_module_from_path(module_name: str, file_path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    assert spec and spec.loader, f"cannot load spec for {module_name} from {file_path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def import_plugin_module(module_name: str, relative_path: str) -> types.ModuleType:
+    plugin_root = str(PLUGIN_DIR.resolve())
+    sys.path.insert(0, plugin_root)
+    try:
+        return load_module_from_path(module_name, PLUGIN_DIR / relative_path)
+    finally:
+        sys.path.pop(0)
+
+
+def create_tool_instance(tool_cls):
+    tool = tool_cls.__new__(tool_cls)
+    tool.response_type = FakeToolInvokeMessage
+    tool.runtime = MagicMock()
+    return tool
+
+
+@pytest.mark.parametrize(
+    ("raw_url", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("http://host:8317", "http://host:8317/v1"),
+        ("http://host:8317/", "http://host:8317/v1"),
+        ("http://host:8317/v1", "http://host:8317/v1"),
+        ("http://host:8317/v1/", "http://host:8317/v1"),
+    ],
+)
+def test_normalize_openai_base_url(raw_url, expected):
+    helpers = import_plugin_module("openai_helpers", "openai_client.py")
+    assert helpers.normalize_openai_base_url(raw_url) == expected
+
+
+def test_provider_validate_credentials_uses_models_list():
+    provider_module = import_plugin_module("openai_provider", "provider/openai.py")
+    provider = provider_module.OpenAIProvider.__new__(provider_module.OpenAIProvider)
+
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = [{"id": "gpt-image-1"}]
+
+    with patch.object(provider_module, "OpenAI", return_value=mock_client) as mock_openai:
+        provider._validate_credentials(
+            {
+                "openai_api_key": "test-key",
+                "openai_base_url": "http://host:8317/v1",
+                "openai_organization_id": "org-test",
+            }
+        )
+
+    mock_openai.assert_called_once_with(
+        api_key="test-key",
+        base_url="http://host:8317/v1",
+        organization="org-test",
+    )
+    mock_client.models.list.assert_called_once_with()
+
+
+def test_provider_validate_credentials_wraps_errors():
+    provider_module = import_plugin_module("openai_provider", "provider/openai.py")
+    provider = provider_module.OpenAIProvider.__new__(provider_module.OpenAIProvider)
+
+    mock_client = MagicMock()
+    mock_client.models.list.side_effect = RuntimeError("bad credentials")
+
+    with patch.object(provider_module, "OpenAI", return_value=mock_client):
+        with pytest.raises(FakeToolProviderCredentialValidationError, match="bad credentials"):
+            provider._validate_credentials(
+                {
+                    "openai_api_key": "test-key",
+                    "openai_base_url": "http://host:8317",
+                }
+            )
+
+
+def test_gpt_image_2_generate_uses_normalized_base_url():
+    tool_module = import_plugin_module("gpt_image_2_generate_tool", "tools/gpt_image_2_generate.py")
+    tool = create_tool_instance(tool_module.GPTImage2GenerateTool)
+    tool.runtime.credentials = {
+        "openai_api_key": "test-key",
+        "openai_base_url": "http://host:8317/v1/",
+        "openai_organization_id": "org-test",
+    }
+
+    mock_client = MagicMock()
+    mock_client.images.generate.side_effect = RuntimeError("network failed")
+
+    with patch.object(tool_module, "OpenAI", return_value=mock_client) as mock_openai:
+        results = list(tool._invoke({"prompt": "a cat"}))
+
+    mock_openai.assert_called_once_with(
+        api_key="test-key",
+        base_url="http://host:8317/v1",
+        organization="org-test",
+    )
+    assert len(results) == 1
+    assert "Failed to generate image: network failed" in str(results[0])

--- a/tests/tools/openai/test_openai_tool.py
+++ b/tests/tools/openai/test_openai_tool.py
@@ -87,7 +87,9 @@ def create_tool_instance(tool_cls):
     [
         (None, None),
         ("", None),
+        ("   ", None),
         ("http://host:8317", "http://host:8317/v1"),
+        ("  http://host:8317  ", "http://host:8317/v1"),
         ("http://host:8317/", "http://host:8317/v1"),
         ("http://host:8317/v1", "http://host:8317/v1"),
         ("http://host:8317/v1/", "http://host:8317/v1"),

--- a/tools/openai/manifest.yaml
+++ b/tools/openai/manifest.yaml
@@ -32,4 +32,4 @@ tags:
 - image
 - productivity
 type: plugin
-version: 0.1.9
+version: 0.1.10

--- a/tools/openai/openai_client.py
+++ b/tools/openai/openai_client.py
@@ -1,12 +1,12 @@
-from yarl import URL
-
-
 def normalize_openai_base_url(base_url: str | None) -> str | None:
     if not base_url:
         return None
 
-    normalized = str(URL(str(base_url).rstrip("/")))
-    if normalized.endswith("/v1"):
-        return normalized
+    cleaned = str(base_url).strip().rstrip("/")
+    if not cleaned:
+        return None
 
-    return str(URL(normalized) / "v1")
+    if cleaned.endswith("/v1"):
+        return cleaned
+
+    return f"{cleaned}/v1"

--- a/tools/openai/openai_client.py
+++ b/tools/openai/openai_client.py
@@ -1,0 +1,12 @@
+from yarl import URL
+
+
+def normalize_openai_base_url(base_url: str | None) -> str | None:
+    if not base_url:
+        return None
+
+    normalized = str(URL(str(base_url).rstrip("/")))
+    if normalized.endswith("/v1"):
+        return normalized
+
+    return str(URL(normalized) / "v1")

--- a/tools/openai/provider/openai.py
+++ b/tools/openai/provider/openai.py
@@ -1,8 +1,10 @@
 from typing import Any
+
 from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 from dify_plugin import ToolProvider
 from openai import OpenAI
-from yarl import URL
+
+from openai_client import normalize_openai_base_url
 
 
 class OpenAIProvider(ToolProvider):
@@ -12,22 +14,12 @@ class OpenAIProvider(ToolProvider):
         organization_id = credentials.get("openai_organization_id")
 
         try:
-            # Initialize OpenAI client with credentials
             client = OpenAI(
                 api_key=api_key,
-                base_url=str(URL(base_url) / "v1") if base_url else None,
-                organization=organization_id
+                base_url=normalize_openai_base_url(base_url),
+                organization=organization_id,
             )
-            
-            # Test the API with a simple request
-            response = client.chat.completions.create(
-                model="gpt-4.1-nano",
-                messages=[{"role": "user", "content": "Tell me a joke."}],
-                max_tokens=10
-            )
-            
-            # If we get here without exception, credentials are valid
-            print(f"API test successful: {response.choices[0].message.content}")
-            
+
+            client.models.list()
         except Exception as e:
             raise ToolProviderCredentialValidationError(str(e))

--- a/tools/openai/pyproject.toml
+++ b/tools/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-openai"
-version = "0.1.5"
+version = "0.1.10"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tools/openai/tools/dalle2.py
+++ b/tools/openai/tools/dalle2.py
@@ -1,10 +1,12 @@
 from base64 import b64decode
 from collections.abc import Generator
 from typing import Literal
-from openai import OpenAI
-from yarl import URL
+
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
+from openai import OpenAI
+
+from openai_client import normalize_openai_base_url
 
 
 class DallE2Tool(Tool):
@@ -19,14 +21,9 @@ class DallE2Tool(Tool):
         )
         if not openai_organization:
             openai_organization = None
-        openai_base_url = self.runtime.credentials.get("openai_base_url", None)
-        if not openai_base_url:
-            openai_base_url = None
-        else:
-            openai_base_url = str(URL(openai_base_url) / "v1")
         client = OpenAI(
             api_key=self.runtime.credentials["openai_api_key"],
-            base_url=openai_base_url,
+            base_url=normalize_openai_base_url(self.runtime.credentials.get("openai_base_url")),
             organization=openai_organization,
         )
         SIZE_MAPPING = {"small": "256x256", "medium": "512x512", "large": "1024x1024"}

--- a/tools/openai/tools/dalle3.py
+++ b/tools/openai/tools/dalle3.py
@@ -1,10 +1,12 @@
 import base64
 import random
 from collections.abc import Generator
-from openai import OpenAI
-from yarl import URL
+
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
+from openai import OpenAI
+
+from openai_client import normalize_openai_base_url
 
 
 class DallE3Tool(Tool):
@@ -19,14 +21,9 @@ class DallE3Tool(Tool):
         )
         if not openai_organization:
             openai_organization = None
-        openai_base_url = self.runtime.credentials.get("openai_base_url", None)
-        if not openai_base_url:
-            openai_base_url = None
-        else:
-            openai_base_url = str(URL(openai_base_url) / "v1")
         client = OpenAI(
             api_key=self.runtime.credentials["openai_api_key"],
-            base_url=openai_base_url,
+            base_url=normalize_openai_base_url(self.runtime.credentials.get("openai_base_url")),
             organization=openai_organization,
         )
         SIZE_MAPPING = {

--- a/tools/openai/tools/deep_research.py
+++ b/tools/openai/tools/deep_research.py
@@ -2,11 +2,12 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Optional, List, Dict
 from collections.abc import Generator
-from openai import OpenAI
-from yarl import URL
+
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
+from openai import OpenAI
 
+from openai_client import normalize_openai_base_url
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
@@ -63,7 +64,7 @@ class DeepResearchTool(Tool):
 
         return OpenAI(
             api_key=self.runtime.credentials["openai_api_key"],
-            base_url=str(URL(openai_base_url) / "v1") if openai_base_url else None,
+            base_url=normalize_openai_base_url(openai_base_url),
             organization=openai_organization,
             timeout=timeout if timeout is not None else 3600,
         )

--- a/tools/openai/tools/gpt_image_2_edit.py
+++ b/tools/openai/tools/gpt_image_2_edit.py
@@ -7,8 +7,8 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.file.file import File
 from openai import OpenAI
-from yarl import URL
 
+from openai_client import normalize_openai_base_url
 from tools._image_utils import build_usage_metadata, build_usage_output, decode_image
 
 logger = logging.getLogger(__name__)
@@ -30,13 +30,10 @@ class GPTImage2EditTool(Tool):
             tool_parameters.get("n", 1),
         )
         openai_organization = self.runtime.credentials.get("openai_organization_id") or None
-        openai_base_url = self.runtime.credentials.get("openai_base_url") or None
-        if openai_base_url:
-            openai_base_url = str(URL(openai_base_url) / "v1")
 
         client = OpenAI(
             api_key=self.runtime.credentials["openai_api_key"],
-            base_url=openai_base_url,
+            base_url=normalize_openai_base_url(self.runtime.credentials.get("openai_base_url")),
             organization=openai_organization,
         )
 

--- a/tools/openai/tools/gpt_image_2_generate.py
+++ b/tools/openai/tools/gpt_image_2_generate.py
@@ -5,8 +5,8 @@ from typing import Any
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from openai import OpenAI
-from yarl import URL
 
+from openai_client import normalize_openai_base_url
 from tools._image_utils import build_usage_metadata, build_usage_output, decode_image
 
 logger = logging.getLogger(__name__)
@@ -26,13 +26,10 @@ class GPTImage2GenerateTool(Tool):
             tool_parameters.get("n", 1),
         )
         openai_organization = self.runtime.credentials.get("openai_organization_id") or None
-        openai_base_url = self.runtime.credentials.get("openai_base_url") or None
-        if openai_base_url:
-            openai_base_url = str(URL(openai_base_url) / "v1")
 
         client = OpenAI(
             api_key=self.runtime.credentials["openai_api_key"],
-            base_url=openai_base_url,
+            base_url=normalize_openai_base_url(self.runtime.credentials.get("openai_base_url")),
             organization=openai_organization,
         )
 

--- a/tools/openai/tools/gpt_image_edit.py
+++ b/tools/openai/tools/gpt_image_edit.py
@@ -2,11 +2,13 @@ import base64
 import io
 from collections.abc import Generator
 from typing import Any, Dict
-from openai import OpenAI
-from yarl import URL
+
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
 from dify_plugin.file.file import File
+from openai import OpenAI
+
+from openai_client import normalize_openai_base_url
 
 class GPTImageEditTool(Tool):
     """
@@ -25,15 +27,10 @@ class GPTImageEditTool(Tool):
         )
         if not openai_organization:
             openai_organization = None
-        openai_base_url = self.runtime.credentials.get("openai_base_url", None)
-        if not openai_base_url:
-            openai_base_url = None
-        else:
-            openai_base_url = str(URL(openai_base_url) / "v1")
 
         client = OpenAI(
             api_key=self.runtime.credentials["openai_api_key"],
-            base_url=openai_base_url,
+            base_url=normalize_openai_base_url(self.runtime.credentials.get("openai_base_url")),
             organization=openai_organization,
         )
 

--- a/tools/openai/tools/gpt_image_generate.py
+++ b/tools/openai/tools/gpt_image_generate.py
@@ -2,10 +2,12 @@ import base64
 import random
 from collections.abc import Generator
 from typing import Any, Dict
-from openai import OpenAI
-from yarl import URL
+
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
+from openai import OpenAI
+
+from openai_client import normalize_openai_base_url
 
 
 class GPTImageGenerateTool(Tool):
@@ -20,14 +22,9 @@ class GPTImageGenerateTool(Tool):
         )
         if not openai_organization:
             openai_organization = None
-        openai_base_url = self.runtime.credentials.get("openai_base_url", None)
-        if not openai_base_url:
-            openai_base_url = None
-        else:
-            openai_base_url = str(URL(openai_base_url) / "v1")
         client = OpenAI(
             api_key=self.runtime.credentials["openai_api_key"],
-            base_url=openai_base_url,
+            base_url=normalize_openai_base_url(self.runtime.credentials.get("openai_base_url")),
             organization=openai_organization,
         )
 

--- a/tools/openai/uv.lock
+++ b/tools/openai/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-openai"
-version = "0.1.5"
+version = "0.1.10"
 source = { virtual = "." }
 dependencies = [
     { name = "dify-plugin" },


### PR DESCRIPTION
## Summary

Fixes #3257

This PR fixes two authorization issues in `tools/openai`:

- normalize `openai_base_url` so inputs that already end with `/v1` do not become `/v1/v1`
- replace credential validation based on `chat.completions.create(model="gpt-4.1-nano")` with `client.models.list()`

This is needed because the current authorization flow incorrectly rejects some OpenAI-compatible backends that do not support the hardcoded chat model but do expose valid OpenAI-style endpoints.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| Authorization may fail when `openai_base_url` is entered as `http://host:port/v1` because requests become `/v1/v1/...` | `openai_base_url` is normalized and requests correctly use `/v1/...` |
| Authorization depends on `chat.completions.create(model="gpt-4.1-nano")` | Authorization validates connectivity and credentials with `client.models.list()` |

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

## Testing

- [x] Local deployment — Dify version: not fully verified in a live Dify deployment
- [ ] SaaS (cloud.dify.ai)

Additional verification performed:
- added tests for base URL normalization
- added tests for provider auth validation using `models.list()`
- added tests to confirm tool-side client initialization reuses the normalized base URL

Local test command:
```bash
pytest tests/tools/openai/test_openai_tool.py -q