### PR TITLE
fix(paddleocr): address review comments and fix critical bugs

### DIFF
--- a/tools/paddleocr/manifest.yaml
+++ b/tools/paddleocr/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.7
+version: 0.2.8
 type: plugin
 author: langgenius
 name: paddleocr

--- a/tools/paddleocr/provider/paddleocr.py
+++ b/tools/paddleocr/provider/paddleocr.py
@@ -6,7 +6,7 @@ from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 from tools.document_parsing import DocumentParsingTool
 from tools.document_parsing_vl import DocumentParsingVlTool
 from tools.text_recognition import TextRecognitionTool
-from tools.utils import call_paddleocr_api, get_sdk_client
+from tools.utils import call_paddleocr_api, get_api_client_config
 
 
 class PaddleocrProvider(ToolProvider):
@@ -23,7 +23,7 @@ class PaddleocrProvider(ToolProvider):
         test_file = "https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/general_ocr_002.png"
 
         try:
-            client_config = get_sdk_client(
+            client_config = get_api_client_config(
                 access_token=credentials["aistudio_access_token"],
                 base_url=base_url,
             )

--- a/tools/paddleocr/provider/paddleocr.yaml
+++ b/tools/paddleocr/provider/paddleocr.yaml
@@ -44,5 +44,5 @@ credentials_for_provider:
             en_US: https://paddleocr.aistudio-app.com
             zh_Hans: https://paddleocr.aistudio-app.com
         help:
-            en_US: Leave empty to use the default PaddleOCR service. Only needed for self-hosted deployments.
-            zh_Hans: 留空则使用默认的 PaddleOCR 服务。仅自建服务时需要填写。
+            en_US: Leave empty to use the default PaddleOCR service. Only needed for special gateway scenarios.
+            zh_Hans: 留空则使用默认的 PaddleOCR 服务。仅特殊网关场景时需要填写。

--- a/tools/paddleocr/tools/document_parsing.py
+++ b/tools/paddleocr/tools/document_parsing.py
@@ -5,12 +5,26 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 from tools.utils import (
-    build_pp_structure_v3_options,
     call_paddleocr_api,
+    camel_to_snake,
     cleanup_temp_file,
-    get_sdk_client,
+    get_api_client_config,
     normalize_file_input,
 )
+
+_SKIP_KEYS = {"file", "fileType"}
+
+
+def build_pp_structure_v3_options(params: dict[str, Any]) -> dict[str, Any]:
+    """Build PPStructureV3 options dict from parameters using dynamic conversion."""
+    options_dict = {}
+    for api_name, value in params.items():
+        if value is None or api_name in _SKIP_KEYS:
+            continue
+        if api_name == "markdownIgnoreLabels" and isinstance(value, str):
+            value = [label.strip() for label in value.split(",") if label.strip()]
+        options_dict[camel_to_snake(api_name)] = value
+    return options_dict
 
 
 class DocumentParsingTool(Tool):
@@ -22,7 +36,7 @@ class DocumentParsingTool(Tool):
             )
         access_token = self.runtime.credentials["aistudio_access_token"]
 
-        # Get base_url (optional, uses SDK default if not provided)
+        # Get base_url (optional, uses default if not provided)
         base_url = self.runtime.credentials.get("base_url")
 
         # Normalize file input - returns (input_value, is_temp_file, file_type_code)
@@ -35,7 +49,7 @@ class DocumentParsingTool(Tool):
             options = build_pp_structure_v3_options(tool_parameters)
 
             # Get API client config
-            client_config = get_sdk_client(access_token, base_url)
+            client_config = get_api_client_config(access_token, base_url=base_url)
 
             # Call API with PP-StructureV3 model
             if file_input.startswith(("http://", "https://")):

--- a/tools/paddleocr/tools/document_parsing_vl.py
+++ b/tools/paddleocr/tools/document_parsing_vl.py
@@ -5,12 +5,28 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 from tools.utils import (
-    build_paddleocr_vl_options,
     call_paddleocr_api,
+    camel_to_snake,
     cleanup_temp_file,
-    get_sdk_client,
+    get_api_client_config,
     normalize_file_input,
 )
+
+_SKIP_KEYS = {"file", "fileType"}
+
+
+def build_paddleocr_vl_options(params: dict[str, Any]) -> dict[str, Any]:
+    """Build PaddleOCRVLOptions dict from parameters using dynamic conversion."""
+    options_dict = {}
+    for api_name, value in params.items():
+        if value is None or api_name in _SKIP_KEYS:
+            continue
+        if api_name == "promptLabel" and value == "undefined":
+            continue
+        if api_name == "markdownIgnoreLabels" and isinstance(value, str):
+            value = [label.strip() for label in value.split(",") if label.strip()]
+        options_dict[camel_to_snake(api_name)] = value
+    return options_dict
 
 
 class DocumentParsingVlTool(Tool):
@@ -22,7 +38,7 @@ class DocumentParsingVlTool(Tool):
             )
         access_token = self.runtime.credentials["aistudio_access_token"]
 
-        # Get base_url (optional, uses SDK default if not provided)
+        # Get base_url (optional, uses default if not provided)
         base_url = self.runtime.credentials.get("base_url")
 
         # Normalize file input - returns (input_value, is_temp_file, file_type_code)
@@ -35,7 +51,7 @@ class DocumentParsingVlTool(Tool):
             options = build_paddleocr_vl_options(tool_parameters)
 
             # Get API client config
-            client_config = get_sdk_client(access_token, base_url)
+            client_config = get_api_client_config(access_token, base_url=base_url)
 
             # Call API with PaddleOCR-VL-1.6 model
             if file_input.startswith(("http://", "https://")):

--- a/tools/paddleocr/tools/text_recognition.py
+++ b/tools/paddleocr/tools/text_recognition.py
@@ -5,12 +5,24 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 from tools.utils import (
-    build_ocr_options,
     call_paddleocr_api,
+    camel_to_snake,
     cleanup_temp_file,
-    get_sdk_client,
+    get_api_client_config,
     normalize_file_input,
 )
+
+_SKIP_KEYS = {"file", "fileType"}
+
+
+def build_ocr_options(params: dict[str, Any]) -> dict[str, Any]:
+    """Build OCR options dict from parameters using dynamic conversion."""
+    options_dict = {}
+    for api_name, value in params.items():
+        if value is None or api_name in _SKIP_KEYS:
+            continue
+        options_dict[camel_to_snake(api_name)] = value
+    return options_dict
 
 
 class TextRecognitionTool(Tool):
@@ -22,7 +34,7 @@ class TextRecognitionTool(Tool):
             )
         access_token = self.runtime.credentials["aistudio_access_token"]
 
-        # Get base_url (optional, uses SDK default if not provided)
+        # Get base_url (optional, uses default if not provided)
         base_url = self.runtime.credentials.get("base_url")
 
         # Normalize file input - returns (input_value, is_temp_file, file_type_code)
@@ -35,7 +47,7 @@ class TextRecognitionTool(Tool):
             options = build_ocr_options(tool_parameters)
 
             # Get API client config
-            client_config = get_sdk_client(access_token, base_url)
+            client_config = get_api_client_config(access_token, base_url=base_url)
 
             # Call API
             if file_input.startswith(("http://", "https://")):

--- a/tools/paddleocr/tools/utils.py
+++ b/tools/paddleocr/tools/utils.py
@@ -423,12 +423,12 @@ DEFAULT_MULTIPLIER = 1.5
 DEFAULT_MAX_INTERVAL = 15.0
 
 
-def get_sdk_client(access_token: str, base_url: str | None = None) -> dict[str, Any]:
-    """Get PaddleOCR API client configuration.
+def get_api_client_config(access_token: str, *, base_url: str | None = None) -> dict[str, Any]:
+    """Get PaddleOCR HTTP API client configuration.
 
     Args:
         access_token: AI Studio access token
-        base_url: Base URL (optional, uses SDK default if not provided)
+        base_url: Base URL (optional, uses default if not provided)
 
     Returns:
         Configuration dict with token, base_url, headers
@@ -449,70 +449,6 @@ def get_sdk_client(access_token: str, base_url: str | None = None) -> dict[str, 
     }
 
 
-def build_ocr_options(params: dict[str, Any]) -> dict[str, Any]:
-    """Build OCR options dict from parameters using dynamic conversion.
-
-    Args:
-        params: Tool parameters
-
-    Returns:
-        Options dict with snake_case keys
-    """
-    options_dict = {}
-    for api_name, value in params.items():
-        if value is None:
-            continue
-        # Convert camelCase to snake_case
-        option_name = camel_to_snake(api_name)
-        options_dict[option_name] = value
-    return options_dict
-
-
-def build_pp_structure_v3_options(params: dict[str, Any]) -> dict[str, Any]:
-    """Build PPStructureV3 options dict from parameters using dynamic conversion.
-
-    Args:
-        params: Tool parameters
-
-    Returns:
-        Options dict with snake_case keys
-    """
-    options_dict = {}
-    for api_name, value in params.items():
-        if value is None:
-            continue
-        # Convert camelCase to snake_case
-        option_name = camel_to_snake(api_name)
-        # Handle markdownIgnoreLabels conversion
-        if api_name == "markdownIgnoreLabels" and isinstance(value, str):
-            value = [label.strip() for label in value.split(",") if label.strip()]
-        options_dict[option_name] = value
-    return options_dict
-
-
-def build_paddleocr_vl_options(params: dict[str, Any]) -> dict[str, Any]:
-    """Build PaddleOCRVLOptions dict from parameters using dynamic conversion.
-
-    Args:
-        params: Tool parameters
-
-    Returns:
-        Options dict with snake_case keys
-    """
-    options_dict = {}
-    for api_name, value in params.items():
-        if value is None:
-            continue
-        # Handle promptLabel conversion - skip if "undefined"
-        if api_name == "promptLabel" and value == "undefined":
-            continue
-        # Convert camelCase to snake_case
-        option_name = camel_to_snake(api_name)
-        # Handle markdownIgnoreLabels conversion
-        if api_name == "markdownIgnoreLabels" and isinstance(value, str):
-            value = [label.strip() for label in value.split(",") if label.strip()]
-        options_dict[option_name] = value
-    return options_dict
 
 
 def _submit_job(
@@ -641,8 +577,13 @@ def _poll_job(
             raise RuntimeError(f"Failed to parse poll response: {e}") from e
 
         if state == "done":
-            # Get result URL
-            result_json_url = data.get("data", {}).get("resultJsonUrl") or data.get("resultJsonUrl")
+            # Get result URL — handle both response formats
+            result_data = data.get("data", {})
+            result_json_url = (
+                result_data.get("resultJsonUrl")
+                or (result_data.get("resultUrl") or {}).get("jsonUrl")
+                or data.get("resultJsonUrl")
+            )
             if not result_json_url:
                 raise RuntimeError(f"Result URL not found in response: {data}")
 
@@ -763,7 +704,7 @@ def call_paddleocr_api(
         file_url: URL of the file (if using URL input)
         file_path: Path to the file (if using file input)
         options: Optional payload parameters
-        client_config: Client config from get_sdk_client()
+        client_config: Client config from get_api_client_config()
         is_document_parsing: True for doc parsing, False for OCR
 
     Returns:


### PR DESCRIPTION
## Summary

Addresses review comments by @Bobholamovic from #3247, plus bug fixes discovered during integration testing.

### Review comment fixes:

1. **Rename `get_sdk_client` → `get_api_client_config`**: The function returns HTTP API config dict (not an SDK client), so the name now matches its actual functionality.

2. **Fix base_url help text**: Replaced "self-hosted deployments" with "special gateway scenarios" since the full async service solution is not open-sourced.

### Code improvements (AI reviewer + mentor feedback):

3. **Make `base_url` a keyword-only argument**: Improves call-site readability (`get_api_client_config(token, base_url=url)`).

4. **Move `build_*_options` to respective tool files**: Each options builder is only used in one tool, so they now live next to their consumer rather than in the shared utils module.

### Bug fixes:

5. **Fix `_poll_job` resultUrl parsing**: The API returns the result URL under `data.resultUrl.jsonUrl` (nested), but the code only checked `data.resultJsonUrl` (flat). This caused **100% failure on real API calls**. Added fallback chain to handle both formats.

6. **Filter non-API keys from options**: `build_*_options` functions now skip `file`/`fileType` keys so they are not sent to the API as spurious parameters.

## Testing

All scenarios verified against real PaddleOCR API:
- ✅ Dify File object → OCR text recognition (file upload path)
- ✅ URL string → PP-StructureV3 document parsing
- ✅ Base64 string → PaddleOCR-VL-1.6 document parsing
- ✅ Provider credential validation flow
- ✅ Custom base_url with gateway URL extraction
- ✅ Options filtering (no file/fileType leaked to API)

## Changes
- `tools/paddleocr/tools/utils.py`: Rename function, keyword-only arg, fix resultUrl parsing, remove build_*_options
- `tools/paddleocr/tools/text_recognition.py`: Add build_ocr_options, use keyword arg
- `tools/paddleocr/tools/document_parsing.py`: Add build_pp_structure_v3_options, use keyword arg
- `tools/paddleocr/tools/document_parsing_vl.py`: Add build_paddleocr_vl_options, use keyword arg
- `tools/paddleocr/provider/paddleocr.yaml`: Update help text wording
- `tools/paddleocr/provider/paddleocr.py`: Update import
- `tools/paddleocr/manifest.yaml`: Bump version 0.2.7 → 0.2.8