### PR TITLE
feat(anthropic): add `claude-fable-5` models with adaptive thinking support

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.20
+version: 0.3.21

--- a/models/anthropic/models/llm/_position.yaml
+++ b/models/anthropic/models/llm/_position.yaml
@@ -1,3 +1,4 @@
+- claude-fable-5
 - claude-opus-4-8
 - claude-opus-4-7
 - claude-sonnet-4-6

--- a/models/anthropic/models/llm/claude-fable-5.yaml
+++ b/models/anthropic/models/llm/claude-fable-5.yaml
@@ -1,0 +1,163 @@
+# yaml-language-server: $schema=../../schemas/model-schema.json
+
+# References:
+# https://platform.claude.com/docs/en/about-claude/models/overview.md
+# https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5.md
+# https://platform.claude.com/docs/en/resources/overview.md
+# https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking.md
+# https://platform.claude.com/docs/en/build-with-claude/effort.md
+# https://platform.claude.com/docs/en/about-claude/models/migration-guide.md
+model: claude-fable-5
+label:
+  en_US: claude-fable-5
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: thinking_display
+    label:
+      zh_Hans: 推理内容展示
+      en_US: Thinking Display
+    type: string
+    default: summarized
+    required: false
+    options:
+      - omitted
+      - summarized
+    help:
+      zh_Hans: Claude Fable 5 的 adaptive thinking 始终开启。此参数仅控制响应中推理内容的展示方式：omitted 为官方默认值（响应中不返回 thinking 文本）；summarized 返回摘要化的推理过程，便于在前端展示思考进度。
+      en_US: |
+        Claude Fable 5 always runs with adaptive thinking. This only controls how thinking content is exposed in the response: `omitted` is the official default (thinking text not returned); `summarized` returns summarized reasoning so clients can display progress.
+  - name: effort
+    label:
+      zh_Hans: 推理投入等级
+      en_US: Effort
+    type: string
+    default: high
+    required: false
+    options:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    help:
+      zh_Hans: 通过 output_config.effort 控制智能/token 消耗的权衡。xhigh 推荐用于编码与智能体场景，high 是智能敏感场景的最低建议值；low 与 medium 适合延迟或成本敏感场景。
+      en_US: Controls the intelligence vs. token cost trade-off via output_config.effort. Use `xhigh` for coding and agentic tasks; `high` is the minimum recommendation for intelligence-sensitive tasks; `low`/`medium` for latency- or cost-sensitive tasks.
+  - name: task_budget
+    label:
+      zh_Hans: 任务预算
+      en_US: Task Budget
+    type: int
+    default: 0
+    min: 0
+    max: 1000000
+    required: false
+    help:
+      zh_Hans: |
+        跨完整智能体循环（推理+工具调用+工具结果+最终输出）下发给模型的建议性 token 预算。这是"建议"（模型可见并据此自我调度），不是硬上限；真正的硬上限由 max_tokens 控制。
+        · 0（默认）：不发送该字段 → 模型看不到预算倒计时，按 max_tokens 自由发挥，适合质量优先的开放式任务。这不是"无上限"，而是"不启用预算建议"。
+        · <20000：插件会静默忽略（API 要求最小 20000，避免 400）。
+        · ≥20000：启用并自动追加 beta 头 `task-budgets-2026-03-13`；预算过紧可能导致模型潦草收尾。
+      en_US: |
+        Advisory token budget visible to the model across the full agentic loop (thinking + tool calls + tool results + final output). This is advisory — the hard per-request cap is `max_tokens`.
+        · 0 (default): field is not sent → model runs without a countdown, bounded only by `max_tokens`. Recommended for open-ended agentic tasks where quality matters more than speed. "0" means "no budget hint", NOT "unlimited".
+        · <20000: silently ignored by the plugin (API requires a minimum of 20000 and would otherwise return 400).
+        · ≥20000: enabled and the `task-budgets-2026-03-13` beta header is attached automatically. Overly tight budgets can cause the model to wrap up prematurely.
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    default: 128000
+    min: 1
+    max: 128000
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_ttl
+    label:
+      zh_Hans: 缓存有效期
+      en_US: Cache TTL
+    type: string
+    default: 5m
+    required: true
+    options:
+      - 5m
+      - 1h
+    help:
+      zh_Hans: 控制 prompt caching 的 cache_control.ttl。5m 为默认有效期；1h 可延长缓存有效期，但缓存写入成本更高。
+      en_US: Controls prompt caching cache_control.ttl. 5m is the default duration; 1h extends cache lifetime but has a higher cache write cost.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
+  - name: response_format
+    use_template: response_format
+  - name: json_schema
+    use_template: json_schema
+
+# https://claude.com/pricing#api
+pricing:
+  input: '10.00'
+  output: '50.00'
+  unit: '0.000001'
+  currency: USD

--- a/models/anthropic/models/llm/claude-mythos-5.yaml
+++ b/models/anthropic/models/llm/claude-mythos-5.yaml
@@ -1,0 +1,166 @@
+# yaml-language-server: $schema=../../schemas/model-schema.json
+
+# References:
+# https://platform.claude.com/docs/en/about-claude/models/overview.md
+# https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5.md
+# https://platform.claude.com/docs/en/resources/overview.md
+# https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking.md
+# https://platform.claude.com/docs/en/build-with-claude/effort.md
+# https://platform.claude.com/docs/en/about-claude/models/migration-guide.md
+model: claude-mythos-5
+label:
+  en_US: claude-mythos-5
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: thinking_display
+    label:
+      zh_Hans: 推理内容展示
+      en_US: Thinking Display
+    type: string
+    default: summarized
+    required: false
+    options:
+      - omitted
+      - summarized
+    help:
+      zh_Hans: Claude Mythos 5 的 adaptive thinking 始终开启。此参数仅控制响应中推理内容的展示方式：omitted 为官方默认值（响应中不返回 thinking 文本）；summarized 返回摘要化的推理过程，便于在前端展示思考进度。
+      en_US: |
+        Claude Mythos 5 always runs with adaptive thinking. This only controls how thinking content is exposed in the response: `omitted` is the official default (thinking text not returned); `summarized` returns summarized reasoning so clients can display progress.
+  - name: effort
+    label:
+      zh_Hans: 推理投入等级
+      en_US: Effort
+    type: string
+    default: high
+    required: false
+    options:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    help:
+      zh_Hans: 通过 output_config.effort 控制智能/token 消耗的权衡。xhigh 推荐用于编码与智能体场景，high 是智能敏感场景的最低建议值；low 与 medium 适合延迟或成本敏感场景。
+      en_US: Controls the intelligence vs. token cost trade-off via output_config.effort. Use `xhigh` for coding and agentic tasks; `high` is the minimum recommendation for intelligence-sensitive tasks; `low`/`medium` for latency- or cost-sensitive tasks.
+  - name: task_budget
+    label:
+      zh_Hans: 任务预算
+      en_US: Task Budget
+    type: int
+    default: 0
+    min: 0
+    max: 1000000
+    required: false
+    help:
+      zh_Hans: |
+        跨完整智能体循环（推理+工具调用+工具结果+最终输出）下发给模型的建议性 token 预算。这是"建议"（模型可见并据此自我调度），不是硬上限；真正的硬上限由 max_tokens 控制。
+        · 0（默认）：不发送该字段 → 模型看不到预算倒计时，按 max_tokens 自由发挥，适合质量优先的开放式任务。这不是"无上限"，而是"不启用预算建议"。
+        · <20000：插件会静默忽略（API 要求最小 20000，避免 400）。
+        · ≥20000：启用并自动追加 beta 头 `task-budgets-2026-03-13`；预算过紧可能导致模型潦草收尾。
+      en_US: |
+        Advisory token budget visible to the model across the full agentic loop (thinking + tool calls + tool results + final output). This is advisory — the hard per-request cap is `max_tokens`.
+        · 0 (default): field is not sent → model runs without a countdown, bounded only by `max_tokens`. Recommended for open-ended agentic tasks where quality matters more than speed. "0" means "no budget hint", NOT "unlimited".
+        · <20000: silently ignored by the plugin (API requires a minimum of 20000 and would otherwise return 400).
+        · ≥20000: enabled and the `task-budgets-2026-03-13` beta header is attached automatically. Overly tight budgets can cause the model to wrap up prematurely.
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    default: 128000
+    min: 1
+    max: 128000
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_ttl
+    label:
+      zh_Hans: 缓存有效期
+      en_US: Cache TTL
+    type: string
+    default: 5m
+    required: true
+    options:
+      - 5m
+      - 1h
+    help:
+      zh_Hans: 控制 prompt caching 的 cache_control.ttl。5m 为默认有效期；1h 可延长缓存有效期，但缓存写入成本更高。
+      en_US: Controls prompt caching cache_control.ttl. 5m is the default duration; 1h extends cache lifetime but has a higher cache write cost.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
+  - name: response_format
+    use_template: response_format
+  - name: json_schema
+    use_template: json_schema
+
+# https://claude.com/pricing#api
+pricing:
+  input: '10.00'
+  output: '50.00'
+  unit: '0.000001'
+  currency: USD
+
+# Further testing is needed.
+deprecated: true

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -172,15 +172,21 @@ class PromptCachingHandler:
 class AnthropicLargeLanguageModel(LargeLanguageModel):
     PROMPT_CACHING_TTL_PARAMETER = "prompt_caching_ttl"
     VALID_PROMPT_CACHING_TTLS = {"5m", "1h"}
-    # Models that enforce Opus 4.7+ breaking changes:
+    # Models that enforce the Opus 4.7+ Messages API shape:
     #   - sampling params (temperature/top_p/top_k) rejected with 400
     #   - extended thinking (thinking.budget_tokens) rejected with 400 — adaptive only
     #   - assistant prefill rejected with 400
     #   - thinking content omitted by default — opt in via thinking.display=summarized
     #   - effort / task_budget delivered via output_config
-    OPUS_4_7_PLUS_MODELS: tuple[str, ...] = (
+    ADAPTIVE_THINKING_MODELS: tuple[str, ...] = (
         "claude-opus-4-7",
         "claude-opus-4-8",
+        "claude-fable-5",
+        "claude-mythos-5",
+    )
+    ALWAYS_ON_ADAPTIVE_THINKING_MODELS: tuple[str, ...] = (
+        "claude-fable-5",
+        "claude-mythos-5",
     )
 
     def __init__(self, model_schemas=None):
@@ -196,9 +202,16 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         self._message_flow_cache_threshold: int = 0
         self._prompt_cache_ttl: Optional[str] = None
 
-    def _is_opus_4_7_plus(self, model: str) -> bool:
+    def _uses_adaptive_thinking(self, model: str) -> bool:
         model_id = (model or "").lower()
-        return any(model_id.startswith(prefix) for prefix in self.OPUS_4_7_PLUS_MODELS)
+        return any(model_id.startswith(prefix) for prefix in self.ADAPTIVE_THINKING_MODELS)
+
+    def _has_always_on_adaptive_thinking(self, model: str) -> bool:
+        model_id = (model or "").lower()
+        return any(
+            model_id.startswith(prefix)
+            for prefix in self.ALWAYS_ON_ADAPTIVE_THINKING_MODELS
+        )
 
     def _predefined_model_has_parameter(self, model: str, parameter_name: str) -> bool:
         for model_schema in self.model_schemas:
@@ -251,7 +264,8 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         This allows users to use any Anthropic-compatible model name
         (e.g. from third-party proxies) without being limited to predefined models.
         """
-        is_opus_4_7_plus = self._is_opus_4_7_plus(model)
+        uses_adaptive_thinking = self._uses_adaptive_thinking(model)
+        always_on_adaptive_thinking = self._has_always_on_adaptive_thinking(model)
 
         parameter_rules: list[ParameterRule] = [
             ParameterRule(
@@ -263,16 +277,20 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 label=I18nObject(en_us="Max Tokens", zh_hans="最大标记"),
                 type=ParameterType.INT,
             ),
-            ParameterRule(
-                name="thinking",
-                label=I18nObject(en_us="Thinking Mode", zh_hans="推理模式"),
-                type=ParameterType.BOOLEAN,
-                default=False,
-            ),
         ]
 
-        if is_opus_4_7_plus:
-            # Opus 4.7+ uses adaptive thinking + output_config(effort/task_budget).
+        if not always_on_adaptive_thinking:
+            parameter_rules.append(
+                ParameterRule(
+                    name="thinking",
+                    label=I18nObject(en_us="Thinking Mode", zh_hans="推理模式"),
+                    type=ParameterType.BOOLEAN,
+                    default=False,
+                )
+            )
+
+        if uses_adaptive_thinking:
+            # These models use adaptive thinking + output_config(effort/task_budget).
             # temperature/top_p/top_k/thinking_budget are rejected with 400.
             parameter_rules.extend([
                 ParameterRule(
@@ -397,15 +415,16 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         task_budget = int(model_parameters.pop("task_budget", 0) or 0)
         context_1m = model_parameters.pop("context_1m", False)
 
-        is_opus_4_7_plus = self._is_opus_4_7_plus(model)
+        uses_adaptive_thinking = self._uses_adaptive_thinking(model)
+        always_on_adaptive_thinking = self._has_always_on_adaptive_thinking(model)
 
-        if is_opus_4_7_plus:
-            # Opus 4.7 rejects non-default sampling params with 400; drop unconditionally.
+        if uses_adaptive_thinking:
+            # These models reject non-default sampling params with 400; drop unconditionally.
             for key in ("temperature", "top_p", "top_k"):
                 model_parameters.pop(key, None)
 
-            if thinking:
-                # Extended thinking removed on Opus 4.7 — adaptive is the only supported mode.
+            if thinking or always_on_adaptive_thinking:
+                # Manual budgeted thinking is removed; Fable/Mythos always run adaptive thinking.
                 extra_model_kwargs["thinking"] = {
                     "type": "adaptive",
                     "display": thinking_display or "omitted",
@@ -436,9 +455,9 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 for key in ("temperature", "top_p", "top_k"):
                     model_parameters.pop(key, None)
 
-        # 1M context is GA / native on Opus 4.7+ (no opt-in header). Older models
+        # 1M context is GA / native on adaptive-thinking models here (no opt-in header). Older models
         # (e.g. Sonnet 4) still need the `context-1m-2025-08-07` beta header to opt in.
-        if context_1m and not is_opus_4_7_plus:
+        if context_1m and not uses_adaptive_thinking:
             if "anthropic-beta" in extra_headers:
                 extra_headers["anthropic-beta"] += ",context-1m-2025-08-07"
             else:
@@ -728,8 +747,8 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             stop.append("```\n")
         if "\n```" not in stop:
             stop.append("\n```")
-        # Opus 4.7+ rejects assistant prefill with 400 — rely on system prompt only.
-        supports_prefill = not self._is_opus_4_7_plus(model)
+        # Adaptive-thinking models here reject assistant prefill with 400 — rely on system prompt only.
+        supports_prefill = not self._uses_adaptive_thinking(model)
 
         if len(prompt_messages) > 0 and isinstance(
             prompt_messages[0], SystemPromptMessage
@@ -798,7 +817,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 break
         
         if has_thinking_blocks:
-            if self._is_opus_4_7_plus(model):
+            if self._uses_adaptive_thinking(model):
                 count_tokens_args["thinking"] = {"type": "adaptive"}
             else:
                 count_tokens_args["thinking"] = {

--- a/models/anthropic/pyproject.toml
+++ b/models/anthropic/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "anthropic>=0.104.0",
+    "anthropic>=0.108.0",
     "dify_plugin>=0.9.0",
     "httpx>=0.28.1",
     "pillow>=12.2.0",

--- a/models/anthropic/schemas/model-schema.json
+++ b/models/anthropic/schemas/model-schema.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jhlfund.com/schemas/dify-model.yaml.json",
+  "title": "Dify Plugin Model Configuration",
+  "description": "JSON Schema for Dify plugin model definition YAML files (AIModelEntity). Provides auto-completion and validation for model manifests under models/<type>/*.yaml.",
+  "type": "object",
+  "required": ["model", "model_type", "model_properties"],
+  "additionalProperties": false,
+  "properties": {
+    "model": {
+      "type": "string",
+      "description": "Unique model identifier (e.g. 'gpt-4o', 'gpt-image-2')."
+    },
+    "label": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Fallback label string (treated as en_US)."
+        },
+        {
+          "$ref": "#/definitions/I18nObject"
+        }
+      ],
+      "description": "Human-readable model name. Auto-filled from 'model' when omitted."
+    },
+    "model_type": {
+      "type": "string",
+      "enum": [
+        "llm",
+        "text-embedding",
+        "rerank",
+        "speech2text",
+        "moderation",
+        "tts",
+        "text2img"
+      ],
+      "description": "The functional category of this model."
+    },
+    "features": {
+      "type": "array",
+      "description": "Capabilities this model supports.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "tool-call",
+          "multi-tool-call",
+          "agent-thought",
+          "vision",
+          "stream-tool-call",
+          "document",
+          "video",
+          "audio",
+          "structured-output",
+          "polling"
+        ]
+      }
+    },
+    "fetch_from": {
+      "type": "string",
+      "enum": ["predefined-model", "customizable-model"],
+      "default": "predefined-model",
+      "description": "Whether this model is bundled (predefined) or user-defined (customizable)."
+    },
+    "deprecated": {
+      "type": "boolean",
+      "default": false,
+      "description": "Mark the model as deprecated."
+    },
+    "model_properties": {
+      "type": "object",
+      "description": "Model-type-specific properties. Keys are fixed enums; values depend on the key.",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["chat", "completion"],
+          "description": "(LLM only) Interaction mode: 'chat' for conversational, 'completion' for single-turn."
+        },
+        "context_size": {
+          "type": "integer",
+          "description": "Maximum context window in tokens (e.g. 65536, 131072)."
+        },
+        "max_chunks": {
+          "type": "integer",
+          "description": "(text-embedding) Maximum number of chunks."
+        },
+        "file_upload_limit": {
+          "type": "integer",
+          "description": "Maximum number of files allowed in a single upload."
+        },
+        "supported_file_extensions": {
+          "type": "array",
+          "description": "List of supported file extensions (e.g. ['.pdf', '.txt']).",
+          "items": { "type": "string" }
+        },
+        "max_characters_per_chunk": {
+          "type": "integer",
+          "description": "(text-embedding) Max characters per chunk."
+        },
+        "default_voice": {
+          "type": "string",
+          "description": "(TTS) Default voice identifier."
+        },
+        "voices": {
+          "type": "array",
+          "description": "(TTS) List of available voice objects.",
+          "items": { "type": "object" }
+        },
+        "word_limit": {
+          "type": "integer",
+          "description": "(TTS) Maximum words per request."
+        },
+        "audio_type": {
+          "type": "string",
+          "description": "(TTS) Output audio format (e.g. 'mp3', 'wav')."
+        },
+        "max_workers": {
+          "type": "integer",
+          "description": "(TTS) Max concurrency workers."
+        }
+      },
+      "additionalProperties": false
+    },
+    "parameter_rules": {
+      "type": "array",
+      "description": "List of tunable parameters exposed to end-users in Dify.",
+      "items": { "$ref": "#/definitions/ParameterRule" }
+    },
+    "pricing": {
+      "$ref": "#/definitions/PriceConfig",
+      "description": "Pricing configuration for this model."
+    }
+  },
+  "definitions": {
+    "I18nObject": {
+      "type": "object",
+      "description": "Internationalised label / help text.",
+      "required": ["en_US"],
+      "additionalProperties": false,
+      "properties": {
+        "en_US": {
+          "type": "string",
+          "description": "English (US) — mandatory."
+        },
+        "zh_Hans": {
+          "type": "string",
+          "description": "Simplified Chinese."
+        },
+        "pt_BR": {
+          "type": "string",
+          "description": "Brazilian Portuguese."
+        },
+        "ja_JP": {
+          "type": "string",
+          "description": "Japanese."
+        }
+      }
+    },
+    "ParameterRule": {
+      "type": "object",
+      "description": "A single tunable parameter exposed in the Dify UI.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Machine-readable parameter name (e.g. 'temperature')."
+        },
+        "use_template": {
+          "type": "string",
+          "enum": [
+            "temperature",
+            "top_p",
+            "top_k",
+            "presence_penalty",
+            "frequency_penalty",
+            "max_tokens",
+            "response_format",
+            "json_schema"
+          ],
+          "description": "Reuse a built-in parameter template. When set, template defaults (label, type, help, min, max, etc.) are auto-injected; you can still override any field individually."
+        },
+        "label": {
+          "oneOf": [
+            { "type": "string" },
+            { "$ref": "#/definitions/I18nObject" }
+          ],
+          "description": "Human-readable parameter label. Defaults to 'name' when omitted."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["float", "int", "string", "boolean", "text"],
+          "description": "Data type of the parameter. Required unless 'use_template' is provided."
+        },
+        "help": {
+          "oneOf": [
+            { "type": "string" },
+            { "$ref": "#/definitions/I18nObject" }
+          ],
+          "description": "Tooltip / helper text shown in the UI."
+        },
+        "required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the user must provide a value for this parameter."
+        },
+        "default": {
+          "description": "Default value used when the user does not override it."
+        },
+        "min": {
+          "type": "number",
+          "description": "Minimum allowed value (numeric parameters only)."
+        },
+        "max": {
+          "type": "number",
+          "description": "Maximum allowed value (numeric parameters only)."
+        },
+        "precision": {
+          "type": "integer",
+          "description": "Number of decimal places to keep (float parameters only)."
+        },
+        "options": {
+          "type": "array",
+          "description": "Allowed string values (enum-like) for 'string' or 'text' parameters.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "PriceConfig": {
+      "type": "object",
+      "description": "Per-token (or per-unit) pricing information.",
+      "required": ["input", "unit", "currency"],
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "type": "string",
+          "description": "Input-side price per 'unit' tokens (e.g. '0.0015'). Use string to preserve Decimal precision."
+        },
+        "output": {
+          "type": "string",
+          "description": "Output-side price per 'unit' tokens (e.g. '0.002'). Omit if not applicable (e.g. embedding)."
+        },
+        "unit": {
+          "type": "string",
+          "description": "The divisor that 'input'/'output' map to. E.g. '0.000001' means the price is per 1 000 000 tokens.",
+          "examples": ["0.000001", "0.001", "1"]
+        },
+        "currency": {
+          "type": "string",
+          "description": "ISO currency code.",
+          "examples": ["USD", "CNY"]
+        }
+      }
+    }
+  }
+}

--- a/models/anthropic/uv.lock
+++ b/models/anthropic/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.104.0"
+version = "0.108.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -25,9 +25,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/01/8bfa68b886aa436775325a108700f7da39e290870199ce9251934de3e4aa/anthropic-0.104.0.tar.gz", hash = "sha256:1ae8ef4709e90cc2068c8e8a63c1ecb63cc5360d325a4bef8b296aad76148be3", size = 849329, upload-time = "2026-05-21T20:02:05.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/c7/d7f6d2e3975893958081f0282751217757333a3830d0d95859023d7006d0/anthropic-0.108.0.tar.gz", hash = "sha256:91b70253debb477a99f7ca43dac3f71e52207db79d4b06f104080b8dd1693e3b", size = 909409, upload-time = "2026-06-09T16:37:43.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/6c/595f1893352dbb4d88f1c2f0983296638783936b2063564aca9abb189990/anthropic-0.104.0-py3-none-any.whl", hash = "sha256:18f73ba3429aab237cdd146a486d20b4da3c008fb4a3ba83f237b27793e884c7", size = 832920, upload-time = "2026-05-21T20:02:07.853Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/40/75a937ddd8f230ec129d27de60df69ce8afcab1d0b15f7d651a5a95fac8a/anthropic-0.108.0-py3-none-any.whl", hash = "sha256:bdee7b14c13cf5a60b2c8ae0cf195720e0ea7fd8ab90df5a3899c50f1c91c4be", size = 870079, upload-time = "2026-06-09T16:37:44.895Z" },
 ]
 
 [[package]]
@@ -198,7 +198,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.104.0" },
+    { name = "anthropic", specifier = ">=0.108.0" },
     { name = "dify-plugin", specifier = ">=0.9.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pillow", specifier = ">=12.2.0" },
@@ -435,11 +435,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1400,29 +1400,35 @@ wheels = [
 
 [[package]]
 name = "zope-interface"
-version = "8.4"
+version = "8.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/65/34a6e6e4dfa260c4c55ee02bb2fc53625e126ff0181485286cf0c9d453d6/zope_interface-8.4.tar.gz", hash = "sha256:9dbee7925a23aa6349738892c911019d4095a96cff487b743482073ecbc174a8", size = 257736, upload-time = "2026-04-25T07:22:10.439Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/dc/50550cfcbb2ea3cbca5f1d7ed05c8aa840f831a0f2d63aec0a953f7c590e/zope_interface-8.5.tar.gz", hash = "sha256:7a3ba1c5877f0f3e3906b02ddf793abed2becc2948116414ce0e1dd820b68d6d", size = 257957, upload-time = "2026-05-26T06:50:14.574Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/96/0017b980424125cf98a9851d8fd3e24939818b7a82ecdd19ae672bb2413f/zope_interface-8.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:84064876ed96ddd0744e3ad5d37134c758d77885e54113567792671405a02bac", size = 211604, upload-time = "2026-04-25T07:28:08.13Z" },
-    { url = "https://files.pythonhosted.org/packages/59/4c/2cf5c45477fdd58a2c786d0c0d1817cbaaff8743d98ae72c643c4fe3be7b/zope_interface-8.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:81ed23698bfb588c48b1756129814b890febac971ff6c8a414f82601773145bb", size = 211783, upload-time = "2026-04-25T07:28:10.028Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/8c/efabdafc25ed44ef9c1084aad9870bb6c2c9b78e542684efe6865c0f0067/zope_interface-8.4-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e0b9d7e958657fad414f8272afcdf0b8a873fbbb2bb6a6287232d2f11a232bf8", size = 264752, upload-time = "2026-04-25T07:28:11.773Z" },
-    { url = "https://files.pythonhosted.org/packages/53/5a/c4d52c58d5fee4ff67cc02f0dec24d0e84428520f67a52f1e4086f0e7779/zope_interface-8.4-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eef0a49e041f4dc4d2a6ab894b4fd0c5354e0e8037e731fb953531e59b0d3d33", size = 269829, upload-time = "2026-04-25T07:28:13.988Z" },
-    { url = "https://files.pythonhosted.org/packages/16/d2/df8f339c93bb5adee695546ba90d0daa2917338a4792281f6b8e652a9328/zope_interface-8.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b302f955c36e924e1f4fe70dd9105ff06235857861c6ae72c3b10b016aeee99", size = 269452, upload-time = "2026-04-25T07:28:16.403Z" },
-    { url = "https://files.pythonhosted.org/packages/17/4b/bd97b1a21bb2c16d66a42f6c7a43c0a5afcfaf14c68d3b7d2ee6afb28e52/zope_interface-8.4-cp312-cp312-win_amd64.whl", hash = "sha256:4ae6a1e111642dbf724f635424dcaf5a5c8abbde49eac3f452f5323ffaa10232", size = 214420, upload-time = "2026-04-25T07:28:18.405Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/85/1477f23cf3b0476608ca987b4338f91439abb5b96564ac26b26d2cde38fd/zope_interface-8.4-cp312-cp312-win_arm64.whl", hash = "sha256:2e9e4aa33b76877af903d5532545e64d24ade0f6f80d9d1a31e6efcea76a60bc", size = 212992, upload-time = "2026-04-25T07:28:20.48Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/6a/a08c62bc1fa0e34fe7b8b401646cba4817427c716bfbef6cc88937cd327f/zope_interface-8.4-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:cd55965d715413038774aead54851bc3dbdd74a69f3ce30252182a94407b9905", size = 211924, upload-time = "2026-04-25T07:28:22.219Z" },
-    { url = "https://files.pythonhosted.org/packages/50/30/2011f17e00ff078658bc317e1f7eccd7843fc1ce60695b665b0a52c45c1b/zope_interface-8.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0d88c1f106a4f06e074a3ada2d20f4a602e3f2871c4f55726ed5d91e94ec19b1", size = 211995, upload-time = "2026-04-25T07:28:24.107Z" },
-    { url = "https://files.pythonhosted.org/packages/25/f3/a16fe884571cfa89271412dbb40def6d6865824428d1e14785a82795100c/zope_interface-8.4-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:36c575356732d59ffd3279ad67e302a6fe517e67db5b061b36b377ee0fa016c4", size = 264443, upload-time = "2026-04-25T07:28:26.401Z" },
-    { url = "https://files.pythonhosted.org/packages/83/88/e08923fcd8a8c8704af05a90418b07cd897ac90865925b37d7ad8139adfa/zope_interface-8.4-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:29f09ec8bda65f7b30294328070070a2590b90f252f834ee0817cdb0e2c35f6a", size = 269626, upload-time = "2026-04-25T07:28:28.423Z" },
-    { url = "https://files.pythonhosted.org/packages/27/67/96c94cd307f9946d0b0f03402a335f7aae7b4f0b129b5734cc56cc78cb65/zope_interface-8.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2bc388cebcb753d21eaf2a0481fd6f0ce6840a47300a40dcec0b56bac27d0f97", size = 269583, upload-time = "2026-04-25T07:28:30.434Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/d4/7e9fcc8bb0dba5d023b9fca92035d68c018457cc550e9d51746670b76a6b/zope_interface-8.4-cp313-cp313-win_amd64.whl", hash = "sha256:3e5866917ccb57d929e515a1136d729bd3fa4f367965fb16e38a4bc72cb05521", size = 214422, upload-time = "2026-04-25T07:28:32.201Z" },
-    { url = "https://files.pythonhosted.org/packages/16/26/b0bcde302f6a4c155d047a8ab5cba1003363031919d6e8f3bcdc139c28a6/zope_interface-8.4-cp313-cp313-win_arm64.whl", hash = "sha256:f1f854bef8bc137519e4413bcc1322d55faad28b20b3ca39f7bec49d2f1b26df", size = 213029, upload-time = "2026-04-25T07:28:34.677Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/d5/ca60c8b404b303d9490e1417430a5198a77557dbeb17c1cb31616e432318/zope_interface-8.4-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:7cbb887fdbfaacb4c362dbb487033551646e28013ad5ffe72e96eb260003a1a1", size = 212012, upload-time = "2026-04-25T07:28:36.88Z" },
-    { url = "https://files.pythonhosted.org/packages/83/64/6bb9f54250c817e24b39e986f173b6cd21ff658bec6c6cc0baad05d761e4/zope_interface-8.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a5638c6be715116d3453e6d099c299c6844d54810de7445ce116424e905ede06", size = 212071, upload-time = "2026-04-25T07:28:38.742Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/cf/42851262e102723058019dc7d0b48210b85a935f79ae32ce60ddccc2e8fb/zope_interface-8.4-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:b8147b40bfcd53803870a9519e0879ff066aeecc2fcff8295663c1b17fc38dc2", size = 266075, upload-time = "2026-04-25T07:28:41.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/a7/e48c79b836f6f0a2c219288e2ec343517f90e95c93de5435a8a23918bf20/zope_interface-8.4-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:049ba3c7b38cc400ae08e011617635706e0f442e1d075db1b015246fcbf6091e", size = 269127, upload-time = "2026-04-25T07:28:42.868Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/40/0e26f24d3a2f34f0de2cfeaab6458a865284d9d1fa317ab78913aa1f7322/zope_interface-8.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9c4ac009c2c8e43283842f80387c4d4b41bcbc293391c3b9ab71532ae1ccc301", size = 269446, upload-time = "2026-04-25T07:28:44.97Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d5/20310601450367fc35fa28b0544c98d0347b8cc25eaf106a2c4cc36841e1/zope_interface-8.4-cp314-cp314-win_amd64.whl", hash = "sha256:4713bf651ec36e7eea49d2ace4f0e89bec2b33a339674874b1121f2537edc62a", size = 215199, upload-time = "2026-04-25T07:28:47.146Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/00/0d22ce75126e31f81baa5889e2a40aad37c8e34d1220cf8b18d744f2b5d9/zope_interface-8.4-cp314-cp314-win_arm64.whl", hash = "sha256:d934497c4b72d5f528d2b5ebe9b8b5a7004b5877948ebd4ea00c2432fb27178f", size = 213178, upload-time = "2026-04-25T07:28:48.868Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/b84123a948f3162a34623e188922827cd845244fdd043ed20f8d02228caa/zope_interface-8.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8e6ee90c2e6de7c37058d5fa41f123c8b13a312db8d1e0fb5840d7f4bcdff9c9", size = 212165, upload-time = "2026-05-26T06:49:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/cbceec44f1b27208a76c1a688c131302685852406a23df5aab68324109cc/zope_interface-8.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c1adc90d3576b3b4c4de4953e6002c37bef28b78d7fa54c1bbfd0c50f022fe7c", size = 212341, upload-time = "2026-05-26T06:49:28.182Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c3/005032195ff3b210c139b7c560ed5c534e844b0907d8e44d2b3d8919305e/zope_interface-8.5-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e6347b8d8d12c5eca6502450a92be30079b7acfade2c4f693efa0deb8871b06e", size = 265296, upload-time = "2026-05-26T06:49:29.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/66/1036543d6a66bc04c19df3cf650f3ad938a002ab0a443c24e23e8de5e8b9/zope_interface-8.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e970dabea777a24b0b0bbf9dae3ab75ce8b2d8e948edf4875627034b21f3560", size = 270689, upload-time = "2026-05-26T06:49:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4c/8b56259558cace4414e753ca6740396a1f59d4a95ddb55b4658600408670/zope_interface-8.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0b48ccadaa9839e09ff81e969703cecb3f402c813bfe8b958652e699bea69f5", size = 270280, upload-time = "2026-05-26T06:49:33.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ea/649908c83aa8fdb7faf2ddca4d3cf6fb8f2157121267dc56e8f72681e26c/zope_interface-8.5-cp312-cp312-win_amd64.whl", hash = "sha256:e0e311f1277468c08fd59a2b41f71b43d25dff639789d364747acd1705c0df6e", size = 215019, upload-time = "2026-05-26T06:49:35.607Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/97/da13037b4c563e4df32eedbc819f8c00b754af494f68211e3dffd48d52da/zope_interface-8.5-cp312-cp312-win_arm64.whl", hash = "sha256:652b73107a04159ec6c020db6c1543d4f1e8f4d069bd2aac88a947820923517b", size = 213569, upload-time = "2026-05-26T06:49:37.317Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8c/4c15755d701f2ec0e80d64a18e1ebaf5be2c584c0ec153fd516f5d13eada/zope_interface-8.5-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:28e80457c134d1fa57a7d758004dece348654e1b1467ac22dcdc20fc1d127c52", size = 212512, upload-time = "2026-05-26T06:49:38.996Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/4360c54c465db042cc8fbeeec92abac28b4cedbf6ba63c1f092fd08a190f/zope_interface-8.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09495ce9d559c06b70f2d4855b3e4f48a822a9ddc8be1d30c5b4e5be14ae1ace", size = 212541, upload-time = "2026-05-26T06:49:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a5/692a2b8d70f78e848793231d5fae5fecbf8d0cccd73430fdc34802a6d3c1/zope_interface-8.5-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:7849ad8fa90763cc1087f4dda78ca3a233e950b3e08fac7079297c9cafbbd7bb", size = 265191, upload-time = "2026-05-26T06:49:43.449Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8d/454a9cfc7a050c394ab4f11b3371f7897828b7415e096afff724637e65e0/zope_interface-8.5-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5578c9421ca409a1f39f153d6f7803e4cde01da592ec75a9ac5e1b777d18d33b", size = 270626, upload-time = "2026-05-26T06:49:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/db8409cfa3575b8e9b4800babd7d49f8228433cd1f0c56814bd0ada49c33/zope_interface-8.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e1bd7d96b4ca5fa311f54c9eac16dce4886b428c1531dbe06067763ccdf123b4", size = 270444, upload-time = "2026-05-26T06:49:47.025Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/df/a386940e41469ef615e100a216d8b386521e9e598817147f87932ca203c4/zope_interface-8.5-cp313-cp313-win_amd64.whl", hash = "sha256:0c8123d2a4dfde2a613c7cb772605477724782c20bc2e0ad1d9435376a6a44a3", size = 215021, upload-time = "2026-05-26T06:49:48.478Z" },
+    { url = "https://files.pythonhosted.org/packages/89/75/477eb5669b6b2a7a843decd1a075e9b1971a8720017654143a7183abd3d9/zope_interface-8.5-cp313-cp313-win_arm64.whl", hash = "sha256:6d02be14f3173c6c7288bc2fdf530090c01c3cf8764ad46c68024686f364278e", size = 213610, upload-time = "2026-05-26T06:49:50.01Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/19/5032e954827fdf02db2d2f49737ac4378bb9cfc2cd95a8f2e2a5ae2ec01a/zope_interface-8.5-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:ffaecf013251a89d0de6feb49a46eba48ad8cbbf8a40aeb6045e459e7bec6784", size = 212597, upload-time = "2026-05-26T06:49:51.63Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/53/3ef644012cf8a6a234a2d6134aab5a5c65ac5467c86296865501d4fbc406/zope_interface-8.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:126fa9d1c52295ae076d4cf968634f0a1826afa408a20808b57ff72877b8f69f", size = 212626, upload-time = "2026-05-26T06:49:53.236Z" },
+    { url = "https://files.pythonhosted.org/packages/32/67/bc8b4f465d388039255003e230c284a175cedf1203c692f23cb7bff64efe/zope_interface-8.5-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:3090e3a663d20194756a59a272e0c8508b889341e31d5894223331fe6b4f9b21", size = 266827, upload-time = "2026-05-26T06:49:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/eb/37d05b935ede53d79690fecc8d201440084418e590bcfc05f384451c7593/zope_interface-8.5-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9342fb74e2afefdb081bf1df727d209ea56995c6e13f5a0540e6d7aff4beafb8", size = 270139, upload-time = "2026-05-26T06:49:57.116Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/fd0c54579e2ce8dc6cf1a757903f3374bc6fbda929a46af9e0f53cb0e5f0/zope_interface-8.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6c54725d818f1b57a7efb8b16528326e1f3c257b602b32393fd255c45af8799d", size = 270338, upload-time = "2026-05-26T06:49:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1d/c420dcd777bb761067ea92879ac766694a5ca78608185f1aecea64cbfc11/zope_interface-8.5-cp314-cp314-win_amd64.whl", hash = "sha256:29d74febbae1afeb6834c4ccbf42e242a673c860060f09e53142825270456140", size = 215789, upload-time = "2026-05-26T06:50:00.405Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/50b5eb8f94e527edceac14f9955e58917424ea79bb572ddc18548561cbc2/zope_interface-8.5-cp314-cp314-win_arm64.whl", hash = "sha256:633c8c49396f38df030340797c533e9fe460d1b5d1e42d88e55e938e525f548c", size = 213757, upload-time = "2026-05-26T06:50:01.973Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6f/5d5f32c4dfcdb16ce2ec5363da686840f13c13e1a1214cb70b49e1cd6d9f/zope_interface-8.5-cp314-cp314t-macosx_10_9_x86_64.whl", hash = "sha256:133999820fdbae513c36c03d6f29ef87317aaa3edef39112222b155083664714", size = 213591, upload-time = "2026-05-26T06:50:03.529Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/55/de0c3459ff717fce3342f9a29464c281fdeb0d36c3171ee88d119d5f0650/zope_interface-8.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8bd75c96966e573232f0599deaff717564828031c7f05563ccc1ac35c5ee0304", size = 213733, upload-time = "2026-05-26T06:50:05.101Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/d97430abd5ae9677e8b9295b58720c0064a5b557dbb6b8bf5928484cf0d8/zope_interface-8.5-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:14b0e9799351d4c34fe99afd67f0cdd76e55ba15c66a98699d5fc22ea8241e08", size = 294905, upload-time = "2026-05-26T06:50:07.384Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ec/a0f8f3dad6e74992f4654bdd94802be0929eabca7b871cac3b6fbb5e961b/zope_interface-8.5-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0cd6a732ac84b94eb1ef9222a117347a27efd294ee16810ffdf7ecd307677ed5", size = 300885, upload-time = "2026-05-26T06:50:08.997Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/6881b48803a0ee8d23eb5efa30fce3ed218a2bd9de5758ce489d224fee81/zope_interface-8.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:798b7c87d0e59a7d5d086d642208d0d8700ff0d55c4029134b3c479c3bfb110f", size = 304672, upload-time = "2026-05-26T06:50:10.563Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0e/b4c01320859ff1d585438bc231fd60bd258d096359bccf6654fecdf0cffb/zope_interface-8.5-cp314-cp314t-win_amd64.whl", hash = "sha256:0fc3a9d45f114d27eaa1e53beeb144533689edca8a9f66505b1e8e8b3f075e42", size = 217241, upload-time = "2026-05-26T06:50:12.171Z" },
 ]


### PR DESCRIPTION
## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

Introduces support for the new Claude Fable 5 and Claude Mythos 5 models, which utilize adaptive thinking instead of manual thinking budgets.


## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


<img width="881" height="279" alt="PixPin_2026-06-10_03-38-12" src="https://github.com/user-attachments/assets/a4087f1e-e6ff-49dd-b9f5-558ed2f27c67" />



## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [ ] SaaS (cloud.dify.ai)
