### PR TITLE
fix(anthropic): fix Anthropic tool call message ordering for Dify compatibility

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.22
+version: 0.3.23

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -1429,17 +1429,31 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             content.extend(self.previous_thinking_blocks)
             content.extend(self.previous_redacted_thinking_blocks)
         
-        # Process tool calls or content
+        # Dify stores assistant text and tool calls separately; Anthropic expects the next
+        # user tool_result message to immediately follow the assistant tool_use turn.
+        # Keep assistant prose before tool_use so no text lands between tool_use and tool_result.
+        # https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
+        content.extend(self._create_assistant_text_contents(message))
         if message.tool_calls:
             content.extend(
                 self._create_tool_use_content(tool_call)
                 for tool_call in message.tool_calls
             )
-        if message.content:
-            if isinstance(message.content, str):
-                content.append(self._create_assistant_text_content(message.content))
         
         return {"role": "assistant", "content": content}
+
+    def _create_assistant_text_contents(self, message: AssistantPromptMessage) -> list[dict]:
+        if not message.content:
+            return []
+
+        if isinstance(message.content, str):
+            return [self._create_assistant_text_content(message.content)]
+
+        return [
+            self._create_assistant_text_content(cast(TextPromptMessageContent, content).data)
+            for content in message.content
+            if content.type == PromptMessageContentType.TEXT
+        ]
     
     def _create_tool_use_content(self, tool_call: AssistantPromptMessage.ToolCall) -> dict:
         """Create tool use content dict."""

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -1450,9 +1450,9 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             return [self._create_assistant_text_content(message.content)]
 
         return [
-            self._create_assistant_text_content(cast(TextPromptMessageContent, content).data)
+            self._create_assistant_text_content(content.data)
             for content in message.content
-            if content.type == PromptMessageContentType.TEXT
+            if isinstance(content, TextPromptMessageContent)
         ]
     
     def _create_tool_use_content(self, tool_call: AssistantPromptMessage.ToolCall) -> dict:


### PR DESCRIPTION
## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

The Anthropic API requires that assistant text content appears before tool_use blocks in the message history, especially when integrating with Dify which stores assistant text and tool calls separately. Previously, text content was appended after tool calls, violating this requirement and potentially causing errors.

This commit refactors the message creation logic to ensure assistant prose is always placed before tool_use content. It introduces a helper method `_create_assistant_text_contents` to handle both string and structured text content, ensuring correct ordering according to Anthropic's tool-use guidelines.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [ ] SaaS (cloud.dify.ai)
