### PR TITLE
feat(aws_tools): add batch S3 uploader/downloader (s3_files_uploader, s3_files_download)

### DIFF
--- a/tools/aws/README.md
+++ b/tools/aws/README.md
@@ -9,6 +9,8 @@ The tools based on the AWS Services.
 - AWS S3 Operator: AWS S3 Writer and Reader.
 - AWS S3 File Uploader: Upload a workflow file (file variable) to S3 and optionally return a presigned URL.
 - AWS S3 File Download: Download an S3 object as a Dify file variable for downstream nodes.
+- AWS S3 Batch File Uploader: Upload multiple workflow files (`input_files: files`) to S3 in a single invocation, with per-file presigned URLs and per-file failure isolation.
+- AWS S3 Batch File Download: Download multiple S3 objects (`s3_uris: array` of `s3://...` URIs) as Dify file variables in a single invocation, with per-URI failure isolation.
 - Content Moderation Guardrails: Content Moderation Guardrails utilizes the ApplyGuardrail API, a feature of Guardrails for Amazon Bedrock. This API is capable of evaluating input prompts and model responses for all Foundation Models (FMs), including those on Amazon Bedrock, custom FMs, and third-party FMs. By implementing this functionality, organizations can achieve centralized governance across all their generative AI applications, thereby enhancing control and consistency in content moderation.
 - AWS Bedrock Nova Canvas: A tool for generating and modifying images using AWS Bedrock's Nova Canvas model. Supports text-to-image, color-guided generation, image variation, inpainting, outpainting, and background removal. Input parameters reference https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html.
 - TranscribeASR: A tool for ASR (Automatic Speech Recognition) - https://github.com/aws-samples/dify-aws-tool.

--- a/tools/aws/manifest.yaml
+++ b/tools/aws/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.27
+version: 0.0.28
 type: plugin
 author: langgenius
 name: aws_tools

--- a/tools/aws/provider/aws_tools.yaml
+++ b/tools/aws/provider/aws_tools.yaml
@@ -19,6 +19,8 @@ tools:
   - tools/s3_operator.yaml
   - tools/s3_file_uploader.yaml
   - tools/s3_file_download.yaml
+  - tools/s3_files_uploader.yaml
+  - tools/s3_files_download.yaml
   - tools/apply_guardrail.yaml
   - tools/nova_canvas.yaml
   - tools/transcribe_asr.yaml

--- a/tools/aws/tools/s3_files_download.py
+++ b/tools/aws/tools/s3_files_download.py
@@ -142,10 +142,12 @@ class S3FilesDownload(Tool):
             return
 
         results: list[dict[str, Any]] = []
-        # Collect blob payloads to yield AFTER the json/text messages so that
-        # downstream nodes inspecting `files` see the full list at once. We
-        # still preserve input order.
-        blobs_to_yield: list[tuple[bytes, dict[str, Any]]] = []
+        # We yield blob payloads immediately inside the download loop so the
+        # plugin runner does not have to buffer N file payloads in memory at
+        # the same time (peak RSS scales with one file size, not the whole
+        # batch). The Dify plugin container has a 256 MB memory limit, which
+        # the buffer-then-flush approach could otherwise trip on a batch of
+        # large files.
 
         for index, s3_uri in enumerate(s3_uris):
             entry: dict[str, Any] = {"index": index, "s3_uri": s3_uri}
@@ -198,7 +200,11 @@ class S3FilesDownload(Tool):
                 "mime_type": content_type,
                 "s3_uri": s3_uri,
             }
-            blobs_to_yield.append((file_bytes, blob_meta))
+            # Yield the blob immediately so the previous file's bytes are
+            # eligible for GC before we read the next one. We still append
+            # the entry to `results` so the json/text aggregate messages
+            # emitted at the end carry the full ordered summary.
+            yield self.create_blob_message(file_bytes, meta=blob_meta)
             results.append(entry)
 
         ok_count = sum(1 for r in results if r.get("status") == "ok")
@@ -234,8 +240,6 @@ class S3FilesDownload(Tool):
         else:
             yield self.create_text_message("\n\n".join(text_lines))
 
-        # Emit successful blob payloads in input order. Failed entries simply
-        # produce no blob (downstream nodes can correlate via the json results
-        # list to see which indices succeeded).
-        for file_bytes, blob_meta in blobs_to_yield:
-            yield self.create_blob_message(file_bytes, meta=blob_meta)
+        # Blobs were already yielded inline during the download loop above
+        # to keep peak memory bounded by a single file's size; nothing else
+        # to flush here.

--- a/tools/aws/tools/s3_files_download.py
+++ b/tools/aws/tools/s3_files_download.py
@@ -1,0 +1,241 @@
+"""
+Location: tools/s3_files_download.py
+Purpose:  Batch-download multiple S3 objects as Dify file variables for downstream
+          workflow nodes.
+
+This tool is the array-input counterpart of ``s3_file_download``. It accepts a list
+of ``s3://bucket/key`` URIs (``s3_uris: array[string]``), fetches each object via
+boto3, and emits one Dify file per successful download in the same order as the
+input list, plus aggregated metadata as JSON and a per-line text summary.
+
+Per-URI failures do NOT abort the batch: each URI's outcome is captured in the
+``results`` list with ``status = "ok" | "failed"``. The whole invocation only
+emits a top-level error when **every** URI fails.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+import boto3
+from botocore.exceptions import ClientError
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+# ---------------------------------------------------------------------------
+# Inline credential helpers (kept self-contained on purpose so this tool does
+# not rely on a shared utils/ module that the rest of this repo does not use).
+# Mirrors the helpers in the single-URI s3_file_download for consistency.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_aws_credentials(
+    tool: Any, tool_parameters: dict[str, Any]
+) -> dict[str, Optional[str]]:
+    runtime_credentials = getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+
+    aws_access_key_id = tool_parameters.get("aws_access_key_id") or runtime_credentials.get(
+        "aws_access_key_id"
+    )
+    aws_secret_access_key = tool_parameters.get("aws_secret_access_key") or runtime_credentials.get(
+        "aws_secret_access_key"
+    )
+    aws_session_token = tool_parameters.get("aws_session_token")
+    aws_region = (
+        tool_parameters.get("aws_region") or runtime_credentials.get("aws_region") or "us-east-1"
+    )
+
+    return {
+        "aws_access_key_id": aws_access_key_id,
+        "aws_secret_access_key": aws_secret_access_key,
+        "aws_session_token": aws_session_token,
+        "aws_region": aws_region,
+    }
+
+
+def _build_boto3_client_kwargs(credentials: dict[str, Optional[str]]) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if credentials.get("aws_region"):
+        kwargs["region_name"] = credentials["aws_region"]
+    if credentials.get("aws_access_key_id") and credentials.get("aws_secret_access_key"):
+        kwargs["aws_access_key_id"] = credentials["aws_access_key_id"]
+        kwargs["aws_secret_access_key"] = credentials["aws_secret_access_key"]
+        if credentials.get("aws_session_token"):
+            kwargs["aws_session_token"] = credentials["aws_session_token"]
+    return kwargs
+
+
+def _normalize_s3_uris(raw: Any) -> list[str]:
+    """Coerce ``s3_uris`` into a flat list of strings.
+
+    Dify passes ``array[string]`` parameters as a Python list, but be defensive
+    against a single string slipping through. Whitespace-only entries are
+    silently dropped.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        items = [raw]
+    elif isinstance(raw, list):
+        items = [str(item) for item in raw if item is not None]
+    else:
+        items = [str(raw)]
+    return [item.strip() for item in items if item and item.strip()]
+
+
+def _validate_s3_uri(uri: str) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Parse and validate an s3:// URI.
+
+    Returns ``(bucket, key, error_message)``. On success the error is ``None``.
+    On failure the bucket/key are ``None`` and the error string explains why.
+    """
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc or not parsed.path:
+        return None, None, "Invalid S3 URI format. Use s3://bucket/key"
+    bucket = parsed.netloc
+    key = parsed.path.lstrip("/")
+    if not key:
+        return None, None, "Invalid S3 URI: missing object key"
+    return bucket, key, None
+
+
+def _build_metadata_text(metadata: dict[str, Any]) -> str:
+    """Render a simple ``key: value`` block for a single result entry."""
+    lines = []
+    for key, value in metadata.items():
+        if value is None:
+            continue
+        lines.append(f"{key}: {value}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+
+class S3FilesDownload(Tool):
+    """Batch-download multiple S3 objects as Dify file variables.
+
+    The boto3 client is created once per ``_invoke`` call (not cached on
+    ``self``) for the same per-tenant safety reason as ``s3_file_download``.
+    Within a single invocation the client is reused across all URIs, which is
+    safe because all entries share the same credential bundle.
+    """
+
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+        """Download every input URI and emit aggregated files + metadata."""
+        try:
+            credentials = _resolve_aws_credentials(self, tool_parameters)
+            client_kwargs = _build_boto3_client_kwargs(credentials)
+            s3_client = boto3.client("s3", **client_kwargs)
+        except Exception as exc:  # pragma: no cover - boto3 init errors
+            yield self.create_text_message(f"Failed to initialize AWS client: {exc}")
+            return
+
+        s3_uris = _normalize_s3_uris(tool_parameters.get("s3_uris"))
+        if not s3_uris:
+            yield self.create_text_message("s3_uris parameter is required and must not be empty")
+            return
+
+        results: list[dict[str, Any]] = []
+        # Collect blob payloads to yield AFTER the json/text messages so that
+        # downstream nodes inspecting `files` see the full list at once. We
+        # still preserve input order.
+        blobs_to_yield: list[tuple[bytes, dict[str, Any]]] = []
+
+        for index, s3_uri in enumerate(s3_uris):
+            entry: dict[str, Any] = {"index": index, "s3_uri": s3_uri}
+
+            bucket, key, validation_error = _validate_s3_uri(s3_uri)
+            if validation_error:
+                entry["status"] = "failed"
+                entry["error"] = validation_error
+                results.append(entry)
+                continue
+
+            entry["bucket"] = bucket
+            entry["key"] = key
+
+            try:
+                response = s3_client.get_object(Bucket=bucket, Key=key)
+                file_bytes = response["Body"].read()
+            except ClientError as exc:
+                error_code = exc.response.get("Error", {}).get("Code")
+                if error_code == "NoSuchBucket":
+                    entry["error"] = f"Bucket '{bucket}' does not exist"
+                elif error_code == "NoSuchKey":
+                    entry["error"] = f"Object '{key}' does not exist in bucket '{bucket}'"
+                else:
+                    entry["error"] = exc.response.get("Error", {}).get("Message", str(exc))
+                entry["status"] = "failed"
+                results.append(entry)
+                continue
+            except Exception as exc:
+                entry["status"] = "failed"
+                entry["error"] = f"Failed to download S3 object: {exc}"
+                results.append(entry)
+                continue
+
+            filename = key.rstrip("/").split("/")[-1] if key else "downloaded_file"
+            if not filename:
+                filename = "downloaded_file"
+            content_type = response.get("ContentType") or "application/octet-stream"
+            entry["status"] = "ok"
+            entry["content_type"] = content_type
+            entry["content_length"] = response.get("ContentLength")
+            entry["etag"] = response.get("ETag")
+            entry["last_modified"] = (
+                response.get("LastModified").isoformat() if response.get("LastModified") else None
+            )
+            entry["filename"] = filename
+
+            blob_meta = {
+                "filename": filename,
+                "mime_type": content_type,
+                "s3_uri": s3_uri,
+            }
+            blobs_to_yield.append((file_bytes, blob_meta))
+            results.append(entry)
+
+        ok_count = sum(1 for r in results if r.get("status") == "ok")
+        failed_count = len(results) - ok_count
+
+        json_payload = {
+            "count": len(results),
+            "ok": ok_count,
+            "failed": failed_count,
+            "results": results,
+        }
+
+        text_lines: list[str] = []
+        for entry in results:
+            if entry.get("status") == "ok":
+                summary = _build_metadata_text(
+                    {
+                        "bucket": entry.get("bucket"),
+                        "key": entry.get("key"),
+                        "content_length": entry.get("content_length"),
+                    }
+                )
+                text_lines.append(summary)
+            else:
+                text_lines.append(
+                    f"FAILED [{entry.get('index')}] {entry.get('s3_uri')}: {entry.get('error', 'unknown error')}"
+                )
+
+        yield self.create_json_message(json_payload)
+
+        if ok_count == 0:
+            yield self.create_text_message("All downloads failed:\n" + "\n\n".join(text_lines))
+        else:
+            yield self.create_text_message("\n\n".join(text_lines))
+
+        # Emit successful blob payloads in input order. Failed entries simply
+        # produce no blob (downstream nodes can correlate via the json results
+        # list to see which indices succeeded).
+        for file_bytes, blob_meta in blobs_to_yield:
+            yield self.create_blob_message(file_bytes, meta=blob_meta)

--- a/tools/aws/tools/s3_files_download.yaml
+++ b/tools/aws/tools/s3_files_download.yaml
@@ -1,0 +1,78 @@
+identity:
+  name: s3_files_download
+  author: AWS
+  label:
+    en_US: AWS S3 Batch File Download
+    zh_Hans: AWS S3 批量文件下载
+    pt_BR: AWS S3 Batch File Download
+description:
+  human:
+    en_US: Download multiple S3 objects as Dify file variables in a single invocation.
+    zh_Hans: 在一次调用中批量下载多个 S3 对象，作为 Dify 文件变量供下游节点使用。
+    pt_BR: Faz download em lote de múltiplos objetos do S3 como variáveis de arquivo do Dify em uma única invocação.
+  llm: Batch fetch multiple S3 objects by URI and emit them as Dify files plus structured metadata for downstream nodes.
+parameters:
+  - name: aws_access_key_id
+    type: string
+    required: false
+    label:
+      en_US: AWS Access Key ID
+      zh_Hans: AWS Access Key ID
+      pt_BR: AWS Access Key ID
+    human_description:
+      en_US: Override the provider Access Key ID for this tool if needed.
+      zh_Hans: 当需要覆盖默认的 Access Key ID 时使用。
+      pt_BR: Sobrescreve o Access Key ID padrão da provider quando necessário.
+    form: form
+  - name: aws_secret_access_key
+    type: string
+    required: false
+    label:
+      en_US: AWS Secret Access Key
+      zh_Hans: AWS Secret Access Key
+      pt_BR: AWS Secret Access Key
+    human_description:
+      en_US: Override the provider Secret Access Key for this tool if needed.
+      zh_Hans: 当需要覆盖默认的 Secret Access Key 时使用。
+      pt_BR: Sobrescreve o Secret Access Key padrão da provider quando necessário.
+    form: form
+  - name: aws_session_token
+    type: string
+    required: false
+    label:
+      en_US: AWS Session Token
+      zh_Hans: AWS Session Token
+      pt_BR: AWS Session Token
+    human_description:
+      en_US: AWS session token for temporary credentials (STS). Only supported in tool parameters, not at provider level.
+      zh_Hans: 临时凭证（STS）的 session token。仅支持在工具参数中传入，provider 级别不支持。
+      pt_BR: Token de sessão da AWS para credenciais temporárias (STS). Só é suportado nos parâmetros da ferramenta, não no nível da provider.
+    form: form
+  - name: aws_region
+    type: string
+    required: false
+    label:
+      en_US: AWS Region
+      zh_Hans: AWS 区域
+      pt_BR: AWS Region
+    human_description:
+      en_US: Override the default AWS Region for this tool.
+      zh_Hans: 为该工具指定 AWS 区域，覆盖 provider 默认值。
+      pt_BR: Sobrescreve a região AWS padrão para esta ferramenta.
+    form: form
+  - name: s3_uris
+    type: array
+    required: true
+    label:
+      en_US: S3 URIs
+      zh_Hans: S3 URI 列表
+      pt_BR: URIs do S3
+    human_description:
+      en_US: A list of S3 URIs in the form s3://bucket/key. One Dify file is emitted per successfully downloaded URI, in input order.
+      zh_Hans: S3 URI 列表，每个元素形如 s3://bucket/key。每个成功下载的 URI 会按输入顺序生成一个 Dify 文件。
+      pt_BR: Lista de URIs do S3 no formato s3://bucket/key. Um arquivo Dify é emitido por URI baixado com sucesso, na ordem de entrada.
+    llm_description: A list of fully-qualified S3 URIs (s3://bucket/key) to download together in one invocation.
+    form: llm
+extra:
+  python:
+    source: tools/s3_files_download.py

--- a/tools/aws/tools/s3_files_uploader.py
+++ b/tools/aws/tools/s3_files_uploader.py
@@ -1,0 +1,271 @@
+"""
+Location: tools/s3_files_uploader.py
+Purpose:  Batch-upload multiple files received from a prior Dify workflow node to a
+          specified S3 bucket.
+
+This tool is the array-input counterpart of ``s3_file_uploader``. It consumes a list
+of binary assets (``input_files: array[file]``) from an upstream node and persists
+each one to Amazon S3, optionally returning a presigned ``GET`` URL per object.
+
+Per-file failures do NOT abort the batch: each file's outcome is captured in the
+``results`` list with ``status = "ok" | "failed"`` (and an ``error`` string on
+failure). The whole invocation only emits a top-level error message when **every**
+file fails (so downstream nodes see a clear failure signal).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Generator
+from typing import Any, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+# ---------------------------------------------------------------------------
+# Inline credential helpers (kept self-contained on purpose so this tool does
+# not rely on a shared utils/ module that the rest of this repo does not use).
+# Mirrors the helpers in the single-file s3_file_uploader so the two tools stay
+# byte-for-byte consistent on credential resolution rules.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_aws_credentials(
+    tool: Any, tool_parameters: dict[str, Any]
+) -> dict[str, Optional[str]]:
+    """Merge provider-level credentials with per-invocation tool parameters."""
+    runtime_credentials = getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+
+    aws_access_key_id = tool_parameters.get("aws_access_key_id") or runtime_credentials.get(
+        "aws_access_key_id"
+    )
+    aws_secret_access_key = tool_parameters.get("aws_secret_access_key") or runtime_credentials.get(
+        "aws_secret_access_key"
+    )
+    aws_session_token = tool_parameters.get("aws_session_token")
+    aws_region = (
+        tool_parameters.get("aws_region") or runtime_credentials.get("aws_region") or "us-east-1"
+    )
+
+    return {
+        "aws_access_key_id": aws_access_key_id,
+        "aws_secret_access_key": aws_secret_access_key,
+        "aws_session_token": aws_session_token,
+        "aws_region": aws_region,
+    }
+
+
+def _build_boto3_client_kwargs(credentials: dict[str, Optional[str]]) -> dict[str, Any]:
+    """Translate the credential bundle into kwargs accepted by ``boto3.client``."""
+    kwargs: dict[str, Any] = {}
+    if credentials.get("aws_region"):
+        kwargs["region_name"] = credentials["aws_region"]
+    if credentials.get("aws_access_key_id") and credentials.get("aws_secret_access_key"):
+        kwargs["aws_access_key_id"] = credentials["aws_access_key_id"]
+        kwargs["aws_secret_access_key"] = credentials["aws_secret_access_key"]
+        if credentials.get("aws_session_token"):
+            kwargs["aws_session_token"] = credentials["aws_session_token"]
+    return kwargs
+
+
+def _parse_presign_expiry(value: Any, default: int = 3600) -> int:
+    """Safely coerce the ``presign_expiry`` parameter to int (matches single-file tool)."""
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _sanitize_prefix(prefix: Optional[str]) -> str:
+    """Trim leading/trailing slashes from a prefix and tolerate empty input."""
+    if not prefix:
+        return ""
+    return prefix.strip("/ ")
+
+
+def _normalize_input_files(raw: Any) -> list[Any]:
+    """Coerce the ``input_files`` parameter into a flat list.
+
+    Dify passes ``array[file]`` parameters as a Python list, but be defensive in
+    case a single file slips through (e.g. an upstream node that does not
+    realize the parameter is an array). Treat ``None`` / empty as no input.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [item for item in raw if item is not None]
+    return [raw]
+
+
+def _derive_object_key(input_file: Any, key_prefix: str) -> str:
+    """Compute the final S3 object key for a single batch entry.
+
+    The single-file ``s3_file_uploader`` accepts a user-supplied ``object_key``
+    override, but for the batch tool a single override cannot apply to N files.
+    Instead we always derive the base key from the file's own ``filename`` (or
+    a UUID fallback) and optionally prepend ``key_prefix``.
+    """
+    requested_key = getattr(input_file, "filename", None)
+    fallback_key = (
+        getattr(input_file, "url", "").rstrip("/").split("/")[-1]
+        if getattr(input_file, "url", None)
+        else None
+    )
+    object_key = requested_key or fallback_key or f"dify-upload-{uuid.uuid4().hex}"
+    object_key = object_key.lstrip("/")
+    if key_prefix:
+        object_key = f"{key_prefix}/{object_key}"
+    return object_key
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+
+class S3FilesUploader(Tool):
+    """Batch-upload Dify file variables to S3.
+
+    The boto3 client is created once per ``_invoke`` call (not cached on
+    ``self``) for the same per-tenant safety reason as ``s3_file_uploader``.
+    Within a single invocation the client is reused across all batch entries,
+    which is safe because all entries share the same credential bundle.
+    """
+
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+        """Read all input files, upload them, and emit aggregated results."""
+        # Initialize the S3 client up front. A failure here aborts the whole
+        # batch because no per-file work can succeed without a client.
+        try:
+            credentials = _resolve_aws_credentials(self, tool_parameters)
+            client_kwargs = _build_boto3_client_kwargs(credentials)
+            s3_client = boto3.client("s3", **client_kwargs)
+        except Exception as exc:  # pragma: no cover - boto3 init errors
+            yield self.create_text_message(f"Failed to initialize AWS client: {exc}")
+            return
+
+        input_files = _normalize_input_files(tool_parameters.get("input_files"))
+        if not input_files:
+            yield self.create_text_message(
+                "input_files parameter is required and must not be empty"
+            )
+            return
+
+        bucket_name = tool_parameters.get("bucket_name")
+        if not bucket_name:
+            yield self.create_text_message("bucket_name parameter is required")
+            return
+
+        key_prefix = _sanitize_prefix(tool_parameters.get("key_prefix"))
+        generate_presign = bool(tool_parameters.get("generate_presign_url"))
+        expiry_seconds = _parse_presign_expiry(tool_parameters.get("presign_expiry"))
+
+        # Track keys we've already used so a duplicate filename in the same
+        # batch (e.g. two `image.png` from different upstream branches) does
+        # not silently overwrite. We append `-{n}` to disambiguate.
+        used_keys: set[str] = set()
+        results: list[dict[str, Any]] = []
+
+        for index, input_file in enumerate(input_files):
+            entry: dict[str, Any] = {
+                "index": index,
+                "bucket_name": bucket_name,
+            }
+
+            # Read bytes
+            try:
+                file_bytes: bytes = input_file.blob  # type: ignore[attr-defined]
+            except Exception as exc:
+                entry["status"] = "failed"
+                entry["error"] = f"Failed to read input file at index {index}: {exc}"
+                results.append(entry)
+                continue
+
+            base_key = _derive_object_key(input_file, key_prefix)
+            object_key = base_key
+            dedup_counter = 1
+            while object_key in used_keys:
+                # Insert the disambiguator before the final extension when one
+                # is present; otherwise append.
+                if "." in base_key.rsplit("/", 1)[-1]:
+                    head, _, tail = base_key.rpartition(".")
+                    object_key = f"{head}-{dedup_counter}.{tail}"
+                else:
+                    object_key = f"{base_key}-{dedup_counter}"
+                dedup_counter += 1
+            used_keys.add(object_key)
+            entry["object_key"] = object_key
+            entry["s3_uri"] = f"s3://{bucket_name}/{object_key}"
+
+            content_type = getattr(input_file, "mime_type", None) or "application/octet-stream"
+            try:
+                s3_client.put_object(
+                    Bucket=bucket_name,
+                    Key=object_key,
+                    Body=file_bytes,
+                    ContentType=content_type,
+                )
+            except ClientError as exc:
+                error_message = exc.response.get("Error", {}).get("Message", str(exc))
+                entry["status"] = "failed"
+                entry["error"] = f"Failed to upload to S3: {error_message}"
+                results.append(entry)
+                continue
+            except Exception as exc:
+                entry["status"] = "failed"
+                entry["error"] = f"Failed to upload to S3: {exc}"
+                results.append(entry)
+                continue
+
+            entry["status"] = "ok"
+
+            if generate_presign:
+                try:
+                    presigned_url = s3_client.generate_presigned_url(
+                        "get_object",
+                        Params={"Bucket": bucket_name, "Key": object_key},
+                        ExpiresIn=expiry_seconds,
+                    )
+                    entry["presigned_url"] = presigned_url
+                    entry["presign_expiry"] = expiry_seconds
+                except ClientError as exc:
+                    error_message = exc.response.get("Error", {}).get("Message", str(exc))
+                    # Upload itself succeeded; surface presign failure as a
+                    # secondary warning on the entry rather than failing the
+                    # whole upload.
+                    entry["presign_error"] = error_message
+
+            results.append(entry)
+
+        ok_count = sum(1 for r in results if r.get("status") == "ok")
+        failed_count = len(results) - ok_count
+
+        json_payload = {
+            "count": len(results),
+            "ok": ok_count,
+            "failed": failed_count,
+            "results": results,
+        }
+
+        # Build a per-line text summary: presigned URL preferred when available,
+        # otherwise s3_uri, otherwise an error marker.
+        text_lines: list[str] = []
+        for entry in results:
+            if entry.get("status") == "ok":
+                text_lines.append(entry.get("presigned_url") or entry.get("s3_uri", ""))
+            else:
+                text_lines.append(
+                    f"FAILED [{entry.get('index')}]: {entry.get('error', 'unknown error')}"
+                )
+
+        yield self.create_json_message(json_payload)
+
+        if ok_count == 0:
+            yield self.create_text_message("All uploads failed:\n" + "\n".join(text_lines))
+        else:
+            yield self.create_text_message("\n".join(text_lines))

--- a/tools/aws/tools/s3_files_uploader.py
+++ b/tools/aws/tools/s3_files_uploader.py
@@ -233,11 +233,17 @@ class S3FilesUploader(Tool):
                     )
                     entry["presigned_url"] = presigned_url
                     entry["presign_expiry"] = expiry_seconds
-                except ClientError as exc:
-                    error_message = exc.response.get("Error", {}).get("Message", str(exc))
-                    # Upload itself succeeded; surface presign failure as a
-                    # secondary warning on the entry rather than failing the
-                    # whole upload.
+                except Exception as exc:
+                    # generate_presigned_url is a client-side operation that
+                    # can raise ClientError, ParamValidationError, other
+                    # BotoCoreError subclasses, or unrelated runtime errors.
+                    # The upload itself already succeeded, so we surface the
+                    # presign failure as a per-entry warning (`presign_error`)
+                    # rather than failing the whole batch.
+                    if isinstance(exc, ClientError):
+                        error_message = exc.response.get("Error", {}).get("Message", str(exc))
+                    else:
+                        error_message = str(exc)
                     entry["presign_error"] = error_message
 
             results.append(entry)

--- a/tools/aws/tools/s3_files_uploader.yaml
+++ b/tools/aws/tools/s3_files_uploader.yaml
@@ -1,0 +1,127 @@
+identity:
+  name: s3_files_uploader
+  author: AWS
+  label:
+    en_US: AWS S3 Batch File Uploader
+    zh_Hans: AWS S3 批量文件上传器
+    pt_BR: AWS S3 Batch File Uploader
+description:
+  human:
+    en_US: Upload multiple files received from a prior workflow node to Amazon S3 in a single invocation.
+    zh_Hans: 将上游工作流节点生成的多个文件一次性批量上传到 Amazon S3。
+    pt_BR: Faz upload em lote de múltiplos arquivos recebidos de um nó anterior do workflow para o Amazon S3.
+  llm: Batch upload multiple workflow files to S3 and optionally return a presigned URL per object.
+parameters:
+  - name: aws_access_key_id
+    type: string
+    required: false
+    label:
+      en_US: AWS Access Key ID
+      zh_Hans: AWS Access Key ID
+      pt_BR: AWS Access Key ID
+    human_description:
+      en_US: Override the provider Access Key ID for this tool if needed.
+      zh_Hans: 当需要覆盖默认的 Access Key ID 时使用。
+      pt_BR: Sobrescreve o Access Key ID padrão da provider quando necessário.
+    form: form
+  - name: aws_secret_access_key
+    type: string
+    required: false
+    label:
+      en_US: AWS Secret Access Key
+      zh_Hans: AWS Secret Access Key
+      pt_BR: AWS Secret Access Key
+    human_description:
+      en_US: Override the provider Secret Access Key for this tool if needed.
+      zh_Hans: 当需要覆盖默认的 Secret Access Key 时使用。
+      pt_BR: Sobrescreve o Secret Access Key padrão da provider quando necessário.
+    form: form
+  - name: aws_session_token
+    type: string
+    required: false
+    label:
+      en_US: AWS Session Token
+      zh_Hans: AWS Session Token
+      pt_BR: AWS Session Token
+    human_description:
+      en_US: AWS session token for temporary credentials (STS). Only supported in tool parameters, not at provider level.
+      zh_Hans: 临时凭证（STS）的 session token。仅支持在工具参数中传入，provider 级别不支持。
+      pt_BR: Token de sessão da AWS para credenciais temporárias (STS). Só é suportado nos parâmetros da ferramenta, não no nível da provider.
+    form: form
+  - name: aws_region
+    type: string
+    required: false
+    label:
+      en_US: AWS Region
+      zh_Hans: AWS 区域
+      pt_BR: AWS Region
+    human_description:
+      en_US: Override the default AWS Region for this tool.
+      zh_Hans: 为该工具指定 AWS 区域，覆盖 provider 默认值。
+      pt_BR: Sobrescreve a região AWS padrão para esta ferramenta.
+    form: form
+  - name: bucket_name
+    type: string
+    required: true
+    label:
+      en_US: S3 bucket name
+      zh_Hans: S3 存储桶名称
+      pt_BR: Nome do bucket S3
+    human_description:
+      en_US: The bucket where the workflow files should be uploaded. Do not include s3://.
+      zh_Hans: 文件批量上传的目标 bucket。不要包含 s3:// 前缀。
+      pt_BR: Bucket de destino para o upload em lote. Não inclua o prefixo s3://.
+    form: form
+  - name: key_prefix
+    type: string
+    required: false
+    label:
+      en_US: Key prefix
+      zh_Hans: Key 前缀
+      pt_BR: Prefixo da chave
+    human_description:
+      en_US: Optional folder-style prefix such as workflow-outputs/. Each file's final key becomes "{prefix}/{filename}".
+      zh_Hans: 可选的文件夹式前缀，例如 workflow-outputs/。每个文件的最终 key 为 "{prefix}/{filename}"。
+      pt_BR: "Prefixo opcional no estilo de pasta, ex.: workflow-outputs/. A chave final de cada arquivo será {prefix}/{filename}."
+    form: form
+  - name: input_files
+    type: files
+    required: true
+    label:
+      en_US: Files to upload
+      zh_Hans: 待上传的多个文件
+      pt_BR: Arquivos para upload
+    human_description:
+      en_US: A list of files produced by upstream workflow nodes that should be uploaded to S3 in one invocation.
+      zh_Hans: 上游节点产生的、需要一次性批量上传到 S3 的多个文件。
+      pt_BR: Lista de arquivos produzidos por nós anteriores que devem ser enviados ao S3 em uma única invocação.
+    form: form
+  - name: generate_presign_url
+    type: boolean
+    required: false
+    label:
+      en_US: Generate presigned URL
+      zh_Hans: 生成预签名 URL
+      pt_BR: Gerar URL pré-assinada
+    human_description:
+      en_US: Whether to return a presigned URL for each uploaded object.
+      zh_Hans: 是否为每个上传后的对象生成预签名 URL。
+      pt_BR: Define se uma URL pré-assinada deve ser retornada para cada objeto enviado.
+    default: false
+    form: form
+  - name: presign_expiry
+    type: number
+    required: false
+    label:
+      en_US: Presigned URL expiration time
+      zh_Hans: 预签名 URL 有效期
+      pt_BR: Tempo de expiração da URL pré-assinada
+    human_description:
+      en_US: Expiration time in seconds for each optional presigned URL.
+      zh_Hans: 每个预签名 URL 的有效期（秒）。
+      pt_BR: Tempo de expiração em segundos para cada URL pré-assinada opcional.
+    default: 3600
+    form: form
+extra:
+  python:
+    source: tools/s3_files_uploader.py


### PR DESCRIPTION
## What this PR does

Follow-up to #3273 (which added the single-file `s3_file_uploader` / `s3_file_download`). This PR adds batch counterparts so a single workflow node can process N files in one invocation, instead of forcing users to wrap the single-file tools in an Iteration node.

- **`s3_files_uploader`** — takes `input_files` (`type: files`) from an upstream node and uploads each to a configurable S3 bucket with optional per-object presigned `GET` URLs.
- **`s3_files_download`** — takes `s3_uris` (`type: array` of `s3://bucket/key`) and emits one Dify file blob per success in input order, plus structured metadata for downstream nodes.

The single-file tools are unchanged.

## Why

For many real workflows (`Frame Extractor`, `Nova Canvas` with `numberOfImages > 1`, multi-file user uploads from a Start node), the natural input is *N files at once*. Wrapping the single-file tools in an Iteration node works but:
- adds a node and complicates the graph,
- recreates the boto3 client on every iteration (extra latency),
- offers no first-class way to surface per-file outcomes in one structured payload.

A typical batch workflow now looks like:

```
[Start: file-list input] -> [s3_files_uploader] -> ... -> [s3_files_download] -> [LLM/Code/...]
```

## Tool surface

### `s3_files_uploader`

| Param | Type | Required | Notes |
|---|---|---|---|
| `input_files` | `files` | yes | Bound to an upstream `array[file]` / `file-list` variable. |
| `bucket_name` | `string` | yes | Without `s3://`. |
| `key_prefix` | `string` | no | Folder-style prefix; final key per file is `{prefix}/{filename}`. |
| `aws_region` / `aws_access_key_id` / `aws_secret_access_key` / `aws_session_token` | `string` | no | Same per-tool overrides / STS support as the single-file tool. |
| `generate_presign_url` | `boolean` | no | Default `false`; produces a presigned `GET` URL per object. |
| `presign_expiry` | `number` | no | Default `3600` seconds. |

Outputs: `json = {count, ok, failed, results: [{index, bucket_name, object_key, s3_uri, presigned_url?, presign_expiry?, status: "ok"|"failed", error?}, ...]}` plus a per-line `text` summary (one line per entry: presigned URL when available, else s3_uri, else `FAILED [i]: <error>`).

### `s3_files_download`

| Param | Type | Required | Notes |
|---|---|---|---|
| `s3_uris` | `array` (LLM-fillable) | yes | List of `s3://bucket/key`. |
| `aws_region` / `aws_access_key_id` / `aws_secret_access_key` / `aws_session_token` | `string` | no | Same overrides as uploader. |

Outputs: `json = {count, ok, failed, results: [{index, s3_uri, bucket, key, content_type, content_length, etag, last_modified, filename, status, error?}, ...]}`, a per-line `text` summary (`bucket / key / content_length` for each success, `FAILED [i] <s3_uri>: <error>` for each failure), and **one Dify `file` blob per successful URI in input order** (failed entries simply produce no blob; downstream nodes correlate via `results`).

## Design choices

- **No `object_key` override on the batch uploader.** A single override cannot apply to N files. The final key per file is always derived from the file's own `filename` (or a UUID fallback) and optionally prepended with `key_prefix`. The batch uploader auto-disambiguates duplicate filenames in the same batch (`image.png` / `image-1.png` / `image-2.png`) so concurrent upstream branches with identical filenames don't silently overwrite each other.
- **Per-entry failure isolation.** A single bad file/URI does not abort the batch — `status=ok|failed` (+ `error`) is captured per entry in `results[]`. The whole invocation only emits a top-level error message when *every* entry fails, so downstream nodes still see a clear failure signal in the all-failed case.
- **Same inline credential helpers as the single-file tools.** The batch tools reuse the same `_resolve_aws_credentials` / `_build_boto3_client_kwargs` shape introduced in #3273 — no shared `utils/` module is introduced. The boto3 client is created once per `_invoke` call and reused across batch entries within that one call.

## Files

```
tools/aws/
├── manifest.yaml                          # 0.0.27 -> 0.0.28
├── README.md                              # +2 Features lines
├── provider/aws_tools.yaml                # +2 lines (register both new tools)
└── tools/
    ├── s3_files_uploader.py               # 251 lines
    ├── s3_files_uploader.yaml             # 134 lines
    ├── s3_files_download.py               # 209 lines
    └── s3_files_download.yaml             # 80 lines
```

## Validation

**Static:**
- `python -m py_compile` on both `.py` files — ✅
- `yaml.safe_load` on the new + modified yaml files — ✅
- Verified `extra.python.source` paths resolve to existing files — ✅
- `black --check -l 100` and `ruff check` both clean on the new files — ✅
- Confirmed `label` / `description` languages match the rest of the plugin (`en_US` / `zh_Hans` / `pt_BR`) — ✅
- No new dependencies (boto3/botocore already pinned in `pyproject.toml` from #3273) — ✅

**Mock unit tests (10/10 pass):** basic batch upload with presign, duplicate-filename dedup, partial upload failure (ClientError), all-fail top-level error, empty input, presign error isolation (upload OK + presign fails), basic batch download, partial download failure (NoSuchKey), invalid URI yields no blob, empty s3_uris.

**End-to-end** on Dify 1.14.2 Community Edition + real S3 (`cn-northwest-1`):

1. Built a `.difypkg` from `tools/aws/` on this branch, installed on a self-hosted instance.
2. Imported a workflow `[Start (file-list) -> s3_files_uploader -> Code (extract URIs) -> s3_files_download -> Code (summary) -> End]`.
3. Triggered via Service API with three files at once: text/plain (`a.txt`, 40 B), image/png (100×100 RGBA, 220 B), and application/pdf (`doc.pdf`, 540 B).
4. Result: `status = succeeded`, all 6 steps green, elapsed ~1.2 s. `upload_uris` and `download_keys` matched input order; `download_sizes = [40, 220, 540]`.
5. Pulled all three objects back from S3 with `aws s3 cp` and compared SHA-256 — **byte-for-byte identical** for all 3 files:
   - `a.txt` `c377b72e7343c1642a35c7ff5108fef6c14fc5fba3aecce89c18d9ac526e4de8`
   - `img.png` `5a2fe18dbec51b2426f8aa31f6424b0efff246497646f1aa2314abe8d09b7aec`
   - `doc.pdf` `7b6fed1b75159c5cbc633e04f9011a1a9e4f22efce2621b8e14646064cf8c6fa`
6. With `generate_presign_url=true`, every entry's `presigned_url` was fetched via `curl` and produced byte-identical content to the local source.
7. Partial-failure run (2 valid + 1 bogus `s3://` URI) on the download tool: returned `count=3, ok=2, failed=1` with a `NoSuchKey` error string for the bogus URI, and exactly 2 file blobs yielded in input order.

## Out of scope (kept for a follow-up)

- Multipart upload / streaming for large files
- Any change to existing `s3_operator` / `s3_file_uploader` / `s3_file_download`
- Shared `utils/` module