### PR TITLE
[codex] Add Moonshot JSON schema response format

### DIFF
--- a/models/moonshot/manifest.yaml
+++ b/models/moonshot/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.7
+version: 0.1.8

--- a/models/moonshot/models/llm/kimi-k2-0711-preview.yaml
+++ b/models/moonshot/models/llm/kimi-k2-0711-preview.yaml
@@ -33,6 +33,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '0.2'
   output: '0.2'

--- a/models/moonshot/models/llm/kimi-k2-0905-preview.yaml
+++ b/models/moonshot/models/llm/kimi-k2-0905-preview.yaml
@@ -33,6 +33,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '0.2'
   output: '0.2'

--- a/models/moonshot/models/llm/kimi-k2-thinking-turbo.yaml
+++ b/models/moonshot/models/llm/kimi-k2-thinking-turbo.yaml
@@ -33,6 +33,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '8'
   output: '58'

--- a/models/moonshot/models/llm/kimi-k2-thinking.yaml
+++ b/models/moonshot/models/llm/kimi-k2-thinking.yaml
@@ -33,6 +33,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '4'
   output: '16'

--- a/models/moonshot/models/llm/kimi-k2-turbo-preview.yaml
+++ b/models/moonshot/models/llm/kimi-k2-turbo-preview.yaml
@@ -33,6 +33,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '0.2'
   output: '0.2'

--- a/models/moonshot/models/llm/kimi-k2.5.yaml
+++ b/models/moonshot/models/llm/kimi-k2.5.yaml
@@ -52,6 +52,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '4'
   output: '21'

--- a/models/moonshot/models/llm/kimi-k2.6.yaml
+++ b/models/moonshot/models/llm/kimi-k2.6.yaml
@@ -52,6 +52,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '4'
   output: '14'

--- a/models/moonshot/models/llm/llm.py
+++ b/models/moonshot/models/llm/llm.py
@@ -1,7 +1,8 @@
 
+import json
 import re
 from collections.abc import Generator
-from typing import Optional, Union, cast
+from typing import Optional, Union
 
 from dify_plugin import OAICompatLargeLanguageModel
 
@@ -56,6 +57,23 @@ class MoonshotLargeLanguageModel(OAICompatLargeLanguageModel):
                 model_parameters["thinking"] = {"type": "enabled"}
             else:
                 model_parameters["thinking"] = {"type": "disabled"}
+
+        response_format = model_parameters.get("response_format")
+        if response_format:
+            if response_format == "json_schema":
+                json_schema = model_parameters.get("json_schema")
+                if not json_schema:
+                    raise ValueError("Must define JSON Schema when the response format is json_schema")
+                try:
+                    schema = json.loads(json_schema)
+                except Exception:
+                    raise ValueError(f"not correct json_schema format: {json_schema}")
+                model_parameters.pop("json_schema")
+                model_parameters["response_format"] = {"type": "json_schema", "json_schema": schema}
+            else:
+                model_parameters["response_format"] = {"type": response_format}
+        elif "json_schema" in model_parameters:
+            del model_parameters["json_schema"]
 
         # Merge consecutive messages with the same role to strictly follow API specs
         prompt_messages = self._clean_messages(prompt_messages)

--- a/models/moonshot/models/llm/moonshot-v1-128k.yaml
+++ b/models/moonshot/models/llm/moonshot-v1-128k.yaml
@@ -33,6 +33,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '0.06'
   output: '0.06'

--- a/models/moonshot/models/llm/moonshot-v1-32k.yaml
+++ b/models/moonshot/models/llm/moonshot-v1-32k.yaml
@@ -33,6 +33,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '0.024'
   output: '0.024'

--- a/models/moonshot/models/llm/moonshot-v1-8k.yaml
+++ b/models/moonshot/models/llm/moonshot-v1-8k.yaml
@@ -33,6 +33,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: '0.012'
   output: '0.012'


### PR DESCRIPTION
## Summary

- add `json_schema` as a supported Moonshot response format option
- expose the `json_schema` parameter on built-in Moonshot/Kimi LLM model schemas
- convert Dify's `response_format=json_schema` parameter into Moonshot's structured output request shape
- bump the Moonshot plugin manifest to `0.1.8`

## Why

Moonshot/Kimi's current API supports structured output through `response_format: {"type": "json_schema"}`, but the Dify Moonshot plugin only exposed `text` and `json_object`. This lets workflow LLM nodes use Dify's JSON Schema structured output mode with Moonshot models.

## Validation

- `uv run ruff check models/llm/llm.py`
- `python -m compileall models/llm/llm.py`
- parsed `models/moonshot/manifest.yaml` and all `models/moonshot/models/llm/*.yaml` with Ruby YAML
- local monkeypatch assertion for `response_format=json_schema` conversion into Moonshot API payload shape
