### PR TITLE
fix(bing): build related searches from related_searches, not news

### DIFF
--- a/tools/bing/manifest.yaml
+++ b/tools/bing/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 type: plugin
 author: "langgenius"
 name: "bing"

--- a/tools/bing/manifest.yaml
+++ b/tools/bing/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.11
+version: 0.0.12
 type: plugin
 author: "langgenius"
 name: "bing"

--- a/tools/bing/tools/bing_web_search.py
+++ b/tools/bing/tools/bing_web_search.py
@@ -114,7 +114,8 @@ class BingWebSearchTool(Tool):
 
             if related_searches:
                 result["related searches"] = [
-                    {"displayText": item.get("displayText", ""), "url": item.get("webSearchUrl", "")} for item in news
+                    {"displayText": item.get("displayText", ""), "url": item.get("webSearchUrl", "")}
+                    for item in related_searches
                 ]
 
             yield self.create_json_message(result)


### PR DESCRIPTION
## Summary

In the `json` result path, the **related searches** block iterates over `news` instead of `related_searches`:

```python
if related_searches:
    result["related searches"] = [
        {"displayText": item.get("displayText", ""), "url": item.get("webSearchUrl", "")}
        for item in news   # should be related_searches
    ]
```

`news` items carry `name`/`url`, not `displayText`/`webSearchUrl`, so whenever both news and related searches are present the "related searches" output is filled with **empty strings**; and when `news` is empty but related searches exist, the entire "related searches" section silently **disappears**.

Two things confirm the intended behavior:
- The sibling `link` result path (same file) correctly iterates `related_searches` and reads `displayText`.
- `related_searches` is built from `response["relatedSearches"]["value"]`, and the mapped keys (`displayText`, `webSearchUrl`) are relatedSearches fields — so the comprehension was written for `related_searches`; `news` is a copy-paste slip from the `news` block directly above.

Fix: iterate `related_searches`. Version bumped `0.0.10` → `0.0.11`.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

N/A — JSON output correctness fix.

| Before | After |
| ------ | ----- |
| `"related searches": [{"displayText": "", "url": ""}]` (or missing when news is empty) | `"related searches"` populated from the real `relatedSearches` results |
