### PR TITLE
fix(brave): return on empty query; correct provider name in no-results message

### DIFF
--- a/tools/brave/manifest.yaml
+++ b/tools/brave/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
   - search
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/brave/manifest.yaml
+++ b/tools/brave/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
   - search
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/brave/tools/brave_search.py
+++ b/tools/brave/tools/brave_search.py
@@ -121,6 +121,7 @@ class BraveSearchTool(Tool):
             base_url = BRAVE_BASE_URL
         if not query:
             yield self.create_text_message("Please input query")
+            return
         tool = BraveSearch.from_api_key(
             api_key=api_key,
             base_url=base_url,
@@ -129,6 +130,6 @@ class BraveSearchTool(Tool):
         )
         results = tool._run(query)
         if not results:
-            yield self.create_text_message(f"No results found for '{query}' in Tavily")
+            yield self.create_text_message(f"No results found for '{query}' in Brave")
         else:
             yield self.create_text_message(text=results)


### PR DESCRIPTION
## Summary

Two bugs in the Brave search tool's `_invoke`:

1. **Empty query isn't short-circuited.** When `query` is empty the tool yields `"Please input query"` but then **continues** to build the client and call `tool._run("")` with the empty query — producing a confusing second message (and a wasted/erroring search call). Added `return` after the guard so an empty query stops there.

   ```python
   if not query:
       yield self.create_text_message("Please input query")
       return   # was missing — execution fell through to the search call
   ```

2. **Wrong provider name in the no-results message.** The message read `No results found for '...' in Tavily` inside the **Brave** tool (copy-paste slip). Corrected to `Brave`.

Version bumped `0.0.7` → `0.0.8`.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

N/A — control-flow + message correctness fix.
