### PR TITLE
feat(aihubmix): make API endpoint configurable via credentials

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.32
+version: 0.0.33
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.31
+version: 0.0.32
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/anthropic.py
+++ b/models/aihubmix/models/llm/anthropic.py
@@ -965,9 +965,8 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             "timeout": Timeout(315.0, read=300.0, write=10.0, connect=5.0),
             "max_retries": 1,
         }
-        api_url = credentials.get("api_url")
-
-        
+        _sel = credentials.get("api_url")
+        api_url = credentials.get("api_url_custom") if _sel == "__custom__" else _sel
         if api_url:
             credentials_kwargs["base_url"] = api_url.rstrip("/")
         return credentials_kwargs

--- a/models/aihubmix/models/llm/google.py
+++ b/models/aihubmix/models/llm/google.py
@@ -990,8 +990,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         # == InitConfig == #
 
         config = types.GenerateContentConfig()
+        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
         genai_client = genai.Client(api_key=credentials["api_key"], http_options={
-            "base_url": "https://aihubmix.com/gemini",
+            "base_url": f"{api_url}/gemini",
             "headers": {
                 "APP-Code": "Dify2025"
             }

--- a/models/aihubmix/models/llm/google.py
+++ b/models/aihubmix/models/llm/google.py
@@ -990,7 +990,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         # == InitConfig == #
 
         config = types.GenerateContentConfig()
-        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        api_url = ((credentials.get("api_url_custom") if credentials.get("api_url") == "__custom__" else credentials.get("api_url")) or "https://aihubmix.com").rstrip("/")
         genai_client = genai.Client(api_key=credentials["api_key"], http_options={
             "base_url": f"{api_url}/gemini",
             "headers": {

--- a/models/aihubmix/models/llm/llm.py
+++ b/models/aihubmix/models/llm/llm.py
@@ -34,7 +34,8 @@ RESPONSE_SERIES_COMPATIBILITY = ("gpt-5-codex", "gpt-5-pro", "o3-pro")
 
 class AihubmixLargeLanguageModel(OAICompatLargeLanguageModel):
     def _update_credential(self, model: str, credentials: dict):
-        credentials["endpoint_url"] = "https://aihubmix.com/v1"
+        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        credentials["endpoint_url"] = f"{api_url}/v1"
         credentials["mode"] = self.get_model_mode(model).value
         credentials["function_calling_type"] = "tool_call"
         credentials["extra_headers"] = {

--- a/models/aihubmix/models/llm/llm.py
+++ b/models/aihubmix/models/llm/llm.py
@@ -34,7 +34,7 @@ RESPONSE_SERIES_COMPATIBILITY = ("gpt-5-codex", "gpt-5-pro", "o3-pro")
 
 class AihubmixLargeLanguageModel(OAICompatLargeLanguageModel):
     def _update_credential(self, model: str, credentials: dict):
-        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        api_url = ((credentials.get("api_url_custom") if credentials.get("api_url") == "__custom__" else credentials.get("api_url")) or "https://aihubmix.com").rstrip("/")
         credentials["endpoint_url"] = f"{api_url}/v1"
         credentials["mode"] = self.get_model_mode(model).value
         credentials["function_calling_type"] = "tool_call"

--- a/models/aihubmix/models/llm/openai_response.py
+++ b/models/aihubmix/models/llm/openai_response.py
@@ -23,9 +23,10 @@ class AihubmixOpenAIResponses:
 
     def _to_credential_kwargs(self, credentials: Mapping[str, Any]) -> Mapping[str, Any]:
         # Align with aihubmix provider style (see anthropic.py)
+        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
         return {
             "api_key": credentials["api_key"],
-            "base_url": "https://aihubmix.com/v1",
+            "base_url": f"{api_url}/v1",
             "timeout": Timeout(315.0, read=300.0, write=10.0, connect=5.0),
             "max_retries": 1,
         }

--- a/models/aihubmix/models/llm/openai_response.py
+++ b/models/aihubmix/models/llm/openai_response.py
@@ -23,7 +23,7 @@ class AihubmixOpenAIResponses:
 
     def _to_credential_kwargs(self, credentials: Mapping[str, Any]) -> Mapping[str, Any]:
         # Align with aihubmix provider style (see anthropic.py)
-        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        api_url = ((credentials.get("api_url_custom") if credentials.get("api_url") == "__custom__" else credentials.get("api_url")) or "https://aihubmix.com").rstrip("/")
         return {
             "api_key": credentials["api_key"],
             "base_url": f"{api_url}/v1",

--- a/models/aihubmix/models/rerank/rerank.py
+++ b/models/aihubmix/models/rerank/rerank.py
@@ -26,7 +26,7 @@ class AihubmixRerankModel(RerankModel):
     ) -> RerankResult:
         if len(docs) == 0:
             return RerankResult(model=model, docs=[])
-        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        api_url = ((credentials.get("api_url_custom") if credentials.get("api_url") == "__custom__" else credentials.get("api_url")) or "https://aihubmix.com").rstrip("/")
         base_url = f"{api_url}/v1"
         try:
             response = httpx.post(

--- a/models/aihubmix/models/rerank/rerank.py
+++ b/models/aihubmix/models/rerank/rerank.py
@@ -26,7 +26,7 @@ class AihubmixRerankModel(RerankModel):
     ) -> RerankResult:
         if len(docs) == 0:
             return RerankResult(model=model, docs=[])
-        api_url = (credentials.get("api_url") or "https://aihubmix.com").removesuffix("/")
+        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
         base_url = f"{api_url}/v1"
         try:
             response = httpx.post(

--- a/models/aihubmix/models/rerank/rerank.py
+++ b/models/aihubmix/models/rerank/rerank.py
@@ -26,8 +26,8 @@ class AihubmixRerankModel(RerankModel):
     ) -> RerankResult:
         if len(docs) == 0:
             return RerankResult(model=model, docs=[])
-        base_url = credentials.get("base_url", "https://aihubmix.com/v1")
-        base_url = base_url.removesuffix("/")
+        api_url = (credentials.get("api_url") or "https://aihubmix.com").removesuffix("/")
+        base_url = f"{api_url}/v1"
         try:
             response = httpx.post(
                 base_url + "/rerank",

--- a/models/aihubmix/models/speech2text/speech2text.py
+++ b/models/aihubmix/models/speech2text/speech2text.py
@@ -7,7 +7,8 @@ class AihubmixSpeech2TextModel(OAICompatSpeech2TextModel):
     Model class for Aihubmix Speech to text model.
     """
     def _update_credential(self, credentials: dict):
-        credentials["endpoint_url"] = "https://aihubmix.com/v1"
+        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        credentials["endpoint_url"] = f"{api_url}/v1"
 
 
     def _invoke(self, model: str, credentials: dict, file: IO[bytes], user: Optional[str] = None) -> str:

--- a/models/aihubmix/models/speech2text/speech2text.py
+++ b/models/aihubmix/models/speech2text/speech2text.py
@@ -7,7 +7,7 @@ class AihubmixSpeech2TextModel(OAICompatSpeech2TextModel):
     Model class for Aihubmix Speech to text model.
     """
     def _update_credential(self, credentials: dict):
-        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        api_url = ((credentials.get("api_url_custom") if credentials.get("api_url") == "__custom__" else credentials.get("api_url")) or "https://aihubmix.com").rstrip("/")
         credentials["endpoint_url"] = f"{api_url}/v1"
 
 

--- a/models/aihubmix/models/text_embedding/text_embedding.py
+++ b/models/aihubmix/models/text_embedding/text_embedding.py
@@ -10,7 +10,7 @@ class AihubmixTextEmbeddingModel(OAICompatEmbeddingModel):
     """
 
     def _update_credential(self, credentials: dict):
-        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        api_url = ((credentials.get("api_url_custom") if credentials.get("api_url") == "__custom__" else credentials.get("api_url")) or "https://aihubmix.com").rstrip("/")
         credentials["endpoint_url"] = f"{api_url}/v1"
 
 

--- a/models/aihubmix/models/text_embedding/text_embedding.py
+++ b/models/aihubmix/models/text_embedding/text_embedding.py
@@ -10,7 +10,8 @@ class AihubmixTextEmbeddingModel(OAICompatEmbeddingModel):
     """
 
     def _update_credential(self, credentials: dict):
-        credentials["endpoint_url"] = "https://aihubmix.com/v1"
+        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        credentials["endpoint_url"] = f"{api_url}/v1"
 
 
     def _invoke(

--- a/models/aihubmix/models/tts/tts.py
+++ b/models/aihubmix/models/tts/tts.py
@@ -29,7 +29,8 @@ class AihubmixText2SpeechModel(OAICompatText2SpeechModel):
         :return: text translated to audio file
         """
     
-        credentials["endpoint_url"] = "https://aihubmix.com/v1"
+        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        credentials["endpoint_url"] = f"{api_url}/v1"
         return super()._invoke(model, tenant_id, credentials, content_text, voice, user)
     
 

--- a/models/aihubmix/models/tts/tts.py
+++ b/models/aihubmix/models/tts/tts.py
@@ -29,7 +29,7 @@ class AihubmixText2SpeechModel(OAICompatText2SpeechModel):
         :return: text translated to audio file
         """
     
-        api_url = (credentials.get("api_url") or "https://aihubmix.com").rstrip("/")
+        api_url = ((credentials.get("api_url_custom") if credentials.get("api_url") == "__custom__" else credentials.get("api_url")) or "https://aihubmix.com").rstrip("/")
         credentials["endpoint_url"] = f"{api_url}/v1"
         return super()._invoke(model, tenant_id, credentials, content_text, voice, user)
     

--- a/models/aihubmix/provider/aihubmix.yaml
+++ b/models/aihubmix/provider/aihubmix.yaml
@@ -35,6 +35,19 @@ provider_credential_schema:
       placeholder:
         zh_Hans: 在此输入您的 API Key
         en_US: Enter your API Key
+    - variable: api_url
+      label:
+        en_US: API Endpoint
+        zh_Hans: 自定义 API endpoint 地址
+      type: text-input
+      required: false
+      default: https://aihubmix.com
+      placeholder:
+        zh_Hans: "Base URL，例如 https://aihubmix.com"
+        en_US: "Base URL, e.g. https://aihubmix.com"
+      help:
+        zh_Hans: "API 基础地址（留空使用默认 https://aihubmix.com）。无需包含 /v1 等路径后缀，插件会按模型类型自动追加（/v1、/gemini 等）。"
+        en_US: "API base URL (leave empty to use the default https://aihubmix.com). Do not include a path suffix such as /v1; the plugin appends it automatically per model type (/v1, /gemini, etc.)."
 model_credential_schema:
   model:
     label:
@@ -52,6 +65,19 @@ model_credential_schema:
       placeholder:
         zh_Hans: 在此输入您的 API Key
         en_US: Enter your API Key
+    - variable: api_url
+      label:
+        en_US: API Endpoint
+        zh_Hans: 自定义 API endpoint 地址
+      type: text-input
+      required: false
+      default: https://aihubmix.com
+      placeholder:
+        zh_Hans: "Base URL，例如 https://aihubmix.com"
+        en_US: "Base URL, e.g. https://aihubmix.com"
+      help:
+        zh_Hans: "API 基础地址（留空使用默认 https://aihubmix.com）。无需包含 /v1 等路径后缀，插件会按模型类型自动追加（/v1、/gemini 等）。"
+        en_US: "API base URL (leave empty to use the default https://aihubmix.com). Do not include a path suffix such as /v1; the plugin appends it automatically per model type (/v1, /gemini, etc.)."
     - variable: mode
       show_on:
         - variable: __model_type

--- a/models/aihubmix/provider/aihubmix.yaml
+++ b/models/aihubmix/provider/aihubmix.yaml
@@ -43,8 +43,8 @@ provider_credential_schema:
       required: false
       default: https://aihubmix.com
       placeholder:
-        zh_Hans: "Base URL，例如 https://aihubmix.com"
-        en_US: "Base URL, e.g. https://aihubmix.com"
+        zh_Hans: "Base URL，例如 https://aihubmix.com 或 https://api.inferera.com"
+        en_US: "Base URL, e.g. https://aihubmix.com or https://api.inferera.com"
       help:
         zh_Hans: "API 基础地址（留空使用默认 https://aihubmix.com）。无需包含 /v1 等路径后缀，插件会按模型类型自动追加（/v1、/gemini 等）。"
         en_US: "API base URL (leave empty to use the default https://aihubmix.com). Do not include a path suffix such as /v1; the plugin appends it automatically per model type (/v1, /gemini, etc.)."
@@ -73,8 +73,8 @@ model_credential_schema:
       required: false
       default: https://aihubmix.com
       placeholder:
-        zh_Hans: "Base URL，例如 https://aihubmix.com"
-        en_US: "Base URL, e.g. https://aihubmix.com"
+        zh_Hans: "Base URL，例如 https://aihubmix.com 或 https://api.inferera.com"
+        en_US: "Base URL, e.g. https://aihubmix.com or https://api.inferera.com"
       help:
         zh_Hans: "API 基础地址（留空使用默认 https://aihubmix.com）。无需包含 /v1 等路径后缀，插件会按模型类型自动追加（/v1、/gemini 等）。"
         en_US: "API base URL (leave empty to use the default https://aihubmix.com). Do not include a path suffix such as /v1; the plugin appends it automatically per model type (/v1, /gemini, etc.)."

--- a/models/aihubmix/provider/aihubmix.yaml
+++ b/models/aihubmix/provider/aihubmix.yaml
@@ -39,15 +39,37 @@ provider_credential_schema:
       label:
         en_US: API Endpoint
         zh_Hans: 自定义 API endpoint 地址
+      type: select
+      required: false
+      default: https://api.inferera.com
+      options:
+        - value: https://api.inferera.com
+          label:
+            en_US: "https://api.inferera.com (default)"
+            zh_Hans: "https://api.inferera.com（默认）"
+        - value: https://aihubmix.com
+          label:
+            en_US: "https://aihubmix.com"
+            zh_Hans: "https://aihubmix.com"
+        - value: __custom__
+          label:
+            en_US: "Custom…"
+            zh_Hans: "自定义…"
+    - variable: api_url_custom
+      show_on:
+        - variable: api_url
+          value: __custom__
+      label:
+        en_US: Custom API Endpoint
+        zh_Hans: 自定义 endpoint 地址
       type: text-input
       required: false
-      default: https://aihubmix.com
       placeholder:
-        zh_Hans: "Base URL，例如 https://aihubmix.com 或 https://api.inferera.com"
-        en_US: "Base URL, e.g. https://aihubmix.com or https://api.inferera.com"
+        zh_Hans: "Base URL，例如 https://your-gateway.example.com"
+        en_US: "Base URL, e.g. https://your-gateway.example.com"
       help:
-        zh_Hans: "API 基础地址（留空使用默认 https://aihubmix.com）。无需包含 /v1 等路径后缀，插件会按模型类型自动追加（/v1、/gemini 等）。"
-        en_US: "API base URL (leave empty to use the default https://aihubmix.com). Do not include a path suffix such as /v1; the plugin appends it automatically per model type (/v1, /gemini, etc.)."
+        zh_Hans: "选择自定义时在此填写。填裸 host，不要带 /v1 等后缀，插件会自动追加（/v1、/gemini 等）。"
+        en_US: "Fill this when Custom is selected. Bare host, no /v1 suffix; the plugin appends it automatically."
 model_credential_schema:
   model:
     label:
@@ -69,15 +91,37 @@ model_credential_schema:
       label:
         en_US: API Endpoint
         zh_Hans: 自定义 API endpoint 地址
+      type: select
+      required: false
+      default: https://api.inferera.com
+      options:
+        - value: https://api.inferera.com
+          label:
+            en_US: "https://api.inferera.com (default)"
+            zh_Hans: "https://api.inferera.com（默认）"
+        - value: https://aihubmix.com
+          label:
+            en_US: "https://aihubmix.com"
+            zh_Hans: "https://aihubmix.com"
+        - value: __custom__
+          label:
+            en_US: "Custom…"
+            zh_Hans: "自定义…"
+    - variable: api_url_custom
+      show_on:
+        - variable: api_url
+          value: __custom__
+      label:
+        en_US: Custom API Endpoint
+        zh_Hans: 自定义 endpoint 地址
       type: text-input
       required: false
-      default: https://aihubmix.com
       placeholder:
-        zh_Hans: "Base URL，例如 https://aihubmix.com 或 https://api.inferera.com"
-        en_US: "Base URL, e.g. https://aihubmix.com or https://api.inferera.com"
+        zh_Hans: "Base URL，例如 https://your-gateway.example.com"
+        en_US: "Base URL, e.g. https://your-gateway.example.com"
       help:
-        zh_Hans: "API 基础地址（留空使用默认 https://aihubmix.com）。无需包含 /v1 等路径后缀，插件会按模型类型自动追加（/v1、/gemini 等）。"
-        en_US: "API base URL (leave empty to use the default https://aihubmix.com). Do not include a path suffix such as /v1; the plugin appends it automatically per model type (/v1, /gemini, etc.)."
+        zh_Hans: "选择自定义时在此填写。填裸 host，不要带 /v1 等后缀，插件会自动追加（/v1、/gemini 等）。"
+        en_US: "Fill this when Custom is selected. Bare host, no /v1 suffix; the plugin appends it automatically."
     - variable: mode
       show_on:
         - variable: __model_type


### PR DESCRIPTION
## Summary

Make the AIHubMix API endpoint configurable from the credential UI instead of being hard-coded in each handler.

`api_url` is now a dropdown (`select`) offering preset base URLs plus a custom option, in both the provider and model credential schemas:

- `https://api.inferera.com` — default
- `https://aihubmix.com`
- `Custom…` — reveals an `api_url_custom` text field (via `show_on`) for entering any base URL

## Change Type

- [x] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (0.0.31 → 0.0.33)

## Testing

- [x] Local deployment — endpoint dropdown (presets + custom) loads and credential validation passes against the selected endpoint