### PR TITLE
feat(aihubmix_image): add configurable API base URL

### DIFF
--- a/tools/aihubmix_image/provider/aihubmix-image.py
+++ b/tools/aihubmix_image/provider/aihubmix-image.py
@@ -12,9 +12,11 @@ class AIHubMixImageProvider(ToolProvider):
         if not api_key:
             raise ToolProviderCredentialValidationError("API Key is required")
 
+        base_url = (credentials.get("base_url") or "https://api.inferera.com").rstrip("/")
+
         try:
             response = requests.get(
-                "https://aihubmix.com/v1/models",
+                f"{base_url}/v1/models",
                 headers={
                     "Authorization": f"Bearer {api_key}",
                     "Content-Type": "application/json",

--- a/tools/aihubmix_image/provider/aihubmix-image.yaml
+++ b/tools/aihubmix_image/provider/aihubmix-image.yaml
@@ -33,6 +33,34 @@ credentials_schema:
       pt_BR: "A chave API é usada para autenticar solicitações à API AIHubMix. Obtenha sua chave em https://docs.aihubmix.com/token"
       ja_JP: "APIキーはAIHubMix APIへのリクエスト認証に使用されます。https://docs.aihubmix.com/token からAPIキーを取得してください"
 
+  - name: "base_url"
+    type: "select"
+    required: false
+    default: "https://api.inferera.com"
+    label:
+      en_US: "API Base URL"
+      zh_Hans: "API 接口地址"
+      pt_BR: "URL Base da API"
+      ja_JP: "API ベース URL"
+    options:
+      - value: "https://api.inferera.com"
+        label:
+          en_US: "https://api.inferera.com"
+          zh_Hans: "https://api.inferera.com"
+          pt_BR: "https://api.inferera.com"
+          ja_JP: "https://api.inferera.com"
+      - value: "https://aihubmix.com"
+        label:
+          en_US: "https://aihubmix.com"
+          zh_Hans: "https://aihubmix.com"
+          pt_BR: "https://aihubmix.com"
+          ja_JP: "https://aihubmix.com"
+    help:
+      en_US: "The API gateway base URL. Defaults to Inferera."
+      zh_Hans: "API 网关的基础地址，默认使用 Inferera。"
+      pt_BR: "A URL base do gateway da API. Padrão: Inferera."
+      ja_JP: "API ゲートウェイのベース URL。デフォルトは Inferera です。"
+
 #########################################################################################
 # OAuth configuration can be enabled by uncommenting the section below
 # This provides alternative authentication method using OAuth 2.0 flow

--- a/tools/aihubmix_image/tools/doubao.py
+++ b/tools/aihubmix_image/tools/doubao.py
@@ -20,13 +20,16 @@ class DoubaoTool(Tool):
     - Sequential Generation: Create consistent series of images (storyboards, variations)
     """
 
-    BASE_URL = "https://aihubmix.com/v1"
+    DEFAULT_BASE_URL = "https://api.inferera.com"
 
     DEFAULT_MODEL = "doubao-seedream-5.0-lite"
-    
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+
     def get_endpoint(self, model: str) -> str:
         """Get the appropriate endpoint based on model selection"""
-        return f"{self.BASE_URL}/models/doubao/{model}/predictions"
+        return f"{self.get_base_url()}/v1/models/doubao/{model}/predictions"
     
     # Generation modes
     MODE_TEXT_TO_IMAGE = "text_to_image"

--- a/tools/aihubmix_image/tools/ernie-irag-edit.py
+++ b/tools/aihubmix_image/tools/ernie-irag-edit.py
@@ -22,9 +22,14 @@ class ErnieIragEditTool(Tool):
     """
     
     # API endpoints
-    BASE_URL = "https://aihubmix.com/v1"
-    PREDICTIONS_ENDPOINT = f"{BASE_URL}/models/qianfan/ernie-irag-edit/predictions"
-    
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+
+    def get_endpoint(self) -> str:
+        return f"{self.get_base_url()}/v1/models/qianfan/ernie-irag-edit/predictions"
+
     def create_image_info(self, base64_data: str, guidance: float) -> dict:
         mime_type = "image/png"
         return {
@@ -150,7 +155,7 @@ class ErnieIragEditTool(Tool):
             
             # Make API request
             response = requests.post(
-                self.PREDICTIONS_ENDPOINT,
+                self.get_endpoint(),
                 headers=headers,
                 json=payload,
                 timeout=60

--- a/tools/aihubmix_image/tools/ernie-irag.py
+++ b/tools/aihubmix_image/tools/ernie-irag.py
@@ -16,9 +16,14 @@ class ErnieIragTool(Tool):
     """
     
     # API endpoints
-    BASE_URL = "https://aihubmix.com/v1"
-    PREDICTIONS_ENDPOINT = f"{BASE_URL}/models/qianfan/irag-1.0/predictions"
-    
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+
+    def get_endpoint(self) -> str:
+        return f"{self.get_base_url()}/v1/models/qianfan/irag-1.0/predictions"
+
     def create_image_info(self, base64_data: str, resolution: str) -> dict:
         mime_type = "image/png"
         return {
@@ -139,7 +144,7 @@ class ErnieIragTool(Tool):
             
             # Make API request
             response = requests.post(
-                self.PREDICTIONS_ENDPOINT,
+                self.get_endpoint(),
                 headers=headers,
                 json=payload,
                 timeout=60

--- a/tools/aihubmix_image/tools/flux-kontext.py
+++ b/tools/aihubmix_image/tools/flux-kontext.py
@@ -17,9 +17,14 @@ class FluxKontextTool(Tool):
     """
     
     # API endpoints configuration
-    BASE_URL = "https://aihubmix.com/v1"
-    SYNC_ENDPOINT = f"{BASE_URL}/images/generations"
-    
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+
+    def get_sync_endpoint(self) -> str:
+        return f"{self.get_base_url()}/v1/images/generations"
+
     def create_image_info(self, base64_data: str, resolution: str) -> dict:
         mime_type = "image/png"
         return {
@@ -85,7 +90,7 @@ class FluxKontextTool(Tool):
         
         # Make API request
         response = requests.post(
-            self.SYNC_ENDPOINT,
+            self.get_sync_endpoint(),
             headers=headers,
             json=payload,
             timeout=60

--- a/tools/aihubmix_image/tools/gemini-3-pro-image-preview.py
+++ b/tools/aihubmix_image/tools/gemini-3-pro-image-preview.py
@@ -34,8 +34,12 @@ class Gemini3ProImagePreviewTool(Tool):
     Supports text-to-image, image-to-image transformation, and multi-image reference.
     """
     
-    BASE_URL = "https://aihubmix.com/gemini"
-    
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_gemini_base_url(self) -> str:
+        root = (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+        return f"{root}/gemini"
+
     # Generation modes
     MODE_TEXT_TO_IMAGE = "text_to_image"
     MODE_IMAGE_TO_IMAGE = "image_to_image"
@@ -164,7 +168,7 @@ class Gemini3ProImagePreviewTool(Tool):
             # Initialize Google GenAI client
             client = genai.Client(
                 api_key=api_key,
-                http_options={"base_url": self.BASE_URL}
+                http_options={"base_url": self.get_gemini_base_url()}
             )
             
             # Prepare contents list

--- a/tools/aihubmix_image/tools/glm-image.py
+++ b/tools/aihubmix_image/tools/glm-image.py
@@ -9,8 +9,13 @@ from dify_plugin.errors.model import InvokeError
 
 
 class GlmImageTool(Tool):
-    BASE_URL = "https://aihubmix.com/v1"
-    ENDPOINT = f"{BASE_URL}/models/openai/glm-image/predictions"
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+
+    def get_endpoint(self) -> str:
+        return f"{self.get_base_url()}/v1/models/openai/glm-image/predictions"
 
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         try:
@@ -39,7 +44,7 @@ class GlmImageTool(Tool):
 
             yield self.create_text_message(f"Generating image with GLM ({quality}, {size})...")
 
-            response = requests.post(self.ENDPOINT, headers=headers, json=payload, timeout=120)
+            response = requests.post(self.get_endpoint(), headers=headers, json=payload, timeout=120)
 
             if response.status_code != 200:
                 error_msg = f"GLM Image API request failed with status {response.status_code}"

--- a/tools/aihubmix_image/tools/gpt-image-edit.py
+++ b/tools/aihubmix_image/tools/gpt-image-edit.py
@@ -21,6 +21,11 @@ class GptImageEditTool(Tool):
     - Base64 encoded strings
     """
     
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+
     def create_image_info(self, base64_data: str, size: str) -> dict:
         mime_type = "image/png"
         return {
@@ -126,7 +131,7 @@ class GptImageEditTool(Tool):
             # Initialize OpenAI client with AiHubMix endpoint
             client = OpenAI(
                 api_key=api_key,
-                base_url="https://aihubmix.com/v1",
+                base_url=f"{self.get_base_url()}/v1",
                 timeout=180  # Increase timeout to 180 seconds for image editing
             )
             

--- a/tools/aihubmix_image/tools/gpt-image.py
+++ b/tools/aihubmix_image/tools/gpt-image.py
@@ -16,17 +16,20 @@ class GptImageTool(Tool):
     """
     
     # API endpoints
-    BASE_URL = "https://aihubmix.com/v1"
-    
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+
     def create_image_info(self, base64_data: str, resolution: str) -> dict:
         mime_type = "image/png"
         return {
             "url": f"data:{mime_type};base64,{base64_data}",
             "resolution": resolution
         }
-    
+
     def get_endpoint(self, model: str) -> str:
-        return f"{self.BASE_URL}/models/openai/{model}/predictions"
+        return f"{self.get_base_url()}/v1/models/openai/{model}/predictions"
     
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         """

--- a/tools/aihubmix_image/tools/ideogram.py
+++ b/tools/aihubmix_image/tools/ideogram.py
@@ -9,8 +9,13 @@ from dify_plugin.errors.model import InvokeError
 
 
 class IdeogramTool(Tool):
-    BASE_URL = "https://aihubmix.com/v1"
-    ENDPOINT = f"{BASE_URL}/models/ideogram/V3/predictions"
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+
+    def get_endpoint(self) -> str:
+        return f"{self.get_base_url()}/v1/models/ideogram/V3/predictions"
 
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         try:
@@ -41,7 +46,7 @@ class IdeogramTool(Tool):
                 f"Generating image with Ideogram V3 ({rendering_speed}, {aspect_ratio})..."
             )
 
-            response = requests.post(self.ENDPOINT, headers=headers, json=payload, timeout=120)
+            response = requests.post(self.get_endpoint(), headers=headers, json=payload, timeout=120)
 
             if response.status_code != 200:
                 error_msg = f"Ideogram API request failed with status {response.status_code}"

--- a/tools/aihubmix_image/tools/imagen.py
+++ b/tools/aihubmix_image/tools/imagen.py
@@ -31,8 +31,11 @@ class ImagenTool(Tool):
     """
     
     # API configuration
-    BASE_URL = "https://aihubmix.com/v1"
-    
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
+
     def create_image_info(self, base64_data: str, aspect_ratio: str) -> dict:
         mime_type = "image/png"
         return {
@@ -79,7 +82,7 @@ class ImagenTool(Tool):
                 yield self.create_text_message("Trying Google GenAI SDK...")
                 client = genai.Client(
                     api_key=api_key,
-                    http_options={"base_url": "https://aihubmix.com/gemini"},
+                    http_options={"base_url": f"{self.get_base_url()}/gemini"},
                 )
                 
                 config = types.GenerateImagesConfig(
@@ -137,7 +140,7 @@ class ImagenTool(Tool):
             # Method 2: Try predictions endpoint
             try:
                 yield self.create_text_message("Trying predictions endpoint...")
-                endpoint = f"{self.BASE_URL}/models/google/{model}/predictions"
+                endpoint = f"{self.get_base_url()}/v1/models/google/{model}/predictions"
                 
                 headers = {
                     "Authorization": f"Bearer {api_key}",
@@ -224,7 +227,7 @@ class ImagenTool(Tool):
             # Method 3: Try Gemini style endpoint
             try:
                 yield self.create_text_message("Trying Gemini style endpoint...")
-                endpoint = f"{self.BASE_URL}/imagen/generate"
+                endpoint = f"{self.get_base_url()}/v1/imagen/generate"
                 
                 headers = {
                     "Authorization": f"Bearer {api_key}",

--- a/tools/aihubmix_image/tools/qwen-image-edit.py
+++ b/tools/aihubmix_image/tools/qwen-image-edit.py
@@ -22,11 +22,14 @@ class QwenImageEditTool(Tool):
     """
     
     # API endpoints
-    BASE_URL = "https://aihubmix.com/v1"
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
 
     def get_endpoint(self, model: str) -> str:
         vendor = "qianfan" if model == "qwen-image-edit" else "bailian"
-        return f"{self.BASE_URL}/models/{vendor}/{model}/predictions"
+        return f"{self.get_base_url()}/v1/models/{vendor}/{model}/predictions"
     
     def create_image_info(self, base64_data: str, guidance: float) -> dict:
         mime_type = "image/png"

--- a/tools/aihubmix_image/tools/qwen-image.py
+++ b/tools/aihubmix_image/tools/qwen-image.py
@@ -15,11 +15,14 @@ class QwenImageTool(Tool):
     Uses qianfan/qwen-image model optimized for Chinese prompts
     """
     
-    BASE_URL = "https://aihubmix.com/v1"
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
 
     def get_endpoint(self, model: str) -> str:
         vendor = "qianfan" if model == "qwen-image" else "bailian"
-        return f"{self.BASE_URL}/models/{vendor}/{model}/predictions"
+        return f"{self.get_base_url()}/v1/models/{vendor}/{model}/predictions"
     
     def create_image_info(self, base64_data: str, resolution: str) -> dict:
         mime_type = "image/png"

--- a/tools/aihubmix_image/tools/wan.py
+++ b/tools/aihubmix_image/tools/wan.py
@@ -9,10 +9,13 @@ from dify_plugin.errors.model import InvokeError
 
 
 class WanTool(Tool):
-    BASE_URL = "https://aihubmix.com/v1"
+    DEFAULT_BASE_URL = "https://api.inferera.com"
+
+    def get_base_url(self) -> str:
+        return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
 
     def get_endpoint(self, model: str) -> str:
-        return f"{self.BASE_URL}/models/bailian/{model}/predictions"
+        return f"{self.get_base_url()}/v1/models/bailian/{model}/predictions"
 
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         try:


### PR DESCRIPTION
Add a base_url credential (select) to the provider with two presets: https://api.inferera.com (default) and https://aihubmix.com. All 13 tools and the credential validation now read the gateway root from credentials at runtime and append /v1 or /gemini as needed, replacing the previously hardcoded https://aihubmix.com.

## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->



## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [ ] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [ ] SaaS (cloud.dify.ai)
