### PR TITLE
feat(lemonade): add speech2text & tts model types, structured output, and update default port to 13305

### DIFF
--- a/models/lemonade/README.md
+++ b/models/lemonade/README.md
@@ -6,7 +6,7 @@
 
 Lemonade enables local execution of LLMs, providing enhanced data privacy and security by keeping your data on your own machine while leveraging hardware acceleration for improved performance.
 
-Dify integrates with Lemonade Server to provide LLM, text embedding, and reranking capabilities for models deployed locally.
+Dify integrates with Lemonade Server to provide LLM (including vision and structured output), text embedding, reranking, speech-to-text (Whisper), and text-to-speech (Kokoro) capabilities for models deployed locally.
 
 ## Configure
 
@@ -43,15 +43,27 @@ Then, fill in the following configuration:
 ![](./_assets/lemonade-03.png)
 
 **Basic Configuration:**
-- **Model Type**: Choose from `llm`, `text-embedding`, or `rerank` based on your use case
+- **Model Type**: Choose from `llm`, `text-embedding`, `rerank`, `speech2text`, or `tts` based on your use case
 - **Model Name**: Your selected model. You can see available models [here](https://lemonade-server.ai/docs/server/server_models/).
 - **API Endpoint URL**: Base URL where the Lemonade Server
   - For most cases this should be `http://127.0.0.1:13305`
   - If Dify is deployed using Docker, consider using the local network IP address, e.g., `http://192.168.1.100:13305` or `http://host.docker.internal:13305`
 - **Authorization Name**: Leave this field blank. Lemonade uses built-in authentication and does not require an API key.
+
+**LLM options:**
 - **Model Context Size**: The maximum context size of the model (default: 4096).
-- **Agent Thought Support**: Select "Support" if your model supports reasoning chains
+- **Agent Thought Support**: Select "Support" if your model supports reasoning chains.
 - **Vision Support**: Select "Support" if your model supports image understanding.
+- **Structured Output Support**: Select "Support" if your model can return JSON object / JSON schema responses.
+
+**Speech-to-Text options** (Whisper recipes):
+- **Language**: The primary language of the audio (e.g. `en`, `zh`).
+- **Initial Prompt**: Optional prompt to bias the transcription.
+
+**Text-to-Speech options** (Kokoro recipes):
+- **Available Voices**: Comma-separated list of voice names; the first is used as the default.
+- **Audio Format**: Output format (`mp3` or `wav`).
+- **Words per chunk**: Maximum words sent per request for long inputs.
 
 **Sample Configuration:**
 ```

--- a/models/lemonade/README.md
+++ b/models/lemonade/README.md
@@ -21,7 +21,7 @@ lemonade-server serve
 ```
 > Note: If you installer from source use `lemonade-server-dev` instead
 
-Once started, Lemonade will be accessible at `http://localhost:8000`.
+Once started, Lemonade will be accessible at `http://localhost:13305`.
 
 
 ### 2. Install Lemonade Plugin in Dify
@@ -46,8 +46,8 @@ Then, fill in the following configuration:
 - **Model Type**: Choose from `llm`, `text-embedding`, or `rerank` based on your use case
 - **Model Name**: Your selected model. You can see available models [here](https://lemonade-server.ai/docs/server/server_models/).
 - **API Endpoint URL**: Base URL where the Lemonade Server
-  - For most cases this should be `http://127.0.0.1:8000`
-  - If Dify is deployed using Docker, consider using the local network IP address, e.g., `http://192.168.1.100:8000` or `http://host.docker.internal:8000`
+  - For most cases this should be `http://127.0.0.1:13305`
+  - If Dify is deployed using Docker, consider using the local network IP address, e.g., `http://192.168.1.100:13305` or `http://host.docker.internal:13305`
 - **Authorization Name**: Leave this field blank. Lemonade uses built-in authentication and does not require an API key.
 - **Model Context Size**: The maximum context size of the model (default: 4096).
 - **Agent Thought Support**: Select "Support" if your model supports reasoning chains
@@ -73,7 +73,7 @@ You can now use Lemonade with your favorite Dify workflow!
 ### Additional Models
 
 You can manage which models are installed on Lemonade using the Model Management GUI.
-- Open your web browser and navigate to `http://localhost:8000`
+- Open your web browser and navigate to `http://localhost:13305`
 - Click on the "Model Management" tab
 - Browse available models and install them with one click
 

--- a/models/lemonade/manifest.yaml
+++ b/models/lemonade/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.13
+version: 0.0.14
 type: plugin
 author: "langgenius"
 name: "lemonade"
@@ -17,6 +17,11 @@ resource:
     model:
       enabled: true
       llm: true
+      text_embedding: true
+      rerank: true
+      speech2text: true
+      tts: true
+      moderation: false
 plugins:
   models:
     - "provider/lemonade.yaml"

--- a/models/lemonade/manifest.yaml
+++ b/models/lemonade/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 type: plugin
 author: "langgenius"
 name: "lemonade"

--- a/models/lemonade/models/llm/llm.py
+++ b/models/lemonade/models/llm/llm.py
@@ -111,8 +111,6 @@ def validate_lemonade_credentials(credentials: dict, model: str = None) -> None:
         
         # Check if the requested model is available
         if model not in available_models:
-            base_url = credentials.get("endpoint_url", "").rstrip("/")
-            management_url = f"{base_url}:8000/#model-management"
             raise CredentialsValidateFailedError(
                 f"Model '{model}' is not available on the Lemonade server. "
                 "Please pull the model first. You can find more information about it at "

--- a/models/lemonade/models/speech2text/speech2text.py
+++ b/models/lemonade/models/speech2text/speech2text.py
@@ -1,0 +1,64 @@
+from typing import IO, Optional
+from urllib.parse import urljoin
+
+import requests
+
+from dify_plugin.entities.model import AIModelEntity, FetchFrom, I18nObject, ModelType
+from dify_plugin.errors.model import InvokeBadRequestError
+from dify_plugin.interfaces.model.openai_compatible.speech2text import OAICompatSpeech2TextModel
+
+from ..llm.llm import validate_lemonade_credentials
+
+
+def _lemonade_base_url(credentials: dict) -> str:
+    """
+    Normalize the configured endpoint to the Lemonade ``/api/v1`` base URL
+    (with a trailing slash so ``urljoin`` keeps the version prefix).
+    """
+    endpoint_url = (credentials.get("endpoint_url") or "").rstrip("/")
+    if endpoint_url and "/api/v1" not in endpoint_url:
+        endpoint_url += "/api/v1"
+    return endpoint_url + "/"
+
+
+class LemonadeSpeech2TextModel(OAICompatSpeech2TextModel):
+    """
+    Speech-to-text model backed by Lemonade's OpenAI-compatible
+    ``/api/v1/audio/transcriptions`` endpoint (Whisper recipes).
+    """
+
+    def _invoke(
+        self, model: str, credentials: dict, file: IO[bytes], user: Optional[str] = None
+    ) -> str:
+        # Lemonade uses a fixed, unused API key.
+        headers = {"Authorization": "Bearer lemonade"}
+
+        endpoint_url = urljoin(_lemonade_base_url(credentials), "audio/transcriptions")
+
+        language = credentials.get("language") or "en"
+        prompt = credentials.get("initial_prompt") or "convert the audio to text"
+        payload = {"model": model, "language": language, "prompt": prompt}
+        files = [("file", file)]
+
+        response = requests.post(
+            endpoint_url, headers=headers, data=payload, files=files, timeout=(10, 300)
+        )
+
+        if response.status_code != 200:
+            raise InvokeBadRequestError(response.text)
+        return response.json()["text"]
+
+    def validate_credentials(self, model: str, credentials: dict) -> None:
+        # Reuse the shared server health + model availability check.
+        validate_lemonade_credentials(credentials, model)
+
+    def get_customizable_model_schema(self, model: str, credentials: dict) -> AIModelEntity:
+        entity = AIModelEntity(
+            model=model,
+            label=I18nObject(en_us=model),
+            fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
+            model_type=ModelType.SPEECH2TEXT,
+            model_properties={},
+            parameter_rules=[],
+        )
+        return entity

--- a/models/lemonade/models/tts/tts.py
+++ b/models/lemonade/models/tts/tts.py
@@ -1,0 +1,59 @@
+from typing import Any, Optional
+
+from dify_plugin.entities.model import AIModelEntity
+from dify_plugin.interfaces.model.openai_compatible.tts import OAICompatText2SpeechModel
+
+from ..llm.llm import validate_lemonade_credentials
+
+
+class LemonadeText2SpeechModel(OAICompatText2SpeechModel):
+    """
+    Text-to-speech model backed by Lemonade's OpenAI-compatible
+    ``/api/v1/audio/speech`` endpoint (Kokoro recipes).
+    """
+
+    def _invoke(
+        self,
+        model: str,
+        tenant_id: str,
+        credentials: dict,
+        content_text: str,
+        voice: str,
+        user: Optional[str] = None,
+    ) -> Any:
+        return super()._invoke(
+            model, tenant_id, self._to_lemonade_credentials(credentials), content_text, voice, user
+        )
+
+    def validate_credentials(
+        self, model: str, credentials: dict, user: Optional[str] = None
+    ) -> None:
+        # Reuse the shared server health + model availability check.
+        validate_lemonade_credentials(credentials, model)
+
+    def get_customizable_model_schema(self, model: str, credentials: dict) -> AIModelEntity:
+        return super().get_customizable_model_schema(
+            model, self._to_lemonade_credentials(credentials)
+        )
+
+    def get_tts_model_voices(
+        self, model: str, credentials: dict, language: Optional[str] = None
+    ) -> list:
+        return super().get_tts_model_voices(
+            model, self._to_lemonade_credentials(credentials), language
+        )
+
+    @staticmethod
+    def _to_lemonade_credentials(credentials: dict) -> dict:
+        """
+        Inject the fixed Lemonade API key and ensure the endpoint targets the
+        ``/api/v1`` base expected by the OpenAI-compatible TTS implementation.
+        """
+        creds = dict(credentials)
+        creds.setdefault("api_key", "lemonade")
+
+        endpoint_url = (creds.get("endpoint_url") or "").rstrip("/")
+        if endpoint_url and "/api/v1" not in endpoint_url:
+            endpoint_url += "/api/v1"
+        creds["endpoint_url"] = endpoint_url
+        return creds

--- a/models/lemonade/provider/lemonade.yaml
+++ b/models/lemonade/provider/lemonade.yaml
@@ -28,8 +28,8 @@ model_credential_schema:
       type: text-input
       required: true
       placeholder:
-        zh_Hans: Lemonade Server 的地址，如 http://127.0.0.1:8000
-        en_US: Base URL of Lemonade Server, e.g. http://127.0.0.1:8000
+        zh_Hans: Lemonade Server 的地址，如 http://127.0.0.1:13305
+        en_US: Base URL of Lemonade Server, e.g. http://127.0.0.1:13305
     - variable: context_size
       label:
         zh_Hans: 模型上下文长度

--- a/models/lemonade/provider/lemonade.yaml
+++ b/models/lemonade/provider/lemonade.yaml
@@ -10,6 +10,8 @@ supported_model_types:
   - llm
   - rerank
   - text-embedding
+  - speech2text
+  - tts
 configurate_methods:
   - customizable-model
 model_credential_schema:
@@ -80,6 +82,113 @@ model_credential_schema:
           label:
             en_US: Not Support
             zh_Hans: 不支持
+    - variable: structured_output_support
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        zh_Hans: 结构化输出支持
+        en_US: Structured Output Support
+      type: radio
+      required: false
+      default: not_supported
+      options:
+        - value: supported
+          label:
+            en_US: Support
+            zh_Hans: 支持
+        - value: not_supported
+          label:
+            en_US: Not Support
+            zh_Hans: 不支持
+    - variable: language
+      show_on:
+        - variable: __model_type
+          value: speech2text
+      label:
+        en_US: Language
+        zh_Hans: 语言
+      type: select
+      required: false
+      default: en
+      placeholder:
+        zh_Hans: 模型支持的语言，例如 en,zh
+        en_US: The language supported by the model, e.g. en,zh
+      options:
+        - value: en
+          label:
+            en_US: en-US
+            zh_Hans: 英文
+        - value: zh
+          label:
+            en_US: zh-Hans
+            zh_Hans: 中文
+        - value: ja
+          label:
+            en_US: ja-JP
+            zh_Hans: 日语
+        - value: ko
+          label:
+            en_US: ko-KR
+            zh_Hans: 韩语
+    - variable: initial_prompt
+      show_on:
+        - variable: __model_type
+          value: speech2text
+      label:
+        en_US: Initial Prompt
+        zh_Hans: 初始提示
+      type: text-input
+      required: false
+      placeholder:
+        zh_Hans: 模型在转录开始时的初始提示
+        en_US: The initial prompt for the model at the start of the transcription.
+    - variable: voices
+      show_on:
+        - variable: __model_type
+          value: tts
+      label:
+        en_US: Available Voices (comma-separated)
+        zh_Hans: 可用声音（用英文逗号分隔）
+      type: text-input
+      required: false
+      default: "af_sky"
+      placeholder:
+        en_US: "af_sky,af_bella,am_adam,bf_emma"
+        zh_Hans: "af_sky,af_bella,am_adam,bf_emma"
+      help:
+        en_US: "List Kokoro voice names separated by commas. The first voice is used as the default."
+        zh_Hans: "用英文逗号分隔的 Kokoro 声音列表。第一个声音将作为默认值。"
+    - variable: audio_type
+      show_on:
+        - variable: __model_type
+          value: tts
+      label:
+        en_US: Audio Format
+        zh_Hans: 音频格式
+      type: select
+      required: false
+      default: mp3
+      options:
+        - value: mp3
+          label:
+            en_US: mp3
+        - value: wav
+          label:
+            en_US: wav
+    - variable: word_limit
+      show_on:
+        - variable: __model_type
+          value: tts
+      label:
+        en_US: Words per chunk
+        zh_Hans: 每段最大字数
+      type: text-input
+      required: false
+      default: "4096"
+      placeholder:
+        en_US: Maximum number of words sent to the model per request
+        zh_Hans: 每次请求发送给模型的最大字数
 extra:
   python:
     provider_source: provider/lemonade.py
@@ -87,6 +196,8 @@ extra:
       - "models/llm/llm.py"
       - "models/text_embedding/text_embedding.py"
       - "models/rerank/rerank.py"
+      - "models/speech2text/speech2text.py"
+      - "models/tts/tts.py"
 help:
   title:
     en_US: How to integrate with Lemonade


### PR DESCRIPTION
## Summary

Brings the Lemonade model provider in line with the latest [Lemonade Server docs](https://lemonade-server.ai/docs/api/openai/) and expands it to cover the full set of OpenAI-compatible capabilities the server exposes.

## What's new

**New model types**
- **`speech2text`** — Whisper transcription via `/api/v1/audio/transcriptions` (with `language` and `initial_prompt` options).
- **`tts`** — Kokoro speech synthesis via `/api/v1/audio/speech` (with configurable `voices`, `audio_type`, and `word_limit`).

**LLM enhancements**
- **Structured output** — added the `structured_output_support` toggle to the provider schema. The handling already existed in `llm.py` but had no UI field, so it was previously unreachable.
- Vision, agent-thought, reranking, and text-embedding support were already present and are unchanged.

**Maintenance**
- Default server port updated from `8000` → `13305` (placeholder, README examples, and removal of a stale `:8000` model-management URL string).
- Declared `text_embedding` / `rerank` / `speech2text` / `tts` permissions in the manifest.
- Bumped plugin version `0.0.12` → `0.0.14`.

## Notes
- The plugin targets the OpenAI-compatible API under `/api/v1`, which the server still accepts as a compatibility prefix; both new model types reuse the shared `validate_lemonade_credentials` health + model-availability check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)