### PR TITLE
fix(dify_extractor): catch BadZipFile for corrupt office files

### DIFF
--- a/tools/dify_extractor/manifest.yaml
+++ b/tools/dify_extractor/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 type: plugin
 author: langgenius
 name: dify_extractor

--- a/tools/dify_extractor/pyproject.toml
+++ b/tools/dify_extractor/pyproject.toml
@@ -24,4 +24,6 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=9.1.1",
+]

--- a/tools/dify_extractor/tests/test_dify_extractor.py
+++ b/tools/dify_extractor/tests/test_dify_extractor.py
@@ -31,7 +31,7 @@ def test_invoke_returns_error_for_corrupt_docx():
     assert len(messages) == 1
     assert messages[0]["type"] == "text"
     assert "not a valid .docx file" in messages[0]["value"]
-    assert "corrupted or in an incompatible format" in messages[0]["value"]
+    assert "old binary .doc instead of .docx" in messages[0]["value"]
 
 
 def test_invoke_returns_error_for_corrupt_pptx():
@@ -43,6 +43,7 @@ def test_invoke_returns_error_for_corrupt_pptx():
     assert len(messages) == 1
     assert messages[0]["type"] == "text"
     assert "not a valid .pptx file" in messages[0]["value"]
+    assert "old binary .ppt instead of .pptx" in messages[0]["value"]
 
 
 def test_invoke_returns_error_for_corrupt_xlsx():
@@ -54,3 +55,4 @@ def test_invoke_returns_error_for_corrupt_xlsx():
     assert len(messages) == 1
     assert messages[0]["type"] == "text"
     assert "not a valid .xlsx file" in messages[0]["value"]
+    assert "old binary .xls instead of .xlsx" in messages[0]["value"]

--- a/tools/dify_extractor/tests/test_dify_extractor.py
+++ b/tools/dify_extractor/tests/test_dify_extractor.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.dify_extractor import DifyExtractorTool
+
+
+class _MessageToolMixin:
+    def create_text_message(self, value):
+        return {"type": "text", "value": value}
+
+    def create_variable_message(self, name, value):
+        return {"type": "variable", "name": name, "value": value}
+
+
+def _make_tool() -> DifyExtractorTool:
+    tool = object.__new__(DifyExtractorTool)
+    tool.create_text_message = _MessageToolMixin.create_text_message.__get__(tool, DifyExtractorTool)
+    tool.create_variable_message = _MessageToolMixin.create_variable_message.__get__(tool, DifyExtractorTool)
+    return tool
+
+
+def test_invoke_returns_error_for_corrupt_docx():
+    tool = _make_tool()
+    corrupt_file = SimpleNamespace(filename="report.docx", blob=b"not a zip file")
+
+    messages = list(tool._invoke({"file": corrupt_file}))
+
+    assert len(messages) == 1
+    assert messages[0]["type"] == "text"
+    assert "not a valid .docx file" in messages[0]["value"]
+    assert "corrupted or in an incompatible format" in messages[0]["value"]
+
+
+def test_invoke_returns_error_for_corrupt_pptx():
+    tool = _make_tool()
+    corrupt_file = SimpleNamespace(filename="slides.pptx", blob=b"not a zip file")
+
+    messages = list(tool._invoke({"file": corrupt_file}))
+
+    assert len(messages) == 1
+    assert messages[0]["type"] == "text"
+    assert "not a valid .pptx file" in messages[0]["value"]
+
+
+def test_invoke_returns_error_for_corrupt_xlsx():
+    tool = _make_tool()
+    corrupt_file = SimpleNamespace(filename="sheet.xlsx", blob=b"not a zip file")
+
+    messages = list(tool._invoke({"file": corrupt_file}))
+
+    assert len(messages) == 1
+    assert messages[0]["type"] == "text"
+    assert "not a valid .xlsx file" in messages[0]["value"]

--- a/tools/dify_extractor/tools/dify_extractor.py
+++ b/tools/dify_extractor/tools/dify_extractor.py
@@ -1,6 +1,7 @@
 import os
 from collections.abc import Generator
 from typing import Any
+from zipfile import BadZipFile
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
@@ -24,7 +25,13 @@ class DifyExtractorTool(Tool):
             raise ValueError("file is required")
         file_name = file.filename
         file_extension = os.path.splitext(file_name)[-1].lower()
-        file_bytes = file.blob
+
+        try:
+            file_bytes = file.blob
+        except Exception as e:
+            yield self.create_text_message(f"Failed to read file '{file_name}': {e}")
+            return
+
         if file_extension in {".xlsx", ".xls"}:
             extractor = ExcelExtractor(file_bytes, file_name)
         elif file_extension == ".pdf":
@@ -46,7 +53,19 @@ class DifyExtractorTool(Tool):
         else:
             # txt
             extractor = TextExtractor(file_bytes, file_name, autodetect_encoding=True)
-        extractor_result = extractor.extract()
+
+        try:
+            extractor_result = extractor.extract()
+        except BadZipFile:
+            yield self.create_text_message(
+                f"File '{file_name}' is not a valid {file_extension} file. "
+                f"It may be corrupted or in an incompatible format (e.g., old binary .doc instead of .docx)."
+            )
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Failed to extract '{file_name}': {e}")
+            return
+
         if extractor_result.img_list:
             yield self.create_variable_message("images", extractor_result.img_list)
         yield self.create_text_message(extractor_result.md_content)

--- a/tools/dify_extractor/tools/dify_extractor.py
+++ b/tools/dify_extractor/tools/dify_extractor.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import logging
 from collections.abc import Generator
 from typing import Any
 from zipfile import BadZipFile
@@ -37,10 +36,9 @@ class DifyExtractorTool(Tool):
         file_extension = os.path.splitext(file_name)[-1].lower()
 
         try:
-        try:
             file_bytes = file.blob
         except Exception as e:
-            logging.exception(f"Failed to read file '{file_name}'")
+            logger.exception("Failed to read file '%s'", file_name)
             yield self.create_text_message(f"Failed to read file '{file_name}': {e}")
             return
 
@@ -69,21 +67,14 @@ class DifyExtractorTool(Tool):
         try:
             extractor_result = extractor.extract()
         except BadZipFile:
-        except BadZipFile:
-            example_map = {
-                ".docx": " (e.g., old binary .doc instead of .docx)",
-                ".xlsx": " (e.g., old binary .xls instead of .xlsx)",
-                ".pptx": " (e.g., old binary .ppt instead of .pptx)",
-            }
-            example = example_map.get(file_extension, "")
+            example = _BAD_ZIP_FORMAT_EXAMPLES.get(file_extension, "")
             yield self.create_text_message(
                 f"File '{file_name}' is not a valid {file_extension} file. "
                 f"It may be corrupted or in an incompatible format{example}."
             )
             return
         except Exception as e:
-        except Exception as e:
-            logging.exception(f"Failed to extract '{file_name}'")
+            logger.exception("Failed to extract '%s'", file_name)
             yield self.create_text_message(f"Failed to extract '{file_name}': {e}")
             return
 

--- a/tools/dify_extractor/tools/dify_extractor.py
+++ b/tools/dify_extractor/tools/dify_extractor.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import logging
 from collections.abc import Generator
 from typing import Any
 from zipfile import BadZipFile
@@ -36,9 +37,10 @@ class DifyExtractorTool(Tool):
         file_extension = os.path.splitext(file_name)[-1].lower()
 
         try:
+        try:
             file_bytes = file.blob
         except Exception as e:
-            logger.exception("Failed to read file '%s'", file_name)
+            logging.exception(f"Failed to read file '{file_name}'")
             yield self.create_text_message(f"Failed to read file '{file_name}': {e}")
             return
 
@@ -67,14 +69,21 @@ class DifyExtractorTool(Tool):
         try:
             extractor_result = extractor.extract()
         except BadZipFile:
-            example = _BAD_ZIP_FORMAT_EXAMPLES.get(file_extension, "")
+        except BadZipFile:
+            example_map = {
+                ".docx": " (e.g., old binary .doc instead of .docx)",
+                ".xlsx": " (e.g., old binary .xls instead of .xlsx)",
+                ".pptx": " (e.g., old binary .ppt instead of .pptx)",
+            }
+            example = example_map.get(file_extension, "")
             yield self.create_text_message(
                 f"File '{file_name}' is not a valid {file_extension} file. "
                 f"It may be corrupted or in an incompatible format{example}."
             )
             return
         except Exception as e:
-            logger.exception("Failed to extract '%s'", file_name)
+        except Exception as e:
+            logging.exception(f"Failed to extract '{file_name}'")
             yield self.create_text_message(f"Failed to extract '{file_name}': {e}")
             return
 

--- a/tools/dify_extractor/tools/dify_extractor.py
+++ b/tools/dify_extractor/tools/dify_extractor.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections.abc import Generator
 from typing import Any
@@ -17,6 +18,14 @@ from tools.word_extractor import WordExtractor
 from tools.pptx_extractor import PPTXExtractor
 from tools.yaml_extractor import YAMLExtractor
 
+logger = logging.getLogger(__name__)
+
+_BAD_ZIP_FORMAT_EXAMPLES = {
+    ".docx": " (e.g., old binary .doc instead of .docx)",
+    ".xlsx": " (e.g., old binary .xls instead of .xlsx)",
+    ".pptx": " (e.g., old binary .ppt instead of .pptx)",
+}
+
 
 class DifyExtractorTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
@@ -29,6 +38,7 @@ class DifyExtractorTool(Tool):
         try:
             file_bytes = file.blob
         except Exception as e:
+            logger.exception("Failed to read file '%s'", file_name)
             yield self.create_text_message(f"Failed to read file '{file_name}': {e}")
             return
 
@@ -57,12 +67,14 @@ class DifyExtractorTool(Tool):
         try:
             extractor_result = extractor.extract()
         except BadZipFile:
+            example = _BAD_ZIP_FORMAT_EXAMPLES.get(file_extension, "")
             yield self.create_text_message(
                 f"File '{file_name}' is not a valid {file_extension} file. "
-                f"It may be corrupted or in an incompatible format (e.g., old binary .doc instead of .docx)."
+                f"It may be corrupted or in an incompatible format{example}."
             )
             return
         except Exception as e:
+            logger.exception("Failed to extract '%s'", file_name)
             yield self.create_text_message(f"Failed to extract '{file_name}': {e}")
             return
 

--- a/tools/dify_extractor/uv.lock
+++ b/tools/dify_extractor/uv.lock
@@ -126,7 +126,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and sys_platform == 'win32'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -298,6 +298,11 @@ dependencies = [
     { name = "xlrd" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
@@ -316,7 +321,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
 
 [[package]]
 name = "dify-plugin"
@@ -538,6 +543,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1138,6 +1152,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1345,6 +1368,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pypdfium2"
 version = "5.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1371,6 +1403,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/11/7b/6ed4782e0d7a5278330598ce8c4b2df7255f4585a0b3d04520fa580d6507/pypdfium2-5.8.0-py3-none-win32.whl", hash = "sha256:3f25fd436920a907291462b41bdc0ab9f8235c3944b4c9c15398da595ffd1fed", size = 3636680, upload-time = "2026-05-04T17:39:38.49Z" },
     { url = "https://files.pythonhosted.org/packages/19/55/da7223d4202b2461f4f889b0baf10dddec3db7f88e6fd8c52db4a516eecd/pypdfium2-5.8.0-py3-none-win_amd64.whl", hash = "sha256:55592af0bddd2d62bed18e0053c546c9b72041430c5115e54870f7f6163125b0", size = 3754962, upload-time = "2026-05-04T17:39:40.13Z" },
     { url = "https://files.pythonhosted.org/packages/fc/7a/f3dcefe6ee7389aad3ca1488c177e8fbf978206de21c7a99ccf487ea38ab/pypdfium2-5.8.0-py3-none-win_arm64.whl", hash = "sha256:3f17ed97ae8a5a1705301ca93af256a5b02f9009dee4e99c5e175831d46ebd7c", size = 3548362, upload-time = "2026-05-04T17:39:42.304Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Catch `BadZipFile` when extracting `.docx`, `.xlsx`, and `.pptx` files in `dify_extractor`
- Return a clear user-facing error message instead of letting the exception propagate and stall the pipeline
- Add regression tests for corrupt docx/pptx/xlsx inputs

This addresses **Fix 1** from #3351 only. The separate `pipeline_runner.py` / `GraphRunAbortedEvent` follow-up in main Dify is intentionally out of scope for this PR.

Fixes #3351

## Test plan
- [x] `uv run pytest tools/dify_extractor/tests/test_dify_extractor.py -v` (3 tests pass)
- [ ] Upload a corrupted `.docx` to a RAG pipeline using `dify_extractor` and confirm a clear error is returned immediately (no 1200s hang)


Made with [Cursor](https://cursor.com)