### PR TITLE
fix(azure_openai): cache clients and fix Responses API usage

### DIFF
--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.59
+version: 0.0.60

--- a/models/azure_openai/models/common.py
+++ b/models/azure_openai/models/common.py
@@ -132,15 +132,9 @@ class _CommonAzureOpenAI:
 
         cache_key = cls._credential_cache_key(credentials)
         with _client_cache_lock:
-            cached = _client_cache.get(cache_key)
-            if cached is not None:
-                return cached
-
-        client = cls._build_client(credentials)
-
-        with _client_cache_lock:
-            _client_cache[cache_key] = client
-        return client
+            if cache_key not in _client_cache:
+                _client_cache[cache_key] = cls._build_client(credentials)
+            return _client_cache[cache_key]
 
     @property
     def _invoke_error_mapping(self) -> dict[type[InvokeError], list[type[Exception]]]:

--- a/models/azure_openai/models/common.py
+++ b/models/azure_openai/models/common.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlparse
+import threading
 
 import openai
 from dify_plugin.errors.model import (
@@ -12,6 +13,9 @@ from dify_plugin.errors.model import (
 from httpx import Timeout
 
 from .constants import AZURE_OPENAI_API_VERSION
+
+_client_cache: dict[tuple, openai.AzureOpenAI | openai.OpenAI] = {}
+_client_cache_lock = threading.Lock()
 
 
 class _CommonAzureOpenAI:
@@ -99,12 +103,44 @@ class _CommonAzureOpenAI:
 
         return credentials_kwargs
 
+    @staticmethod
+    def _credential_cache_key(credentials: dict) -> tuple:
+        auth_method = credentials.get("auth_method", "api_key")
+        api_base = credentials.get("openai_api_base", "").strip()
+        api_version = credentials.get("openai_api_version") or AZURE_OPENAI_API_VERSION
+        return (
+            api_base,
+            auth_method,
+            credentials.get("openai_api_key"),
+            credentials.get("azure_tenant_id"),
+            credentials.get("azure_client_id"),
+            credentials.get("azure_client_secret"),
+            api_version,
+        )
+
     @classmethod
-    def _create_client(cls, credentials: dict):
+    def _build_client(cls, credentials: dict):
         client_kwargs = cls._to_credential_kwargs(credentials)
         if cls._is_v1_api_base(credentials["openai_api_base"]):
             return openai.OpenAI(**client_kwargs)
         return openai.AzureOpenAI(**client_kwargs)
+
+    @classmethod
+    def _create_client(cls, credentials: dict, *, use_cache: bool = True):
+        if not use_cache:
+            return cls._build_client(credentials)
+
+        cache_key = cls._credential_cache_key(credentials)
+        with _client_cache_lock:
+            cached = _client_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        client = cls._build_client(credentials)
+
+        with _client_cache_lock:
+            _client_cache[cache_key] = client
+        return client
 
     @property
     def _invoke_error_mapping(self) -> dict[type[InvokeError], list[type[Exception]]]:

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -152,7 +152,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             )
 
         try:
-            client = self._create_client(credentials)
+            client = self._create_client(credentials, use_cache=False)
             if self._uses_responses_api(base_model_name):
                 client.responses.create(
                     input="ping",

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -841,44 +841,12 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         # Calculate token usage
         prompt_tokens = 0
         completion_tokens = 0
-        prompt_tokens_details: Optional[dict] = None
-        completion_tokens_details: Optional[dict] = None
 
         if hasattr(response, 'usage') and response.usage:
             usage_obj = response.usage
             # Support Responses API usage fields
             prompt_tokens = getattr(usage_obj, 'input_tokens', None) or getattr(usage_obj, 'prompt_tokens', 0)
             completion_tokens = getattr(usage_obj, 'output_tokens', None) or getattr(usage_obj, 'completion_tokens', 0)
-            # Support implementations that expose detailed fields (convert SDK types to dict)
-            # Prefer the unified prompt_tokens_details/completion_tokens_details fields
-            if hasattr(usage_obj, 'prompt_tokens_details') and usage_obj.prompt_tokens_details:
-                _ptd = usage_obj.prompt_tokens_details
-                if hasattr(_ptd, 'to_dict'):
-                    prompt_tokens_details = _ptd.to_dict()
-                elif isinstance(_ptd, dict):
-                    prompt_tokens_details = _ptd
-                else:
-                    prompt_tokens_details = {
-                        'cached_tokens': getattr(_ptd, 'cached_tokens', None)
-                    }
-            elif hasattr(usage_obj, 'input_tokens_details') and usage_obj.input_tokens_details:
-                it = usage_obj.input_tokens_details
-                if hasattr(it, 'to_dict'):
-                    prompt_tokens_details = it.to_dict()
-                else:
-                    prompt_tokens_details = {
-                        'cached_tokens': getattr(it, 'cached_tokens', None)
-                    }
-            if hasattr(usage_obj, 'completion_tokens_details') and usage_obj.completion_tokens_details:
-                completion_tokens_details = usage_obj.completion_tokens_details
-            elif hasattr(usage_obj, 'output_tokens_details') and usage_obj.output_tokens_details:
-                ot = usage_obj.output_tokens_details
-                if hasattr(ot, 'to_dict'):
-                    completion_tokens_details = ot.to_dict()
-                else:
-                    completion_tokens_details = {
-                        'reasoning_tokens': getattr(ot, 'reasoning_tokens', None)
-                    }
         else:
             # Estimate usage when it is not provided
             prompt_tokens = self._num_tokens_from_messages(
@@ -890,8 +858,6 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
         usage = self._calc_response_usage(
             model, credentials, prompt_tokens, completion_tokens,
-            prompt_tokens_details=prompt_tokens_details,
-            completion_tokens_details=completion_tokens_details
         )
 
         return LLMResult(

--- a/models/azure_openai/models/speech2text/speech2text.py
+++ b/models/azure_openai/models/speech2text/speech2text.py
@@ -36,12 +36,12 @@ class AzureOpenAISpeech2TextModel(_CommonAzureOpenAI, Speech2TextModel):
         try:
             audio_file_path = self._get_demo_file_path()
             with open(audio_file_path, "rb") as audio_file:
-                self._speech2text_invoke(model, credentials, audio_file)
+                self._speech2text_invoke(model, credentials, audio_file, use_cache=False)
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 
     def _speech2text_invoke(
-        self, model: str, credentials: dict, file: IO[bytes]
+        self, model: str, credentials: dict, file: IO[bytes], *, use_cache: bool = True
     ) -> str:
         """
         Invoke speech2text model
@@ -51,7 +51,7 @@ class AzureOpenAISpeech2TextModel(_CommonAzureOpenAI, Speech2TextModel):
         :param file: audio file
         :return: text for given audio file
         """
-        client = self._create_client(credentials)
+        client = self._create_client(credentials, use_cache=use_cache)
         base_model_name = self._get_base_model_name(credentials)
         ai_model_entity = self._get_ai_model_entity(base_model_name, model)
         extra_params = ai_model_entity.extra_invoke_params if ai_model_entity else {}

--- a/models/azure_openai/models/text_embedding/text_embedding.py
+++ b/models/azure_openai/models/text_embedding/text_embedding.py
@@ -131,7 +131,7 @@ class AzureOpenAITextEmbeddingModel(_CommonAzureOpenAI, TextEmbeddingModel):
                 f"Base Model Name {credentials['base_model_name']} is invalid"
             )
         try:
-            client = self._create_client(credentials)
+            client = self._create_client(credentials, use_cache=False)
             self._embedding_invoke(
                 model=model, client=client, texts=["ping"], extra_model_kwargs={}
             )

--- a/models/azure_openai/models/tts/tts.py
+++ b/models/azure_openai/models/tts/tts.py
@@ -59,12 +59,13 @@ class AzureOpenAIText2SpeechModel(_CommonAzureOpenAI, TTSModel):
                 credentials=credentials,
                 content_text="Hello Dify!",
                 voice=self._get_model_default_voice(model, credentials),
+                use_cache=False,
             )
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 
     def _tts_invoke_streaming(
-        self, model: str, credentials: dict, content_text: str, voice: str
+        self, model: str, credentials: dict, content_text: str, voice: str, *, use_cache: bool = True
     ) -> Any:
         """
         _tts_invoke_streaming text2speech model
@@ -75,7 +76,7 @@ class AzureOpenAIText2SpeechModel(_CommonAzureOpenAI, TTSModel):
         :return: text translated to audio file
         """
         try:
-            client = self._create_client(credentials)
+            client = self._create_client(credentials, use_cache=use_cache)
             audio_type = self._get_model_audio_type(model, credentials)
             max_length = 3500
             if len(content_text) > max_length:

--- a/models/azure_openai/pyproject.toml
+++ b/models/azure_openai/pyproject.toml
@@ -20,4 +20,6 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=9.1.1",
+]

--- a/models/azure_openai/tests/test_common.py
+++ b/models/azure_openai/tests/test_common.py
@@ -1,10 +1,14 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
-from models.common import _CommonAzureOpenAI
+from models.common import _CommonAzureOpenAI, _client_cache
 from models.constants import AZURE_OPENAI_API_VERSION
 
 
 class CommonAzureOpenAITestCase(unittest.TestCase):
+    def setUp(self):
+        _client_cache.clear()
+
     def test_non_v1_endpoint_keeps_api_version(self):
         credentials = {
             "openai_api_base": "https://example-resource.openai.azure.com/",
@@ -35,6 +39,53 @@ class CommonAzureOpenAITestCase(unittest.TestCase):
         )
         self.assertNotIn("api_version", kwargs)
         self.assertNotIn("azure_endpoint", kwargs)
+
+    @patch("models.common.openai.AzureOpenAI")
+    def test_create_client_reuses_cached_client(self, mock_azure_openai):
+        mock_client = MagicMock()
+        mock_azure_openai.return_value = mock_client
+        credentials = {
+            "openai_api_base": "https://example-resource.openai.azure.com/",
+            "openai_api_key": "test-key",
+        }
+
+        first = _CommonAzureOpenAI._create_client(credentials)
+        second = _CommonAzureOpenAI._create_client(credentials)
+
+        self.assertIs(first, second)
+        mock_azure_openai.assert_called_once()
+
+    @patch("models.common.openai.AzureOpenAI")
+    def test_create_client_different_credentials_create_separate_clients(
+        self, mock_azure_openai
+    ):
+        mock_azure_openai.side_effect = [MagicMock(), MagicMock()]
+        base_credentials = {
+            "openai_api_base": "https://example-resource.openai.azure.com/",
+            "openai_api_key": "test-key",
+        }
+
+        first = _CommonAzureOpenAI._create_client(base_credentials)
+        second = _CommonAzureOpenAI._create_client(
+            {**base_credentials, "openai_api_key": "other-key"}
+        )
+
+        self.assertIsNot(first, second)
+        self.assertEqual(mock_azure_openai.call_count, 2)
+
+    @patch("models.common.openai.AzureOpenAI")
+    def test_create_client_use_cache_false_bypasses_cache(self, mock_azure_openai):
+        mock_azure_openai.side_effect = [MagicMock(), MagicMock()]
+        credentials = {
+            "openai_api_base": "https://example-resource.openai.azure.com/",
+            "openai_api_key": "test-key",
+        }
+
+        first = _CommonAzureOpenAI._create_client(credentials, use_cache=False)
+        second = _CommonAzureOpenAI._create_client(credentials, use_cache=False)
+
+        self.assertIsNot(first, second)
+        self.assertEqual(mock_azure_openai.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/models/azure_openai/tests/test_llm.py
+++ b/models/azure_openai/tests/test_llm.py
@@ -24,6 +24,7 @@ from dify_plugin.entities.model.message import (
     TextPromptMessageContent,
     UserPromptMessage,
 )
+from dify_plugin.entities.model.llm import LLMUsage
 from models.llm.llm import AzureOpenAILargeLanguageModel
 from models.constants import LLM_BASE_MODELS, uses_responses_api
 
@@ -391,6 +392,46 @@ class TestResponsesPayloadWithWebSearch(unittest.TestCase):
                     "web_search_user_country": "usa",
                 }
             )
+
+
+class TestResponsesUsageCalculation(unittest.TestCase):
+    """Regression for issue #3322: SDK 0.9.0 _calc_response_usage rejects detail kwargs."""
+
+    def test_handle_responses_response_uses_four_arg_calc_usage(self):
+        llm = make_llm()
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 10
+        mock_usage.output_tokens = 5
+        mock_usage.prompt_tokens_details = MagicMock(cached_tokens=2)
+
+        message_item = MagicMock(type="message", content="hello")
+        response = MagicMock(output=[message_item], usage=mock_usage, id="resp-1")
+
+        llm._calc_response_usage = MagicMock(
+            return_value=LLMUsage(
+                prompt_tokens=10,
+                prompt_unit_price=0,
+                prompt_price_unit=0,
+                prompt_price=0,
+                completion_tokens=5,
+                completion_unit_price=0,
+                completion_price_unit=0,
+                completion_price=0,
+                total_tokens=15,
+                total_price=0,
+                currency="USD",
+                latency=0,
+            )
+        )
+
+        llm._handle_responses_response(
+            model="gpt-5",
+            credentials={},
+            response=response,
+            prompt_messages=[UserPromptMessage(content="hi")],
+        )
+
+        llm._calc_response_usage.assert_called_once_with("gpt-5", {}, 10, 5)
 
 
 if __name__ == "__main__":

--- a/models/azure_openai/uv.lock
+++ b/models/azure_openai/uv.lock
@@ -69,6 +69,11 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "azure-core", specifier = ">=1.41.0" },
@@ -83,7 +88,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
 
 [[package]]
 name = "blinker"
@@ -530,6 +535,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -969,6 +983,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1176,6 +1199,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1187,6 +1219,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Cache `openai.AzureOpenAI` / `openai.OpenAI` clients in a module-level dict keyed by credential fields (api base, auth method, keys/secrets, api version)
- Reuse cached clients across LLM, TTS, embedding, and speech2text invocations to avoid repeated TCP+TLS (and Entra ID token provider setup) on every call
- `validate_credentials` paths pass `use_cache=False` so credential checks still verify with a fresh client
- Drop unsupported `prompt_tokens_details` / `completion_tokens_details` kwargs from Responses API usage calculation (dify_plugin 0.9.0)
- Bump plugin manifest version to **0.0.60**

Fixes #3332
Fixes #3322

## Test plan
- [x] `uv run pytest tests/test_common.py tests/test_llm.py -q` — 33 passed
- [ ] Manual: configure Azure OpenAI provider in Dify and confirm repeated chat completions work without errors