### PR TITLE
fix(volcengine): require Dify 1.15.0 for polling feature support

### DIFF
--- a/models/volcengine/manifest.yaml
+++ b/models/volcengine/manifest.yaml
@@ -16,6 +16,7 @@ meta:
     language: python
     version: "3.12"
   version: 0.0.1
+  minimum_dify_version: "1.15.0"
 name: volcengine
 plugins:
   models:
@@ -32,4 +33,4 @@ resource:
       text_embedding: false
       tts: false
 type: plugin
-version: 0.0.8
+version: 0.0.9


### PR DESCRIPTION
## Summary
- Add `minimum_dify_version: "1.15.0"` to `models/volcengine/manifest.yaml`
- Bump volcengine plugin version **0.0.8 → 0.0.9**

PR #3195 added models declaring the `polling` feature, but Dify only supports that feature starting in **v1.15.0**. Without a minimum version, users on Dify Cloud (v1.14.2) hit a plugin daemon parse error (HTTP 400) when installing v0.0.8.

Fixes #3356

## Test plan
- [x] Manifest diff is limited to `minimum_dify_version` + version bump
- [ ] CI plugin validation on PR approval


Made with [Cursor](https://cursor.com)