### PR TITLE
chore: Harden trigger OAuth and permissions

### DIFF
--- a/tests/triggers/test_trigger_hardening.py
+++ b/tests/triggers/test_trigger_hardening.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TRIGGERS = ROOT / "triggers"
+
+EXPECTED_MANIFEST_VERSIONS = {
+    "airtable_trigger": "1.1.0",
+    "github_trigger": "1.5.0",
+    "gmail_trigger": "0.1.0",
+    "google_calendar_trigger": "0.1.0",
+    "google_drive_trigger": "1.4.0",
+    "lark_trigger": "0.1.0",
+    "linear_trigger": "0.6.0",
+    "notion_trigger": "0.2.0",
+    "outlook_trigger": "0.2.0",
+    "rsshub_trigger": "0.1.0",
+    "slack_trigger": "0.3.0",
+    "telegram_trigger": "0.1.0",
+    "twilio_trigger": "0.1.0",
+    "typeform_trigger": "0.2.0",
+    "woocommerce_trigger": "1.1.0",
+    "zendesk_trigger": "1.1.0",
+}
+
+STORAGE_TRIGGERS = {
+    "airtable_trigger",
+    "github_trigger",
+    "gmail_trigger",
+    "google_calendar_trigger",
+    "google_drive_trigger",
+    "linear_trigger",
+    "outlook_trigger",
+    "typeform_trigger",
+    "zendesk_trigger",
+}
+
+OAUTH_PROVIDERS = {
+    "github_trigger": "provider/github.py",
+    "gmail_trigger": "provider/gmail_trigger.py",
+    "google_calendar_trigger": "provider/google_calendar_trigger.py",
+    "google_drive_trigger": "provider/google_drive.py",
+    "linear_trigger": "provider/linear_simple.py",
+    "outlook_trigger": "provider/outlook.py",
+    "typeform_trigger": "provider/typeform_simple.py",
+    "zendesk_trigger": "provider/zendesk.py",
+}
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_trigger_manifest_versions_and_permissions_are_least_privilege() -> None:
+    for trigger_name, expected_version in EXPECTED_MANIFEST_VERSIONS.items():
+        manifest = _read(TRIGGERS / trigger_name / "manifest.yaml")
+
+        assert re.search(rf"^version: {re.escape(expected_version)}$", manifest, re.MULTILINE), trigger_name
+        assert "    model:" not in manifest
+        assert "    tool:" not in manifest
+
+        if trigger_name in STORAGE_TRIGGERS:
+            assert "    storage:" in manifest, trigger_name
+            assert "      enabled: true" in manifest, trigger_name
+            assert "      size: 1048576" in manifest, trigger_name
+        else:
+            assert "  permission: {}" in manifest, trigger_name
+
+
+def test_trigger_dependency_lower_bounds_are_current() -> None:
+    for pyproject in TRIGGERS.glob("*/pyproject.toml"):
+        text = _read(pyproject)
+        assert "dify_plugin>=0.9.1" in text, pyproject
+        assert "dify_plugin>=0.9.0" not in text, pyproject
+
+    gmail = _read(TRIGGERS / "gmail_trigger" / "pyproject.toml")
+    assert "google-auth>=2.55.1" in gmail
+    assert "google-cloud-pubsub>=2.39.0" in gmail
+
+    lark = _read(TRIGGERS / "lark_trigger" / "pyproject.toml")
+    assert "lark-oapi>=1.6.9" in lark
+
+
+def test_oauth_providers_validate_callback_state() -> None:
+    for trigger_name, provider_path in OAUTH_PROVIDERS.items():
+        source = _read(TRIGGERS / trigger_name / provider_path)
+        assert "_store_oauth_state(redirect_uri, state)" in source, trigger_name
+        assert "_validate_oauth_state(redirect_uri, request.args.get(\"state\"))" in source, trigger_name
+        assert "callback missing state" in source, trigger_name
+
+
+def test_google_drive_uses_compatible_token_field_and_scoped_page_tokens() -> None:
+    yaml_text = _read(TRIGGERS / "google_drive_trigger" / "provider/google_drive.yaml")
+    assert "- name: access_token" in yaml_text
+    assert "- name: access_tokens" not in yaml_text
+
+    source = _read(TRIGGERS / "google_drive_trigger" / "provider/google_drive.py")
+    assert 'credentials.get("access_token") or credentials.get("access_tokens")' in source
+    assert "_page_token_storage_key_from_key(subscription_key)" in source
+    assert '"subscription_key": subscription_key' in source
+
+
+def test_outlook_cleanup_removed_copied_github_logic_and_secret_storage() -> None:
+    source = _read(TRIGGERS / "outlook_trigger" / "provider/outlook.py")
+    assert "class OutlookSubscriptionConstructor" in source
+    assert "api.github.com/user/repos" not in source
+    assert "Channel.ReadBasic.All" not in source
+    assert '"access_tokens": credentials.get' not in source
+    assert '"refresh_token": credentials.get' not in source
+    assert "_token_url(system_credentials)" in source
+
+
+def test_zendesk_webhook_signatures_are_verified_when_secret_is_present() -> None:
+    source = _read(TRIGGERS / "zendesk_trigger" / "provider/zendesk.py")
+    assert "X-Zendesk-Webhook-Signature" in source
+    assert "X-Zendesk-Webhook-Signature-Timestamp" in source
+    assert "hmac.compare_digest" in source

--- a/triggers/airtable_trigger/manifest.yaml
+++ b/triggers/airtable_trigger/manifest.yaml
@@ -26,11 +26,6 @@ plugins:
 resource:
   memory: 1048576
   permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
     storage:
       enabled: true
       size: 1048576
@@ -38,4 +33,4 @@ tags:
 - productivity
 - utilities
 type: plugin
-version: 1.0.5
+version: 1.1.0

--- a/triggers/airtable_trigger/pyproject.toml
+++ b/triggers/airtable_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Refresh the lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "httpx>=0.28.1",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/airtable_trigger/uv.lock
+++ b/triggers/airtable_trigger/uv.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -198,9 +198,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]

--- a/triggers/github_trigger/manifest.yaml
+++ b/triggers/github_trigger/manifest.yaml
@@ -26,12 +26,10 @@ plugins:
 resource:
   memory: 1048576
   permission:
-    model:
+    storage:
       enabled: true
-      llm: true
-    tool:
-      enabled: true
+      size: 1048576
 tags:
 - utilities
 type: plugin
-version: 1.4.7
+version: 1.5.0

--- a/triggers/github_trigger/provider/github.py
+++ b/triggers/github_trigger/provider/github.py
@@ -246,6 +246,9 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
 
         access_tokens = response_json.get("access_token")
         if not access_tokens:
+            error_msg = response_json.get("error_description") or response_json.get("error")
+            if error_msg:
+                raise TriggerProviderOAuthError(f"GitHub OAuth failed: {error_msg}")
             raise TriggerProviderOAuthError("GitHub OAuth response missing access_token")
 
         return TriggerOAuthCredentials(credentials={"access_tokens": access_tokens}, expires_at=-1)

--- a/triggers/github_trigger/provider/github.py
+++ b/triggers/github_trigger/provider/github.py
@@ -458,6 +458,8 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
         return options
 
     def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        import hashlib
+
         digest = hashlib.sha256(f"github:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
         return f"github:oauth_state:{digest}"
 

--- a/triggers/github_trigger/provider/github.py
+++ b/triggers/github_trigger/provider/github.py
@@ -176,6 +176,7 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
     _TOKEN_URL = "https://github.com/login/oauth/access_token"
     _API_USER_URL = "https://api.github.com/user"
     _WEBHOOK_TTL = 30 * 24 * 60 * 60
+    _DEFAULT_SCOPE = "read:user admin:repo_hook"
 
     def _validate_api_key(self, credentials: Mapping[str, Any]) -> None:
         access_token = credentials.get("access_tokens")
@@ -196,11 +197,16 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
             raise TriggerProviderCredentialValidationError(str(exc)) from exc
 
     def _oauth_get_authorization_url(self, redirect_uri: str, system_credentials: Mapping[str, Any]) -> str:
+        client_id = system_credentials.get("client_id")
+        if not client_id:
+            raise TriggerProviderOAuthError("GitHub OAuth client_id is missing.")
+
         state = secrets.token_urlsafe(16)
+        self._store_oauth_state(redirect_uri, state)
         params = {
-            "client_id": system_credentials["client_id"],
+            "client_id": client_id,
             "redirect_uri": redirect_uri,
-            "scope": system_credentials.get("scope", "read:user admin:repo_hook"),
+            "scope": system_credentials.get("scope", self._DEFAULT_SCOPE),
             "state": state,
         }
         return f"{self._AUTH_URL}?{urllib.parse.urlencode(params)}"
@@ -208,6 +214,13 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
     def _oauth_get_credentials(
         self, redirect_uri: str, system_credentials: Mapping[str, Any], request: Request
     ) -> TriggerOAuthCredentials:
+        error = request.args.get("error")
+        if error:
+            description = request.args.get("error_description") or ""
+            raise TriggerProviderOAuthError(f"GitHub OAuth authorization failed: {error}: {description}".strip(": "))
+
+        self._validate_oauth_state(redirect_uri, request.args.get("state"))
+
         code = request.args.get("code")
         if not code:
             raise TriggerProviderOAuthError("No code provided")
@@ -222,11 +235,18 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
             "redirect_uri": redirect_uri,
         }
         headers = {"Accept": "application/json"}
-        response = requests.post(self._TOKEN_URL, data=data, headers=headers, timeout=10)
-        response_json = response.json()
+        try:
+            response = requests.post(self._TOKEN_URL, data=data, headers=headers, timeout=10)
+        except requests.RequestException as exc:
+            raise TriggerProviderOAuthError(f"Network error during GitHub OAuth token exchange: {exc}") from exc
+
+        response_json = self._safe_json(response)
+        if response.status_code >= 400:
+            raise TriggerProviderOAuthError(f"GitHub OAuth token exchange failed: {self._extract_error(response)}")
+
         access_tokens = response_json.get("access_token")
         if not access_tokens:
-            raise TriggerProviderOAuthError(f"Error in GitHub OAuth: {response_json}")
+            raise TriggerProviderOAuthError("GitHub OAuth response missing access_token")
 
         return TriggerOAuthCredentials(credentials={"access_tokens": access_tokens}, expires_at=-1)
 
@@ -433,3 +453,39 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
             page += 1
 
         return options
+
+    def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        digest = hashlib.sha256(f"github:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
+        return f"github:oauth_state:{digest}"
+
+    def _store_oauth_state(self, redirect_uri: str, state: str) -> None:
+        try:
+            self.runtime.session.storage.set(self._oauth_state_key(redirect_uri, state), b"1")
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to persist GitHub OAuth state; storage permission is required.") from exc
+
+    def _validate_oauth_state(self, redirect_uri: str, state: str | None) -> None:
+        if not state:
+            raise TriggerProviderOAuthError("GitHub OAuth callback missing state.")
+        key = self._oauth_state_key(redirect_uri, state)
+        try:
+            if not self.runtime.session.storage.exist(key):
+                raise TriggerProviderOAuthError("GitHub OAuth state is invalid or expired.")
+            self.runtime.session.storage.delete(key)
+        except TriggerProviderOAuthError:
+            raise
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to validate GitHub OAuth state.") from exc
+
+    @staticmethod
+    def _safe_json(response: requests.Response) -> dict[str, Any]:
+        try:
+            payload = response.json()
+            return payload if isinstance(payload, dict) else {}
+        except Exception:
+            return {}
+
+    def _extract_error(self, response: requests.Response) -> str:
+        payload = self._safe_json(response)
+        message = payload.get("error_description") or payload.get("message") or payload.get("error")
+        return str(message or response.text or f"HTTP {response.status_code}")[:500]

--- a/triggers/github_trigger/pyproject.toml
+++ b/triggers/github_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "requests>=2.34.2",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/github_trigger/uv.lock
+++ b/triggers/github_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/gmail_trigger/manifest.yaml
+++ b/triggers/gmail_trigger/manifest.yaml
@@ -26,15 +26,10 @@ plugins:
 resource:
   memory: 1048576
   permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
     storage:
       enabled: true
       size: 1048576
 tags:
 - utilities
 type: plugin
-version: 0.0.7
+version: 0.1.0

--- a/triggers/gmail_trigger/provider/gmail_trigger.py
+++ b/triggers/gmail_trigger/provider/gmail_trigger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import secrets
 import time
@@ -238,9 +239,14 @@ class GmailSubscriptionConstructor(TriggerSubscriptionConstructor):
         )
 
     def _oauth_get_authorization_url(self, redirect_uri: str, system_credentials: Mapping[str, Any]) -> str:
+        client_id = system_credentials.get("client_id")
+        if not client_id:
+            raise TriggerProviderOAuthError("Client ID is required to start Gmail OAuth flow")
+
         state = secrets.token_urlsafe(16)
+        self._store_oauth_state(redirect_uri, state)
         params = {
-            "client_id": system_credentials["client_id"],
+            "client_id": client_id,
             "redirect_uri": redirect_uri,
             "response_type": "code",
             "scope": self._DEFAULT_SCOPE,
@@ -254,6 +260,13 @@ class GmailSubscriptionConstructor(TriggerSubscriptionConstructor):
     def _oauth_get_credentials(
         self, redirect_uri: str, system_credentials: Mapping[str, Any], request: Request
     ) -> TriggerOAuthCredentials:
+        error = request.args.get("error")
+        if error:
+            description = request.args.get("error_description") or ""
+            raise TriggerProviderOAuthError(f"Gmail OAuth authorization failed: {error}: {description}".strip(": "))
+
+        self._validate_oauth_state(redirect_uri, request.args.get("state"))
+
         code = request.args.get("code")
         if not code:
             raise TriggerProviderOAuthError("No code provided")
@@ -270,15 +283,23 @@ class GmailSubscriptionConstructor(TriggerSubscriptionConstructor):
             "grant_type": "authorization_code",
         }
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
-        resp: requests.Response = requests.post(self._TOKEN_URL, data=data, headers=headers, timeout=10)
-        payload: dict[str, Any] = resp.json()
+        try:
+            resp: requests.Response = requests.post(self._TOKEN_URL, data=data, headers=headers, timeout=10)
+        except requests.RequestException as exc:
+            raise TriggerProviderOAuthError(f"Network error during Gmail OAuth token exchange: {exc}") from exc
+        try:
+            payload: dict[str, Any] = resp.json()
+        except ValueError as exc:
+            raise TriggerProviderOAuthError("Gmail OAuth token response was not valid JSON") from exc
+        if resp.status_code >= 400:
+            raise TriggerProviderOAuthError(f"Gmail OAuth token exchange failed: {self._extract_google_error(resp, payload)}")
         access_token: str | None = payload.get("access_token")
         if not access_token:
             raise TriggerProviderOAuthError(f"Error in Google OAuth: {payload}")
 
         expires_in: int = int(payload.get("expires_in") or 0)
         refresh_token: str | None = payload.get("refresh_token")
-        expires_at: int = int(time.time()) + expires_in if expires_in else -1
+        expires_at: int = int(time.time()) + max(expires_in - 60, 0) if expires_in else -1
 
         # 2. Parse and store GCP configuration from system_credentials
         import json as _json
@@ -345,14 +366,22 @@ class GmailSubscriptionConstructor(TriggerSubscriptionConstructor):
             "grant_type": "refresh_token",
         }
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
-        resp: requests.Response = requests.post(self._TOKEN_URL, data=data, headers=headers, timeout=10)
-        payload: dict[str, Any] = resp.json()
+        try:
+            resp: requests.Response = requests.post(self._TOKEN_URL, data=data, headers=headers, timeout=10)
+        except requests.RequestException as exc:
+            raise TriggerProviderOAuthError(f"Network error during Gmail OAuth refresh: {exc}") from exc
+        try:
+            payload: dict[str, Any] = resp.json()
+        except ValueError as exc:
+            raise TriggerProviderOAuthError("Gmail OAuth refresh response was not valid JSON") from exc
+        if resp.status_code >= 400:
+            raise TriggerProviderOAuthError(f"OAuth refresh failed: {self._extract_google_error(resp, payload)}")
         access_token: str | None = payload.get("access_token")
         if not access_token:
             raise TriggerProviderOAuthError(f"OAuth refresh failed: {payload}")
 
         expires_in: int = int(payload.get("expires_in") or 0)
-        expires_at: int = int(time.time()) + expires_in if expires_in else -1
+        expires_at: int = int(time.time()) + max(expires_in - 60, 0) if expires_in else -1
         refreshed: dict[str, str] = {"access_token": access_token}
         if refresh_token:
             refreshed["refresh_token"] = refresh_token
@@ -755,3 +784,36 @@ class GmailSubscriptionConstructor(TriggerSubscriptionConstructor):
             if lid:
                 options.append(ParameterOption(value=lid, label=I18nObject(en_us=name)))
         return options
+
+    def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        digest = hashlib.sha256(f"gmail:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
+        return f"gmail:oauth_state:{digest}"
+
+    def _store_oauth_state(self, redirect_uri: str, state: str) -> None:
+        try:
+            self.runtime.session.storage.set(self._oauth_state_key(redirect_uri, state), b"1")
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to persist Gmail OAuth state; storage permission is required.") from exc
+
+    def _validate_oauth_state(self, redirect_uri: str, state: str | None) -> None:
+        if not state:
+            raise TriggerProviderOAuthError("Gmail OAuth callback missing state.")
+        key = self._oauth_state_key(redirect_uri, state)
+        try:
+            if not self.runtime.session.storage.exist(key):
+                raise TriggerProviderOAuthError("Gmail OAuth state is invalid or expired.")
+            self.runtime.session.storage.delete(key)
+        except TriggerProviderOAuthError:
+            raise
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to validate Gmail OAuth state.") from exc
+
+    @staticmethod
+    def _extract_google_error(response: requests.Response, payload: Mapping[str, Any]) -> str:
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message") or error.get("status")
+            if message:
+                return str(message)
+        message = payload.get("error_description") or payload.get("error")
+        return str(message or response.text or f"HTTP {response.status_code}")[:500]

--- a/triggers/gmail_trigger/pyproject.toml
+++ b/triggers/gmail_trigger/pyproject.toml
@@ -7,9 +7,9 @@ requires-python = ">=3.12"
 
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
-    "google-auth>=2.53.0",
-    "google-cloud-pubsub>=2.38.0",
+    "dify_plugin>=0.9.1",
+    "google-auth>=2.55.1",
+    "google-cloud-pubsub>=2.39.0",
     "requests>=2.34.2",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/gmail_trigger/uv.lock
+++ b/triggers/gmail_trigger/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -270,9 +270,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -365,9 +365,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
-    { name = "google-auth", specifier = ">=2.53.0" },
-    { name = "google-cloud-pubsub", specifier = ">=2.38.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
+    { name = "google-auth", specifier = ">=2.55.1" },
+    { name = "google-cloud-pubsub", specifier = ">=2.39.0" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]
@@ -399,35 +399,35 @@ grpc = [
 
 [[package]]
 name = "google-auth"
-version = "2.53.0"
+version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
 ]
 
 [[package]]
 name = "google-cloud-pubsub"
-version = "2.38.0"
+version = "2.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
     { name = "grpc-google-iam-v1" },
-    { name = "grpcio", marker = "python_full_version < '3.14'" },
+    { name = "grpcio" },
     { name = "grpcio-status" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/a5/0c7b27493ad6e744d175999e93bc51141ae70b23184d0bdbcb13fc9a4b29/google_cloud_pubsub-2.38.0.tar.gz", hash = "sha256:9212309f8d6cfaefb577bca52492b13464b56e584505408685d63e69346c56cf", size = 402783, upload-time = "2026-05-07T08:04:29.024Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/2b/4bf2c17e319ff65340389565b0e1b4d72696d87802b2f5f94390fbefa73c/google_cloud_pubsub-2.39.0.tar.gz", hash = "sha256:eed65e25f57f95bf3e02d96d7ee171688b23922471f9f21b5a91ed90e1282c0f", size = 402096, upload-time = "2026-06-03T15:28:26.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ea/d000ce0663c8989651f80b02e2ea8bb700d29140ade580f275b4ec4c9687/google_cloud_pubsub-2.38.0-py3-none-any.whl", hash = "sha256:fed2c40cfb77d58f6dced563a8146a8c34319c7dfbbb4d045b6c9c101e043db9", size = 324839, upload-time = "2026-05-07T08:03:04.923Z" },
+    { url = "https://files.pythonhosted.org/packages/93/20/dd0b27d4ad4577c062e77ff968ca3e2d404186cd78c8a2a53a0ef5fe5389/google_cloud_pubsub-2.39.0-py3-none-any.whl", hash = "sha256:7210d691a46d7a66559696899ebe6eb731e63de29b624964b3be4dd2d12d3e19", size = 324665, upload-time = "2026-06-03T15:27:41.119Z" },
 ]
 
 [[package]]

--- a/triggers/google_calendar_trigger/manifest.yaml
+++ b/triggers/google_calendar_trigger/manifest.yaml
@@ -26,15 +26,10 @@ plugins:
 resource:
   memory: 1048576
   permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
     storage:
       enabled: true
       size: 1048576
 tags:
 - utilities
 type: plugin
-version: 0.0.6
+version: 0.1.0

--- a/triggers/google_calendar_trigger/provider/google_calendar_trigger.py
+++ b/triggers/google_calendar_trigger/provider/google_calendar_trigger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
 import secrets
 import time
@@ -357,9 +358,14 @@ class GoogleCalendarSubscriptionConstructor(TriggerSubscriptionConstructor):
         )
 
     def _oauth_get_authorization_url(self, redirect_uri: str, system_credentials: Mapping[str, Any]) -> str:
+        client_id = system_credentials.get("client_id")
+        if not client_id:
+            raise TriggerProviderOAuthError("Client ID is required to start Google Calendar OAuth flow")
+
         state = secrets.token_urlsafe(16)
+        self._store_oauth_state(redirect_uri, state)
         params = {
-            "client_id": system_credentials["client_id"],
+            "client_id": client_id,
             "redirect_uri": redirect_uri,
             "response_type": "code",
             "scope": self._DEFAULT_SCOPE,
@@ -376,6 +382,15 @@ class GoogleCalendarSubscriptionConstructor(TriggerSubscriptionConstructor):
         system_credentials: Mapping[str, Any],
         request: Request,
     ) -> TriggerOAuthCredentials:
+        error = request.args.get("error")
+        if error:
+            description = request.args.get("error_description") or ""
+            raise TriggerProviderOAuthError(
+                f"Google Calendar OAuth authorization failed: {error}: {description}".strip(": ")
+            )
+
+        self._validate_oauth_state(redirect_uri, request.args.get("state"))
+
         code = request.args.get("code")
         if not code:
             raise TriggerProviderOAuthError("No authorization code provided")
@@ -401,13 +416,16 @@ class GoogleCalendarSubscriptionConstructor(TriggerSubscriptionConstructor):
         if resp.status_code != 200:
             raise TriggerProviderOAuthError(f"OAuth token exchange failed: {_parse_google_error(resp)}")
 
-        payload: dict[str, Any] = resp.json() or {}
+        try:
+            payload: dict[str, Any] = resp.json() or {}
+        except ValueError as exc:
+            raise TriggerProviderOAuthError("Google OAuth token response was not valid JSON") from exc
         access_token: str | None = payload.get("access_token")
         if not access_token:
             raise TriggerProviderOAuthError("Google OAuth response missing access_token")
 
         expires_in: int = int(payload.get("expires_in") or 0)
-        expires_at: int = int(time.time()) + expires_in if expires_in else -1
+        expires_at: int = int(time.time()) + max(expires_in - 60, 0) if expires_in else -1
 
         credentials: dict[str, Any] = {"access_token": access_token}
         refresh_token = payload.get("refresh_token")
@@ -458,13 +476,16 @@ class GoogleCalendarSubscriptionConstructor(TriggerSubscriptionConstructor):
         if resp.status_code != 200:
             raise TriggerProviderOAuthError(f"OAuth refresh failed: {_parse_google_error(resp)}")
 
-        payload: dict[str, Any] = resp.json() or {}
+        try:
+            payload: dict[str, Any] = resp.json() or {}
+        except ValueError as exc:
+            raise TriggerProviderOAuthError("Google OAuth refresh response was not valid JSON") from exc
         access_token: str | None = payload.get("access_token")
         if not access_token:
             raise TriggerProviderOAuthError("Google OAuth refresh response missing access_token")
 
         expires_in: int = int(payload.get("expires_in") or 0)
-        expires_at: int = int(time.time()) + expires_in if expires_in else -1
+        expires_at: int = int(time.time()) + max(expires_in - 60, 0) if expires_in else -1
 
         refreshed: dict[str, Any] = {"access_token": access_token, "refresh_token": refresh_token}
         if credentials.get("account_email"):
@@ -716,3 +737,28 @@ class GoogleCalendarSubscriptionConstructor(TriggerSubscriptionConstructor):
         if not any(opt.value == "primary" for opt in options):
             options.insert(0, ParameterOption(value="primary", label=I18nObject(en_us="Primary Calendar")))
         return options
+
+    def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        digest = hashlib.sha256(f"google_calendar:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
+        return f"google_calendar:oauth_state:{digest}"
+
+    def _store_oauth_state(self, redirect_uri: str, state: str) -> None:
+        try:
+            self.runtime.session.storage.set(self._oauth_state_key(redirect_uri, state), b"1")
+        except Exception as exc:
+            raise TriggerProviderOAuthError(
+                "Unable to persist Google Calendar OAuth state; storage permission is required."
+            ) from exc
+
+    def _validate_oauth_state(self, redirect_uri: str, state: str | None) -> None:
+        if not state:
+            raise TriggerProviderOAuthError("Google Calendar OAuth callback missing state.")
+        key = self._oauth_state_key(redirect_uri, state)
+        try:
+            if not self.runtime.session.storage.exist(key):
+                raise TriggerProviderOAuthError("Google Calendar OAuth state is invalid or expired.")
+            self.runtime.session.storage.delete(key)
+        except TriggerProviderOAuthError:
+            raise
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to validate Google Calendar OAuth state.") from exc

--- a/triggers/google_calendar_trigger/pyproject.toml
+++ b/triggers/google_calendar_trigger/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
     "requests>=2.34.2",
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "werkzeug>=3.1.8",
 ]
 

--- a/triggers/google_calendar_trigger/uv.lock
+++ b/triggers/google_calendar_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/google_drive_trigger/manifest.yaml
+++ b/triggers/google_drive_trigger/manifest.yaml
@@ -27,7 +27,7 @@ resource:
   memory: 1048576
   permission:
     storage:
-      size: 1048576
       enabled: true
+      size: 1048576
 type: plugin
-version: 1.3.5
+version: 1.4.0

--- a/triggers/google_drive_trigger/provider/google_drive.py
+++ b/triggers/google_drive_trigger/provider/google_drive.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import secrets
 import time
@@ -29,7 +30,7 @@ class GoogleDriveTrigger(Trigger):
     """Validate Google Drive webhook headers and dispatch change events."""
 
     _EVENT_NAME = "drive_change_detected"
-    _STORAGE_KEY = "google-drive-trigger:last-page-token"
+    _STORAGE_KEY_PREFIX = "google-drive-trigger:last-page-token"
     _CHANGES_ENDPOINT = "https://www.googleapis.com/drive/v3/changes"
 
     def _dispatch_event(self, subscription: Subscription, request: Request) -> EventDispatch:
@@ -57,13 +58,13 @@ class GoogleDriveTrigger(Trigger):
         expected_resource = subscription.properties.get("resource_id")
         expected_token = subscription.properties.get("channel_token")
 
-        if expected_channel and channel_id and expected_channel != channel_id:
+        if expected_channel and channel_id != expected_channel:
             raise TriggerValidationError("Mismatched channel ID in Google Drive notification")
 
-        if expected_resource and resource_id and expected_resource != resource_id:
+        if expected_resource and resource_id != expected_resource:
             raise TriggerValidationError("Mismatched resource ID in Google Drive notification")
 
-        if expected_token and channel_token and expected_token != channel_token:
+        if expected_token and channel_token != expected_token:
             raise TriggerValidationError("Invalid channel token for Google Drive notification")
 
         body = request.get_json(silent=True)
@@ -88,7 +89,7 @@ class GoogleDriveTrigger(Trigger):
 
         # fetch changes
         changes = self._fetch_changes(
-            access_token=self.runtime.credentials.get("access_token") or "",
+            access_token=GoogleDriveSubscriptionConstructor._get_access_token(self.runtime.credentials) or "",
             spaces=subscription.properties.get("spaces") or [],
             include_removed=subscription.parameters.get("include_removed", False),
             restrict_to_my_drive=subscription.parameters.get("restrict_to_my_drive", False),
@@ -167,22 +168,22 @@ class GoogleDriveTrigger(Trigger):
                         changes.append(dict(change))
 
             if next_page_token:
-                self._set_max_page_token(next_page_token)
+                self._set_max_page_token(subscription, next_page_token)
 
             if new_start_page_token:
-                self._set_max_page_token(new_start_page_token)
+                self._set_max_page_token(subscription, new_start_page_token)
                 break
 
         return changes
 
-    def _set_max_page_token(self, token: str) -> None:
+    def _set_max_page_token(self, subscription: Subscription, token: str) -> None:
         """
         Set the maximum page token to the storage.
 
         If the storage is not found, do nothing.
         """
         try:
-            self.runtime.session.storage.set(self._STORAGE_KEY, token.encode())
+            self.runtime.session.storage.set(self._page_token_storage_key(subscription), token.encode())
         except Exception:
             pass
 
@@ -193,9 +194,23 @@ class GoogleDriveTrigger(Trigger):
         If the storage is not found, return 0.
         """
         try:
-            return self.runtime.session.storage.get(self._STORAGE_KEY).decode() or "0"
+            return self.runtime.session.storage.get(self._page_token_storage_key(subscription)).decode() or "0"
         except Exception:
             return subscription.properties.get("start_page_token") or "0"
+
+    @staticmethod
+    def _page_token_storage_key_from_key(subscription_key: str) -> str:
+        return f"{GoogleDriveTrigger._STORAGE_KEY_PREFIX}:{subscription_key}"
+
+    @staticmethod
+    def _page_token_storage_key(subscription: Subscription) -> str:
+        properties = subscription.properties or {}
+        subscription_key = properties.get("subscription_key")
+        if subscription_key:
+            return GoogleDriveTrigger._page_token_storage_key_from_key(str(subscription_key))
+        fallback = properties.get("channel_id") or properties.get("resource_id") or "legacy"
+        digest = hashlib.sha256(str(fallback).encode("utf-8")).hexdigest()
+        return f"{GoogleDriveTrigger._STORAGE_KEY_PREFIX}:legacy:{digest}"
 
     @staticmethod
     def _ok_response() -> Response:
@@ -223,6 +238,8 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
         if not client_id:
             raise TriggerProviderOAuthError("Client ID is required to start Google Drive OAuth flow")
 
+        state = secrets.token_urlsafe(16)
+        self._store_oauth_state(redirect_uri, state)
         scope = system_credentials.get("scope", self._DEFAULT_SCOPE)
         params = {
             "response_type": "code",
@@ -232,12 +249,20 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
             "access_type": "offline",
             "prompt": "consent",
             "include_granted_scopes": "true",
+            "state": state,
         }
         return f"{self._AUTH_URL}?{urllib.parse.urlencode(params, quote_via=urllib.parse.quote)}"
 
     def _oauth_get_credentials(
         self, redirect_uri: str, system_credentials: Mapping[str, Any], request: Request
     ) -> TriggerOAuthCredentials:
+        error = request.args.get("error")
+        if error:
+            description = request.args.get("error_description") or ""
+            raise TriggerProviderOAuthError(f"Google Drive OAuth authorization failed: {error}: {description}".strip(": "))
+
+        self._validate_oauth_state(redirect_uri, request.args.get("state"))
+
         code = request.args.get("code")
         if not code:
             raise TriggerProviderOAuthError("Missing authorization code in callback request")
@@ -260,10 +285,13 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
         except requests.RequestException as exc:
             raise TriggerProviderOAuthError(f"Failed to exchange authorization code: {exc}") from exc
 
-        payload = response.json() if response.content else {}
+        try:
+            payload = response.json() if response.content else {}
+        except ValueError as exc:
+            raise TriggerProviderOAuthError("Google Drive OAuth token response was not valid JSON") from exc
         if response.status_code != 200:
             raise TriggerProviderOAuthError(
-                f"Failed to obtain Google Drive OAuth tokens: {payload.get('error_description') or payload}"
+                f"Failed to obtain Google Drive OAuth tokens: {self._extract_google_error(response, payload)}"
             )
 
         access_token = payload.get("access_token")
@@ -272,7 +300,7 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
         if not access_token or not refresh_token:
             raise TriggerProviderOAuthError("OAuth response does not contain access_token or refresh_token")
 
-        expires_at = int(time.time()) + int(expires_in) if expires_in else -1
+        expires_at = int(time.time()) + max(int(expires_in) - 60, 0) if expires_in else -1
         profile = self._fetch_about(access_token)
 
         credentials = {
@@ -309,10 +337,13 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
         except requests.RequestException as exc:
             raise TriggerProviderOAuthError(f"Failed to refresh Google Drive OAuth token: {exc}") from exc
 
-        payload = response.json() if response.content else {}
+        try:
+            payload = response.json() if response.content else {}
+        except ValueError as exc:
+            raise TriggerProviderOAuthError("Google Drive OAuth refresh response was not valid JSON") from exc
         if response.status_code != 200:
             raise TriggerProviderOAuthError(
-                f"Unable to refresh Google Drive OAuth token: {payload.get('error_description') or payload}"
+                f"Unable to refresh Google Drive OAuth token: {self._extract_google_error(response, payload)}"
             )
 
         access_token = payload.get("access_token")
@@ -320,7 +351,7 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
         if not access_token:
             raise TriggerProviderOAuthError("Refresh response does not contain access_token")
 
-        expires_at = int(time.time()) + int(expires_in) if expires_in else -1
+        expires_at = int(time.time()) + max(int(expires_in) - 60, 0) if expires_in else -1
         refreshed_credentials = {
             **credentials,
             "access_token": access_token,
@@ -340,7 +371,7 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
         if credential_type != CredentialType.OAUTH:
             raise SubscriptionError("Google Drive trigger requires OAuth credentials", error_code="OAUTH_REQUIRED")
 
-        access_token = credentials.get("access_token")
+        access_token = self._get_access_token(credentials)
         if not access_token:
             raise SubscriptionError("Missing Google Drive OAuth access token", error_code="MISSING_ACCESS_TOKEN")
 
@@ -348,10 +379,14 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
         if not spaces:
             raise SubscriptionError("At least one Drive space must be selected", error_code="SPACES_REQUIRED")
 
+        subscription_key = uuid.uuid4().hex
         start_page_token = self._fetch_start_page_token(access_token, spaces)
 
         # set the start_page_token to the storage
-        self.runtime.session.storage.set(GoogleDriveTrigger._STORAGE_KEY, str(start_page_token).encode("utf-8"))
+        self.runtime.session.storage.set(
+            GoogleDriveTrigger._page_token_storage_key_from_key(subscription_key),
+            str(start_page_token).encode("utf-8"),
+        )
 
         channel_id = str(uuid.uuid4())
         channel_token = secrets.token_urlsafe(24)
@@ -400,6 +435,7 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
             "channel_id": channel_id,
             "resource_id": resource_id,
             "channel_token": channel_token,
+            "subscription_key": subscription_key,
             "watch_expiration": expiration,
             "start_page_token": start_page_token,
             "spaces": spaces,
@@ -422,7 +458,7 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
                 "Google Drive trigger requires OAuth credentials to unsubscribe", error_code="OAUTH_REQUIRED"
             )
 
-        access_token = credentials.get("access_token")
+        access_token = self._get_access_token(credentials)
         if not access_token:
             raise UnsubscribeError("Missing Google Drive OAuth access token", error_code="MISSING_ACCESS_TOKEN")
 
@@ -506,6 +542,21 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
         return str(token)
 
     @staticmethod
+    def _get_access_token(credentials: Mapping[str, Any]) -> str | None:
+        token = credentials.get("access_token") or credentials.get("access_tokens")
+        return str(token) if token else None
+
+    @staticmethod
+    def _extract_google_error(response: requests.Response, payload: Mapping[str, Any]) -> str:
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message") or error.get("status")
+            if message:
+                return str(message)
+        message = payload.get("error_description") or payload.get("error")
+        return str(message or response.text or f"HTTP {response.status_code}")[:500]
+
+    @staticmethod
     def _normalize_spaces(raw: Any) -> list[str]:
         if not raw:
             return []
@@ -518,3 +569,28 @@ class GoogleDriveSubscriptionConstructor(TriggerSubscriptionConstructor):
                     normalized.append(item.strip())
             return normalized
         raise SubscriptionError("spaces must be a string or list of strings", error_code="INVALID_SPACES")
+
+    def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        digest = hashlib.sha256(f"google_drive:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
+        return f"google_drive:oauth_state:{digest}"
+
+    def _store_oauth_state(self, redirect_uri: str, state: str) -> None:
+        try:
+            self.runtime.session.storage.set(self._oauth_state_key(redirect_uri, state), b"1")
+        except Exception as exc:
+            raise TriggerProviderOAuthError(
+                "Unable to persist Google Drive OAuth state; storage permission is required."
+            ) from exc
+
+    def _validate_oauth_state(self, redirect_uri: str, state: str | None) -> None:
+        if not state:
+            raise TriggerProviderOAuthError("Google Drive OAuth callback missing state.")
+        key = self._oauth_state_key(redirect_uri, state)
+        try:
+            if not self.runtime.session.storage.exist(key):
+                raise TriggerProviderOAuthError("Google Drive OAuth state is invalid or expired.")
+            self.runtime.session.storage.delete(key)
+        except TriggerProviderOAuthError:
+            raise
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to validate Google Drive OAuth state.") from exc

--- a/triggers/google_drive_trigger/provider/google_drive.yaml
+++ b/triggers/google_drive_trigger/provider/google_drive.yaml
@@ -65,7 +65,7 @@ subscription_constructor:
           ja_JP: "スコープを入力してください"
         url: https://console.cloud.google.com/apis/credentials
     credentials_schema:
-      - name: access_tokens
+      - name: access_token
         type: secret-input
         label:
           en_US: Access Token

--- a/triggers/google_drive_trigger/pyproject.toml
+++ b/triggers/google_drive_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "requests>=2.34.2",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/google_drive_trigger/uv.lock
+++ b/triggers/google_drive_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/lark_trigger/manifest.yaml
+++ b/triggers/lark_trigger/manifest.yaml
@@ -25,13 +25,8 @@ plugins:
     - provider/lark.yaml
 resource:
   memory: 1048576
-  permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
+  permission: {}
 tags:
   - utilities
 type: plugin
-version: 0.0.8
+version: 0.1.0

--- a/triggers/lark_trigger/pyproject.toml
+++ b/triggers/lark_trigger/pyproject.toml
@@ -7,9 +7,9 @@ requires-python = ">=3.12"
 
 # uv lock
 dependencies = [
-    "lark-oapi>=1.6.5",
+    "lark-oapi>=1.6.9",
     "cachetools>=7.1.4",
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "werkzeug>=3.1.8",
 ]
 

--- a/triggers/lark_trigger/uv.lock
+++ b/triggers/lark_trigger/uv.lock
@@ -170,7 +170,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -187,9 +187,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "lark-oapi"
-version = "1.6.5"
+version = "1.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -413,9 +413,8 @@ dependencies = [
     { name = "requests-toolbelt" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/6a/cfaa24851e05000a3bede7a3d30b834116d684d56738d08980da621e9c1a/lark_oapi-1.6.5.tar.gz", hash = "sha256:abf1fd348bd527502c70f2fe771c6fd37c2b8bbed188c9313596063864d43f59", size = 2079307, upload-time = "2026-05-14T06:00:44.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/28/a425593c6de71b80ad642ed8e624468a2848ea0e4ad7cb32a8380941fd7f/lark_oapi-1.6.5-py3-none-any.whl", hash = "sha256:a56fa548aebdae9c36ef0114fbbc6e5d004eb2e15398e11cf88a5737f0cf8641", size = 7143193, upload-time = "2026-05-14T06:00:39.816Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/00982093154f92ffc2bfe8448367323a07513bd1db1e92672f9573c92ddf/lark_oapi-1.6.9-py3-none-any.whl", hash = "sha256:ebc93c09eba66e3d2d8823d9df4988370b2e0245870b3249b61cdf6d6cd1642c", size = 7801043, upload-time = "2026-06-24T06:15:19.989Z" },
 ]
 
 [[package]]
@@ -432,8 +431,8 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cachetools", specifier = ">=7.1.4" },
-    { name = "dify-plugin", specifier = ">=0.9.0" },
-    { name = "lark-oapi", specifier = ">=1.6.5" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
+    { name = "lark-oapi", specifier = ">=1.6.9" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]
 

--- a/triggers/linear_trigger/manifest.yaml
+++ b/triggers/linear_trigger/manifest.yaml
@@ -26,12 +26,10 @@ plugins:
 resource:
   memory: 1048576
   permission:
-    model:
+    storage:
       enabled: true
-      llm: true
-    tool:
-      enabled: true
+      size: 1048576
 tags:
 - productivity
 type: plugin
-version: 0.5.7
+version: 0.6.0

--- a/triggers/linear_trigger/provider/linear_simple.py
+++ b/triggers/linear_trigger/provider/linear_simple.py
@@ -724,6 +724,8 @@ class LinearSubscriptionConstructor(TriggerSubscriptionConstructor):
             }
 
     def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        import hashlib
+
         digest = hashlib.sha256(f"linear:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
         return f"linear:oauth_state:{digest}"
 

--- a/triggers/linear_trigger/provider/linear_simple.py
+++ b/triggers/linear_trigger/provider/linear_simple.py
@@ -144,29 +144,23 @@ class LinearTrigger(Trigger):
         Linear includes webhookTimestamp in the payload (UNIX timestamp in milliseconds).
         We reject webhooks older than 60 seconds.
         """
+        payload = request.get_json(force=True)
+        if not isinstance(payload, Mapping):
+            raise TriggerValidationError("Linear payload must be a JSON object")
+
+        webhook_timestamp = payload.get("webhookTimestamp")
+        if not webhook_timestamp:
+            # Older Linear webhook deliveries may not include a timestamp.
+            return
+
         try:
-            payload = request.get_json(force=True)
-            webhook_timestamp = payload.get("webhookTimestamp")
+            webhook_time = float(webhook_timestamp) / 1000
+        except (TypeError, ValueError) as exc:
+            raise TriggerValidationError("Invalid Linear webhook timestamp") from exc
 
-            if not webhook_timestamp:
-                # Timestamp validation is optional
-                return
-
-            # Convert to seconds (Linear sends milliseconds)
-            webhook_time = webhook_timestamp / 1000
-            current_time = time.time()
-
-            # Check if timestamp is within 60 seconds
-            if abs(current_time - webhook_time) > 60:
-                raise TriggerValidationError(
-                    "Webhook timestamp is too old or too far in the future"
-                )
-
-        except TriggerValidationError:
-            raise
-        except Exception:
-            # If timestamp validation fails, just log and continue
-            pass
+        current_time = time.time()
+        if abs(current_time - webhook_time) > 60:
+            raise TriggerValidationError("Webhook timestamp is too old or too far in the future")
 
 
 class LinearSubscriptionConstructor(TriggerSubscriptionConstructor):
@@ -189,6 +183,14 @@ class LinearSubscriptionConstructor(TriggerSubscriptionConstructor):
         Refresh Linear OAuth credentials.
         """
         return OAuthCredentials(credentials=credentials, expires_at=-1)
+
+    def _oauth_refresh_credentials(
+        self,
+        redirect_uri: str,
+        system_credentials: Mapping[str, Any],
+        credentials: Mapping[str, Any],
+    ) -> TriggerOAuthCredentials:
+        return TriggerOAuthCredentials(credentials=dict(credentials), expires_at=-1)
 
     def _validate_api_key(self, credentials: Mapping[str, Any]) -> None:
         """
@@ -252,6 +254,7 @@ class LinearSubscriptionConstructor(TriggerSubscriptionConstructor):
 
         # Generate CSRF protection state
         state = secrets.token_urlsafe(16)
+        self._store_oauth_state(redirect_uri, state)
 
         # Build authorization URL parameters
         params = {
@@ -281,6 +284,13 @@ class LinearSubscriptionConstructor(TriggerSubscriptionConstructor):
         Returns:
             OAuth credentials containing access_token
         """
+        error = request.args.get("error")
+        if error:
+            description = request.args.get("error_description") or ""
+            raise TriggerProviderOAuthError(f"Linear OAuth authorization failed: {error}: {description}".strip(": "))
+
+        self._validate_oauth_state(redirect_uri, request.args.get("state"))
+
         # Extract authorization code from callback
         code = request.args.get("code")
         if not code:
@@ -313,7 +323,15 @@ class LinearSubscriptionConstructor(TriggerSubscriptionConstructor):
                 timeout=10,
             )
 
-            data = response.json()
+            try:
+                data = response.json()
+            except ValueError as exc:
+                raise TriggerProviderOAuthError("Linear OAuth token response was not valid JSON") from exc
+
+            if response.status_code >= 400:
+                raise TriggerProviderOAuthError(
+                    f"OAuth error: {data.get('error_description') or data.get('error') or response.text}"
+                )
 
             # Check for errors in response
             if "error" in data:
@@ -704,3 +722,26 @@ class LinearSubscriptionConstructor(TriggerSubscriptionConstructor):
                     {"message": f"HTTP {response.status_code}: {response.text[:200]}"}
                 ]
             }
+
+    def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        digest = hashlib.sha256(f"linear:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
+        return f"linear:oauth_state:{digest}"
+
+    def _store_oauth_state(self, redirect_uri: str, state: str) -> None:
+        try:
+            self.runtime.session.storage.set(self._oauth_state_key(redirect_uri, state), b"1")
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to persist Linear OAuth state; storage permission is required.") from exc
+
+    def _validate_oauth_state(self, redirect_uri: str, state: str | None) -> None:
+        if not state:
+            raise TriggerProviderOAuthError("Linear OAuth callback missing state.")
+        key = self._oauth_state_key(redirect_uri, state)
+        try:
+            if not self.runtime.session.storage.exist(key):
+                raise TriggerProviderOAuthError("Linear OAuth state is invalid or expired.")
+            self.runtime.session.storage.delete(key)
+        except TriggerProviderOAuthError:
+            raise
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to validate Linear OAuth state.") from exc

--- a/triggers/linear_trigger/pyproject.toml
+++ b/triggers/linear_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "requests>=2.34.2",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/linear_trigger/uv.lock
+++ b/triggers/linear_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -405,7 +405,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/notion_trigger/manifest.yaml
+++ b/triggers/notion_trigger/manifest.yaml
@@ -25,13 +25,8 @@ plugins:
   - provider/notion_simple.yaml
 resource:
   memory: 1048576
-  permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
+  permission: {}
 tags:
 - productivity
 type: plugin
-version: 0.1.5
+version: 0.2.0

--- a/triggers/notion_trigger/pyproject.toml
+++ b/triggers/notion_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "requests>=2.34.2",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/notion_trigger/uv.lock
+++ b/triggers/notion_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -567,7 +567,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/outlook_trigger/manifest.yaml
+++ b/triggers/outlook_trigger/manifest.yaml
@@ -26,14 +26,9 @@ plugins:
 resource:
   memory: 1048576
   permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
     storage:
       enabled: true
       size: 1048576
 tags: []
 type: plugin
-version: 0.1.6
+version: 0.2.0

--- a/triggers/outlook_trigger/provider/outlook.py
+++ b/triggers/outlook_trigger/provider/outlook.py
@@ -9,12 +9,11 @@ import time
 import urllib.parse
 import uuid
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any
 
 import requests
 from werkzeug import Request, Response
 
-from dify_plugin.entities import I18nObject, ParameterOption
 from dify_plugin.entities.oauth import TriggerOAuthCredentials
 from dify_plugin.entities.provider_config import CredentialType
 from dify_plugin.entities.trigger import EventDispatch, Subscription, UnsubscribeResult
@@ -29,35 +28,77 @@ from dify_plugin.errors.trigger import (
 from dify_plugin.interfaces.trigger import Trigger, TriggerSubscriptionConstructor
 
 
+def _safe_json(response: requests.Response) -> dict[str, Any]:
+    try:
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _extract_error(response: requests.Response) -> str:
+    payload = _safe_json(response)
+    error = payload.get("error")
+    if isinstance(error, Mapping):
+        message = error.get("message") or error.get("code")
+        if message:
+            return str(message)
+    message = payload.get("error_description") or payload.get("message") or payload.get("error")
+    return str(message or response.text or f"HTTP {response.status_code}")[:500]
+
+
+def _get_access_token(credentials: Mapping[str, Any] | None) -> str | None:
+    if not credentials:
+        return None
+    token = credentials.get("access_tokens") or credentials.get("access_token")
+    return str(token) if token else None
+
+
 class OutlookTrigger(Trigger):
     """Handle Outlook webhook event dispatch."""
 
     def _dispatch_event(
         self, subscription: Subscription, request: Request
     ) -> EventDispatch:
-        client_state = subscription.properties.get("client_state")
+        properties = subscription.properties or {}
+        client_state = properties.get("client_state")
 
         body = request.get_data()
 
         if len(body) == 0:  # validation request
-
             validationToken = request.args.get("validationToken")
             if validationToken:
                 returnText = urllib.parse.unquote(validationToken)
                 return EventDispatch(events=[], response=Response(response=returnText, status=200, mimetype="application/text"))
-            pass
+            return EventDispatch(events=[], response=Response(response="", status=202, mimetype="application/text"))
         else:
-            payload = json.loads(body)
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError as exc:
+                raise TriggerDispatchError(f"Invalid Outlook notification JSON: {exc}") from exc
 
-            value = payload.get("value")[0]
+            values = payload.get("value")
+            if not isinstance(values, list) or not values:
+                raise TriggerDispatchError("Outlook notification missing value array")
+            value = values[0]
+            if not isinstance(value, Mapping):
+                raise TriggerDispatchError("Outlook notification value must be an object")
 
-            id = value.get("resourceData").get("id")
+            resource_data = value.get("resourceData")
+            if not isinstance(resource_data, Mapping):
+                raise TriggerDispatchError("Outlook notification missing resourceData")
+
+            message_id = resource_data.get("id")
+            if not message_id:
+                raise TriggerDispatchError("Outlook notification missing resourceData.id")
 
             # check if the email is already processed
-            if self._is_email_processed(id):
+            if self._is_email_processed(str(message_id)):
                 return EventDispatch(events=[], response=Response(response="Email already processed", status=200, mimetype="application/text"))
 
             resource = value.get("resource")
+            if not resource:
+                raise TriggerDispatchError("Outlook notification missing resource")
 
             if value.get("clientState") != client_state:
                 raise TriggerDispatchError("Invalid client state")
@@ -65,20 +106,26 @@ class OutlookTrigger(Trigger):
             events = ["email_received"]
 
             fetch_url = f"https://graph.microsoft.com/v1.0/{resource}"
+            access_token = _get_access_token(self.runtime.credentials if self.runtime else None) or _get_access_token(properties)
+            if not access_token:
+                raise TriggerDispatchError("Missing Outlook OAuth access token")
             headers = {
-                "Authorization": f"Bearer {subscription.properties.get('access_tokens')}",
+                "Authorization": f"Bearer {access_token}",
                 "Accept": "application/json",
             }
-            response = requests.get(fetch_url, headers=headers, timeout=10)
+            try:
+                response = requests.get(fetch_url, headers=headers, timeout=10)
+            except requests.RequestException as exc:
+                raise TriggerDispatchError(f"Network error while fetching Outlook resource: {exc}") from exc
             if response.status_code == 200:
-                data = response.json()
+                data = _safe_json(response)
                 
                 response = Response(response='Accepted', status=202, mimetype="application/text")
 
                 events = ["email_received"]
                 return EventDispatch(events=events, response=response, payload=data)
             else:
-                raise TriggerDispatchError(f"Failed to fetch resource: {response.json().get('message', 'Unknown error')}")
+                raise TriggerDispatchError(f"Failed to fetch resource: {_extract_error(response)}")
 
     def _is_email_processed(self, id: str) -> bool:
         processed = self.runtime.session.storage.exist(f"email_processed_{id}")
@@ -90,52 +137,55 @@ class OutlookTrigger(Trigger):
             return False
 
 
-class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
-    """Manage GitHub trigger subscriptions."""
+class OutlookSubscriptionConstructor(TriggerSubscriptionConstructor):
+    """Manage Outlook trigger subscriptions."""
 
-    _AUTH_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
-    _TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-    # _API_USER_URL = "https://api.github.com/user"
+    _AUTHORITY_URL = "https://login.microsoftonline.com"
+    _DEFAULT_SCOPE = "offline_access https://graph.microsoft.com/Mail.Read"
+    _API_ME_URL = "https://graph.microsoft.com/v1.0/me"
     _WEBHOOK_TTL = 3 * 24 * 60 * 60
 
     def _validate_api_key(self, credentials: Mapping[str, Any]) -> None:
-        # access_token = credentials.get("access_tokens")
-        # if not access_token:
-        #     raise TriggerProviderCredentialValidationError("GitHub API Access Token is required.")
+        access_token = _get_access_token(credentials)
+        if not access_token:
+            raise TriggerProviderCredentialValidationError("Outlook access token is required.")
 
-        # headers = {
-        #     "Authorization": f"Bearer {access_token}",
-        #     "Accept": "application/vnd.github+json",
-        # }
-        # try:
-        #     response = requests.get(self._API_USER_URL, headers=headers, timeout=10)
-        #     if response.status_code != 200:
-        #         raise TriggerProviderCredentialValidationError(response.json().get("message"))
-        # except TriggerProviderCredentialValidationError:
-        #     raise
-        # except Exception as exc:  # pragma: no cover - defensive logging path
-        #     raise TriggerProviderCredentialValidationError(str(exc)) from exc
-        pass
+        headers = {"Authorization": f"Bearer {access_token}", "Accept": "application/json"}
+        try:
+            response = requests.get(self._API_ME_URL, headers=headers, timeout=10)
+        except requests.RequestException as exc:
+            raise TriggerProviderCredentialValidationError(f"Failed to validate Outlook credentials: {exc}") from exc
+        if response.status_code != 200:
+            raise TriggerProviderCredentialValidationError(f"Outlook credential validation failed: {_extract_error(response)}")
 
     def _oauth_get_authorization_url(
         self, redirect_uri: str, system_credentials: Mapping[str, Any]
     ) -> str:
+        client_id = system_credentials.get("client_id")
+        if not client_id:
+            raise TriggerProviderOAuthError("Outlook OAuth client_id is missing.")
+
         state = secrets.token_urlsafe(16)
+        self._store_oauth_state(redirect_uri, state)
         params = {
-            "client_id": system_credentials["client_id"],
+            "client_id": client_id,
             "redirect_uri": redirect_uri,
-            "scope": system_credentials.get(
-                "scope",
-                "offline_access https://graph.microsoft.com/Channel.ReadBasic.All https://graph.microsoft.com/Mail.Read",
-            ),
+            "scope": system_credentials.get("scope", self._DEFAULT_SCOPE),
             "response_type": "code",
             "state": state,
         }
-        return f"{self._AUTH_URL}?{urllib.parse.urlencode(params)}"
+        return f"{self._auth_url(system_credentials)}?{urllib.parse.urlencode(params)}"
 
     def _oauth_get_credentials(
         self, redirect_uri: str, system_credentials: Mapping[str, Any], request: Request
     ) -> TriggerOAuthCredentials:
+        error = request.args.get("error")
+        if error:
+            description = request.args.get("error_description") or ""
+            raise TriggerProviderOAuthError(f"Outlook OAuth authorization failed: {error}: {description}".strip(": "))
+
+        self._validate_oauth_state(redirect_uri, request.args.get("state"))
+
         code = request.args.get("code")
         if not code:
             raise TriggerProviderOAuthError("No code provided")
@@ -151,19 +201,19 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
             "code": code,
             "redirect_uri": redirect_uri,
             "grant_type": "authorization_code",
-            "scope": system_credentials.get(
-                "scope",
-                "offline_access https://graph.microsoft.com/Channel.ReadBasic.All https://graph.microsoft.com/Mail.Read",
-            ),
+            "scope": system_credentials.get("scope", self._DEFAULT_SCOPE),
         }
         headers = {"Accept": "application/json"}
-        response = requests.post(
-            self._TOKEN_URL, data=data, headers=headers, timeout=10
-        )
-        response_json = response.json()
+        try:
+            response = requests.post(self._token_url(system_credentials), data=data, headers=headers, timeout=10)
+        except requests.RequestException as exc:
+            raise TriggerProviderOAuthError(f"Network error during Outlook OAuth token exchange: {exc}") from exc
+        response_json = _safe_json(response)
+        if response.status_code >= 400:
+            raise TriggerProviderOAuthError(f"Outlook OAuth token exchange failed: {_extract_error(response)}")
         access_tokens = response_json.get("access_token")
         if not access_tokens:
-            raise TriggerProviderOAuthError(f"Error in Outlook OAuth: {response_json}")
+            raise TriggerProviderOAuthError("Outlook OAuth response missing access_token")
         refresh_token = response_json.get("refresh_token")
         if not refresh_token:
             raise TriggerProviderOAuthError("No refresh token in response")
@@ -173,34 +223,41 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
                 "access_tokens": access_tokens,
                 "refresh_token": refresh_token,
             },
-            expires_at=response_json.get("expires_in", 3599) + int(time.time()),
+            expires_at=max(int(response_json.get("expires_in", 3599)) - 60, 0) + int(time.time()),
         )
 
     def _oauth_refresh_credentials(self, redirect_uri: str, system_credentials: Mapping[str, Any], credentials: Mapping[str, Any]) -> TriggerOAuthCredentials:
-        url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded",
         }
+        refresh_token = credentials.get("refresh_token")
+        if not refresh_token:
+            raise TriggerProviderOAuthError("Outlook refresh token is missing; please re-authorize.")
         data = {
             "grant_type": "refresh_token",
-            "refresh_token": credentials.get("refresh_token"),
+            "refresh_token": refresh_token,
             "client_id": system_credentials.get("client_id"),
             "client_secret": system_credentials.get("client_secret"),
         }
-        response = requests.post(url, headers=headers, data=data, timeout=10)
+        try:
+            response = requests.post(self._token_url(system_credentials), headers=headers, data=data, timeout=10)
+        except requests.RequestException as exc:
+            raise TriggerProviderOAuthError(f"Network error during Outlook OAuth refresh: {exc}") from exc
+        payload = _safe_json(response)
         if response.status_code == 200:
-            access_tokens = response.json().get("access_token")
-            refresh_token = response.json().get("refresh_token")
+            access_tokens = payload.get("access_token")
+            if not access_tokens:
+                raise TriggerProviderOAuthError("Outlook OAuth refresh response missing access_token")
             return TriggerOAuthCredentials(
                 credentials={
                     "access_tokens": access_tokens,
-                    "refresh_token": refresh_token,
+                    "refresh_token": payload.get("refresh_token") or refresh_token,
                 },
-                expires_at=response.json().get("expires_in", 3599) + int(time.time()),
+                expires_at=max(int(payload.get("expires_in", 3599)) - 60, 0) + int(time.time()),
             )
         else:
-            raise TriggerProviderOAuthError(f"Failed to refresh access token: {response.json().get('message', 'Unknown error')}") from response.json()
+            raise TriggerProviderOAuthError(f"Failed to refresh Outlook access token: {_extract_error(response)}")
 
     def _create_subscription(
         self,
@@ -211,8 +268,11 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
     ) -> Subscription:
 
         url = "https://graph.microsoft.com/v1.0/subscriptions"
+        access_token = _get_access_token(credentials)
+        if not access_token:
+            raise SubscriptionError("Missing Outlook OAuth access token", error_code="MISSING_ACCESS_TOKEN")
         headers = {
-            "Authorization": f"Bearer {credentials.get('access_tokens')}",
+            "Authorization": f"Bearer {access_token}",
             "Accept": "application/json",
         }
 
@@ -238,7 +298,7 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
             ) from exc
             
         if response.status_code == 201:
-            subscription = response.json()
+            subscription = _safe_json(response)
             return Subscription(
                 expires_at=int(time.time()) + self._WEBHOOK_TTL,
                 endpoint=endpoint,
@@ -246,15 +306,14 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
                 properties={
                     "subscription_id": subscription.get("id"),
                     "client_state": client_state,
-                    "access_tokens": credentials.get('access_tokens'),
-                    "refresh_token": credentials.get('refresh_token'),
                 },
             )
         else:
+            response_data = _safe_json(response)
             raise SubscriptionError(
-                message=f"Failed to create subscription: {response.json().get('message', 'Unknown error')}",
+                message=f"Failed to create subscription: {_extract_error(response)}",
                 error_code="SUBSCRIPTION_CREATION_FAILED",
-                external_response=response.json(),
+                external_response=response_data,
             )
 
     def _delete_subscription(
@@ -265,25 +324,29 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
     ) -> UnsubscribeResult:
         subscription_id = subscription.properties.get("subscription_id")
         if not subscription_id:
-            raise UnsubscribeError(
-                message="Missing subscription ID",
-                error_code="MISSING_PROPERTIES",
-                external_response=None,
-            )
+            return UnsubscribeResult(success=True, message="Missing Outlook subscription ID; subscription already removed.")
         
         url = f"https://graph.microsoft.com/v1.0/subscriptions/{subscription_id}"
+        access_token = _get_access_token(credentials)
+        if not access_token:
+            return UnsubscribeResult(success=False, message="Missing Outlook OAuth access token")
         headers = {
-            "Authorization": f"Bearer {credentials.get('access_tokens')}",
+            "Authorization": f"Bearer {access_token}",
             "Accept": "application/json",
         }
-        response = requests.delete(url, headers=headers, timeout=10)
+        try:
+            response = requests.delete(url, headers=headers, timeout=10)
+        except requests.RequestException as exc:
+            return UnsubscribeResult(success=False, message=f"Network error while deleting Outlook subscription: {exc}")
         if response.status_code == 204:
             return UnsubscribeResult(success=True, message=f"Successfully deleted subscription {subscription_id}")
+        if response.status_code == 404:
+            return UnsubscribeResult(success=True, message=f"Outlook subscription {subscription_id} was already removed")
         else:
             raise UnsubscribeError(
-                message=f"Failed to delete subscription: {response.json().get('message', 'Unknown error')}",
+                message=f"Failed to delete subscription: {_extract_error(response)}",
                 error_code="SUBSCRIPTION_DELETION_FAILED",
-                external_response=response.json(),
+                external_response=_safe_json(response),
             )
 
     def _refresh_subscription(
@@ -303,109 +366,75 @@ class GithubSubscriptionConstructor(TriggerSubscriptionConstructor):
                 external_response=None,
             )
 
+        access_token = _get_access_token(credentials)
+        if not access_token:
+            raise SubscriptionError("Missing Outlook OAuth access token", error_code="MISSING_ACCESS_TOKEN")
         headers = {
-            "Authorization": f"Bearer {credentials.get('access_tokens')}",
+            "Authorization": f"Bearer {access_token}",
             "Accept": "application/json",
         }
         data = {
             "expirationDateTime": new_expiration_date_str,
         }
         url = f"https://graph.microsoft.com/v1.0/subscriptions/{subscription_id}"
-        response = requests.patch(url, headers=headers, json=data, timeout=10)
+        try:
+            response = requests.patch(url, headers=headers, json=data, timeout=10)
+        except requests.RequestException as exc:
+            raise SubscriptionError(
+                f"Network error while refreshing Outlook subscription: {exc}",
+                error_code="NETWORK_ERROR",
+            ) from exc
         if response.status_code == 200:
+            properties = dict(subscription.properties or {})
+            properties.update(
+                {
+                    "subscription_id": subscription_id,
+                    "client_state": properties.get("client_state"),
+                }
+            )
+            properties.pop("access_tokens", None)
+            properties.pop("refresh_token", None)
             return Subscription(
                 expires_at=int(new_expiration_date.timestamp()),
                 endpoint=subscription.endpoint,
-                properties={
-                    "subscription_id": subscription_id,
-                    "client_state": subscription.properties.get("client_state"),
-                    "access_tokens": credentials.get('access_tokens'),
-                    "refresh_token": credentials.get('refresh_token'),
-                },
+                properties=properties,
             )
         else:
             raise SubscriptionError(
-                message=f"Failed to refresh subscription: {response.json().get('message', 'Unknown error')}",
+                message=f"Failed to refresh subscription: {_extract_error(response)}",
                 error_code="SUBSCRIPTION_REFRESH_FAILED",
-                external_response=response.json(),
+                external_response=_safe_json(response),
             )
 
-    def _fetch_parameter_options(
-        self,
-        parameter: str,
-        credentials: Mapping[str, Any],
-        credential_type: CredentialType,
-    ) -> list[ParameterOption]:
-        if parameter != "repository":
-            return []
+    def _tenant_id(self, system_credentials: Mapping[str, Any]) -> str:
+        tenant_id = str(system_credentials.get("tenant_id") or "common").strip()
+        return urllib.parse.quote(tenant_id or "common", safe="")
 
-        token = credentials.get("access_tokens")
-        if not token:
-            raise ValueError("access_tokens is required to fetch repositories")
-        return self._fetch_repositories(token)
+    def _auth_url(self, system_credentials: Mapping[str, Any]) -> str:
+        return f"{self._AUTHORITY_URL}/{self._tenant_id(system_credentials)}/oauth2/v2.0/authorize"
 
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
+    def _token_url(self, system_credentials: Mapping[str, Any]) -> str:
+        return f"{self._AUTHORITY_URL}/{self._tenant_id(system_credentials)}/oauth2/v2.0/token"
 
-    def _fetch_repositories(self, access_token: str) -> list[ParameterOption]:
-        headers: Mapping[str, str] = {
-            "Authorization": f"Bearer {access_token}",
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
+    def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        digest = hashlib.sha256(f"outlook:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
+        return f"outlook:oauth_state:{digest}"
 
-        options: list[ParameterOption] = []
-        per_page = 100
-        page = 1
+    def _store_oauth_state(self, redirect_uri: str, state: str) -> None:
+        try:
+            self.runtime.session.storage.set(self._oauth_state_key(redirect_uri, state), b"1")
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to persist Outlook OAuth state; storage permission is required.") from exc
 
-        while True:
-            params = {
-                "per_page": per_page,
-                "page": page,
-                "affiliation": "owner,collaborator,organization_member",
-                "sort": "full_name",
-                "direction": "asc",
-            }
-
-            response = requests.get(
-                "https://api.github.com/user/repos",
-                headers=headers,
-                params=params,
-                timeout=10,
-            )
-
-            if response.status_code != 200:
-                try:
-                    err = response.json()
-                    message = err.get("message", str(err))
-                except Exception:  # pragma: no cover - fallback path
-                    message = response.text
-                raise ValueError(f"Failed to fetch repositories from GitHub: {message}")
-
-            raw_repos: Any = response.json() or []
-            if not isinstance(raw_repos, list):
-                raise ValueError(
-                    "Unexpected response format from GitHub API when fetching repositories"
-                )
-
-            repos = cast(list[dict[str, Any]], raw_repos)
-            for repo in repos:
-                full_name = repo.get("full_name")
-                owner: dict[str, Any] = repo.get("owner") or {}
-                avatar_url: str | None = owner.get("avatar_url")
-                if full_name:
-                    options.append(
-                        ParameterOption(
-                            value=full_name,
-                            label=I18nObject(en_us=full_name),
-                            icon=avatar_url,
-                        )
-                    )
-
-            if len(repos) < per_page:
-                break
-
-            page += 1
-
-        return options
+    def _validate_oauth_state(self, redirect_uri: str, state: str | None) -> None:
+        if not state:
+            raise TriggerProviderOAuthError("Outlook OAuth callback missing state.")
+        key = self._oauth_state_key(redirect_uri, state)
+        try:
+            if not self.runtime.session.storage.exist(key):
+                raise TriggerProviderOAuthError("Outlook OAuth state is invalid or expired.")
+            self.runtime.session.storage.delete(key)
+        except TriggerProviderOAuthError:
+            raise
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to validate Outlook OAuth state.") from exc

--- a/triggers/outlook_trigger/provider/outlook.py
+++ b/triggers/outlook_trigger/provider/outlook.py
@@ -223,7 +223,7 @@ class OutlookSubscriptionConstructor(TriggerSubscriptionConstructor):
                 "access_tokens": access_tokens,
                 "refresh_token": refresh_token,
             },
-            expires_at=max(int(response_json.get("expires_in", 3599)) - 60, 0) + int(time.time()),
+            expires_at=max(int(response_json.get("expires_in") or 3599) - 60, 0) + int(time.time()),
         )
 
     def _oauth_refresh_credentials(self, redirect_uri: str, system_credentials: Mapping[str, Any], credentials: Mapping[str, Any]) -> TriggerOAuthCredentials:
@@ -254,7 +254,7 @@ class OutlookSubscriptionConstructor(TriggerSubscriptionConstructor):
                     "access_tokens": access_tokens,
                     "refresh_token": payload.get("refresh_token") or refresh_token,
                 },
-                expires_at=max(int(payload.get("expires_in", 3599)) - 60, 0) + int(time.time()),
+                expires_at=max(int(payload.get("expires_in") or 3599) - 60, 0) + int(time.time()),
             )
         else:
             raise TriggerProviderOAuthError(f"Failed to refresh Outlook access token: {_extract_error(response)}")

--- a/triggers/outlook_trigger/provider/outlook.py
+++ b/triggers/outlook_trigger/provider/outlook.py
@@ -417,6 +417,8 @@ class OutlookSubscriptionConstructor(TriggerSubscriptionConstructor):
         return f"{self._AUTHORITY_URL}/{self._tenant_id(system_credentials)}/oauth2/v2.0/token"
 
     def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        import hashlib
+
         digest = hashlib.sha256(f"outlook:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
         return f"outlook:oauth_state:{digest}"
 

--- a/triggers/outlook_trigger/pyproject.toml
+++ b/triggers/outlook_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "requests>=2.34.2",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/outlook_trigger/uv.lock
+++ b/triggers/outlook_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -567,7 +567,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/rsshub_trigger/manifest.yaml
+++ b/triggers/rsshub_trigger/manifest.yaml
@@ -25,13 +25,8 @@ plugins:
     - provider/rsshub.yaml
 resource:
   memory: 1048576
-  permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
+  permission: {}
 tags:
   - utilities
 type: plugin
-version: 0.0.6
+version: 0.1.0

--- a/triggers/rsshub_trigger/pyproject.toml
+++ b/triggers/rsshub_trigger/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "werkzeug>=3.1.8",
 ]
 

--- a/triggers/rsshub_trigger/uv.lock
+++ b/triggers/rsshub_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]
 

--- a/triggers/slack_trigger/manifest.yaml
+++ b/triggers/slack_trigger/manifest.yaml
@@ -25,13 +25,8 @@ plugins:
     - provider/slack.yaml
 resource:
   memory: 1048576
-  permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
+  permission: {}
 tags:
   - utilities
 type: plugin
-version: 0.2.5
+version: 0.3.0

--- a/triggers/slack_trigger/pyproject.toml
+++ b/triggers/slack_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Refresh the lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "werkzeug>=3.1.8",
 ]
 

--- a/triggers/slack_trigger/uv.lock
+++ b/triggers/slack_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]
 

--- a/triggers/telegram_trigger/manifest.yaml
+++ b/triggers/telegram_trigger/manifest.yaml
@@ -25,11 +25,6 @@ plugins:
     - provider/telegram.yaml
 resource:
   memory: 1048576
-  permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
+  permission: {}
 type: plugin
-version: 0.0.6
+version: 0.1.0

--- a/triggers/telegram_trigger/pyproject.toml
+++ b/triggers/telegram_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "requests>=2.34.2",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/telegram_trigger/uv.lock
+++ b/triggers/telegram_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -950,7 +950,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/twilio_trigger/manifest.yaml
+++ b/triggers/twilio_trigger/manifest.yaml
@@ -25,13 +25,8 @@ plugins:
   - provider/twilio.yaml
 resource:
   memory: 1048576
-  permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
+  permission: {}
 tags:
 - utilities
 type: plugin
-version: 0.0.5
+version: 0.1.0

--- a/triggers/twilio_trigger/pyproject.toml
+++ b/triggers/twilio_trigger/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
     "requests>=2.34.2",
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "werkzeug>=3.1.8",
 ]
 

--- a/triggers/twilio_trigger/uv.lock
+++ b/triggers/twilio_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -997,7 +997,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/typeform_trigger/manifest.yaml
+++ b/triggers/typeform_trigger/manifest.yaml
@@ -26,12 +26,10 @@ plugins:
 resource:
   memory: 1048576
   permission:
-    model:
+    storage:
       enabled: true
-      llm: true
-    tool:
-      enabled: true
+      size: 1048576
 tags:
 - productivity
 type: plugin
-version: 0.1.6
+version: 0.2.0

--- a/triggers/typeform_trigger/provider/typeform_simple.py
+++ b/triggers/typeform_trigger/provider/typeform_simple.py
@@ -623,6 +623,8 @@ class TypeformSubscriptionConstructor(TriggerSubscriptionConstructor):
         return f"dify-{form_id[:8]}-{unique}"
 
     def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        import hashlib
+
         digest = hashlib.sha256(f"typeform:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
         return f"typeform:oauth_state:{digest}"
 

--- a/triggers/typeform_trigger/provider/typeform_simple.py
+++ b/triggers/typeform_trigger/provider/typeform_simple.py
@@ -248,6 +248,7 @@ class TypeformSubscriptionConstructor(TriggerSubscriptionConstructor):
             raise TriggerProviderOAuthError("client_id is required for Typeform OAuth.")
 
         state = secrets.token_urlsafe(16)
+        self._store_oauth_state(redirect_uri, state)
         params = {
             "client_id": client_id,
             "redirect_uri": redirect_uri,
@@ -263,6 +264,13 @@ class TypeformSubscriptionConstructor(TriggerSubscriptionConstructor):
         system_credentials: Mapping[str, Any],
         request: Request,
     ) -> TriggerOAuthCredentials:
+        error = self._normalize_optional_string(request.args.get("error"))
+        if error:
+            description = self._normalize_optional_string(request.args.get("error_description")) or ""
+            raise TriggerProviderOAuthError(f"Typeform OAuth authorization failed: {error}: {description}".strip(": "))
+
+        self._validate_oauth_state(redirect_uri, request.args.get("state"))
+
         code = self._normalize_optional_string(request.args.get("code"))
         if not code:
             raise TriggerProviderOAuthError("Missing authorization code in callback.")
@@ -613,3 +621,26 @@ class TypeformSubscriptionConstructor(TriggerSubscriptionConstructor):
     def _generate_webhook_tag(form_id: str) -> str:
         unique = uuid.uuid4().hex[:10]
         return f"dify-{form_id[:8]}-{unique}"
+
+    def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        digest = hashlib.sha256(f"typeform:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
+        return f"typeform:oauth_state:{digest}"
+
+    def _store_oauth_state(self, redirect_uri: str, state: str) -> None:
+        try:
+            self.runtime.session.storage.set(self._oauth_state_key(redirect_uri, state), b"1")
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to persist Typeform OAuth state; storage permission is required.") from exc
+
+    def _validate_oauth_state(self, redirect_uri: str, state: str | None) -> None:
+        if not state:
+            raise TriggerProviderOAuthError("Typeform OAuth callback missing state.")
+        key = self._oauth_state_key(redirect_uri, state)
+        try:
+            if not self.runtime.session.storage.exist(key):
+                raise TriggerProviderOAuthError("Typeform OAuth state is invalid or expired.")
+            self.runtime.session.storage.delete(key)
+        except TriggerProviderOAuthError:
+            raise
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to validate Typeform OAuth state.") from exc

--- a/triggers/typeform_trigger/pyproject.toml
+++ b/triggers/typeform_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "requests>=2.34.2",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/typeform_trigger/uv.lock
+++ b/triggers/typeform_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -997,7 +997,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/woocommerce_trigger/manifest.yaml
+++ b/triggers/woocommerce_trigger/manifest.yaml
@@ -25,11 +25,6 @@ plugins:
     - provider/woocommerce.yaml
 resource:
   memory: 1048576
-  permission:
-    model:
-      enabled: true
-      llm: true
-    tool:
-      enabled: true
+  permission: {}
 type: plugin
-version: 1.0.5
+version: 1.1.0

--- a/triggers/woocommerce_trigger/pyproject.toml
+++ b/triggers/woocommerce_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Refresh the plugin lockfile with: uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "httpx>=0.28.1",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/woocommerce_trigger/uv.lock
+++ b/triggers/woocommerce_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]

--- a/triggers/zendesk_trigger/manifest.yaml
+++ b/triggers/zendesk_trigger/manifest.yaml
@@ -26,12 +26,10 @@ plugins:
 resource:
   memory: 1048576
   permission:
-    model:
+    storage:
       enabled: true
-      llm: true
-    tool:
-      enabled: true
+      size: 1048576
 tags:
 - utilities
 type: plugin
-version: 1.0.5
+version: 1.1.0

--- a/triggers/zendesk_trigger/provider/zendesk.py
+++ b/triggers/zendesk_trigger/provider/zendesk.py
@@ -1,4 +1,6 @@
 import base64
+import hashlib
+import hmac
 import json
 import secrets
 import time
@@ -18,6 +20,7 @@ from dify_plugin.errors.trigger import (
     TriggerDispatchError,
     TriggerProviderCredentialValidationError,
     TriggerProviderOAuthError,
+    TriggerValidationError,
     UnsubscribeError,
 )
 from dify_plugin.interfaces.trigger import Trigger, TriggerSubscriptionConstructor
@@ -27,6 +30,10 @@ class ZendeskTrigger(Trigger):
     """Handle Zendesk webhook event dispatch."""
 
     def _dispatch_event(self, subscription: Subscription, request: Request) -> EventDispatch:
+        webhook_secret = (subscription.properties or {}).get("webhook_secret")
+        if webhook_secret:
+            self._verify_signature(secret=str(webhook_secret), request=request)
+
         payload: Mapping[str, Any] = self._validate_payload(request)
         response = Response(response='{"status": "ok"}', status=200, mimetype="application/json")
         events: list[str] = self._dispatch_trigger_events(payload=payload)
@@ -84,6 +91,20 @@ class ZendeskTrigger(Trigger):
         except Exception as exc:
             raise TriggerDispatchError(f"Failed to parse payload: {exc}") from exc
 
+    @staticmethod
+    def _verify_signature(secret: str, request: Request) -> None:
+        signature = request.headers.get("X-Zendesk-Webhook-Signature")
+        timestamp = request.headers.get("X-Zendesk-Webhook-Signature-Timestamp")
+        if not signature or not timestamp:
+            raise TriggerValidationError("Missing Zendesk webhook signature headers")
+
+        body = request.get_data(cache=True, as_text=False)
+        signed_payload = timestamp.encode("utf-8") + body
+        digest = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).digest()
+        expected = base64.b64encode(digest).decode("ascii")
+        if not hmac.compare_digest(signature, expected):
+            raise TriggerValidationError("Invalid Zendesk webhook signature")
+
 
 class ZendeskSubscriptionConstructor(TriggerSubscriptionConstructor):
     """Manage Zendesk trigger subscriptions."""
@@ -134,6 +155,7 @@ class ZendeskSubscriptionConstructor(TriggerSubscriptionConstructor):
             raise TriggerProviderOAuthError("Zendesk OAuth client_id is missing.")
 
         state = secrets.token_urlsafe(16)
+        self._store_oauth_state(redirect_uri, state)
         params: dict[str, str] = {
             "response_type": "code",
             "client_id": client_id,
@@ -153,6 +175,8 @@ class ZendeskSubscriptionConstructor(TriggerSubscriptionConstructor):
             description = request.args.get("error_description") or ""
             message = f"{error}: {description}".strip(": ")
             raise TriggerProviderOAuthError(f"Zendesk OAuth authorization failed: {message}")
+
+        self._validate_oauth_state(redirect_uri, request.args.get("state"))
 
         code = request.args.get("code")
         if not code:
@@ -395,7 +419,7 @@ class ZendeskSubscriptionConstructor(TriggerSubscriptionConstructor):
         except (TypeError, ValueError):
             expires_in = None
 
-        expires_at = int(time.time()) + expires_in if expires_in else -1
+        expires_at = int(time.time()) + max(expires_in - 60, 0) if expires_in else -1
 
         credentials: dict[str, Any] = {
             "access_token": access_token,
@@ -408,3 +432,26 @@ class ZendeskSubscriptionConstructor(TriggerSubscriptionConstructor):
         filtered_credentials = {key: value for key, value in credentials.items() if value}
 
         return TriggerOAuthCredentials(credentials=filtered_credentials, expires_at=expires_at)
+
+    def _oauth_state_key(self, redirect_uri: str, state: str) -> str:
+        digest = hashlib.sha256(f"zendesk:{redirect_uri}:{state}".encode("utf-8")).hexdigest()
+        return f"zendesk:oauth_state:{digest}"
+
+    def _store_oauth_state(self, redirect_uri: str, state: str) -> None:
+        try:
+            self.runtime.session.storage.set(self._oauth_state_key(redirect_uri, state), b"1")
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to persist Zendesk OAuth state; storage permission is required.") from exc
+
+    def _validate_oauth_state(self, redirect_uri: str, state: str | None) -> None:
+        if not state:
+            raise TriggerProviderOAuthError("Zendesk OAuth callback missing state.")
+        key = self._oauth_state_key(redirect_uri, state)
+        try:
+            if not self.runtime.session.storage.exist(key):
+                raise TriggerProviderOAuthError("Zendesk OAuth state is invalid or expired.")
+            self.runtime.session.storage.delete(key)
+        except TriggerProviderOAuthError:
+            raise
+        except Exception as exc:
+            raise TriggerProviderOAuthError("Unable to validate Zendesk OAuth state.") from exc

--- a/triggers/zendesk_trigger/pyproject.toml
+++ b/triggers/zendesk_trigger/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # uv lock
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.9.1",
     "httpx>=0.28.1",
     "werkzeug>=3.1.8",
 ]

--- a/triggers/zendesk_trigger/uv.lock
+++ b/triggers/zendesk_trigger/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/9b/5d78d22aa32942f9d5375f2b0d913b3e529f8456cb91aaf04fa50638b8d5/dify_plugin-0.9.1.tar.gz", hash = "sha256:81f96f9a78ca76b22361eb40c54935bb6cf9b3d0d2be44828d63e0a25e3cb0e8", size = 318876, upload-time = "2026-06-17T03:15:11.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/9538bfce0df4e816f28a91c38e762fcf45fc10f4a0751e3bb0f83bcf4f11/dify_plugin-0.9.1-py3-none-any.whl", hash = "sha256:1c45ed4f06ccd9375382c728ebd6b7394da854273f59666c25c0d7b914a0dbf0", size = 376977, upload-time = "2026-06-17T03:15:10.345Z" },
 ]
 
 [[package]]
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.9.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "werkzeug", specifier = ">=3.1.8" },
 ]


### PR DESCRIPTION
## Summary
- add OAuth state validation and defensive token handling across trigger OAuth providers
- tighten webhook safety for Outlook, Google Drive, Linear, and Zendesk
- apply least-privilege trigger manifest permissions, minor manifest version bumps, dependency lower-bound bumps, and refreshed uv locks
- add focused trigger hardening tests

## Validation
- `uvx pytest -q tests/triggers/test_trigger_hardening.py`
- `find triggers tests/triggers -name '*.py' -print0 | xargs -0 python3 -m py_compile`\n- `ruby -ryaml -e 'Dir["triggers/**/*.yaml"].each { |f| YAML.load_file(f) }'`\n- `git diff --check`\n\n## Notes\n- Existing unrelated local Discord changes were intentionally left out of this PR.\n