### PR TITLE
fix(linear): accept status name in Update Linear Issue tool

### DIFF
--- a/tools/linear/manifest.yaml
+++ b/tools/linear/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: langgenius
 name: linear

--- a/tools/linear/tools/linear_update_issue.py
+++ b/tools/linear/tools/linear_update_issue.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Generator, Optional, Tuple
+from typing import Dict, Any, Generator
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
@@ -7,6 +7,7 @@ from client.Exceptions import (
     LinearApiException,
     LinearAuthenticationException,
     LinearResourceNotFoundException,
+    LinearValidationException,
 )  # Import standard exceptions
 
 
@@ -15,7 +16,7 @@ class LinearUpdateIssueTool(Tool):
 
     def _resolve_state_id(
         self, linear_client: Linear, issue_id: str, status_value: str
-    ) -> Tuple[Optional[str], Optional[str]]:
+    ) -> str:
         """Resolve a status name (or workflow state ID) to a workflow state ID.
 
         Linear only accepts the workflow state ID. Users normally provide a
@@ -24,7 +25,11 @@ class LinearUpdateIssueTool(Tool):
         backward compatibility.
 
         Returns:
-            (state_id, None) on success, or (None, error_message) on failure.
+            The resolved workflow state ID.
+
+        Raises:
+            LinearResourceNotFoundException: If the issue does not exist.
+            LinearValidationException: If the team or status cannot be resolved.
         """
         team_query = """
         query IssueTeam($id: String!) {
@@ -41,12 +46,16 @@ class LinearUpdateIssueTool(Tool):
         team_data = team_result.get("data") if team_result else None
         issue = team_data.get("issue") if isinstance(team_data, dict) else None
         if not issue:
-            return None, f"Issue with ID '{issue_id}' not found."
+            raise LinearResourceNotFoundException(
+                f"Issue with ID '{issue_id}' not found."
+            )
 
         team = issue.get("team")
         team_id = team.get("id") if isinstance(team, dict) else None
         if not team_id:
-            return None, "Could not resolve the issue's team to map the status."
+            raise LinearValidationException(
+                "Could not resolve the issue's team to map the status."
+            )
 
         states_query = """
         query TeamStates($filter: WorkflowStateFilter, $limit: Int!) {
@@ -72,15 +81,15 @@ class LinearUpdateIssueTool(Tool):
 
         for state in states:
             if state.get("name", "").strip().lower() == target:
-                return state["id"], None
+                return state["id"]
 
         # Backward compatibility: accept a raw workflow state ID.
         for state in states:
             if state.get("id") == status_value:
-                return state["id"], None
+                return state["id"]
 
         available = ", ".join(state.get("name", "") for state in states)
-        return None, (
+        raise LinearValidationException(
             f"Status '{status_value}' not found. Available statuses: {available}"
         )
 
@@ -152,13 +161,9 @@ class LinearUpdateIssueTool(Tool):
                 update_input["description"] = str(description)
                 updated_field_names.append("description")
             if state_id:
-                resolved_state_id, state_error = self._resolve_state_id(
+                update_input["stateId"] = self._resolve_state_id(
                     linear_client, issue_id, str(state_id)
                 )
-                if state_error:
-                    yield self.create_text_message(f"Error: {state_error}")
-                    return
-                update_input["stateId"] = resolved_state_id
                 updated_field_names.append("status (stateId)")
 
             # Handle assignee update (including unassigning)
@@ -302,6 +307,8 @@ class LinearUpdateIssueTool(Tool):
             yield self.create_text_message(
                 f"Error: Issue with ID '{issue_id}' not found. Details: {str(e)}"
             )
+        except LinearValidationException as e:
+            yield self.create_text_message(f"Error: {str(e)}")
         except LinearApiException as e:
             yield self.create_text_message(f"Linear API error: {str(e)}")
         except ValueError as e:  # Catch potential int conversion errors

--- a/tools/linear/tools/linear_update_issue.py
+++ b/tools/linear/tools/linear_update_issue.py
@@ -31,11 +31,18 @@ class LinearUpdateIssueTool(Tool):
           }
         }
         """
+        status_value = status_value.strip()
+
         team_result = linear_client.query_graphql(
             team_query, variables={"id": issue_id}
         )
-        issue = (team_result or {}).get("data", {}).get("issue")
-        team_id = (issue or {}).get("team", {}).get("id") if issue else None
+        team_data = team_result.get("data") if team_result else None
+        issue = team_data.get("issue") if isinstance(team_data, dict) else None
+        if not issue:
+            return None, f"Issue with ID '{issue_id}' not found."
+
+        team = issue.get("team")
+        team_id = team.get("id") if isinstance(team, dict) else None
         if not team_id:
             return None, "Could not resolve the issue's team to map the status."
 
@@ -50,13 +57,16 @@ class LinearUpdateIssueTool(Tool):
             states_query,
             variables={"filter": {"team": {"id": {"eq": team_id}}}, "limit": 250},
         )
-        states = (
-            (states_result or {})
-            .get("data", {})
-            .get("workflowStates", {})
-            .get("nodes", [])
+        states_data = states_result.get("data") if states_result else None
+        workflow_states = (
+            states_data.get("workflowStates") if isinstance(states_data, dict) else None
         )
-        target = status_value.strip().lower()
+        states = (
+            workflow_states.get("nodes", [])
+            if isinstance(workflow_states, dict)
+            else []
+        )
+        target = status_value.lower()
 
         for state in states:
             if state.get("name", "").strip().lower() == target:

--- a/tools/linear/tools/linear_update_issue.py
+++ b/tools/linear/tools/linear_update_issue.py
@@ -13,6 +13,65 @@ from client.Exceptions import (
 class LinearUpdateIssueTool(Tool):
     """Tool for updating issues in Linear."""
 
+    def _resolve_state_id(self, linear_client, issue_id, status_value):
+        """Resolve a status name (or workflow state ID) to a workflow state ID.
+
+        Linear only accepts the workflow state ID. Users normally provide a
+        readable name like "Todo" / "In Progress", so map it to the matching
+        state within the issue's team. A raw state ID is accepted unchanged for
+        backward compatibility.
+
+        Returns:
+            (state_id, None) on success, or (None, error_message) on failure.
+        """
+        team_query = """
+        query IssueTeam($id: String!) {
+          issue(id: $id) {
+            team { id }
+          }
+        }
+        """
+        team_result = linear_client.query_graphql(
+            team_query, variables={"id": issue_id}
+        )
+        issue = (team_result or {}).get("data", {}).get("issue")
+        team_id = (issue or {}).get("team", {}).get("id") if issue else None
+        if not team_id:
+            return None, "Could not resolve the issue's team to map the status."
+
+        states_query = """
+        query TeamStates($filter: WorkflowStateFilter, $limit: Int!) {
+          workflowStates(filter: $filter, first: $limit) {
+            nodes { id name }
+          }
+        }
+        """
+        states_result = linear_client.query_graphql(
+            states_query,
+            variables={"filter": {"team": {"id": {"eq": team_id}}}, "limit": 250},
+        )
+        states = (
+            (states_result or {})
+            .get("data", {})
+            .get("workflowStates", {})
+            .get("nodes", [])
+        )
+        target = status_value.strip().lower()
+
+        for state in states:
+            if state.get("name", "").strip().lower() == target:
+                return state["id"], None
+
+        # Backward compatibility: accept a raw workflow state ID.
+        for state in states:
+            if state.get("id") == status_value:
+                return state["id"], None
+
+        available = ", ".join(state.get("name", "") for state in states)
+        return None, (
+            f"Status '{status_value}' not found. Available statuses: {available}"
+        )
+
     def _invoke(
         self, tool_parameters: Dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:
@@ -81,7 +140,13 @@ class LinearUpdateIssueTool(Tool):
                 update_input["description"] = str(description)
                 updated_field_names.append("description")
             if state_id:
-                update_input["stateId"] = str(state_id)
+                resolved_state_id, state_error = self._resolve_state_id(
+                    linear_client, issue_id, str(state_id)
+                )
+                if state_error:
+                    yield self.create_text_message(f"Error: {state_error}")
+                    return
+                update_input["stateId"] = resolved_state_id
                 updated_field_names.append("status (stateId)")
 
             # Handle assignee update (including unassigning)

--- a/tools/linear/tools/linear_update_issue.py
+++ b/tools/linear/tools/linear_update_issue.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Generator
+from typing import Dict, Any, Generator, Optional, Tuple
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
@@ -13,7 +13,9 @@ from client.Exceptions import (
 class LinearUpdateIssueTool(Tool):
     """Tool for updating issues in Linear."""
 
-    def _resolve_state_id(self, linear_client, issue_id, status_value):
+    def _resolve_state_id(
+        self, linear_client: Linear, issue_id: str, status_value: str
+    ) -> Tuple[Optional[str], Optional[str]]:
         """Resolve a status name (or workflow state ID) to a workflow state ID.
 
         Linear only accepts the workflow state ID. Users normally provide a

--- a/tools/linear/tools/linear_update_issue.yaml
+++ b/tools/linear/tools/linear_update_issue.yaml
@@ -99,7 +99,7 @@ parameters:
       pt_BR: "Novo status para o problema (ex: \"A fazer\", \"Em andamento\", \"Concluído\")"
       ja_JP: "課題の新しいステータス（例：「未着手」、「進行中」、「完了」）"
       zh_Hant: "問題的新狀態（例如，\"待辦\"，\"進行中\"，\"已完成\"）"
-    llm_description: New workflow state ID of the issue
+    llm_description: 'New workflow state for the issue, given as the status name (e.g., "Todo", "In Progress", "Done"). A workflow state ID is also accepted.'
     form: llm
 extra:
   python:


### PR DESCRIPTION
## Problem

The **Update Linear Issue** tool's `New Status` field is documented to take a status name (e.g. "Todo", "In Progress", "Done"), but the code passed the value straight through as `stateId`. So it only worked when users pasted a raw workflow-state UUID — names failed silently.

## Fix

Resolve the provided status to a workflow state ID before the update:

1. Fetch the issue's team (`issue(id){ team { id } }`).
2. List that team's workflow states (`workflowStates(filter: {team:{id:{eq}}}, first: 250)`) — same proven query as `linear_list_issue_statuses`.
3. Match by name (case-insensitive). Fall back to matching a raw state ID for backward compatibility. Unknown name returns an error listing available statuses.

Workflow states are **per-team** in Linear, so resolution is scoped to the issue's own team to stay unambiguous. `first: 250` is Linear's per-page max — covers any team without pagination.

## Changes

- `tools/linear_update_issue.py` — add `_resolve_state_id()`
- `tools/linear_update_issue.yaml` — update `llm_description` to reflect name input
- `manifest.yaml` — version 0.0.7 → 0.0.8

## Notes

Not yet tested against a live Linear workspace.