### PR TITLE
fix(aws_s3_storage): rename misnamed provider class

### DIFF
--- a/datasources/aws_s3_storage/manifest.yaml
+++ b/datasources/aws_s3_storage/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.3.11
+version: 0.3.12
 type: plugin
 author: langgenius
 name: aws_s3_storage

--- a/datasources/aws_s3_storage/provider/aws_s3_storage.py
+++ b/datasources/aws_s3_storage/provider/aws_s3_storage.py
@@ -6,7 +6,7 @@ import boto3  # type: ignore
 from botocore.client import Config  # type: ignore
 
 
-class GoogleCloudStorageDatasourceProvider(DatasourceProvider):
+class AwsS3StorageDatasourceProvider(DatasourceProvider):
     def _validate_credentials(self, credentials: Mapping[str, Any]) -> None:
         try:
             if not credentials or not credentials.get("secret_access_key"):

--- a/datasources/aws_s3_storage/provider/aws_s3_storage.py
+++ b/datasources/aws_s3_storage/provider/aws_s3_storage.py
@@ -21,7 +21,7 @@ class AwsS3StorageDatasourceProvider(DatasourceProvider):
                 raise ToolProviderCredentialValidationError(
                     "AWS S3 Storage region is required."
                 )
-            
+
             client = boto3.client(
                 "s3",
                 aws_secret_access_key=credentials.get("secret_access_key"),


### PR DESCRIPTION
Fixes #3365

The AWS S3 Storage datasource provider used `GoogleCloudStorageDatasourceProvider`, the same class name as the Google Cloud Storage plugin. Renamed to `AwsS3StorageDatasourceProvider` to match other datasource providers. Bumped patch version to 0.3.12.

## Change Type

- [x] Non-LLM plugin (tools, extensions, datasource, etc.)

## Testing

- `python3 -m py_compile datasources/aws_s3_storage/provider/aws_s3_storage.py`
