### PR TITLE
feat(anthropic): add support for Claude Sonnet 5 model

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.23
+version: 0.3.24

--- a/models/anthropic/models/llm/_position.yaml
+++ b/models/anthropic/models/llm/_position.yaml
@@ -1,3 +1,4 @@
+- claude-sonnet-5
 - claude-fable-5
 - claude-opus-4-8
 - claude-opus-4-7

--- a/models/anthropic/models/llm/claude-sonnet-5.yaml
+++ b/models/anthropic/models/llm/claude-sonnet-5.yaml
@@ -1,0 +1,154 @@
+# https://platform.claude.com/docs/en/about-claude/models/overview
+# https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
+# https://platform.claude.com/docs/en/about-claude/models/migration-guide
+# https://platform.claude.com/docs/en/resources/overview
+# Note: Claude Sonnet 5 uses a new tokenizer (~30% more tokens for the same text
+# vs Sonnet 4.6). Revisit max_tokens budgets sized close to expected output length.
+# Pricing: standard $3/$15 per Mtok. Introductory $2/$10 per Mtok is in effect
+# through 2026-08-31; this card uses the standard (post-intro) rate for durability.
+model: claude-sonnet-5
+label:
+  en_US: claude-sonnet-5
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 自适应推理
+      en_US: Adaptive Thinking
+    type: boolean
+    default: true
+    required: true
+    help:
+      zh_Hans: |
+        Claude Sonnet 5 默认即启用自适应推理（adaptive thinking on by default），手动 extended thinking（thinking.budget_tokens）已被移除并返回 400，temperature/top_p/top_k 设为非默认值也会返回 400。开启此项以 adaptive 模式运行并按 Thinking Display 返回推理内容（便于前端展示思考进度）；关闭则不发送 thinking 字段，由 API 默认运行 adaptive thinking（推理内容按官方默认 omitted 不返回）。推理深度由 Effort 参数控制。
+      en_US: |
+        Claude Sonnet 5 runs adaptive thinking by default; manual extended thinking (thinking.budget_tokens) is removed and returns a 400, and non-default temperature/top_p/top_k also return a 400. Enable to run adaptive thinking and surface reasoning via Thinking Display; disable omits the thinking field and lets the API default apply (adaptive on, reasoning omitted per the official default). Depth is controlled by the Effort parameter.
+  - name: thinking_display
+    label:
+      zh_Hans: 推理内容展示
+      en_US: Thinking Display
+    type: string
+    default: omitted
+    required: true
+    options:
+      - omitted
+      - summarized
+    help:
+      zh_Hans: 响应中推理内容的展示方式。omitted 为官方默认值（响应中不返回 thinking 文本）；summarized 返回摘要化的推理过程，便于在前端展示思考进度。
+      en_US: How thinking content is exposed in the response. `omitted` is the official default (thinking text not returned); `summarized` returns summarized reasoning so clients can display progress.
+  - name: effort
+    label:
+      zh_Hans: 推理投入等级
+      en_US: Effort
+    type: string
+    default: xhigh
+    required: true
+    options:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    help:
+      zh_Hans: 通过 output_config.effort 控制智能/token 消耗的权衡。xhigh 推荐用于编码与智能体场景，high 是智能敏感场景的最低建议值；low 与 medium 适合延迟或成本敏感场景。
+      en_US: Controls the intelligence vs. token cost trade-off via output_config.effort. Use `xhigh` for coding and agentic tasks; `high` is the minimum recommendation for intelligence-sensitive tasks; `low`/`medium` for latency- or cost-sensitive tasks.
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    default: 128000
+    min: 1
+    max: 128000
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_ttl
+    label:
+      zh_Hans: 缓存有效期
+      en_US: Cache TTL
+    type: string
+    default: 5m
+    required: true
+    options:
+      - 5m
+      - 1h
+    help:
+      zh_Hans: 控制 prompt caching 的 cache_control.ttl。5m 为默认有效期；1h 可延长缓存有效期，但缓存写入成本更高。
+      en_US: Controls prompt caching cache_control.ttl. 5m is the default duration; 1h extends cache lifetime but has a higher cache write cost.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
+  - name: response_format
+    use_template: response_format
+  - name: json_schema
+    use_template: json_schema
+
+# https://claude.com/pricing#api
+# *Introductory pricing of $2/$10 per million input/output tokens through August 31, 2026; $3/$15 standard pricing thereafter.
+pricing:
+  input: '3.00'
+  output: '15.00'
+  unit: '0.000001'
+  currency: USD

--- a/models/anthropic/models/llm/claude-sonnet-5.yaml
+++ b/models/anthropic/models/llm/claude-sonnet-5.yaml
@@ -28,8 +28,14 @@ parameter_rules:
     default: true
     required: true
     help:
-      zh_Hans: 开启自适应推理，并按"推理内容展示"返回推理过程；关闭则不进行推理。Claude Sonnet 5 默认启用自适应推理，推理深度由 Effort 参数控制。
-      en_US: Enable adaptive thinking and surface reasoning per Thinking Display; disable turns thinking off. Claude Sonnet 5 runs adaptive thinking by default; depth is controlled by the Effort parameter.
+      zh_Hans: |
+        Claude Sonnet 5 默认启用自适应推理，推理深度由 Effort 参数控制。
+        开启此项时，插件会发送 `thinking.type=adaptive`，并按"推理内容展示"返回或省略推理内容。
+        关闭此项时，插件会显式发送 `thinking.type=disabled`，完全关闭推理以获得最低延迟与成本。
+      en_US: |
+        Claude Sonnet 5 runs adaptive thinking by default; depth is controlled by the Effort parameter.
+        When enabled, the plugin sends `thinking.type=adaptive` and uses Thinking Display to return or omit thinking content.
+        When disabled, the plugin explicitly sends `thinking.type=disabled` to completely turn off reasoning for the lowest latency and cost.
   - name: thinking_display
     label:
       zh_Hans: 推理内容展示

--- a/models/anthropic/models/llm/claude-sonnet-5.yaml
+++ b/models/anthropic/models/llm/claude-sonnet-5.yaml
@@ -48,7 +48,7 @@ parameter_rules:
       zh_Hans: 推理投入等级
       en_US: Effort
     type: string
-    default: xhigh
+    default: high
     required: true
     options:
       - low
@@ -57,8 +57,8 @@ parameter_rules:
       - xhigh
       - max
     help:
-      zh_Hans: 通过 output_config.effort 控制智能/token 消耗的权衡。xhigh 推荐用于编码与智能体场景，high 是智能敏感场景的最低建议值；low 与 medium 适合延迟或成本敏感场景。
-      en_US: Controls the intelligence vs. token cost trade-off via output_config.effort. Use `xhigh` for coding and agentic tasks; `high` is the minimum recommendation for intelligence-sensitive tasks; `low`/`medium` for latency- or cost-sensitive tasks.
+      zh_Hans: 通过 output_config.effort 控制智能/token 消耗的权衡。high 是官方默认值，适合复杂推理、编码与智能体场景；xhigh 适合最困难的长程编码与智能体任务；low 与 medium 适合延迟或成本敏感场景。
+      en_US: Controls the intelligence vs. token cost trade-off via output_config.effort. `high` is the official default for complex reasoning, coding, and agentic tasks; use `xhigh` for the hardest long-running coding and agentic tasks; use `low`/`medium` for latency- or cost-sensitive workloads.
   - name: max_tokens
     use_template: max_tokens
     required: true

--- a/models/anthropic/models/llm/claude-sonnet-5.yaml
+++ b/models/anthropic/models/llm/claude-sonnet-5.yaml
@@ -28,10 +28,8 @@ parameter_rules:
     default: true
     required: true
     help:
-      zh_Hans: |
-        Claude Sonnet 5 默认即启用自适应推理（adaptive thinking on by default），手动 extended thinking（thinking.budget_tokens）已被移除并返回 400，temperature/top_p/top_k 设为非默认值也会返回 400。开启此项以 adaptive 模式运行并按 Thinking Display 返回推理内容（便于前端展示思考进度）；关闭则不发送 thinking 字段，由 API 默认运行 adaptive thinking（推理内容按官方默认 omitted 不返回）。推理深度由 Effort 参数控制。
-      en_US: |
-        Claude Sonnet 5 runs adaptive thinking by default; manual extended thinking (thinking.budget_tokens) is removed and returns a 400, and non-default temperature/top_p/top_k also return a 400. Enable to run adaptive thinking and surface reasoning via Thinking Display; disable omits the thinking field and lets the API default apply (adaptive on, reasoning omitted per the official default). Depth is controlled by the Effort parameter.
+      zh_Hans: 开启自适应推理，并按"推理内容展示"返回推理过程；关闭则不进行推理。Claude Sonnet 5 默认启用自适应推理，推理深度由 Effort 参数控制。
+      en_US: Enable adaptive thinking and surface reasoning per Thinking Display; disable turns thinking off. Claude Sonnet 5 runs adaptive thinking by default; depth is controlled by the Effort parameter.
   - name: thinking_display
     label:
       zh_Hans: 推理内容展示

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -181,6 +181,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
     ADAPTIVE_THINKING_MODELS: tuple[str, ...] = (
         "claude-opus-4-7",
         "claude-opus-4-8",
+        "claude-sonnet-5",
         "claude-fable-5",
         "claude-mythos-5",
     )
@@ -424,7 +425,8 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 model_parameters.pop(key, None)
 
             if thinking or always_on_adaptive_thinking:
-                # Manual budgeted thinking is removed; Fable/Mythos always run adaptive thinking.
+                # Fable/Mythos always run adaptive thinking; other adaptive models opt in.
+                # When omitted, the API applies its own default (off for Opus, adaptive-on for Sonnet 5).
                 extra_model_kwargs["thinking"] = {
                     "type": "adaptive",
                     "display": thinking_display or "omitted",

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -189,6 +189,13 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         "claude-fable-5",
         "claude-mythos-5",
     )
+    # Models whose API default is adaptive-on and where thinking can be turned off
+    # with thinking: {type: "disabled"}. The thinking toggle is required on these,
+    # so false is translated to an explicit disabled (rather than omitting the field,
+    # which the API would interpret as its adaptive-on default).
+    ADAPTIVE_THINKING_DEFAULT_ON_MODELS: tuple[str, ...] = (
+        "claude-sonnet-5",
+    )
 
     def __init__(self, model_schemas=None):
         super().__init__(model_schemas or [])
@@ -212,6 +219,13 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         return any(
             model_id.startswith(prefix)
             for prefix in self.ALWAYS_ON_ADAPTIVE_THINKING_MODELS
+        )
+
+    def _has_adaptive_thinking_default_on(self, model: str) -> bool:
+        model_id = (model or "").lower()
+        return any(
+            model_id.startswith(prefix)
+            for prefix in self.ADAPTIVE_THINKING_DEFAULT_ON_MODELS
         )
 
     def _predefined_model_has_parameter(self, model: str, parameter_name: str) -> bool:
@@ -418,19 +432,30 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
 
         uses_adaptive_thinking = self._uses_adaptive_thinking(model)
         always_on_adaptive_thinking = self._has_always_on_adaptive_thinking(model)
+        adaptive_thinking_default_on = self._has_adaptive_thinking_default_on(model)
 
         if uses_adaptive_thinking:
             # These models reject non-default sampling params with 400; drop unconditionally.
             for key in ("temperature", "top_p", "top_k"):
                 model_parameters.pop(key, None)
 
-            if thinking or always_on_adaptive_thinking:
-                # Fable/Mythos always run adaptive thinking; other adaptive models opt in.
-                # When omitted, the API applies its own default (off for Opus, adaptive-on for Sonnet 5).
+            if always_on_adaptive_thinking:
+                # Fable/Mythos: adaptive thinking is always on and cannot be disabled.
                 extra_model_kwargs["thinking"] = {
                     "type": "adaptive",
                     "display": thinking_display or "omitted",
                 }
+            elif thinking:
+                # User enabled thinking: run adaptive and surface reasoning.
+                extra_model_kwargs["thinking"] = {
+                    "type": "adaptive",
+                    "display": thinking_display or "omitted",
+                }
+            elif adaptive_thinking_default_on:
+                # Sonnet 5: API default is adaptive-on, so false must be sent as an
+                # explicit disabled to actually turn thinking off.
+                extra_model_kwargs["thinking"] = {"type": "disabled"}
+            # else: Opus 4.7/4.8 — thinking is off unless opted in; omit the field.
 
             output_config: dict[str, Any] = {}
             if effort:

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -189,6 +189,12 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         "claude-fable-5",
         "claude-mythos-5",
     )
+    TASK_BUDGET_SUPPORTED_MODELS: tuple[str, ...] = (
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-fable-5",
+        "claude-mythos-5",
+    )
     # Models whose API default is adaptive-on and where thinking can be turned off
     # with thinking: {type: "disabled"}. The thinking toggle is required on these,
     # so false is translated to an explicit disabled (rather than omitting the field,
@@ -227,6 +233,10 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             model_id.startswith(prefix)
             for prefix in self.ADAPTIVE_THINKING_DEFAULT_ON_MODELS
         )
+
+    def _supports_task_budget(self, model: str) -> bool:
+        model_id = (model or "").lower()
+        return any(model_id.startswith(prefix) for prefix in self.TASK_BUDGET_SUPPORTED_MODELS)
 
     def _predefined_model_has_parameter(self, model: str, parameter_name: str) -> bool:
         for model_schema in self.model_schemas:
@@ -423,16 +433,19 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 "max_tokens_to_sample"
             )
 
+        thinking_was_set = "thinking" in model_parameters
         thinking = model_parameters.pop("thinking", False)
         thinking_budget = model_parameters.pop("thinking_budget", 1024)
-        thinking_display = model_parameters.pop("thinking_display", "summarized")
-        effort = model_parameters.pop("effort", None)
-        task_budget = int(model_parameters.pop("task_budget", 0) or 0)
-        context_1m = model_parameters.pop("context_1m", False)
-
         uses_adaptive_thinking = self._uses_adaptive_thinking(model)
         always_on_adaptive_thinking = self._has_always_on_adaptive_thinking(model)
         adaptive_thinking_default_on = self._has_adaptive_thinking_default_on(model)
+        thinking_display = model_parameters.pop(
+            "thinking_display",
+            "omitted" if uses_adaptive_thinking else "summarized",
+        )
+        effort = model_parameters.pop("effort", None)
+        task_budget = int(model_parameters.pop("task_budget", 0) or 0)
+        context_1m = model_parameters.pop("context_1m", False)
 
         if uses_adaptive_thinking:
             # These models reject non-default sampling params with 400; drop unconditionally.
@@ -451,16 +464,16 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     "type": "adaptive",
                     "display": thinking_display or "omitted",
                 }
-            elif adaptive_thinking_default_on:
-                # Sonnet 5: API default is adaptive-on, so false must be sent as an
-                # explicit disabled to actually turn thinking off.
+            elif adaptive_thinking_default_on and thinking_was_set:
+                # Sonnet 5: omitted thinking uses the API's adaptive-on default.
+                # Only an explicit false should turn thinking off.
                 extra_model_kwargs["thinking"] = {"type": "disabled"}
             # else: Opus 4.7/4.8 — thinking is off unless opted in; omit the field.
 
             output_config: dict[str, Any] = {}
             if effort:
                 output_config["effort"] = effort
-            if task_budget >= 20000:
+            if task_budget >= 20000 and self._supports_task_budget(model):
                 output_config["task_budget"] = {
                     "type": "tokens",
                     "total": task_budget,

--- a/models/anthropic/tests/conftest.py
+++ b/models/anthropic/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))

--- a/models/anthropic/tests/test_llm_call.py
+++ b/models/anthropic/tests/test_llm_call.py
@@ -43,7 +43,7 @@ def get_all_models() -> list[str]:
 def test_llm_invoke(model_name: str) -> None:
     api_key = os.getenv("ANTHROPIC_API_KEY")
     if not api_key:
-        raise ValueError("ANTHROPIC_API_KEY environment variable is required")
+        pytest.skip("ANTHROPIC_API_KEY is not set")
 
     plugin_path = os.getenv("PLUGIN_FILE_PATH")
     if not plugin_path:

--- a/models/anthropic/tests/test_sonnet5_parameters.py
+++ b/models/anthropic/tests/test_sonnet5_parameters.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+import yaml
+from dify_plugin.entities.model.message import UserPromptMessage
+
+from models.llm import llm as llm_module
+from models.llm.llm import AnthropicLargeLanguageModel
+
+
+class _Messages:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return object()
+
+
+class _Anthropic:
+    instances: list["_Anthropic"] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.messages = _Messages()
+        self.instances.append(self)
+
+
+def _capture_payload(
+    monkeypatch,
+    model_parameters: dict,
+    model: str = "claude-sonnet-5",
+) -> dict:
+    _Anthropic.instances = []
+    monkeypatch.setattr(llm_module, "Anthropic", _Anthropic)
+
+    AnthropicLargeLanguageModel()._chat_generate(
+        model=model,
+        credentials={"anthropic_api_key": "test-key"},
+        prompt_messages=[UserPromptMessage(content="Hello")],
+        model_parameters=dict(model_parameters),
+        stream=True,
+    )
+
+    return _Anthropic.instances[0].messages.calls[0]
+
+
+def test_sonnet5_schema_defaults_match_anthropic_docs() -> None:
+    schema_path = Path(__file__).parents[1] / "models" / "llm" / "claude-sonnet-5.yaml"
+    schema = yaml.safe_load(schema_path.read_text(encoding="utf-8"))
+    rules = {rule["name"]: rule for rule in schema["parameter_rules"]}
+
+    assert rules["thinking"]["default"] is True
+    assert rules["thinking_display"]["default"] == "omitted"
+    assert rules["effort"]["default"] == "high"
+    assert "task_budget" not in rules
+
+
+def test_sonnet5_omitted_thinking_preserves_api_default(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {
+            "max_tokens": 1024,
+            "temperature": 0,
+            "top_p": 0.1,
+            "top_k": 1,
+            "task_budget": 64000,
+        },
+    )
+
+    assert "thinking" not in payload
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+    assert "top_k" not in payload
+    assert "output_config" not in payload
+    assert payload["extra_headers"] == {}
+
+
+def test_sonnet5_explicit_false_disables_thinking_without_display(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {
+            "max_tokens": 1024,
+            "thinking": False,
+            "thinking_display": "summarized",
+            "effort": "low",
+        },
+    )
+
+    assert payload["thinking"] == {"type": "disabled"}
+    assert payload["output_config"] == {"effort": "low"}
+
+
+def test_sonnet5_explicit_true_uses_adaptive_thinking(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {
+            "max_tokens": 1024,
+            "thinking": True,
+            "thinking_display": "summarized",
+            "effort": "xhigh",
+        },
+    )
+
+    assert payload["thinking"] == {"type": "adaptive", "display": "summarized"}
+    assert payload["output_config"] == {"effort": "xhigh"}
+
+
+def test_sonnet5_adaptive_thinking_defaults_display_to_omitted(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {
+            "max_tokens": 1024,
+            "thinking": True,
+        },
+    )
+
+    assert payload["thinking"] == {"type": "adaptive", "display": "omitted"}
+
+
+def test_task_budget_still_sent_for_supported_adaptive_models(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {
+            "max_tokens": 1024,
+            "thinking": True,
+            "task_budget": 64000,
+        },
+        model="claude-opus-4-8",
+    )
+
+    assert payload["output_config"]["task_budget"] == {"type": "tokens", "total": 64000}
+    assert payload["extra_headers"] == {"anthropic-beta": "task-budgets-2026-03-13"}


### PR DESCRIPTION
## Summary

Refs #3377.

Introduces support for the new Claude Sonnet 5 model.

This PR also updates the Anthropic live CI test so it skips when `ANTHROPIC_API_KEY` is not configured.

That keeps fork PR and no-secret CI runs from failing only because live provider credentials are unavailable.

Changes include:

- Added `claude-sonnet-5.yaml` configuration with model properties, parameter rules, and standard post-intro pricing.
- Updated `manifest.yaml` version to 0.3.24.
- Added `claude-sonnet-5` to the model position list and adaptive thinking model handling.
- Aligned Claude Sonnet 5 `effort` default with Anthropic docs: `high` by default, with `xhigh` reserved for the hardest long-running coding and agentic tasks.
- Preserved the API default adaptive-thinking behavior when the `thinking` parameter is omitted; only explicit `thinking: false` sends `thinking: {"type": "disabled"}`.
- Kept Sonnet 5 sampling parameters out of the request payload because non-default `temperature`, `top_p`, and `top_k` return 400.
- Prevented unsupported Sonnet 5 `task_budget` payloads while preserving task-budget support for Opus 4.7, Opus 4.8, Fable 5, and Mythos 5.
- Added offline payload tests for Sonnet 5 thinking, effort, sampling, and task-budget behavior.
- Changed the Anthropic live LLM test to `pytest.skip(...)` when `ANTHROPIC_API_KEY` is missing.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        | <img width="1672" height="822" alt="PixPin_2026-07-01_08-48-09" src="https://github.com/user-attachments/assets/27691362-f06d-42d1-b9dd-e98cc5d8c4b4" /> |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml`.
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`, or kept in `requirements.txt` for legacy plugins without `uv.lock`.

## Testing

- [x] Local deployment.
- [ ] SaaS (cloud.dify.ai).
- [x] `UV_PROJECT_ENVIRONMENT=.ci-test-uv-venv uv run --python 3.12 --frozen --with pytest pytest tests/test_sonnet5_parameters.py -q`.
- [x] `UV_PROJECT_ENVIRONMENT=.ci-test-uv-venv uv run --python 3.12 --frozen --with ruff ruff check tests/test_sonnet5_parameters.py tests/conftest.py models/llm/llm.py`.
- [x] `env -u ANTHROPIC_API_KEY UV_PROJECT_ENVIRONMENT=.ci-test-uv-venv uv run --python 3.12 --frozen --with pytest pytest tests -q`.

Expected local result without Anthropic credentials: `6 passed, 13 skipped, 2 warnings`.
