### PR TITLE
fix(models): skip live tests without provider keys

### DIFF
--- a/models/deepseek/manifest.yaml
+++ b/models/deepseek/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.17
+version: 0.0.18

--- a/models/deepseek/tests/test_llm_call.py
+++ b/models/deepseek/tests/test_llm_call.py
@@ -42,10 +42,14 @@ def get_all_models() -> list[str]:
 def test_llm_invoke(model_name: str) -> None:
     api_key = os.getenv("DEEPSEEK_API_KEY")
     if not api_key:
-        raise ValueError("DEEPSEEK_API_KEY environment variable is required")
+        pytest.skip("DEEPSEEK_API_KEY is not set")
 
     plugin_path = os.getenv("PLUGIN_FILE_PATH")
     if not plugin_path:
+        if os.getenv("CI"):
+            raise ValueError(
+                "PLUGIN_FILE_PATH environment variable is required in CI when provider API key is set"
+            )
         plugin_path = str(Path(__file__).parent.parent)
 
     payload = ModelInvokeLLMRequest(

--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.0
+version: 0.9.1

--- a/models/gemini/tests/test_embedding_call.py
+++ b/models/gemini/tests/test_embedding_call.py
@@ -42,10 +42,14 @@ def get_all_embedding_models() -> list[str]:
 def test_embedding_invoke(model_name: str) -> None:
     api_key = os.getenv("GEMINI_API_KEY")
     if not api_key:
-        raise ValueError("GEMINI_API_KEY environment variable is required")
+        pytest.skip("GEMINI_API_KEY is not set")
 
     plugin_path = os.getenv("PLUGIN_FILE_PATH")
     if not plugin_path:
+        if os.getenv("CI"):
+            raise ValueError(
+                "PLUGIN_FILE_PATH environment variable is required in CI when provider API key is set"
+            )
         plugin_path = str(Path(__file__).parent.parent)
 
     payload = ModelInvokeTextEmbeddingRequest(

--- a/models/gemini/tests/test_llm_call.py
+++ b/models/gemini/tests/test_llm_call.py
@@ -43,11 +43,14 @@ def get_all_models() -> list[str]:
 def test_llm_invoke(model_name: str) -> None:
     api_key = os.getenv("GEMINI_API_KEY")
     if not api_key:
-        raise ValueError("GEMINI_API_KEY environment variable is required")
+        pytest.skip("GEMINI_API_KEY is not set")
 
     plugin_path = os.getenv("PLUGIN_FILE_PATH")
     if not plugin_path:
-        # Default to current directory if not set
+        if os.getenv("CI"):
+            raise ValueError(
+                "PLUGIN_FILE_PATH environment variable is required in CI when provider API key is set"
+            )
         plugin_path = str(Path(__file__).parent.parent)
 
     payload = ModelInvokeLLMRequest(

--- a/models/minimax/manifest.yaml
+++ b/models/minimax/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.21
+version: 0.0.22

--- a/models/minimax/tests/test_llm_call.py
+++ b/models/minimax/tests/test_llm_call.py
@@ -43,11 +43,14 @@ def get_all_models() -> list[str]:
 def test_llm_invoke(model_name: str) -> None:
     api_key = os.getenv("MINIMAX_API_KEY")
     if not api_key:
-        raise ValueError("MINIMAX_API_KEY environment variable is required")
+        pytest.skip("MINIMAX_API_KEY is not set")
 
     plugin_path = os.getenv("PLUGIN_FILE_PATH")
     if not plugin_path:
-        # Default to current directory if not set
+        if os.getenv("CI"):
+            raise ValueError(
+                "PLUGIN_FILE_PATH environment variable is required in CI when provider API key is set"
+            )
         plugin_path = str(Path(__file__).parent.parent)
 
     payload = ModelInvokeLLMRequest(

--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -26,5 +26,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.0.54
+version: 0.0.55
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/openrouter/tests/test_embedding_call.py
+++ b/models/openrouter/tests/test_embedding_call.py
@@ -42,10 +42,14 @@ def get_all_embedding_models() -> list[str]:
 def test_embedding_invoke(model_name: str) -> None:
     api_key = os.getenv("OPENROUTER_API_KEY")
     if not api_key:
-        raise ValueError("OPENROUTER_API_KEY environment variable is required")
+        pytest.skip("OPENROUTER_API_KEY is not set")
 
     plugin_path = os.getenv("PLUGIN_FILE_PATH")
     if not plugin_path:
+        if os.getenv("CI"):
+            raise ValueError(
+                "PLUGIN_FILE_PATH environment variable is required in CI when provider API key is set"
+            )
         plugin_path = str(Path(__file__).parent.parent)
 
     payload = ModelInvokeTextEmbeddingRequest(

--- a/models/openrouter/tests/test_llm_call.py
+++ b/models/openrouter/tests/test_llm_call.py
@@ -44,10 +44,14 @@ def get_all_models() -> list[str]:
 def test_llm_invoke(model_name: str) -> None:
     api_key = os.getenv("OPENROUTER_API_KEY")
     if not api_key:
-        raise ValueError("OPENROUTER_API_KEY environment variable is required")
+        pytest.skip("OPENROUTER_API_KEY is not set")
 
     plugin_path = os.getenv("PLUGIN_FILE_PATH")
     if not plugin_path:
+        if os.getenv("CI"):
+            raise ValueError(
+                "PLUGIN_FILE_PATH environment variable is required in CI when provider API key is set"
+            )
         plugin_path = str(Path(__file__).parent.parent)
 
     payload = ModelInvokeLLMRequest(
@@ -84,4 +88,3 @@ def test_llm_invoke(model_name: str) -> None:
                 time.sleep(1)
                 if failure_count >= 3:
                     raise e
-

--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.2.2
+version: 0.2.3
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/tests/test_llm_call.py
+++ b/models/tongyi/tests/test_llm_call.py
@@ -51,10 +51,14 @@ def get_all_models() -> list[str]:
 def test_llm_invoke(model_name: str) -> None:
     api_key = os.getenv("DASHSCOPE_API_KEY")
     if not api_key:
-        raise ValueError("DASHSCOPE_API_KEY environment variable is required")
+        pytest.skip("DASHSCOPE_API_KEY is not set")
 
     plugin_path = os.getenv("PLUGIN_FILE_PATH")
     if not plugin_path:
+        if os.getenv("CI"):
+            raise ValueError(
+                "PLUGIN_FILE_PATH environment variable is required in CI when provider API key is set"
+            )
         plugin_path = str(Path(__file__).parent.parent)
 
     payload = ModelInvokeLLMRequest(


### PR DESCRIPTION
## Summary

- Skip live provider tests when required provider API keys are absent, including in CI.
- Keep missing `PLUGIN_FILE_PATH` as a CI harness hard failure only when the live test is runnable.
- Fall back to the plugin directory for local runs when `PLUGIN_FILE_PATH` is not set.
- Bump the affected plugin manifest versions.

## Root Cause

GitHub Actions no longer provides several provider secrets, and fork PRs do not receive them by default.
Live provider tests treated missing API keys as hard failures instead of optional runtime prerequisites.
A missing `PLUGIN_FILE_PATH` should still expose CI harness misconfiguration once a live test has the credentials required to run.

## Validation

- `git diff --check`
- `CI=true` with provider key unset and `PLUGIN_FILE_PATH` unset skips: DeepSeek 5, Minimax 10, OpenRouter 69, Tongyi 77, Gemini 18.
- `CI=true DEEPSEEK_API_KEY=dummy` with `PLUGIN_FILE_PATH` unset fails with `ValueError: PLUGIN_FILE_PATH environment variable is required in CI when provider API key is set`.

Fixes #3377