### PR TITLE
fix(openai_api_compatible, gpustack): move reasoning_format to agent_thought_support block

### DIFF
--- a/models/gpustack/models/llm/llm.py
+++ b/models/gpustack/models/llm/llm.py
@@ -196,6 +196,10 @@ class GPUStackLanguageModel(OAICompatLargeLanguageModel):
             # Support top-level `enable_thinking` parameter
             model_parameters["enable_thinking"] = enable_thinking_value
 
+        reasoning_format_value = model_parameters.pop("reasoning_format", None)
+        if reasoning_format_value is not None and strict_compatibility_value is False:
+            model_parameters["reasoning_format"] = reasoning_format_value
+
         reasoning_effort_value = model_parameters.pop("reasoning_effort", None)
         if enable_thinking_value is True and reasoning_effort_value is not None:
             # Propagate reasoning_effort to both:
@@ -486,7 +490,7 @@ class GPUStackLanguageModel(OAICompatLargeLanguageModel):
                     name="reasoning_format",
                     label=I18nObject(en_us="Reasoning Format", zh_hans="推理格式"),
                     help=I18nObject(
-                        en_us="Specifying the format that the model must output reasoning.",
+                        en_us="Specifies the format in which the model must output reasoning.",
                         zh_hans="指定模型必须输出的推理格式。",
                     ),
                     type=ParameterType.STRING,

--- a/models/gpustack/models/llm/llm.py
+++ b/models/gpustack/models/llm/llm.py
@@ -449,19 +449,6 @@ class GPUStackLanguageModel(OAICompatLargeLanguageModel):
             )
             entity.parameter_rules.append(
                 ParameterRule(
-                    name="reasoning_format",
-                    label=I18nObject(en_us="Reasoning Format", zh_hans="推理格式"),
-                    help=I18nObject(
-                        en_us="Specifying the format that the model must output reasoning.",
-                        zh_hans="指定模型必须输出的推理格式。",
-                    ),
-                    type=ParameterType.STRING,
-                    options=["none", "auto", "deepseek", "deepseek-legacy"],
-                    required=False,
-                )
-            )
-            entity.parameter_rules.append(
-                ParameterRule(
                     name=DefaultParameterName.JSON_SCHEMA.value,
                     use_template=DefaultParameterName.JSON_SCHEMA.value,
                 )
@@ -494,6 +481,19 @@ class GPUStackLanguageModel(OAICompatLargeLanguageModel):
             )
 
         if agent_thought_support in ["supported", "only_thinking_supported"]:
+            entity.parameter_rules.append(
+                ParameterRule(
+                    name="reasoning_format",
+                    label=I18nObject(en_us="Reasoning Format", zh_hans="推理格式"),
+                    help=I18nObject(
+                        en_us="Specifying the format that the model must output reasoning.",
+                        zh_hans="指定模型必须输出的推理格式。",
+                    ),
+                    type=ParameterType.STRING,
+                    options=["none", "auto", "deepseek", "deepseek-legacy"],
+                    required=False,
+                )
+            )
             entity.parameter_rules.append(
                 ParameterRule(
                     name="reasoning_effort",

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -300,7 +300,7 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                     name="reasoning_format",
                     label=I18nObject(en_us="Reasoning Format", zh_hans="推理格式"),
                     help=I18nObject(
-                        en_us="Specifying the format that the model must output reasoning.",
+                        en_us="Specifies the format in which the model must output reasoning.",
                         zh_hans="指定模型必须输出的推理格式。",
                     ),
                     type=ParameterType.STRING,
@@ -496,6 +496,10 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             # Support top-level `enable_thinking` parameter
             # This allows compatibility API format: {"enable_thinking": False/True}
             model_parameters["enable_thinking"] = enable_thinking_value
+
+        reasoning_format_value = model_parameters.pop("reasoning_format", None)
+        if reasoning_format_value is not None and strict_compatibility_value is False:
+            model_parameters["reasoning_format"] = reasoning_format_value
 
         reasoning_effort_value = model_parameters.pop("reasoning_effort", None)
         if enable_thinking_value is True and reasoning_effort_value is not None:

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -261,19 +261,6 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             )
             entity.parameter_rules.append(
                 ParameterRule(
-                    name="reasoning_format",
-                    label=I18nObject(en_us="Reasoning Format", zh_hans="推理格式"),
-                    help=I18nObject(
-                        en_us="Specifying the format that the model must output reasoning.",
-                        zh_hans="指定模型必须输出的推理格式。",
-                    ),
-                    type=ParameterType.STRING,
-                    options=["none", "auto", "deepseek", "deepseek-legacy"],
-                    required=False,
-                )
-            )
-            entity.parameter_rules.append(
-                ParameterRule(
                     name=DefaultParameterName.JSON_SCHEMA.value,
                     use_template=DefaultParameterName.JSON_SCHEMA.value,
                 )
@@ -286,11 +273,11 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
 
         # Configure thinking mode parameter based on model support
         agent_thought_support = credentials.get("agent_thought_support", "not_supported")
-        
+
         # Add AGENT_THOUGHT feature if thinking mode is supported (either mode)
         if agent_thought_support in ["supported", "only_thinking_supported"] and ModelFeature.AGENT_THOUGHT not in entity.features:
             entity.features.append(ModelFeature.AGENT_THOUGHT)
-        
+
         # Only add the enable_thinking parameter if the model supports both modes
         # If only_thinking_supported, the parameter is not needed (forced behavior)
         if agent_thought_support == "supported":
@@ -308,6 +295,19 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             )
 
         if agent_thought_support in ["supported", "only_thinking_supported"]:
+            entity.parameter_rules.append(
+                ParameterRule(
+                    name="reasoning_format",
+                    label=I18nObject(en_us="Reasoning Format", zh_hans="推理格式"),
+                    help=I18nObject(
+                        en_us="Specifying the format that the model must output reasoning.",
+                        zh_hans="指定模型必须输出的推理格式。",
+                    ),
+                    type=ParameterType.STRING,
+                    options=["none", "auto", "deepseek", "deepseek-legacy"],
+                    required=False,
+                )
+            )
             entity.parameter_rules.append(
                 ParameterRule(
                     name="reasoning_effort",


### PR DESCRIPTION
## Summary

Fixes #3380

`reasoning_format` was incorrectly placed inside the `structured_output_support == "supported"` block. This caused a `ValueError` for any non-DeepSeek model (e.g. Gemini via LiteLLM) when **Structured Output** was enabled in credentials.

**Root cause:** `reasoning_format` is a DeepSeek-specific parameter for controlling how thinking/reasoning content is formatted in the response. It has no relation to structured JSON output. When a user left it unset, Dify sent it as an empty string `""`. The plugin SDK's `_validate_and_filter_model_parameters()` correctly rejected `""` since it is not one of the defined option values, raising the `ValueError` before `_invoke()` was even called.

**Fix:** Move `reasoning_format` next to `reasoning_effort` under the `agent_thought_support in ["supported", "only_thinking_supported"]` block, where it is semantically correct and only visible to models that actually have thinking/reasoning capabilities.

## Changes

- `models/openai_api_compatible/models/llm/llm.py`
- `models/gpustack/models/llm/llm.py`

## Test plan

Verified with a unit test against `get_customizable_model_schema()` using mock credentials (no network required):

| Credentials | reasoning_format visible? | Result |
|---|---|---|
| `structured_output=supported`, `agent_thought=not_supported` | No (bug fix) | PASS |
| `structured_output=not_supported`, `agent_thought=supported` | Yes | PASS |
| `structured_output=supported`, `agent_thought=supported` | Yes | PASS |
| `agent_thought=only_thinking_supported` | Yes | PASS |
| both `not_supported` | No | PASS |

All 5 cases passed for `openai_api_compatible`; all 3 cases passed for `gpustack`.