### PR TITLE
feat(models): expose Ark video generation custom models

### DIFF
--- a/models/byteplus/manifest.yaml
+++ b/models/byteplus/manifest.yaml
@@ -32,4 +32,4 @@ resource:
       text_embedding: false
       tts: false
 type: plugin
-version: 0.0.2
+version: 0.0.3

--- a/models/byteplus/models/llm/llm.py
+++ b/models/byteplus/models/llm/llm.py
@@ -14,7 +14,18 @@ from volcenginesdkarkruntime import Ark
 from volcenginesdkarkruntime._streaming import Stream
 from volcenginesdkarkruntime.types.chat import ChatCompletion, ChatCompletionChunk
 
+from dify_plugin.entities.model import (
+    AIModelEntity,
+    FetchFrom,
+    I18nObject,
+    ModelFeature,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    ParameterType,
+)
 from dify_plugin.entities.model.llm import (
+    LLMMode,
     LLMPollingResult,
     LLMPollingStatus,
     LLMResult,
@@ -65,6 +76,7 @@ DEFAULT_POLLING_MAX_ATTEMPTS = 60
 DEFAULT_SEEDANCE_INPUT_MODE = "first_frame"
 SEEDANCE_INPUT_MODES = {"first_frame", "first_last_frame", "reference_image"}
 SEEDANCE_IMAGE_ROLES = {"first_frame", "last_frame", "reference_image"}
+VIDEO_GENERATION_ENDPOINT_TYPE = "video_generation"
 
 SEEDANCE_MODEL_PARAMETER_NAMES = {
     "ratio",
@@ -125,6 +137,7 @@ class ArkObjectResponse(ProviderModel):
 class ArkCredentials(RequestModel):
     ark_api_key: str = Field(min_length=1)
     api_endpoint_host: str = Field(min_length=1)
+    endpoint_type: str | None = None
 
 
 class ArkURL(RequestModel):
@@ -557,12 +570,39 @@ def platform_spec_for_model(model: str) -> PlatformSpec | None:
     return None
 
 
-def platform_name_for_model(model: str) -> str:
+def is_custom_video_generation_model(
+    credentials: Mapping[str, Any] | ArkCredentials | None,
+) -> bool:
+    if credentials is None:
+        return False
+    if isinstance(credentials, ArkCredentials):
+        return credentials.endpoint_type == VIDEO_GENERATION_ENDPOINT_TYPE
+    return credentials.get("endpoint_type") == VIDEO_GENERATION_ENDPOINT_TYPE
+
+
+def is_video_generation_model(
+    model: str,
+    credentials: Mapping[str, Any] | ArkCredentials | None = None,
+) -> bool:
+    return is_seedance_model(model) or is_custom_video_generation_model(credentials)
+
+
+def platform_name_for_model(
+    model: str,
+    credentials: Mapping[str, Any] | ArkCredentials | None = None,
+) -> str:
     platform = platform_spec_for_model(model)
+    if platform is None and is_custom_video_generation_model(credentials):
+        platform = PLATFORM_SPECS[0]
     return platform.name if platform else "unknown"
 
 
-def is_seedance_2_model(model: str) -> bool:
+def is_seedance_2_model(
+    model: str,
+    credentials: Mapping[str, Any] | ArkCredentials | None = None,
+) -> bool:
+    if is_custom_video_generation_model(credentials):
+        return True
     platform = platform_spec_for_model(model)
     return bool(platform and model.startswith(f"{platform.seedance_prefix}2-"))
 
@@ -719,7 +759,9 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
             credentials,
             "Invalid Ark credentials",
         )
-        if is_seedance_model(model) or is_seedream_model(model):
+        if is_video_generation_model(model, ark_credentials) or is_seedream_model(
+            model
+        ):
             self.validate_polling_credentials(model, ark_credentials)
             return
 
@@ -742,7 +784,7 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
     ) -> None:
         path = (
             "contents/generations/tasks?page_num=1&page_size=1"
-            if is_seedance_model(model)
+            if is_video_generation_model(model, credentials)
             else "images/generations"
         )
         try:
@@ -771,6 +813,118 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
         # This is acceptable for plugin implementations that do not support token counting.
         text = extract_prompt_text(prompt_messages)
         return max(1, len(text) // 4)
+
+    def get_customizable_model_schema(
+        self, model: str, credentials: Mapping[Any, Any]
+    ) -> AIModelEntity | None:
+        return AIModelEntity(
+            model=model,
+            label=I18nObject(en_us=model),
+            fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
+            model_type=ModelType.LLM,
+            features=[
+                ModelFeature.POLLING,
+                ModelFeature.VISION,
+                ModelFeature.VIDEO,
+                ModelFeature.AUDIO,
+            ],
+            model_properties={
+                ModelPropertyKey.MODE: LLMMode.CHAT.value,
+                ModelPropertyKey.CONTEXT_SIZE: 4000,
+            },
+            parameter_rules=[
+                ParameterRule(
+                    name="input_mode",
+                    label=I18nObject(
+                        zh_hans="输入图片模式", en_us="Image Input Mode"
+                    ),
+                    type=ParameterType.STRING,
+                    required=False,
+                    default="first_frame",
+                    options=["first_frame", "first_last_frame", "reference_image"],
+                ),
+                ParameterRule(
+                    name="resolution",
+                    label=I18nObject(zh_hans="视频分辨率", en_us="Video Resolution"),
+                    type=ParameterType.STRING,
+                    required=False,
+                    default="720p",
+                    options=["480p", "720p", "1080p"],
+                ),
+                ParameterRule(
+                    name="ratio",
+                    label=I18nObject(zh_hans="视频比例", en_us="Video Ratio"),
+                    type=ParameterType.STRING,
+                    required=False,
+                    default="adaptive",
+                    options=["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16", "21:9"],
+                ),
+                ParameterRule(
+                    name="duration",
+                    label=I18nObject(zh_hans="视频时长", en_us="Video Duration"),
+                    type=ParameterType.INT,
+                    required=False,
+                    default=5,
+                    min=-1,
+                    max=15,
+                ),
+                ParameterRule(
+                    name="seed",
+                    label=I18nObject(zh_hans="随机种子", en_us="Random Seed"),
+                    type=ParameterType.INT,
+                    required=False,
+                    default=-1,
+                    min=-1,
+                    max=4294967295,
+                ),
+                ParameterRule(
+                    name="generate_audio",
+                    label=I18nObject(zh_hans="生成音频", en_us="Generate Audio"),
+                    type=ParameterType.BOOLEAN,
+                    required=False,
+                    default=False,
+                ),
+                ParameterRule(
+                    name="watermark",
+                    label=I18nObject(zh_hans="水印", en_us="Watermark"),
+                    type=ParameterType.BOOLEAN,
+                    required=False,
+                    default=False,
+                ),
+                ParameterRule(
+                    name="return_last_frame",
+                    label=I18nObject(zh_hans="返回尾帧", en_us="Return Last Frame"),
+                    type=ParameterType.BOOLEAN,
+                    required=False,
+                    default=False,
+                ),
+                ParameterRule(
+                    name="callback_url",
+                    label=I18nObject(zh_hans="回调地址", en_us="Callback URL"),
+                    type=ParameterType.STRING,
+                    required=False,
+                ),
+                ParameterRule(
+                    name="service_tier",
+                    label=I18nObject(zh_hans="服务档位", en_us="Service Tier"),
+                    type=ParameterType.STRING,
+                    required=False,
+                    default="default",
+                    options=["default", "flex"],
+                ),
+                ParameterRule(
+                    name="execution_expires_after",
+                    label=I18nObject(
+                        zh_hans="任务超时时间", en_us="Execution Expires After"
+                    ),
+                    type=ParameterType.INT,
+                    required=False,
+                    default=172800,
+                    min=3600,
+                    max=259200,
+                ),
+            ],
+        )
 
     def request_model(
         self,
@@ -815,6 +969,7 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
         prompt_messages: list[PromptMessage],
         *,
         model: str,
+        credentials: ArkCredentials | None = None,
         input_mode: object = None,
     ) -> list[SeedanceContentPart]:
         content: list[SeedanceContentPart] = []
@@ -839,7 +994,9 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
             elif isinstance(message_content, AudioPromptMessageContent):
                 audio_contents.append(message_content)
 
-        if (video_contents or audio_contents) and not is_seedance_2_model(model):
+        if (video_contents or audio_contents) and not is_seedance_2_model(
+            model, credentials
+        ):
             raise InvokeError(
                 "Seedance video and audio input is only supported by Seedance 2.0 models."
             )
@@ -854,6 +1011,7 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
 
         image_roles = self.build_seedance_image_roles(
             model=model,
+            credentials=credentials,
             image_contents=image_contents,
             input_mode=input_mode,
             reference_mode=bool(video_contents or audio_contents),
@@ -908,6 +1066,7 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
         self,
         *,
         model: str,
+        credentials: ArkCredentials | None = None,
         image_contents: list[ImagePromptMessageContent],
         input_mode: object,
         reference_mode: bool,
@@ -928,7 +1087,9 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
                 raise InvokeError(
                     "Seedance video and audio input cannot be mixed with frame image roles."
                 )
-            self.validate_seedance_image_roles(model=model, roles=roles)
+            self.validate_seedance_image_roles(
+                model=model, credentials=credentials, roles=roles
+            )
             return roles
 
         if reference_mode:
@@ -952,7 +1113,7 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
                 )
             return ["first_frame", "last_frame"]
 
-        if not is_seedance_2_model(model):
+        if not is_seedance_2_model(model, credentials):
             raise InvokeError(
                 "Seedance reference_image input_mode is only supported by Seedance 2.0 models."
             )
@@ -962,7 +1123,13 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
             )
         return ["reference_image" for _ in image_contents]
 
-    def validate_seedance_image_roles(self, *, model: str, roles: list[str]) -> None:
+    def validate_seedance_image_roles(
+        self,
+        *,
+        model: str,
+        credentials: ArkCredentials | None = None,
+        roles: list[str],
+    ) -> None:
         unsupported_roles = [role for role in roles if role not in SEEDANCE_IMAGE_ROLES]
         if unsupported_roles:
             raise InvokeError(
@@ -973,7 +1140,7 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
                 raise InvokeError(
                     "Seedance reference_image cannot be mixed with frame roles."
                 )
-            if not is_seedance_2_model(model):
+            if not is_seedance_2_model(model, credentials):
                 raise InvokeError(
                     "Seedance reference_image role is only supported by Seedance 2.0 models."
                 )
@@ -1038,7 +1205,7 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
         plugin_state = SeedancePollingState(
             task_id=task_id,
             model=model,
-            platform=platform_name_for_model(model),
+            platform=platform_name_for_model(model, credentials),
         ).to_payload()
         if status in SEEDANCE_RUNNING_STATUSES:
             return LLMPollingResult(
@@ -1133,7 +1300,9 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
             "Invalid Ark credentials",
         )
         platform = platform_spec_for_model(model)
-        if is_seedance_model(model):
+        if platform is None and is_custom_video_generation_model(ark_credentials):
+            platform = PLATFORM_SPECS[0]
+        if is_video_generation_model(model, ark_credentials):
             seedance_parameters = filter_model_parameters(
                 model_parameters,
                 SEEDANCE_MODEL_PARAMETER_NAMES,
@@ -1153,6 +1322,7 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
                 content=self.build_seedance_content(
                     prompt_messages,
                     model=model,
+                    credentials=ark_credentials,
                     input_mode=model_parameters.get("input_mode"),
                 ),
                 **seedance_parameters,
@@ -1252,7 +1422,7 @@ class BytePlusArkLargeLanguageModel(LargeLanguageModel):
             credentials,
             "Invalid Ark credentials",
         )
-        if is_seedance_model(model):
+        if is_video_generation_model(model, ark_credentials):
             try:
                 state = parse_model(
                     SeedancePollingState,

--- a/models/byteplus/provider/byteplus.yaml
+++ b/models/byteplus/provider/byteplus.yaml
@@ -1,5 +1,6 @@
 background: '#F9FAFB'
 configurate_methods:
+- customizable-model
 - predefined-model
 description:
   en_US: BytePlus ModelArk pre-provided model invocation.
@@ -24,6 +25,46 @@ icon_small:
 label:
   en_US: BytePlus ModelArk
   zh_Hans: BytePlus ModelArk
+model_credential_schema:
+  model:
+    label:
+      en_US: Video Model ID / Endpoint ID
+      zh_Hans: 视频模型 ID / Endpoint ID
+    placeholder:
+      en_US: Enter a video model ID or Endpoint ID, e.g. seedance-2-0-260128 or ep-xxx
+      zh_Hans: 输入视频模型 ID 或 Endpoint ID，例如 seedance-2-0-260128 或 ep-xxx
+  credential_form_schemas:
+  - label:
+      en_US: API Key
+      zh_Hans: API Key
+    placeholder:
+      en_US: Enter your Ark API Key
+      zh_Hans: 输入 Ark API Key
+    required: true
+    type: secret-input
+    variable: ark_api_key
+  - default: https://ark.ap-southeast.bytepluses.com/api/v3
+    label:
+      en_US: API Endpoint
+      zh_Hans: API Endpoint
+    placeholder:
+      en_US: https://ark.ap-southeast.bytepluses.com/api/v3
+      zh_Hans: https://ark.ap-southeast.bytepluses.com/api/v3
+    required: true
+    type: text-input
+    variable: api_endpoint_host
+  - default: video_generation
+    label:
+      en_US: Endpoint Type
+      zh_Hans: Endpoint Type
+    options:
+    - label:
+        en_US: Video Generation
+        zh_Hans: 视频生成
+      value: video_generation
+    required: true
+    type: select
+    variable: endpoint_type
 models:
   llm:
     position: models/llm/_position.yaml

--- a/models/byteplus/tests/test_polling_llm.py
+++ b/models/byteplus/tests/test_polling_llm.py
@@ -6,13 +6,14 @@ from typing import Any
 from urllib.error import URLError
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from dify_plugin.config.config import DifyPluginEnv
 from dify_plugin.core.plugin_registration import PluginRegistration
-from dify_plugin.entities.model import ModelType
-from dify_plugin.entities.model.llm import LLMPollingStatus, LLMUsage
+from dify_plugin.entities.model import ModelFeature, ModelPropertyKey, ModelType
+from dify_plugin.entities.model.llm import LLMMode, LLMPollingStatus, LLMUsage
 from dify_plugin.entities.model.message import (
     AudioPromptMessageContent,
     ImagePromptMessageContent,
@@ -42,6 +43,10 @@ def credentials() -> dict[str, str]:
         "ark_api_key": "test-key",
         "api_endpoint_host": "https://ark.ap-southeast.bytepluses.com/api/v3",
     }
+
+
+def video_credentials() -> dict[str, str]:
+    return {**credentials(), "endpoint_type": "video_generation"}
 
 
 @dataclass(frozen=True)
@@ -185,6 +190,53 @@ def test_request_model_uses_configured_endpoint(
     assert requests[0][1] == 60
 
 
+def test_provider_yaml_exposes_custom_video_model() -> None:
+    provider_file = Path(__file__).resolve().parents[1] / "provider/byteplus.yaml"
+    provider = yaml.safe_load(provider_file.read_text(encoding="utf-8"))
+
+    assert "customizable-model" in provider["configurate_methods"]
+    assert (
+        provider["model_credential_schema"]["model"]["label"]["en_US"]
+        == "Video Model ID / Endpoint ID"
+    )
+    variables = {
+        field["variable"]
+        for field in provider["model_credential_schema"]["credential_form_schemas"]
+    }
+    assert {"ark_api_key", "api_endpoint_host", "endpoint_type"} <= variables
+
+
+def test_custom_video_schema_exposes_polling_features() -> None:
+    schema = make_model().get_customizable_model_schema(
+        "ep-test", video_credentials()
+    )
+
+    assert schema is not None
+    assert schema.model == "ep-test"
+    assert schema.model_properties[ModelPropertyKey.MODE] == LLMMode.CHAT.value
+    assert {
+        ModelFeature.POLLING,
+        ModelFeature.VISION,
+        ModelFeature.VIDEO,
+        ModelFeature.AUDIO,
+    } <= set(schema.features or [])
+    rule_names = {rule.name for rule in schema.parameter_rules}
+    assert {
+        "input_mode",
+        "resolution",
+        "ratio",
+        "duration",
+        "seed",
+        "generate_audio",
+        "watermark",
+        "return_last_frame",
+        "callback_url",
+        "service_tier",
+        "execution_expires_after",
+    } <= rule_names
+    assert "web_search" not in rule_names
+
+
 def test_seedance_validate_credentials_uses_non_generation_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -198,6 +250,28 @@ def test_seedance_validate_credentials_uses_non_generation_probe(
     monkeypatch.setattr(model, "request_model", fake_request_model)
 
     model.validate_credentials("seedance-2-0-260128", credentials())
+
+    assert requests == [
+        CapturedRequest(
+            method="GET",
+            path="contents/generations/tasks?page_num=1&page_size=1",
+        )
+    ]
+
+
+def test_custom_video_validate_credentials_uses_non_generation_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = make_model()
+    requests: list[CapturedRequest] = []
+
+    def fake_request_model(**kwargs: Any) -> Any:
+        requests.append(CapturedRequest.from_kwargs(kwargs))
+        return provider_response(kwargs, {"data": []})
+
+    monkeypatch.setattr(model, "request_model", fake_request_model)
+
+    model.validate_credentials("ep-test", video_credentials())
 
     assert requests == [
         CapturedRequest(
@@ -310,6 +384,70 @@ def test_seedance_start_polling_creates_task_without_web_search(
     }
 
 
+def test_custom_video_start_polling_creates_task_without_web_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = make_model()
+    requests: list[CapturedRequest] = []
+
+    def fake_request_model(**kwargs: Any) -> Any:
+        requests.append(CapturedRequest.from_kwargs(kwargs))
+        return provider_response(kwargs, {"id": "task-1", "status": "queued"})
+
+    monkeypatch.setattr(model, "request_model", fake_request_model)
+
+    result = model._start_polling(
+        model="ep-test",
+        credentials=video_credentials(),
+        prompt_messages=[
+            UserPromptMessage(
+                content=[
+                    TextPromptMessageContent(data="make a calm ocean video"),
+                    VideoPromptMessageContent(
+                        format="mp4",
+                        mime_type="video/mp4",
+                        url="https://example.com/reference.mp4",
+                    ),
+                    AudioPromptMessageContent(
+                        format="mp3",
+                        mime_type="audio/mpeg",
+                        url="https://example.com/reference.mp3",
+                    ),
+                ],
+            )
+        ],
+        model_parameters={"duration": 5, "resolution": "720p", "web_search": True},
+        stream=False,
+    )
+
+    assert result.status == LLMPollingStatus.RUNNING
+    assert result.plugin_state == {
+        "task_id": "task-1",
+        "model": "ep-test",
+        "platform": "byteplus",
+    }
+    assert requests[0].method == "POST"
+    assert requests[0].path == "contents/generations/tasks"
+    assert requests[0].payload_dict() == {
+        "model": "ep-test",
+        "content": [
+            {"type": "text", "text": "make a calm ocean video"},
+            {
+                "type": "video_url",
+                "video_url": {"url": "https://example.com/reference.mp4"},
+                "role": "reference_video",
+            },
+            {
+                "type": "audio_url",
+                "audio_url": {"url": "https://example.com/reference.mp3"},
+                "role": "reference_audio",
+            },
+        ],
+        "duration": 5,
+        "resolution": "720p",
+    }
+
+
 def test_seedance_public_start_polling_works_without_legacy_forwarded_keywords(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -401,6 +539,45 @@ def test_seedance_check_polling_returns_video_result(
     assert isinstance(video, VideoPromptMessageContent)
     assert video.url == "https://example.com/result.mp4"
     assert video.mime_type == "video/mp4"
+
+
+def test_custom_video_check_polling_returns_video_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = make_model()
+    monkeypatch.setattr(
+        model,
+        "usage_from_provider_payload",
+        lambda **_: LLMUsage.empty_usage(),
+    )
+
+    def fake_request_model(**kwargs: Any) -> Any:
+        assert kwargs["method"] == "GET"
+        assert kwargs["path"] == "contents/generations/tasks/task-1"
+        return provider_response(
+            kwargs,
+            {
+                "id": "task-1",
+                "status": "succeeded",
+                "content": {"video_url": "https://example.com/result.mp4"},
+                "usage": {"completion_tokens": 12, "total_tokens": 12},
+            },
+        )
+
+    monkeypatch.setattr(model, "request_model", fake_request_model)
+
+    result = model._check_polling(
+        model="ep-test",
+        credentials=video_credentials(),
+        plugin_state={"task_id": "task-1"},
+    )
+
+    assert result.status == LLMPollingStatus.SUCCEEDED
+    assert result.result is not None
+    assert isinstance(result.result.message.content, list)
+    video = result.result.message.content[0]
+    assert isinstance(video, VideoPromptMessageContent)
+    assert video.url == "https://example.com/result.mp4"
 
 
 def test_seedance_public_check_polling_works_without_legacy_forwarded_keywords(

--- a/models/volcengine/manifest.yaml
+++ b/models/volcengine/manifest.yaml
@@ -33,4 +33,4 @@ resource:
       text_embedding: false
       tts: false
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/models/volcengine/models/llm/llm.py
+++ b/models/volcengine/models/llm/llm.py
@@ -14,7 +14,18 @@ from volcenginesdkarkruntime import Ark
 from volcenginesdkarkruntime._streaming import Stream
 from volcenginesdkarkruntime.types.chat import ChatCompletion, ChatCompletionChunk
 
+from dify_plugin.entities.model import (
+    AIModelEntity,
+    FetchFrom,
+    I18nObject,
+    ModelFeature,
+    ModelPropertyKey,
+    ModelType,
+    ParameterRule,
+    ParameterType,
+)
 from dify_plugin.entities.model.llm import (
+    LLMMode,
     LLMPollingResult,
     LLMPollingStatus,
     LLMResult,
@@ -65,6 +76,7 @@ DEFAULT_POLLING_MAX_ATTEMPTS = 60
 DEFAULT_SEEDANCE_INPUT_MODE = "first_frame"
 SEEDANCE_INPUT_MODES = {"first_frame", "first_last_frame", "reference_image"}
 SEEDANCE_IMAGE_ROLES = {"first_frame", "last_frame", "reference_image"}
+VIDEO_GENERATION_ENDPOINT_TYPE = "video_generation"
 
 SEEDANCE_MODEL_PARAMETER_NAMES = {
     "ratio",
@@ -125,6 +137,7 @@ class ArkObjectResponse(ProviderModel):
 class ArkCredentials(RequestModel):
     ark_api_key: str = Field(min_length=1)
     api_endpoint_host: str = Field(min_length=1)
+    endpoint_type: str | None = None
 
 
 class ArkURL(RequestModel):
@@ -557,12 +570,39 @@ def platform_spec_for_model(model: str) -> PlatformSpec | None:
     return None
 
 
-def platform_name_for_model(model: str) -> str:
+def is_custom_video_generation_model(
+    credentials: Mapping[str, Any] | ArkCredentials | None,
+) -> bool:
+    if credentials is None:
+        return False
+    if isinstance(credentials, ArkCredentials):
+        return credentials.endpoint_type == VIDEO_GENERATION_ENDPOINT_TYPE
+    return credentials.get("endpoint_type") == VIDEO_GENERATION_ENDPOINT_TYPE
+
+
+def is_video_generation_model(
+    model: str,
+    credentials: Mapping[str, Any] | ArkCredentials | None = None,
+) -> bool:
+    return is_seedance_model(model) or is_custom_video_generation_model(credentials)
+
+
+def platform_name_for_model(
+    model: str,
+    credentials: Mapping[str, Any] | ArkCredentials | None = None,
+) -> str:
     platform = platform_spec_for_model(model)
+    if platform is None and is_custom_video_generation_model(credentials):
+        platform = PLATFORM_SPECS[0]
     return platform.name if platform else "unknown"
 
 
-def is_seedance_2_model(model: str) -> bool:
+def is_seedance_2_model(
+    model: str,
+    credentials: Mapping[str, Any] | ArkCredentials | None = None,
+) -> bool:
+    if is_custom_video_generation_model(credentials):
+        return True
     platform = platform_spec_for_model(model)
     return bool(platform and model.startswith(f"{platform.seedance_prefix}2-"))
 
@@ -719,7 +759,9 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
             credentials,
             "Invalid Ark credentials",
         )
-        if is_seedance_model(model) or is_seedream_model(model):
+        if is_video_generation_model(model, ark_credentials) or is_seedream_model(
+            model
+        ):
             self.validate_polling_credentials(model, ark_credentials)
             return
 
@@ -742,7 +784,7 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
     ) -> None:
         path = (
             "contents/generations/tasks?page_num=1&page_size=1"
-            if is_seedance_model(model)
+            if is_video_generation_model(model, credentials)
             else "images/generations"
         )
         try:
@@ -771,6 +813,125 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
         # This is acceptable for plugin implementations that do not support token counting.
         text = extract_prompt_text(prompt_messages)
         return max(1, len(text) // 4)
+
+    def get_customizable_model_schema(
+        self, model: str, credentials: Mapping[Any, Any]
+    ) -> AIModelEntity | None:
+        return AIModelEntity(
+            model=model,
+            label=I18nObject(en_us=model),
+            fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
+            model_type=ModelType.LLM,
+            features=[
+                ModelFeature.POLLING,
+                ModelFeature.VISION,
+                ModelFeature.VIDEO,
+                ModelFeature.AUDIO,
+            ],
+            model_properties={
+                ModelPropertyKey.MODE: LLMMode.CHAT.value,
+                ModelPropertyKey.CONTEXT_SIZE: 4000,
+            },
+            parameter_rules=[
+                ParameterRule(
+                    name="input_mode",
+                    label=I18nObject(
+                        zh_hans="输入图片模式", en_us="Image Input Mode"
+                    ),
+                    type=ParameterType.STRING,
+                    required=False,
+                    default="first_frame",
+                    options=["first_frame", "first_last_frame", "reference_image"],
+                ),
+                ParameterRule(
+                    name="resolution",
+                    label=I18nObject(zh_hans="视频分辨率", en_us="Video Resolution"),
+                    type=ParameterType.STRING,
+                    required=False,
+                    default="720p",
+                    options=["480p", "720p", "1080p"],
+                ),
+                ParameterRule(
+                    name="ratio",
+                    label=I18nObject(zh_hans="视频比例", en_us="Video Ratio"),
+                    type=ParameterType.STRING,
+                    required=False,
+                    default="adaptive",
+                    options=["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16", "21:9"],
+                ),
+                ParameterRule(
+                    name="duration",
+                    label=I18nObject(zh_hans="视频时长", en_us="Video Duration"),
+                    type=ParameterType.INT,
+                    required=False,
+                    default=5,
+                    min=-1,
+                    max=15,
+                ),
+                ParameterRule(
+                    name="seed",
+                    label=I18nObject(zh_hans="随机种子", en_us="Random Seed"),
+                    type=ParameterType.INT,
+                    required=False,
+                    default=-1,
+                    min=-1,
+                    max=4294967295,
+                ),
+                ParameterRule(
+                    name="generate_audio",
+                    label=I18nObject(zh_hans="生成音频", en_us="Generate Audio"),
+                    type=ParameterType.BOOLEAN,
+                    required=False,
+                    default=False,
+                ),
+                ParameterRule(
+                    name="watermark",
+                    label=I18nObject(zh_hans="水印", en_us="Watermark"),
+                    type=ParameterType.BOOLEAN,
+                    required=False,
+                    default=False,
+                ),
+                ParameterRule(
+                    name="return_last_frame",
+                    label=I18nObject(zh_hans="返回尾帧", en_us="Return Last Frame"),
+                    type=ParameterType.BOOLEAN,
+                    required=False,
+                    default=False,
+                ),
+                ParameterRule(
+                    name="callback_url",
+                    label=I18nObject(zh_hans="回调地址", en_us="Callback URL"),
+                    type=ParameterType.STRING,
+                    required=False,
+                ),
+                ParameterRule(
+                    name="service_tier",
+                    label=I18nObject(zh_hans="服务档位", en_us="Service Tier"),
+                    type=ParameterType.STRING,
+                    required=False,
+                    default="default",
+                    options=["default", "flex"],
+                ),
+                ParameterRule(
+                    name="execution_expires_after",
+                    label=I18nObject(
+                        zh_hans="任务超时时间", en_us="Execution Expires After"
+                    ),
+                    type=ParameterType.INT,
+                    required=False,
+                    default=172800,
+                    min=3600,
+                    max=259200,
+                ),
+                ParameterRule(
+                    name="web_search",
+                    label=I18nObject(zh_hans="联网搜索", en_us="Web Search"),
+                    type=ParameterType.BOOLEAN,
+                    required=False,
+                    default=False,
+                ),
+            ],
+        )
 
     def request_model(
         self,
@@ -815,6 +976,7 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
         prompt_messages: list[PromptMessage],
         *,
         model: str,
+        credentials: ArkCredentials | None = None,
         input_mode: object = None,
     ) -> list[SeedanceContentPart]:
         content: list[SeedanceContentPart] = []
@@ -839,7 +1001,9 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
             elif isinstance(message_content, AudioPromptMessageContent):
                 audio_contents.append(message_content)
 
-        if (video_contents or audio_contents) and not is_seedance_2_model(model):
+        if (video_contents or audio_contents) and not is_seedance_2_model(
+            model, credentials
+        ):
             raise InvokeError(
                 "Seedance video and audio input is only supported by Seedance 2.0 models."
             )
@@ -854,6 +1018,7 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
 
         image_roles = self.build_seedance_image_roles(
             model=model,
+            credentials=credentials,
             image_contents=image_contents,
             input_mode=input_mode,
             reference_mode=bool(video_contents or audio_contents),
@@ -908,6 +1073,7 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
         self,
         *,
         model: str,
+        credentials: ArkCredentials | None = None,
         image_contents: list[ImagePromptMessageContent],
         input_mode: object,
         reference_mode: bool,
@@ -928,7 +1094,9 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
                 raise InvokeError(
                     "Seedance video and audio input cannot be mixed with frame image roles."
                 )
-            self.validate_seedance_image_roles(model=model, roles=roles)
+            self.validate_seedance_image_roles(
+                model=model, credentials=credentials, roles=roles
+            )
             return roles
 
         if reference_mode:
@@ -952,7 +1120,7 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
                 )
             return ["first_frame", "last_frame"]
 
-        if not is_seedance_2_model(model):
+        if not is_seedance_2_model(model, credentials):
             raise InvokeError(
                 "Seedance reference_image input_mode is only supported by Seedance 2.0 models."
             )
@@ -962,7 +1130,13 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
             )
         return ["reference_image" for _ in image_contents]
 
-    def validate_seedance_image_roles(self, *, model: str, roles: list[str]) -> None:
+    def validate_seedance_image_roles(
+        self,
+        *,
+        model: str,
+        credentials: ArkCredentials | None = None,
+        roles: list[str],
+    ) -> None:
         unsupported_roles = [role for role in roles if role not in SEEDANCE_IMAGE_ROLES]
         if unsupported_roles:
             raise InvokeError(
@@ -973,7 +1147,7 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
                 raise InvokeError(
                     "Seedance reference_image cannot be mixed with frame roles."
                 )
-            if not is_seedance_2_model(model):
+            if not is_seedance_2_model(model, credentials):
                 raise InvokeError(
                     "Seedance reference_image role is only supported by Seedance 2.0 models."
                 )
@@ -1038,7 +1212,7 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
         plugin_state = SeedancePollingState(
             task_id=task_id,
             model=model,
-            platform=platform_name_for_model(model),
+            platform=platform_name_for_model(model, credentials),
         ).to_payload()
         if status in SEEDANCE_RUNNING_STATUSES:
             return LLMPollingResult(
@@ -1133,7 +1307,9 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
             "Invalid Ark credentials",
         )
         platform = platform_spec_for_model(model)
-        if is_seedance_model(model):
+        if platform is None and is_custom_video_generation_model(ark_credentials):
+            platform = PLATFORM_SPECS[0]
+        if is_video_generation_model(model, ark_credentials):
             seedance_parameters = filter_model_parameters(
                 model_parameters,
                 SEEDANCE_MODEL_PARAMETER_NAMES,
@@ -1153,6 +1329,7 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
                 content=self.build_seedance_content(
                     prompt_messages,
                     model=model,
+                    credentials=ark_credentials,
                     input_mode=model_parameters.get("input_mode"),
                 ),
                 **seedance_parameters,
@@ -1252,7 +1429,7 @@ class VolcengineArkLargeLanguageModel(LargeLanguageModel):
             credentials,
             "Invalid Ark credentials",
         )
-        if is_seedance_model(model):
+        if is_video_generation_model(model, ark_credentials):
             try:
                 state = parse_model(
                     SeedancePollingState,

--- a/models/volcengine/provider/volcengine.yaml
+++ b/models/volcengine/provider/volcengine.yaml
@@ -1,5 +1,6 @@
 background: '#F9FAFB'
 configurate_methods:
+- customizable-model
 - predefined-model
 description:
   en_US: Volcengine Ark pre-provided model invocation.
@@ -24,6 +25,46 @@ icon_small:
 label:
   en_US: Volcengine Ark
   zh_Hans: 火山方舟
+model_credential_schema:
+  model:
+    label:
+      en_US: Video Model ID / Endpoint ID
+      zh_Hans: 视频模型 ID / Endpoint ID
+    placeholder:
+      en_US: Enter a video model ID or Endpoint ID, e.g. doubao-seedance-2-0-260128 or ep-xxx
+      zh_Hans: 输入视频模型 ID 或 Endpoint ID，例如 doubao-seedance-2-0-260128 或 ep-xxx
+  credential_form_schemas:
+  - label:
+      en_US: API Key
+      zh_Hans: API Key
+    placeholder:
+      en_US: Enter your Ark API Key
+      zh_Hans: 输入 Ark API Key
+    required: true
+    type: secret-input
+    variable: ark_api_key
+  - default: https://ark.cn-beijing.volces.com/api/v3
+    label:
+      en_US: API Endpoint
+      zh_Hans: API Endpoint
+    placeholder:
+      en_US: https://ark.cn-beijing.volces.com/api/v3
+      zh_Hans: https://ark.cn-beijing.volces.com/api/v3
+    required: true
+    type: text-input
+    variable: api_endpoint_host
+  - default: video_generation
+    label:
+      en_US: Endpoint Type
+      zh_Hans: Endpoint Type
+    options:
+    - label:
+        en_US: Video Generation
+        zh_Hans: 视频生成
+      value: video_generation
+    required: true
+    type: select
+    variable: endpoint_type
 models:
   llm:
     position: models/llm/_position.yaml

--- a/models/volcengine/tests/test_polling_llm.py
+++ b/models/volcengine/tests/test_polling_llm.py
@@ -5,13 +5,14 @@ from typing import Any
 from urllib.error import URLError
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from dify_plugin.config.config import DifyPluginEnv
 from dify_plugin.core.plugin_registration import PluginRegistration
-from dify_plugin.entities.model import ModelType
-from dify_plugin.entities.model.llm import LLMPollingStatus, LLMUsage
+from dify_plugin.entities.model import ModelFeature, ModelPropertyKey, ModelType
+from dify_plugin.entities.model.llm import LLMMode, LLMPollingStatus, LLMUsage
 from dify_plugin.entities.model.message import (
     AudioPromptMessageContent,
     ImagePromptMessageContent,
@@ -42,6 +43,10 @@ def credentials() -> dict[str, str]:
         "ark_api_key": "test-key",
         "api_endpoint_host": "https://ark.example.com/api/v3",
     }
+
+
+def video_credentials() -> dict[str, str]:
+    return {**credentials(), "endpoint_type": "video_generation"}
 
 
 @dataclass(frozen=True)
@@ -188,6 +193,53 @@ def test_request_model_uses_configured_endpoint(
     assert requests[0][1] == 60
 
 
+def test_provider_yaml_exposes_custom_video_model() -> None:
+    provider_file = Path(__file__).resolve().parents[1] / "provider/volcengine.yaml"
+    provider = yaml.safe_load(provider_file.read_text(encoding="utf-8"))
+
+    assert "customizable-model" in provider["configurate_methods"]
+    assert (
+        provider["model_credential_schema"]["model"]["label"]["en_US"]
+        == "Video Model ID / Endpoint ID"
+    )
+    variables = {
+        field["variable"]
+        for field in provider["model_credential_schema"]["credential_form_schemas"]
+    }
+    assert {"ark_api_key", "api_endpoint_host", "endpoint_type"} <= variables
+
+
+def test_custom_video_schema_exposes_polling_features() -> None:
+    schema = make_model().get_customizable_model_schema(
+        "ep-test", video_credentials()
+    )
+
+    assert schema is not None
+    assert schema.model == "ep-test"
+    assert schema.model_properties[ModelPropertyKey.MODE] == LLMMode.CHAT.value
+    assert {
+        ModelFeature.POLLING,
+        ModelFeature.VISION,
+        ModelFeature.VIDEO,
+        ModelFeature.AUDIO,
+    } <= set(schema.features or [])
+    rule_names = {rule.name for rule in schema.parameter_rules}
+    assert {
+        "input_mode",
+        "resolution",
+        "ratio",
+        "duration",
+        "seed",
+        "generate_audio",
+        "watermark",
+        "return_last_frame",
+        "callback_url",
+        "service_tier",
+        "execution_expires_after",
+        "web_search",
+    } <= rule_names
+
+
 def test_seedance_validate_credentials_uses_non_generation_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -201,6 +253,28 @@ def test_seedance_validate_credentials_uses_non_generation_probe(
     monkeypatch.setattr(model, "request_model", fake_request_model)
 
     model.validate_credentials("doubao-seedance-2-0-260128", credentials())
+
+    assert requests == [
+        CapturedRequest(
+            method="GET",
+            path="contents/generations/tasks?page_num=1&page_size=1",
+        )
+    ]
+
+
+def test_custom_video_validate_credentials_uses_non_generation_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = make_model()
+    requests: list[CapturedRequest] = []
+
+    def fake_request_model(**kwargs: Any) -> Any:
+        requests.append(CapturedRequest.from_kwargs(kwargs))
+        return provider_response(kwargs, {"data": []})
+
+    monkeypatch.setattr(model, "request_model", fake_request_model)
+
+    model.validate_credentials("ep-test", video_credentials())
 
     assert requests == [
         CapturedRequest(
@@ -293,6 +367,71 @@ def test_seedance_start_polling_creates_task(monkeypatch: pytest.MonkeyPatch) ->
     }
 
 
+def test_custom_video_start_polling_creates_task_with_web_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = make_model()
+    requests: list[CapturedRequest] = []
+
+    def fake_request_model(**kwargs: Any) -> Any:
+        requests.append(CapturedRequest.from_kwargs(kwargs))
+        return provider_response(kwargs, {"id": "task-1", "status": "queued"})
+
+    monkeypatch.setattr(model, "request_model", fake_request_model)
+
+    result = model._start_polling(
+        model="ep-test",
+        credentials=video_credentials(),
+        prompt_messages=[
+            UserPromptMessage(
+                content=[
+                    TextPromptMessageContent(data="make a timely city video"),
+                    VideoPromptMessageContent(
+                        format="mp4",
+                        mime_type="video/mp4",
+                        url="https://example.com/reference.mp4",
+                    ),
+                    AudioPromptMessageContent(
+                        format="mp3",
+                        mime_type="audio/mpeg",
+                        url="https://example.com/reference.mp3",
+                    ),
+                ],
+            )
+        ],
+        model_parameters={"duration": 5, "resolution": "720p", "web_search": True},
+        stream=False,
+    )
+
+    assert result.status == LLMPollingStatus.RUNNING
+    assert result.plugin_state == {
+        "task_id": "task-1",
+        "model": "ep-test",
+        "platform": "volcengine",
+    }
+    assert requests[0].method == "POST"
+    assert requests[0].path == "contents/generations/tasks"
+    assert requests[0].payload_dict() == {
+        "model": "ep-test",
+        "content": [
+            {"type": "text", "text": "make a timely city video"},
+            {
+                "type": "video_url",
+                "video_url": {"url": "https://example.com/reference.mp4"},
+                "role": "reference_video",
+            },
+            {
+                "type": "audio_url",
+                "audio_url": {"url": "https://example.com/reference.mp3"},
+                "role": "reference_audio",
+            },
+        ],
+        "duration": 5,
+        "resolution": "720p",
+        "tools": [{"type": "web_search"}],
+    }
+
+
 def test_seedance_start_polling_fails_on_invalid_task_response_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -359,6 +498,45 @@ def test_seedance_check_polling_returns_video_result(
     assert isinstance(video, VideoPromptMessageContent)
     assert video.url == "https://example.com/result.mp4"
     assert video.mime_type == "video/mp4"
+
+
+def test_custom_video_check_polling_returns_video_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = make_model()
+    monkeypatch.setattr(
+        model,
+        "usage_from_provider_payload",
+        lambda **_: LLMUsage.empty_usage(),
+    )
+
+    def fake_request_model(**kwargs: Any) -> Any:
+        assert kwargs["method"] == "GET"
+        assert kwargs["path"] == "contents/generations/tasks/task-1"
+        return provider_response(
+            kwargs,
+            {
+                "id": "task-1",
+                "status": "succeeded",
+                "content": {"video_url": "https://example.com/result.mp4"},
+                "usage": {"completion_tokens": 12, "total_tokens": 12},
+            },
+        )
+
+    monkeypatch.setattr(model, "request_model", fake_request_model)
+
+    result = model._check_polling(
+        model="ep-test",
+        credentials=video_credentials(),
+        plugin_state={"task_id": "task-1"},
+    )
+
+    assert result.status == LLMPollingStatus.SUCCEEDED
+    assert result.result is not None
+    assert isinstance(result.result.message.content, list)
+    video = result.result.message.content[0]
+    assert isinstance(video, VideoPromptMessageContent)
+    assert video.url == "https://example.com/result.mp4"
 
 
 def test_seedance_check_polling_rejects_legacy_state_alias() -> None:


### PR DESCRIPTION
## Summary
- expose customizable video generation models in BytePlus and Volcengine Ark providers
- route custom video Model IDs and Endpoint IDs through `/contents/generations/tasks`
- keep BytePlus tools disabled while preserving Volcengine `web_search` mapping
- bump BytePlus plugin to `0.0.3` and Volcengine plugin to `0.0.10`

## Root Cause
The Seedance video API accepts either a video Model ID or configured Endpoint ID in the request `model` field, but the plugins only routed predefined Seedance prefixes to the video task API.
Custom Endpoint IDs fell through to chat completions.

## Validation
- `uv run pytest tests/test_polling_llm.py` in `models/byteplus`
- `uv run pytest tests/test_polling_llm.py` in `models/volcengine`
- `uv run pyrefly check models/llm/llm.py` in both packages
- `git diff --check`

Closes #3385