### PR TITLE
feat(siliconflow): add GLM-5.2, LongCat-2.0, Nex-N2-Pro models and json_schema structured output

### DIFF
--- a/models/siliconflow/manifest.yaml
+++ b/models/siliconflow/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.56
+version: 0.0.57
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/siliconflow/models/llm/_position.yaml
+++ b/models/siliconflow/models/llm/_position.yaml
@@ -62,4 +62,7 @@
 - Pro/zai-org/GLM-4.7
 - Pro/zai-org/GLM-5
 - Pro/zai-org/GLM-5.1
+- zai-org/GLM-5.2
 - stepfun-ai/Step-3.5-Flash
+- meituan-longcat/LongCat-2.0
+- nex-agi/Nex-N2-Pro

--- a/models/siliconflow/models/llm/deepseek-v4-flash.yaml
+++ b/models/siliconflow/models/llm/deepseek-v4-flash.yaml
@@ -47,6 +47,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
   - name: enable_thinking
     required: false
     type: boolean

--- a/models/siliconflow/models/llm/deepseek-v4-pro.yaml
+++ b/models/siliconflow/models/llm/deepseek-v4-pro.yaml
@@ -47,6 +47,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
   - name: enable_thinking
     required: false
     type: boolean

--- a/models/siliconflow/models/llm/glm52.yaml
+++ b/models/siliconflow/models/llm/glm52.yaml
@@ -1,0 +1,53 @@
+model: zai-org/GLM-5.2
+label:
+  zh_Hans: zai-org/GLM-5.2
+  en_US: zai-org/GLM-5.2
+model_type: llm
+features:
+  - tool-call
+  - agent-thought
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: true
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking mode
+    help:
+      zh_Hans: 是否开启思考模式。
+      en_US: Whether to enable thinking mode.
+  - name: thinking_budget
+    required: false
+    type: int
+    default: 1048576
+    min: 1
+    max: 1048576
+    label:
+      zh_Hans: 思考长度限制
+      en_US: Thinking budget
+    help:
+      zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
+      en_US: The maximum length of the thinking process, only effective when thinking mode is true.
+pricing:
+  input: "8"
+  output: "28"
+  unit: "0.000001"
+  currency: RMB

--- a/models/siliconflow/models/llm/glm52.yaml
+++ b/models/siliconflow/models/llm/glm52.yaml
@@ -24,6 +24,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
   - name: enable_thinking
     required: false
     type: boolean

--- a/models/siliconflow/models/llm/longcat-2.0.yaml
+++ b/models/siliconflow/models/llm/longcat-2.0.yaml
@@ -1,0 +1,40 @@
+model: meituan-longcat/LongCat-2.0
+label:
+  en_US: meituan-longcat/LongCat-2.0
+  zh_Hans: meituan-longcat/LongCat-2.0
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: true
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking mode
+    help:
+      zh_Hans: 是否开启思考模式。
+      en_US: Whether to enable thinking mode.
+pricing:
+  input: "5"
+  output: "20"
+  unit: "0.000001"
+  currency: RMB

--- a/models/siliconflow/models/llm/nex-n2-pro.yaml
+++ b/models/siliconflow/models/llm/nex-n2-pro.yaml
@@ -1,0 +1,32 @@
+model: nex-agi/Nex-N2-Pro
+label:
+  en_US: nex-agi/Nex-N2-Pro
+  zh_Hans: nex-agi/Nex-N2-Pro
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "1.75"
+  output: "7"
+  unit: "0.000001"
+  currency: RMB

--- a/models/siliconflow/models/llm/nex-n2-pro.yaml
+++ b/models/siliconflow/models/llm/nex-n2-pro.yaml
@@ -25,6 +25,9 @@ parameter_rules:
     options:
       - text
       - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
 pricing:
   input: "1.75"
   output: "7"


### PR DESCRIPTION
## Summary

Expand SiliconFlow LLM support with three new models and structured
(`json_schema`) output for four existing/new models.

- **New models**
  - `zai-org/GLM-5.2` — 1048576 context, thinking mode + thinking budget
  - `meituan-longcat/LongCat-2.0` — 1048576 context, thinking mode
  - `nex-agi/Nex-N2-Pro` — 262144 context, vision support
- **Structured output (`json_schema`)**
  - Added `json_schema` to `response_format` options and a
    `json_schema` parameter rule for: DeepSeek-V4-Flash, DeepSeek-V4-Pro,
    GLM-5.2, Nex-N2-Pro
  - The base `OAICompatLargeLanguageModel` handles the `json_schema` →
    OpenAI-compatible request conversion natively, so only YAML parameter
    rules were updated — no provider Python changes.

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->



## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [ ] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.14.2
- [ ] SaaS (cloud.dify.ai)
