### PR TITLE
feat(vertex_ai): add Claude Sonnet 5 model support

### DIFF
--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.58
+version: 0.0.59

--- a/models/vertex_ai/models/llm/anthropic.claude-sonnet-5.yaml
+++ b/models/vertex_ai/models/llm/anthropic.claude-sonnet-5.yaml
@@ -1,0 +1,66 @@
+# https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/sonnet-5
+# https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
+# Vertex AI API model id: claude-sonnet-5
+# Inputs: text, image, PDF. Outputs: text.
+# Context: 1,000,000 input tokens. Max output: 128,000 tokens.
+model: claude-sonnet-5
+label:
+  en_US: Claude Sonnet 5
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    type: int
+    default: 128000
+    min: 1
+    max: 128000
+    help:
+      zh_Hans: 停止前生成的最大令牌数。Claude Sonnet 5 在 Vertex AI 上的最大输出为 128000。
+      en_US: The maximum number of tokens to generate before stopping. Claude Sonnet 5 on Vertex AI supports up to 128000 output tokens.
+  - name: temperature
+    use_template: temperature
+    required: false
+    type: float
+    default: 1
+    min: 0.0
+    max: 1.0
+    help:
+      zh_Hans: 生成内容的随机性。
+      en_US: The amount of randomness injected into the response.
+  - name: top_p
+    use_template: top_p
+    required: false
+    type: float
+    default: 0.999
+    min: 0.000
+    max: 1.000
+    help:
+      zh_Hans: 在核采样中，Anthropic Claude 按概率递减顺序计算每个后续标记的所有选项的累积分布，并在达到 top_p 指定的特定概率时将其切断。您应该更改温度或top_p，但不能同时更改两者。
+      en_US: In nucleus sampling, Anthropic Claude computes the cumulative distribution over all the options for each subsequent token in decreasing probability order and cuts it off once it reaches a particular probability specified by top_p. You should alter either temperature or top_p, but not both.
+  - name: top_k
+    use_template: top_k
+    required: false
+    type: int
+    default: 0
+    min: 0
+    max: 500
+    help:
+      zh_Hans: 对于每个后续标记，仅从前 K 个选项中进行采样。使用 top_k 删除长尾低概率响应。
+      en_US: Only sample from the top K options for each subsequent token. Use top_k to remove long tail low probability responses.
+# https://platform.claude.com/docs/en/about-claude/pricing
+# Standard $3/$15 per Mtok (post-introductory rate for durability).
+pricing:
+  input: '3.00'
+  output: '15.00'
+  unit: '0.000001'
+  currency: USD

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -206,7 +206,7 @@ class VertexAiLargeLanguageModel(LargeLanguageModel):
         elif any(m in model for m in
                  ["opus", "claude-3-5-sonnet", "claude-3-7-sonnet", "claude-sonnet-4", "claude-haiku-4-5",
                   "claude-sonnet-4-5", "claude-opus-4-5", "claude-sonnet-4-6", "claude-opus-4-6",
-                  "claude-opus-4-7"]):
+                  "claude-opus-4-7", "claude-sonnet-5"]):
             location = "us-east5"
         else:
             location = "us-central1"


### PR DESCRIPTION
## Summary

Fixes #3392

Adds Claude Sonnet 5 (`claude-sonnet-5`) support to the Vertex AI plugin. The Anthropic region-routing substring list in `llm.py` is extended so the new model id resolves to `us-east5` for the `AnthropicVertex` client, matching the multi-region availability on Agent Platform.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| Sonnet 5 not selectable in Vertex AI model picker | `Claude Sonnet 5` listed with vision/document/tool-call features and 1M context |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — model yaml addition only; no manifest version bump required
- [x] `dify_plugin>=0.9.0` is declared in `pyproject.toml` (already present, unchanged)

## Verification

- `python3 -m py_compile models/vertex_ai/models/llm/llm.py` — pass
- YAML structural sanity: `model`, `label`, `model_type: llm`, features list, `context_size: 1000000`, `max_tokens`/`128000`, `pricing:` all present
- No changes to existing models (Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8) or shared code beyond adding one routing entry

## Notes

- Mirrors the canonical `models/anthropic/models/llm/claude-sonnet-5.yaml` feature set but trimmed to the params the existing Vertex AI `_generate_anthropic` path actually forwards (no adaptive-thinking controls; that lives in the Anthropic plugin's `_invoke` not the Vertex one).
- Pricing uses the standard $3/$15 per Mtok rate (not the introductory rate that's only in effect through 2026-08-31) for durability, matching the Anthropic plugin's choice.
- Vertex AI availability per https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/sonnet-5: multi-region in `us-east5`/`europe-west4` plus Asia Pacific `asia-southeast1`. The existing routing already targets `us-east5` for Anthropic on Vertex.