### PR TITLE
fix: fix dataframe iter row index error

### DIFF
--- a/extensions/slack_bot/endpoints/slack.py
+++ b/extensions/slack_bot/endpoints/slack.py
@@ -56,7 +56,6 @@ class SlackEndpoint(Endpoint):
                                     "text": formatted_answer
                                 }
                             }]
-                            
                             result = client.chat_postMessage(
                                 channel=channel,
                                 text=formatted_answer,  # Fallback text

--- a/tools/qa_chunk/tools/qa.py
+++ b/tools/qa_chunk/tools/qa.py
@@ -1,4 +1,5 @@
 import io
+import logging
 from collections.abc import Generator
 from typing import Any
 
@@ -6,6 +7,27 @@ import pandas as pd
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.file.file import File
+
+logger = logging.getLogger(__name__)
+
+
+def _get_cell_by_column(row: pd.Series, column: Any) -> Any:
+    if isinstance(column, str):
+        column = column.strip()
+
+    if column in row.index:
+        return row.loc[column]
+
+    if isinstance(column, int):
+        return row.iloc[column]
+
+    if isinstance(column, float) and column.is_integer():
+        return row.iloc[int(column)]
+
+    if isinstance(column, str) and column.isdigit():
+        return row.iloc[int(column)]
+
+    return row.loc[column]
 
 
 class QAChunkTool(Tool):
@@ -39,13 +61,20 @@ class QAChunkTool(Tool):
                 file_stream.seek(0)
                 df = pd.read_csv(file_stream, encoding='latin-1')
         except Exception as e:
+            logger.error(f"Get CSV file failed: {e}", exc_info=True)
             yield self.create_text_message(f"Get CSV file failed: {e}")
             return
         qa_chunks = []
-        for index, row in df.iterrows():
-            question = str(row[question_column])
-            answer = str(row[answer_column])
-            qa_chunks.append({"question": question, "answer": answer})
+        try:
+            for _, row in df.iterrows():
+                question = str(_get_cell_by_column(row, question_column))
+                answer = str(_get_cell_by_column(row, answer_column))
+                qa_chunks.append({"question": question, "answer": answer})
+        except (IndexError, KeyError) as e:
+            yield self.create_text_message(
+                f"Column not found: {e}. Available columns: {list(df.columns)}"
+            )
+            return
         
         result = {
             "qa_chunks": qa_chunks,


### PR DESCRIPTION
## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

fix #3395 

 df.iterrows() return pd.Series, so it index is column name, if you want use number index, it should use iloc

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [ ] SaaS (cloud.dify.ai)
