### PR TITLE
fix(ci): pin python-version to 3.12.7 in pre-pr-check workflow

### DIFF
--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: 3.12.7
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
## Summary

Fixes #3397

`setup-python@v5` resolves `python-version: '3.12'` to the latest 3.12.x patch on the runner image, which can drift over time. `upload-merged-plugin.yaml` already pinned `3.12.7`. PR-check vs merged-upload could therefore run against different Python patches as runner images updated. Pin both to `3.12.7` for reproducible behavior.

## Change Type

- [x] Documentation / non-plugin change (CI workflow)
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — N/A (workflow-only change)
- [x] `dify_plugin>=0.9.0` is declared in `pyproject.toml` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — N/A

## Verification

- YAML structural sanity: 102 open / 102 close braces balanced, all top-level keys present (`name`, `on`, `jobs`).
- `python-version: 3.12.7` now present in both `.github/workflows/pre-pr-check-per-plugin.yaml` (L82) and `.github/workflows/upload-merged-plugin.yaml` (L78).
- Diff is 1 insertion / 1 deletion in a single file.

## Notes

- No code logic affected. The change is a build/CI version pin.
- Plugins run the same Python interpreter in both the pre-pr-check CI step and the merged-upload CI step going forward.
- Bumping the pin in lockstep is a single follow-up edit when 3.12.x advances.