### PR TITLE
fix(notion): support all property types and conditions in Query Database filter

### DIFF
--- a/tools/notion/manifest.yaml
+++ b/tools/notion/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.11
+version: 0.0.12
 type: plugin
 author: langgenius
 name: notion

--- a/tools/notion/manifest.yaml
+++ b/tools/notion/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 type: plugin
 author: langgenius
 name: notion

--- a/tools/notion/tools/query_database.py
+++ b/tools/notion/tools/query_database.py
@@ -187,7 +187,13 @@ def _build_filter(filter_property: str, filter_condition: str, filter_value: str
         sub_type = _guess_scalar_type(filter_value)
         _validate_condition(SCALAR_TYPE_TO_CONDITION_GROUP[sub_type], filter_condition, filter_property, f"rollup array ({sub_type})")
         value = _condition_value(filter_condition, filter_value)
-        return {"property": filter_property, "rollup": {"any": {sub_type: {filter_condition: value}}}}
+        if sub_type == "number":
+            value = value if filter_condition in NO_VALUE_CONDITIONS else _to_number(value)
+        elif sub_type == "checkbox":
+            value = value if filter_condition in NO_VALUE_CONDITIONS else _to_bool(value)
+        # Notion's array-rollup filter uses the standard property filter key (rich_text), not "string"
+        rollup_key = "rich_text" if sub_type == "string" else sub_type
+        return {"property": filter_property, "rollup": {"any": {rollup_key: {filter_condition: value}}}}
 
     if property_type:
         # Unknown/unsupported property type: fall back to a rich_text-shaped filter

--- a/tools/notion/tools/query_database.py
+++ b/tools/notion/tools/query_database.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from datetime import date
 from typing import Any
 import requests
 
@@ -6,6 +7,196 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 from tools.notion_client import NotionClient
+
+# Conditions whose Notion API value is fixed (not taken from filter_value)
+NO_VALUE_CONDITIONS = {
+    "is_empty", "is_not_empty",
+    "past_week", "past_month", "past_year",
+    "next_week", "next_month", "next_year", "this_week",
+}
+
+# Rollup "function" values that produce a numeric result
+ROLLUP_NUMBER_FUNCTIONS = {
+    "count_all", "count_values", "count_unique_values", "count_empty",
+    "count_not_empty", "percent_empty", "percent_not_empty",
+    "sum", "average", "median", "min", "max", "range",
+}
+
+# Rollup "function" values that produce a date result
+ROLLUP_DATE_FUNCTIONS = {"earliest_date", "latest_date", "date_range"}
+
+# Valid filter_condition values per Notion property "shape" (see developers.notion.com/reference/post-database-query-filter)
+CONDITIONS_BY_GROUP = {
+    "text": {"equals", "does_not_equal", "contains", "does_not_contain", "starts_with", "ends_with", "is_empty", "is_not_empty"},
+    "date": {"equals", "before", "after", "on_or_before", "on_or_after", "is_empty", "is_not_empty",
+              "past_week", "past_month", "past_year", "next_week", "next_month", "next_year", "this_week"},
+    "number": {"equals", "does_not_equal", "greater_than", "greater_than_or_equal_to", "less_than", "less_than_or_equal_to", "is_empty", "is_not_empty"},
+    "checkbox": {"equals", "does_not_equal"},
+    "select": {"equals", "does_not_equal", "is_empty", "is_not_empty"},
+    "multi_select": {"contains", "does_not_contain", "is_empty", "is_not_empty"},
+    "status": {"equals", "does_not_equal", "is_empty", "is_not_empty"},
+    "people": {"contains", "does_not_contain", "is_empty", "is_not_empty"},
+    "relation": {"contains", "does_not_contain", "is_empty", "is_not_empty"},
+    "files": {"is_empty", "is_not_empty"},
+    "unique_id": {"equals", "does_not_equal", "greater_than", "greater_than_or_equal_to", "less_than", "less_than_or_equal_to"},
+}
+
+# Maps a Notion property schema "type" to the CONDITIONS_BY_GROUP key that governs it
+CONDITION_GROUP_BY_PROPERTY_TYPE = {
+    "title": "text", "rich_text": "text", "url": "text", "email": "text", "phone_number": "text",
+    "date": "date", "created_time": "date", "last_edited_time": "date",
+    "number": "number",
+    "checkbox": "checkbox",
+    "select": "select",
+    "multi_select": "multi_select",
+    "status": "status",
+    "people": "people", "created_by": "people", "last_edited_by": "people",
+    "relation": "relation",
+    "files": "files",
+    "unique_id": "unique_id",
+}
+
+# Maps a _guess_scalar_type() result to its CONDITIONS_BY_GROUP key (used for formula / array rollup)
+SCALAR_TYPE_TO_CONDITION_GROUP = {"number": "number", "checkbox": "checkbox", "date": "date", "string": "text"}
+
+
+class InvalidFilterConditionError(ValueError):
+    """Raised when filter_condition is not valid for the resolved property type."""
+
+
+def _validate_condition(group: str, filter_condition: str, filter_property: str, type_label: str) -> None:
+    allowed = CONDITIONS_BY_GROUP[group]
+    if filter_condition not in allowed:
+        raise InvalidFilterConditionError(
+            f"'{filter_condition}' is not a valid filter_condition for property '{filter_property}' "
+            f"(type: {type_label}). Valid conditions: {', '.join(sorted(allowed))}"
+        )
+
+
+def _condition_value(filter_condition: str, filter_value: str) -> Any:
+    """Resolve the raw value to send for a condition, per Notion's fixed-value conditions."""
+    if filter_condition in ("is_empty", "is_not_empty"):
+        return True
+    if filter_condition in ("past_week", "past_month", "past_year", "next_week", "next_month", "next_year", "this_week"):
+        return {}
+    return filter_value
+
+
+def _to_number(value: Any) -> Any:
+    try:
+        num_value = float(value)
+        return int(num_value) if num_value == int(num_value) else num_value
+    except (ValueError, TypeError):
+        return value
+
+
+def _to_bool(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in ("true", "1", "yes")
+
+
+def _extract_person(person: dict) -> Any:
+    if not person:
+        return None
+    return person.get("name") or person.get("id")
+
+
+def _guess_scalar_type(value: Any) -> str:
+    """Best-effort inference of a formula/array-rollup result type from filter_value.
+    Notion's schema API does not expose the computed result type, so this is a heuristic."""
+    if value is None:
+        return "string"
+    text = str(value).strip()
+    if text.lower() in ("true", "false"):
+        return "checkbox"
+    try:
+        float(text)
+        return "number"
+    except (TypeError, ValueError):
+        pass
+    try:
+        date.fromisoformat(text[:10])
+        return "date"
+    except ValueError:
+        pass
+    return "string"
+
+
+def _build_filter(filter_property: str, filter_condition: str, filter_value: str,
+                   property_type: str, prop_data: dict) -> dict:
+    """Build a Notion API filter object for filter_property, validating filter_condition
+    against the property's actual type. Raises InvalidFilterConditionError on a bad combination."""
+
+    # Timestamp types use a different filter structure (no "property" key)
+    if property_type in ("last_edited_time", "created_time"):
+        _validate_condition("date", filter_condition, filter_property, property_type)
+        value = _condition_value(filter_condition, filter_value)
+        return {"timestamp": property_type, property_type: {filter_condition: value}}
+
+    if property_type in CONDITION_GROUP_BY_PROPERTY_TYPE:
+        group = CONDITION_GROUP_BY_PROPERTY_TYPE[property_type]
+        _validate_condition(group, filter_condition, filter_property, property_type)
+        value = _condition_value(filter_condition, filter_value)
+
+        if property_type in ("number", "unique_id"):
+            value = value if filter_condition in NO_VALUE_CONDITIONS else _to_number(value)
+        elif property_type == "checkbox":
+            value = value if filter_condition in NO_VALUE_CONDITIONS else _to_bool(value)
+        elif property_type in ("people", "created_by", "last_edited_by"):
+            # Notion's API uses the "people" filter key for all three property types
+            return {"property": filter_property, "people": {filter_condition: value}}
+        elif property_type == "files":
+            # files only supports is_empty / is_not_empty (value is always true)
+            return {"property": filter_property, "files": {filter_condition: True}}
+
+        return {"property": filter_property, property_type: {filter_condition: value}}
+
+    if property_type == "verification":
+        # verification only supports the "status" condition (verified/expired/none)
+        if filter_value not in ("verified", "expired", "none"):
+            raise InvalidFilterConditionError(
+                f"filter_value for verification property '{filter_property}' must be one of "
+                f"'verified', 'expired', 'none' (got: '{filter_value}')"
+            )
+        return {"property": filter_property, "verification": {"status": filter_value}}
+
+    if property_type == "formula":
+        # Notion's schema API doesn't expose the formula's result type, so infer it from filter_value
+        sub_type = _guess_scalar_type(filter_value)
+        _validate_condition(SCALAR_TYPE_TO_CONDITION_GROUP[sub_type], filter_condition, filter_property, f"formula ({sub_type})")
+        value = _condition_value(filter_condition, filter_value)
+        if sub_type == "number":
+            value = value if filter_condition in NO_VALUE_CONDITIONS else _to_number(value)
+        elif sub_type == "checkbox":
+            value = value if filter_condition in NO_VALUE_CONDITIONS else _to_bool(value)
+        return {"property": filter_property, "formula": {sub_type: {filter_condition: value}}}
+
+    if property_type == "rollup":
+        rollup_function = (prop_data.get("rollup") or {}).get("function", "")
+        if rollup_function in ROLLUP_NUMBER_FUNCTIONS:
+            _validate_condition("number", filter_condition, filter_property, "rollup (number)")
+            value = _condition_value(filter_condition, filter_value)
+            value = value if filter_condition in NO_VALUE_CONDITIONS else _to_number(value)
+            return {"property": filter_property, "rollup": {"number": {filter_condition: value}}}
+        if rollup_function in ROLLUP_DATE_FUNCTIONS:
+            _validate_condition("date", filter_condition, filter_property, "rollup (date)")
+            value = _condition_value(filter_condition, filter_value)
+            return {"property": filter_property, "rollup": {"date": {filter_condition: value}}}
+        # Array rollup (e.g. show_original): best-effort, defaults to "any" + inferred sub-type
+        sub_type = _guess_scalar_type(filter_value)
+        _validate_condition(SCALAR_TYPE_TO_CONDITION_GROUP[sub_type], filter_condition, filter_property, f"rollup array ({sub_type})")
+        value = _condition_value(filter_condition, filter_value)
+        return {"property": filter_property, "rollup": {"any": {sub_type: {filter_condition: value}}}}
+
+    if property_type:
+        # Unknown/unsupported property type: fall back to a rich_text-shaped filter
+        value = _condition_value(filter_condition, filter_value)
+        return {"property": filter_property, "rich_text": {filter_condition: value}}
+
+    # Property not found in the schema: fall back to a simple equals-style text filter
+    return {"property": filter_property, "rich_text": {"equals": filter_value}}
+
 
 class QueryDatabaseTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
@@ -30,35 +221,30 @@ class QueryDatabaseTool(Tool):
             # Initialize the Notion client
             client = NotionClient(integration_token)
             
-            # Prepare filter if both property and value are provided
+            # Prepare filter if a property is provided (value is optional for is_empty/is_not_empty/relative-date conditions)
+            filter_condition = tool_parameters.get("filter_condition", "equals")
             filter_obj = None
-            if filter_property and filter_value:
+            if filter_property and (filter_value or filter_condition in NO_VALUE_CONDITIONS):
                 # Get database schema to determine the property type
                 try:
                     data_source_id = client.get_default_data_source_id(database_id)
                     data_source = client.retrieve_data_source(data_source_id)
                     properties = data_source.get("properties", {})
-                    
-                    # Find the property type
+
+                    # Find the property type (and its schema data, needed for rollup)
                     property_type = None
-                    for prop_name, prop_data in properties.items():
+                    prop_data = {}
+                    for prop_name, p_data in properties.items():
                         if prop_name == filter_property:
-                            property_type = prop_data.get("type")
+                            property_type = p_data.get("type")
+                            prop_data = p_data
                             break
-                    
-                    # Create filter based on property type
-                    if property_type == "title":
-                        filter_obj = client.create_property_filter(filter_property, "title", "equals", filter_value)
-                    elif property_type == "rich_text":
-                        filter_obj = client.create_property_filter(filter_property, "rich_text", "equals", filter_value)
-                    elif property_type:
-                        # For other text-like properties, try rich_text as fallback
-                        filter_obj = client.create_property_filter(filter_property, "rich_text", "equals", filter_value)
-                    else:
-                        # Property not found, use rich_text as default
-                        filter_obj = client.create_simple_text_filter(filter_property, filter_value)
-                except Exception as e:
-                    # If we can't get the schema, fall back to the old behavior
+
+                    filter_obj = _build_filter(filter_property, filter_condition, filter_value, property_type, prop_data)
+                except InvalidFilterConditionError as e:
+                    yield self.create_text_message(str(e))
+                    return
+                except Exception:
                     filter_obj = client.create_simple_text_filter(filter_property, filter_value)
             
             # Query the database
@@ -129,6 +315,35 @@ class QueryDatabaseTool(Tool):
                     elif prop_type == "relation":
                         relation_data = prop_data.get("relation", [])
                         value = [item.get("id") for item in relation_data] if relation_data else []
+                    elif prop_type in ("created_time", "last_edited_time"):
+                        value = prop_data.get(prop_type)
+                    elif prop_type in ("created_by", "last_edited_by"):
+                        value = _extract_person(prop_data.get(prop_type, {}))
+                    elif prop_type == "people":
+                        people_data = prop_data.get("people", [])
+                        value = [_extract_person(person) for person in people_data] if people_data else []
+                    elif prop_type == "files":
+                        files_data = prop_data.get("files", [])
+                        value = []
+                        for file_item in files_data:
+                            file_url = (file_item.get("file") or file_item.get("external") or {}).get("url")
+                            value.append({"name": file_item.get("name"), "url": file_url})
+                    elif prop_type == "unique_id":
+                        unique_id_data = prop_data.get("unique_id", {}) or {}
+                        prefix = unique_id_data.get("prefix")
+                        number = unique_id_data.get("number")
+                        value = f"{prefix}-{number}" if prefix else number
+                    elif prop_type == "verification":
+                        verification_data = prop_data.get("verification") or {}
+                        value = verification_data.get("state")
+                    elif prop_type == "formula":
+                        formula_data = prop_data.get("formula", {}) or {}
+                        formula_result_type = formula_data.get("type")
+                        value = formula_data.get(formula_result_type) if formula_result_type else None
+                    elif prop_type == "rollup":
+                        rollup_data = prop_data.get("rollup", {}) or {}
+                        rollup_result_type = rollup_data.get("type")
+                        value = rollup_data.get(rollup_result_type) if rollup_result_type else None
                     else:
                         # For other property types, just note the type
                         value = f"<{prop_type}>"

--- a/tools/notion/tools/query_database.yaml
+++ b/tools/notion/tools/query_database.yaml
@@ -65,8 +65,73 @@ parameters:
       pt_BR: Valor para filtrar (opcional)
       ja_JP: フィルタリングする値（オプション）
       zh_Hant: 要篩選的值（選填）
-    llm_description: Optional value to filter by. Works with filter_property to create a simple equals filter.
+    llm_description: Optional value to filter by. Works with filter_property and filter_condition. Can be omitted when filter_condition is is_empty, is_not_empty, or a relative date condition (past_week, past_month, past_year, next_week, next_month, next_year, this_week).
     form: llm
+  - name: filter_condition
+    type: select
+    required: false
+    default: equals
+    label:
+      en_US: Filter Condition
+      zh_Hans: 筛选条件
+      pt_BR: Condição de Filtro
+      ja_JP: フィルター条件
+      zh_Hant: 篩選條件
+    human_description:
+      en_US: "Condition for filtering (default: equals). Only conditions valid for the property's actual type are accepted; an invalid combination (e.g. contains on a select property) returns a clear error instead of querying Notion. Text/select/status: equals, contains, starts_with, ends_with. Date/timestamp: equals, before, after, on_or_before, on_or_after (plus relative ranges like past_week). Number: equals, greater_than, less_than, greater_than_or_equal_to, less_than_or_equal_to. People/relation: contains, does_not_contain. Most types also support is_empty/is_not_empty (no filter_value needed)."
+      zh_Hans: "筛选条件（默认：equals）。仅接受与属性实际类型匹配的条件（例如对 select 属性使用 contains 会在查询前返回明确的错误提示）。文本/选择/状态：equals、contains、starts_with、ends_with。日期/时间戳：equals、before、after、on_or_before、on_or_after（以及 past_week 等相对区间）。数字：equals、greater_than、less_than 等。人员/关联：contains、does_not_contain。大多数类型也支持 is_empty/is_not_empty（无需 filter_value）。"
+      pt_BR: "Condição de filtro (padrão: equals). Apenas condições válidas para o tipo real da propriedade são aceitas; uma combinação inválida (ex: contains em uma propriedade select) retorna um erro claro antes de consultar o Notion. Texto/seleção/status: equals, contains, starts_with, ends_with. Data/timestamp: equals, before, after, on_or_before, on_or_after (além de intervalos relativos como past_week). Número: equals, greater_than, less_than. Pessoas/relação: contains, does_not_contain. A maioria dos tipos também suporta is_empty/is_not_empty (sem necessidade de filter_value)."
+      ja_JP: "フィルター条件（デフォルト: equals）。プロパティの実際の型に対して有効な条件のみ受け付けます（例: selectプロパティにcontainsを指定すると、Notionへ問い合わせる前に分かりやすいエラーを返します）。テキスト/セレクト/ステータス: equals, contains, starts_with, ends_with。日付/タイムスタンプ: equals, before, after, on_or_before, on_or_after（past_weekなどの相対条件も可）。数値: equals, greater_than, less_than, greater_than_or_equal_to, less_than_or_equal_to。人物(people/作成者/更新者)・リレーション: contains, does_not_contain。ほとんどの型で is_empty/is_not_empty も使用可能（filter_value不要）。"
+      zh_Hant: "篩選條件（預設：equals）。僅接受與屬性實際類型相符的條件（例如對 select 屬性使用 contains 會在查詢前傳回明確的錯誤訊息）。文字/選擇/狀態：equals、contains、starts_with、ends_with。日期/時間戳：equals、before、after、on_or_before、on_or_after（以及 past_week 等相對區間）。數字：equals、greater_than、less_than 等。人員/關聯：contains、does_not_contain。大多數類型也支援 is_empty/is_not_empty（不需要 filter_value）。"
+    llm_description: "Filter condition, applied based on the actual property type of filter_property. An invalid combination (e.g. contains on a select property) returns a clear error message instead of querying Notion, so pick the condition that matches the property's type. Text/title/rich_text/url/email/phone_number: equals, does_not_equal, contains, does_not_contain, starts_with, ends_with, is_empty, is_not_empty. Select/status: equals, does_not_equal, is_empty, is_not_empty (contains is NOT valid for select/status). Multi_select: contains, does_not_contain, is_empty, is_not_empty. Date/created_time/last_edited_time: equals, before, after, on_or_before, on_or_after, is_empty, is_not_empty, past_week, past_month, past_year, next_week, next_month, next_year, this_week (relative conditions need no filter_value). Number/unique_id: equals, does_not_equal, greater_than, greater_than_or_equal_to, less_than, less_than_or_equal_to, is_empty, is_not_empty. Checkbox: equals, does_not_equal (filter_value: true or false). People/created_by/last_edited_by: contains, does_not_contain (filter_value: a user UUID or \"me\"), is_empty, is_not_empty. Relation: contains, does_not_contain (filter_value: a page UUID), is_empty, is_not_empty. Files: is_empty, is_not_empty only. Verification: filter_value must be one of verified/expired/none (condition is ignored). Formula/rollup: best-effort — the underlying result type (text/number/date/checkbox) is inferred from filter_value since Notion's schema API doesn't expose it. For is_empty/is_not_empty/relative-date conditions, filter_value can be omitted. Default is equals."
+    form: llm
+    options:
+      - value: equals
+        label: {en_US: "equals", zh_Hans: "equals", pt_BR: "equals", ja_JP: "equals", zh_Hant: "equals"}
+      - value: does_not_equal
+        label: {en_US: "does_not_equal", zh_Hans: "does_not_equal", pt_BR: "does_not_equal", ja_JP: "does_not_equal", zh_Hant: "does_not_equal"}
+      - value: contains
+        label: {en_US: "contains", zh_Hans: "contains", pt_BR: "contains", ja_JP: "contains", zh_Hant: "contains"}
+      - value: does_not_contain
+        label: {en_US: "does_not_contain", zh_Hans: "does_not_contain", pt_BR: "does_not_contain", ja_JP: "does_not_contain", zh_Hant: "does_not_contain"}
+      - value: starts_with
+        label: {en_US: "starts_with", zh_Hans: "starts_with", pt_BR: "starts_with", ja_JP: "starts_with", zh_Hant: "starts_with"}
+      - value: ends_with
+        label: {en_US: "ends_with", zh_Hans: "ends_with", pt_BR: "ends_with", ja_JP: "ends_with", zh_Hant: "ends_with"}
+      - value: is_empty
+        label: {en_US: "is_empty", zh_Hans: "is_empty", pt_BR: "is_empty", ja_JP: "is_empty", zh_Hant: "is_empty"}
+      - value: is_not_empty
+        label: {en_US: "is_not_empty", zh_Hans: "is_not_empty", pt_BR: "is_not_empty", ja_JP: "is_not_empty", zh_Hant: "is_not_empty"}
+      - value: before
+        label: {en_US: "before", zh_Hans: "before", pt_BR: "before", ja_JP: "before", zh_Hant: "before"}
+      - value: after
+        label: {en_US: "after", zh_Hans: "after", pt_BR: "after", ja_JP: "after", zh_Hant: "after"}
+      - value: on_or_before
+        label: {en_US: "on_or_before", zh_Hans: "on_or_before", pt_BR: "on_or_before", ja_JP: "on_or_before", zh_Hant: "on_or_before"}
+      - value: on_or_after
+        label: {en_US: "on_or_after", zh_Hans: "on_or_after", pt_BR: "on_or_after", ja_JP: "on_or_after", zh_Hant: "on_or_after"}
+      - value: past_week
+        label: {en_US: "past_week", zh_Hans: "past_week", pt_BR: "past_week", ja_JP: "past_week", zh_Hant: "past_week"}
+      - value: past_month
+        label: {en_US: "past_month", zh_Hans: "past_month", pt_BR: "past_month", ja_JP: "past_month", zh_Hant: "past_month"}
+      - value: past_year
+        label: {en_US: "past_year", zh_Hans: "past_year", pt_BR: "past_year", ja_JP: "past_year", zh_Hant: "past_year"}
+      - value: next_week
+        label: {en_US: "next_week", zh_Hans: "next_week", pt_BR: "next_week", ja_JP: "next_week", zh_Hant: "next_week"}
+      - value: next_month
+        label: {en_US: "next_month", zh_Hans: "next_month", pt_BR: "next_month", ja_JP: "next_month", zh_Hant: "next_month"}
+      - value: next_year
+        label: {en_US: "next_year", zh_Hans: "next_year", pt_BR: "next_year", ja_JP: "next_year", zh_Hant: "next_year"}
+      - value: this_week
+        label: {en_US: "this_week", zh_Hans: "this_week", pt_BR: "this_week", ja_JP: "this_week", zh_Hant: "this_week"}
+      - value: greater_than
+        label: {en_US: "greater_than", zh_Hans: "greater_than", pt_BR: "greater_than", ja_JP: "greater_than", zh_Hant: "greater_than"}
+      - value: greater_than_or_equal_to
+        label: {en_US: "greater_than_or_equal_to", zh_Hans: "greater_than_or_equal_to", pt_BR: "greater_than_or_equal_to", ja_JP: "greater_than_or_equal_to", zh_Hant: "greater_than_or_equal_to"}
+      - value: less_than
+        label: {en_US: "less_than", zh_Hans: "less_than", pt_BR: "less_than", ja_JP: "less_than", zh_Hant: "less_than"}
+      - value: less_than_or_equal_to
+        label: {en_US: "less_than_or_equal_to", zh_Hans: "less_than_or_equal_to", pt_BR: "less_than_or_equal_to", ja_JP: "less_than_or_equal_to", zh_Hant: "less_than_or_equal_to"}
   - name: limit
     type: number
     required: false


### PR DESCRIPTION
## Summary

Fixes #3401.

The Notion "Query Database" tool's filter only supported an `equals` condition and treated every property as `rich_text`, so filtering Notion's `date`, `select`, `people`, `files`, and other property types either produced wrong results or Notion API errors — there was no way to filter dates by range (e.g. "on or after a given date"). This PR:

- Adds a `filter_condition` parameter (dropdown) with the correct Notion condition set per property type, including date ranges (`before`, `after`, `on_or_before`, `on_or_after`) and relative date filters (`past_week`, `next_month`, etc).
- Extends both filter-building and result-formatting to cover every Notion property type: `people`, `created_by`, `last_edited_by`, `relation`, `files`, `unique_id`, `verification`, `formula`, `rollup`, `created_time`, `last_edited_time` (previously several of these were unhandled and either errored or showed up as an opaque `<type>` placeholder in the output).
- Validates the requested condition against the property's actual type before calling the Notion API, returning a clear error message on an invalid combination (e.g. `contains` on a `select` property) instead of a raw API error.

`formula`/`rollup` result types aren't exposed by Notion's schema API, so those two are handled on a best-effort basis (the underlying type is inferred from `filter_value`); this is documented in the parameter description.

## Change Type

- [x] Non-LLM plugin (tools, extensions, datasource, etc.)

## Screenshots / Videos

N/A (no UI layout change beyond `filter_condition` becoming a dropdown of the same field). Verified behavior with automated tests (see Testing) and manually in a running Dify instance.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (0.0.10 → 0.0.11)
- [x] `dify-plugin` is declared in `pyproject.toml` and locked in `uv.lock` (unchanged by this PR)

## Testing

- [x] Local deployment — Dify version: 1.10.1 (Self Hosted, Docker)
- [ ] SaaS (cloud.dify.ai)

In addition to manual testing in a running Dify instance, I wrote automated tests against the tool's internal logic (mocking the Notion API client) covering:

- Filter construction for every supported property type and condition, including date ranges, relative date filters, `is_empty`/`is_not_empty`, and the new property types (75 cases total).
- Result-formatting for every property type.
- Error paths (missing database ID/token, 404, other HTTP errors, no results, `limit` propagation).
- The new pre-flight condition validation (e.g. `contains` on `select` is rejected with a clear message before calling Notion).
