### PR TITLE
fix(aihubmix): default prompt caching to enabled for Claude models

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.34
+version: 0.0.35
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/anthropic.py
+++ b/models/aihubmix/models/llm/anthropic.py
@@ -267,12 +267,11 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             extra_model_kwargs["metadata"] = completion_create_params.Metadata(
                 user_id=user
             )
-        # Extract caching flags early so _convert_prompt_messages can use them
-        self._tool_cache_enabled = model_parameters.pop("prompt_caching_tool_definitions", False)
-        self._system_cache_enabled = model_parameters.pop("prompt_caching_system_message", False)
-        self._image_cache_enabled = model_parameters.pop("prompt_caching_images", False)
-        self._document_cache_enabled = model_parameters.pop("prompt_caching_documents", False)
-        self._tool_results_cache_enabled = model_parameters.pop("prompt_caching_tool_results", False)
+        self._tool_cache_enabled = model_parameters.pop("prompt_caching_tool_definitions", True)
+        self._system_cache_enabled = model_parameters.pop("prompt_caching_system_message", True)
+        self._image_cache_enabled = model_parameters.pop("prompt_caching_images", True)
+        self._document_cache_enabled = model_parameters.pop("prompt_caching_documents", True)
+        self._tool_results_cache_enabled = model_parameters.pop("prompt_caching_tool_results", True)
         self._message_flow_cache_threshold = int(model_parameters.pop("prompt_caching_message_flow", 0) or 0)
 
         (system, prompt_message_dicts) = self._convert_prompt_messages(prompt_messages)

--- a/models/aihubmix/models/llm/anthropic.py
+++ b/models/aihubmix/models/llm/anthropic.py
@@ -267,11 +267,17 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             extra_model_kwargs["metadata"] = completion_create_params.Metadata(
                 user_id=user
             )
-        self._tool_cache_enabled = model_parameters.pop("prompt_caching_tool_definitions", True)
-        self._system_cache_enabled = model_parameters.pop("prompt_caching_system_message", True)
-        self._image_cache_enabled = model_parameters.pop("prompt_caching_images", True)
-        self._document_cache_enabled = model_parameters.pop("prompt_caching_documents", True)
-        self._tool_results_cache_enabled = model_parameters.pop("prompt_caching_tool_results", True)
+        def _model_has_param(param_name: str) -> bool:
+            for schema in self.model_schemas:
+                if schema.model == model:
+                    return any(rule.name == param_name for rule in schema.parameter_rules)
+            return False
+
+        self._tool_cache_enabled = model_parameters.pop("prompt_caching_tool_definitions", _model_has_param("prompt_caching_tool_definitions"))
+        self._system_cache_enabled = model_parameters.pop("prompt_caching_system_message", _model_has_param("prompt_caching_system_message"))
+        self._image_cache_enabled = model_parameters.pop("prompt_caching_images", _model_has_param("prompt_caching_images"))
+        self._document_cache_enabled = model_parameters.pop("prompt_caching_documents", _model_has_param("prompt_caching_documents"))
+        self._tool_results_cache_enabled = model_parameters.pop("prompt_caching_tool_results", _model_has_param("prompt_caching_tool_results"))
         self._message_flow_cache_threshold = int(model_parameters.pop("prompt_caching_message_flow", 0) or 0)
 
         (system, prompt_message_dicts) = self._convert_prompt_messages(prompt_messages)


### PR DESCRIPTION
## Summary
- The `pop()` fallback for 5 `prompt_caching_*` boolean parameters in `anthropic.py` was `False`, while the YAML model definitions declare `default: true`
- When Dify omits parameters that equal their YAML default value, the code incorrectly disabled prompt caching
- This caused prompt caching to silently fail in **workflow mode** — the UI showed caching as enabled (True), but `cache_control` was never sent to the Anthropic API
- Changed the `pop()` fallback to `True` to match the YAML defaults

## Root cause
Dify framework optimizes by not sending model parameters when their value equals the YAML-defined default. In workflow mode, `prompt_caching_system_message` defaults to `true` in the YAML. When the user keeps it at `true`, Dify doesn't include it in `model_parameters`. The code then falls back to `pop("prompt_caching_system_message", False)` → caching disabled.

## Test plan
- [ ] In workflow mode with Claude model, verify `cache_creation_input_tokens > 0` on first call
- [ ] In workflow mode, verify `cache_read_input_tokens > 0` on second identical call within 5 minutes
- [ ] In chat mode, verify caching still works as before
- [ ] In chat mode, verify user can explicitly disable caching by setting to False

🤖 Generated with [Claude Code](https://claude.com/claude-code)