### PR TITLE
feat(x): add grok-4.5 model support

### DIFF
--- a/models/x/manifest.yaml
+++ b/models/x/manifest.yaml
@@ -35,4 +35,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.23
+version: 0.0.24

--- a/models/x/models/llm/grok-4.5.yaml
+++ b/models/x/models/llm/grok-4.5.yaml
@@ -1,0 +1,64 @@
+model: grok-4.5
+label:
+  en_US: grok-4.5
+model_type: llm
+features:
+  - vision
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 500000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    default: 1.0
+    min: 0.0
+    max: 2.0
+  - name: top_p
+    use_template: top_p
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理工作
+      en_US: reasoning_effort
+    type: string
+    help:
+      zh_Hans: 限制推理模型的推理工作
+      en_US: constrains effort on reasoning for reasoning models
+    required: false
+    default: high
+    options:
+      - low
+      - medium
+      - high
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+  - name: search_parameters
+    label:
+      zh_Hans: 联网搜索参数
+      en_US: Live Search Parameters
+    type: text
+    default: "{\n  \"mode\": \"on\"\n}"
+    help:
+      zh_Hans: 联网搜索的 JSON 参数，支持 mode、max_search_results、return_citations、sources、from_date 和 to_date，详见 https://docs.x.ai/developers/rest-api-reference/inference/chat
+      en_US: JSON parameters for live search. Supported keys include mode, max_search_results, return_citations, sources, from_date, and to_date. See https://docs.x.ai/developers/rest-api-reference/inference/chat
+    required: false
+pricing:
+  input: "2.00"
+  output: "6.00"
+  unit: "0.000001"
+  currency: USD

--- a/models/x/models/llm/llm.py
+++ b/models/x/models/llm/llm.py
@@ -7,6 +7,20 @@ from dify_plugin.entities.model.message import PromptMessage, PromptMessageTool
 from yarl import URL
 from dify_plugin import OAICompatLargeLanguageModel
 
+REASONING_MODELS = {
+    "grok-4.5",
+    "grok-4.3",
+    "grok-4-0709",
+    "grok-3-mini",
+    "grok-3-mini-fast",
+}
+REASONING_UNSUPPORTED_PARAMETERS = (
+    "presence_penalty",
+    "frequency_penalty",
+    "presencePenalty",
+    "frequencyPenalty",
+)
+
 
 class XAILargeLanguageModel(OAICompatLargeLanguageModel):
     def _invoke(
@@ -22,6 +36,9 @@ class XAILargeLanguageModel(OAICompatLargeLanguageModel):
     ) -> Union[LLMResult, Generator]:
         self._add_custom_parameters(credentials)
         self._validate_search_parameters(model_parameters)
+        if self._is_reasoning_model(model):
+            stop = None
+            self._remove_reasoning_unsupported_parameters(model_parameters)
         return super()._invoke(model, credentials, prompt_messages, model_parameters, tools, stop, stream)
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
@@ -46,3 +63,14 @@ class XAILargeLanguageModel(OAICompatLargeLanguageModel):
             model_parameters["search_parameters"] = json.loads(search_parameters)
         except json.JSONDecodeError:
             raise ValueError("search_parameters must be a valid JSON string")
+
+    @staticmethod
+    def _is_reasoning_model(model: str) -> bool:
+        if model.endswith("-non-reasoning"):
+            return False
+        return model in REASONING_MODELS or model.endswith("-reasoning")
+
+    @staticmethod
+    def _remove_reasoning_unsupported_parameters(model_parameters: dict) -> None:
+        for parameter in REASONING_UNSUPPORTED_PARAMETERS:
+            model_parameters.pop(parameter, None)

--- a/models/x/models/llm/llm.py
+++ b/models/x/models/llm/llm.py
@@ -8,17 +8,18 @@ from yarl import URL
 from dify_plugin import OAICompatLargeLanguageModel
 
 REASONING_MODELS = {
-    "grok-4.5",
-    "grok-4.3",
-    "grok-4-0709",
     "grok-3-mini",
     "grok-3-mini-fast",
 }
+REASONING_MODEL_PREFIXES = ("grok-4", "grok-code", "grok-build")
 REASONING_UNSUPPORTED_PARAMETERS = (
     "presence_penalty",
     "frequency_penalty",
     "presencePenalty",
     "frequencyPenalty",
+    "stop",
+    "stop_sequences",
+    "stopSequences",
 )
 
 
@@ -66,9 +67,13 @@ class XAILargeLanguageModel(OAICompatLargeLanguageModel):
 
     @staticmethod
     def _is_reasoning_model(model: str) -> bool:
-        if model.endswith("-non-reasoning"):
+        if "-non-reasoning" in model:
             return False
-        return model in REASONING_MODELS or model.endswith("-reasoning")
+        return (
+            model in REASONING_MODELS
+            or model.startswith(REASONING_MODEL_PREFIXES)
+            or model.endswith("-reasoning")
+        )
 
     @staticmethod
     def _remove_reasoning_unsupported_parameters(model_parameters: dict) -> None:

--- a/models/x/provider/x.py
+++ b/models/x/provider/x.py
@@ -16,7 +16,7 @@ class XAIProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model = credentials.get("model", "grok-4-fast")
+            model = credentials.get("model", "grok-4.5")
             model_instance.validate_credentials(model=model, credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex

--- a/models/x/provider/x.yaml
+++ b/models/x/provider/x.yaml
@@ -37,11 +37,14 @@ provider_credential_schema:
       required: true
       type: secret-input
       variable: api_key
-    - default: grok-4-fast
+    - default: grok-4.5
       label:
         en_US: Model
         zh_Hans: 模型
       options:
+        - label:
+            en_US: grok-4.5
+          value: grok-4.5
         - label:
             en_US: grok-4.3
           value: grok-4.3

--- a/models/x/tests/test_llm_reasoning_parameters.py
+++ b/models/x/tests/test_llm_reasoning_parameters.py
@@ -1,0 +1,48 @@
+from models.llm.llm import XAILargeLanguageModel
+
+
+def test_reasoning_model_detection_covers_supported_aliases():
+    reasoning_models = [
+        "grok-4.5",
+        "grok-4.3",
+        "grok-4",
+        "grok-4-fast",
+        "grok-4-1-fast",
+        "grok-4.20-beta-0309-reasoning",
+        "grok-4.20-beta-latest",
+        "grok-4.20-multi-agent-beta-latest",
+        "grok-code-fast-1",
+        "grok-build-0.1",
+        "grok-3-mini",
+        "grok-3-mini-fast",
+    ]
+    non_reasoning_models = [
+        "grok-4-fast-non-reasoning",
+        "grok-4-1-fast-non-reasoning",
+        "grok-4.20-beta-0309-non-reasoning",
+        "grok-4.20-beta-latest-non-reasoning",
+        "grok-4.20-non-reasoning-gv2",
+    ]
+
+    for model in reasoning_models:
+        assert XAILargeLanguageModel._is_reasoning_model(model)
+
+    for model in non_reasoning_models:
+        assert not XAILargeLanguageModel._is_reasoning_model(model)
+
+
+def test_reasoning_unsupported_parameters_are_removed():
+    model_parameters = {
+        "frequencyPenalty": 1,
+        "frequency_penalty": 1,
+        "presencePenalty": 1,
+        "presence_penalty": 1,
+        "stop": ["done"],
+        "stopSequences": ["done"],
+        "stop_sequences": ["done"],
+        "temperature": 1,
+    }
+
+    XAILargeLanguageModel._remove_reasoning_unsupported_parameters(model_parameters)
+
+    assert model_parameters == {"temperature": 1}


### PR DESCRIPTION
## Summary
- Add xAI grok-4.5 as a predefined LLM model.
- Use grok-4.5 as the default credential validation model.
- Drop xAI reasoning-unsupported stop and penalty parameters before invoke.

## Validation
- `uv run python -B -c "..."`
- `git diff --check`

Closes #3404