### PR TITLE
docs: add TokenLab OpenAI-compatible example

### DIFF
--- a/models/openai_api_compatible/README.md
+++ b/models/openai_api_compatible/README.md
@@ -7,3 +7,19 @@ This plugin provides access to models that are OpenAI-compatible, including LLMs
 Configure the OpenAI-API-compatible model by providing its core details (Type, Name, API Key, URL) and adjusting further options like completion, context, and token limits, as well as streaming and vision settings. Save when done.
 
 ![](./_assets/openai_api_compatible-01.png)
+
+### TokenLab example
+
+TokenLab can be configured through this plugin with the OpenAI-compatible API surface:
+
+| Field | Value |
+| --- | --- |
+| Type | `LLM` |
+| Model Name | `gpt-5.4-mini` |
+| API Key | Your TokenLab API key |
+| API Base URL | `https://api.tokenlab.sh/v1` |
+| Completion mode | `Chat` |
+
+Other TokenLab chat models can be added the same way, for example `gpt-5.5`, `claude-opus-4-8`, `claude-sonnet-5`, `gemini-3.5-flash`, `grok-4.3`, `qwen3.7-max`, `deepseek-v4-pro`, `deepseek-v4-flash`, `glm-5.2`, `minimax-m3`, and `kimi-k2.7-code`.
+
+TokenLab also provides native endpoint families such as Responses, Anthropic Messages, and Gemini-compatible APIs. This OpenAI-API-compatible plugin uses TokenLab's `/v1` OpenAI-compatible endpoint.

--- a/models/openai_api_compatible/README.md
+++ b/models/openai_api_compatible/README.md
@@ -20,6 +20,8 @@ TokenLab can be configured through this plugin with the OpenAI-compatible API su
 | API Base URL | `https://api.tokenlab.sh/v1` |
 | Completion mode | `Chat` |
 
+Use `https://api.tokenlab.sh/v1` for LLM/chat models. For non-LLM model types where this plugin appends the API version internally, such as text embedding, rerank, STT, and TTS, use `https://api.tokenlab.sh` instead to avoid a duplicated `/v1/v1` path.
+
 Other TokenLab chat models can be added the same way, for example `gpt-5.5`, `claude-opus-4-8`, `claude-sonnet-5`, `gemini-3.5-flash`, `grok-4.3`, `qwen3.7-max`, `deepseek-v4-pro`, `deepseek-v4-flash`, `glm-5.2`, `minimax-m3`, and `kimi-k2.7-code`.
 
 TokenLab also provides native endpoint families such as Responses, Anthropic Messages, and Gemini-compatible APIs. This OpenAI-API-compatible plugin uses TokenLab's `/v1` OpenAI-compatible endpoint.


### PR DESCRIPTION
## Summary

Adds a TokenLab configuration example to the OpenAI-API-compatible model provider README. The example shows the TokenLab OpenAI-compatible base URL, a default model, and additional chat model IDs that can be configured through the existing plugin.

This is intentionally documentation-only because TokenLab works through the existing OpenAI-compatible model provider. The note also mentions TokenLab's native endpoint families (Responses, Anthropic Messages, Gemini-compatible APIs) while making clear that this plugin uses TokenLab's `/v1` OpenAI-compatible endpoint.

## Change Type

- [x] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| No TokenLab-specific OpenAI-compatible setup example. | README includes a TokenLab setup table and model examples. |

## LLM Plugin Checklist

Not applicable; this PR only updates README documentation for an existing plugin.

## Version

- [ ] Bumped top-level `version` in `manifest.yaml` (not applicable; documentation-only change)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (not applicable; documentation-only change)

## Testing

- [x] `git diff --check`

- [ ] Local deployment — Dify version: not run; documentation-only README change
- [ ] SaaS (cloud.dify.ai): not run; documentation-only README change