### PR TITLE
feat(bedrock): add Claude Sonnet 5 and Claude Fable 5 support

### DIFF
--- a/models/bedrock/README.md
+++ b/models/bedrock/README.md
@@ -18,5 +18,15 @@ The models of Amazon Bedrock.
 ## Usage
 Select **Amazon Bedrock** as the model provider in Dify, choose an available model, and use it in applications, agents, or workflows.
 
+## Claude 5 Models (Sonnet 5 / Fable 5)
+
+The "Anthropic Claude 5" entry provides Claude Sonnet 5 (`anthropic.claude-sonnet-5`) and Claude Fable 5 (`anthropic.claude-fable-5`). These models differ from earlier Claude generations:
+
+- **Inference profiles only.** Invocable exclusively via `us.` (US/Canada regions) or `global.` cross-region inference profiles — there is no on-demand bare-ID invocation and no `eu.`/`apac.` geo profiles. The plugin resolves this from your *Cross-Region Inference* selection; from non-US regions choose `global`.
+- **Adaptive thinking is always on** and cannot be disabled. Thinking depth is controlled by the *Effort* parameter (`low`/`medium`/`high`/`xhigh`/`max`) instead of a thinking budget. Sampling parameters (temperature / top_p / top_k) are not configurable on these models and are not exposed.
+- **Refusals & fallback.** Requests can be declined by safety classifiers (`stop_reason: refusal`; materially more frequent on Fable 5). With *Refusal Fallback* enabled (default), the plugin automatically retries the identical request with Claude 4.8 Opus. Mid-stream refusals that occur after output has been produced cannot fall back and raise an error instead.
+- **Fable 5 prerequisite: data retention opt-in.** Your AWS account must set data retention mode to `provider_data_share` via the Bedrock Data Retention API before invoking Fable 5 (no console UI at launch). See the [Fable 5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html). The plugin never changes account settings.
+- **Pricing note.** Displayed prices are the Global cross-region rates (Sonnet 5 $3/$15, Fable 5 $10/$50 per 1M tokens). Geo/in-region invocation is ~10% higher. Prompt-cache read/write rates are not representable in Dify's cost tracking — refer to your AWS bill.
+
 ## Privacy
 This plugin sends the inputs required by the selected operation to the upstream service. See [PRIVACY.md](PRIVACY.md) for details.

--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.73
+version: 0.0.74
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/_position.yaml
+++ b/models/bedrock/models/llm/_position.yaml
@@ -1,4 +1,5 @@
 - anthropic-claude
+- anthropic-claude-5
 - amazon-nova
 - cohere
 - meta-llama

--- a/models/bedrock/models/llm/anthropic-claude-5.yaml
+++ b/models/bedrock/models/llm/anthropic-claude-5.yaml
@@ -1,0 +1,132 @@
+model: anthropic claude 5
+label:
+  en_US: Anthropic Claude 5
+icon: icon_s_en.svg
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+# Claude 5 generation models (Sonnet 5 / Fable 5).
+# - Invocable ONLY via inference profiles (us. / global.); no on-demand bare-ID calls.
+# - Adaptive thinking is always on and cannot be disabled; depth is controlled
+#   by the effort parameter (replaces reasoning budget).
+# - Sampling parameters (temperature / top_p / top_k) are NOT configurable:
+#   non-default values are rejected by the API, so they are not exposed here.
+# docs:
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
+parameter_rules:
+  - name: model_name
+    label:
+      zh_Hans: Bedrock 模型
+      en_US: Bedrock Model
+    type: string
+    help:
+      zh_Hans: 指定模型名称
+      en_US: specify model name
+    required: true
+    default: Sonnet 5
+    options:
+      - Sonnet 5
+      - Fable 5
+  - name: cross-region
+    label:
+      zh_Hans: 跨区域推理
+      en_US: Cross-Region Inference
+    type: string
+    required: true
+    default: global
+    options:
+      - global
+      - geographic
+    help:
+      zh_Hans: Claude 5 模型仅支持通过推理配置文件调用。Global 可从几乎所有区域调用（推荐）；Geographic 仅限美国/加拿大区域（us. 配置文件），其他区域请选择 Global。
+      en_US: Claude 5 models can only be invoked through inference profiles. Global works from virtually all regions (recommended); Geographic is limited to US/Canada regions (us. profile) — use Global elsewhere.
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    label:
+      zh_Hans: 最大token数
+      en_US: Max Tokens
+    type: int
+    default: 8192
+    min: 1
+    max: 128000
+    help:
+      zh_Hans: 停止前生成的最大令牌数。注意 max_tokens 覆盖思考与回复的总输出。
+      en_US: The maximum number of tokens to generate before stopping. Note that max_tokens covers total output including thinking.
+  - name: effort
+    label:
+      zh_Hans: 思考深度 (Effort)
+      en_US: Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    help:
+      zh_Hans: 控制自适应思考的深度与整体 token 消耗（替代思考预算）。编码/智能体任务推荐 high 或 xhigh。
+      en_US: Controls adaptive thinking depth and overall token spend (replaces thinking budget). Use high or xhigh for coding/agentic tasks.
+  - name: refusal_fallback
+    label:
+      zh_Hans: 拒答回落到 Claude 4.8 Opus
+      en_US: Refusal Fallback to Claude 4.8 Opus
+    type: boolean
+    required: false
+    default: true
+    help:
+      zh_Hans: 当请求被安全分类器拒绝（stop_reason 为 refusal，Fable 5 概率较高）时，自动使用 Claude 4.8 Opus 重试同一请求。流式输出已产生内容后发生的拒绝无法回落，将报错。
+      en_US: When a request is refused by safety classifiers (stop_reason "refusal"; materially more likely on Fable 5), automatically retry the same request with Claude 4.8 Opus. Mid-stream refusals after content was already produced cannot fall back and raise an error instead.
+  - name: system_cache_checkpoint
+    label:
+      zh_Hans: 缓存系统提示词
+      en_US: Cache System Prompt
+    type: boolean
+    required: false
+    help:
+      zh_Hans: 在系统消息中启用缓存检查点，可以提高性能并降低成本。
+      en_US: Enable cache checkpoint in the system message to improve performance and reduce costs.
+  - name: latest_two_messages_cache_checkpoint
+    label:
+      zh_Hans: 缓存用户消息
+      en_US: Cache User Messages
+    type: boolean
+    required: false
+    help:
+      zh_Hans: 在最新的两条用户消息中启用缓存检查点，可以提高性能并降低成本。
+      en_US: Enable cache checkpoint in the latest two user messages to improve performance and reduce costs.
+  - name: anthropic_beta
+    label:
+      zh_Hans: anthropic_beta
+      en_US: anthropic_beta
+    required: false
+    type: string
+    help:
+      zh_Hans: anthropic beta 参数是一串测试版标题的列表，用于表示选择加入一组特定的测试版功能。使用英文逗号连接。
+      en_US: The anthropic beta parameter is a list of strings of beta headers used to indicate opt-in to a particular set of beta features. Use commas to join.
+  - name: json_schema
+    label:
+      zh_Hans: JSON Schema
+      en_US: JSON Schema
+    type: string
+    required: false
+    help:
+      zh_Hans: JSON Schema for structured output
+      en_US: JSON Schema for structured output
+  - name: response_format
+    use_template: response_format
+pricing:
+  input: "0.003"
+  output: "0.015"
+  unit: "0.001"
+  currency: USD

--- a/models/bedrock/models/llm/cache_config.py
+++ b/models/bedrock/models/llm/cache_config.py
@@ -7,6 +7,8 @@ logger = logging.getLogger(__name__)
 
 # Models that support prompt caching
 CACHE_SUPPORTED_MODELS = [
+    "anthropic.claude-sonnet-5",
+    "anthropic.claude-fable-5",
     "anthropic.claude-opus-4-8",
     "anthropic.claude-opus-4-7",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -24,6 +26,16 @@ CACHE_SUPPORTED_MODELS = [
 
 # Cache configuration for each model
 CACHE_CONFIG = {
+    "anthropic.claude-sonnet-5": {
+        "min_tokens": 4096,
+        "max_checkpoints": 4,
+        "supported_fields": ["system", "messages", "tools"]
+    },
+    "anthropic.claude-fable-5": {
+        "min_tokens": 1024,
+        "max_checkpoints": 4,
+        "supported_fields": ["system", "messages", "tools"]
+    },
     "anthropic.claude-opus-4-8": {
         "min_tokens": 4096,
         "max_checkpoints": 4,
@@ -86,14 +98,25 @@ CACHE_CONFIG = {
     }
 }
 
+_PROFILE_PREFIXES = ("global.", "us.", "eu.", "apac.", "jp.", "au.")
+
+
+def _strip_profile_prefix(model_id: str) -> str:
+    """Remove a leading cross-region profile prefix if present."""
+    for prefix in _PROFILE_PREFIXES:
+        if model_id.startswith(prefix):
+            return model_id[len(prefix):]
+    return model_id
+
+
 def is_cache_supported(model_id: str) -> bool:
     """
     Check if the model supports prompt caching
-    
+
     :param model_id: Model ID to check
     :return: True if the model supports caching, False otherwise
     """
-    model_id = model_id.replace("us.","").replace("eu.","").replace("apac.","")
+    model_id = _strip_profile_prefix(model_id)
 
     result = model_id in CACHE_SUPPORTED_MODELS
     # Removed redundant print statement
@@ -106,7 +129,7 @@ def get_cache_config(model_id: str) -> dict:
     :param model_id: Model ID
     :return: Cache configuration dictionary
     """
-    model_id = model_id.replace("us.","").replace("eu.","").replace("apac.","")
+    model_id = _strip_profile_prefix(model_id)
 
     if model_id in CACHE_CONFIG:
         config = CACHE_CONFIG[model_id]

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -223,11 +223,12 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         reasoning_texts = [
             block["reasoningContent"]["reasoningText"]["text"]
             for block in content
-            if "reasoningContent" in block
-            and "reasoningText" in block.get("reasoningContent", {})
-            and "text" in block["reasoningContent"]["reasoningText"]
+            if isinstance(block, dict)
+            and isinstance(block.get("reasoningContent"), dict)
+            and isinstance(block["reasoningContent"].get("reasoningText"), dict)
+            and isinstance(block["reasoningContent"]["reasoningText"].get("text"), str)
         ]
-        filtered = [b for b in content if "reasoningContent" not in b]
+        filtered = [b for b in content if not isinstance(b, dict) or "reasoningContent" not in b]
         reasoning_prefix = f"<think>\n{''.join(reasoning_texts)}\n</think>\n" if reasoning_texts else ""
         return filtered, reasoning_prefix
 
@@ -644,6 +645,12 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                                 raise self._map_client_to_invoke_error(
                                     error_code, f"{error_code}: {ex.response['Error']['Message']}"
                                 )
+                            except Exception as ex:
+                                # Runs at stream-iteration time, outside the SDK's
+                                # _transform_invoke_error wrapper — normalize non-API
+                                # failures (network, endpoint) to InvokeError, matching
+                                # what the wrapper produces for the primary call.
+                                raise InvokeError(str(ex))
                             return self._handle_converse_stream_response(
                                 fb_id, fb_credentials, fb_response, prompt_messages
                             )
@@ -714,7 +721,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             full_error_msg = f"{error_code}: {error_message}"
             # Fable 5 requires account-level data-retention opt-in; surface
             # actionable guidance instead of the raw ValidationException.
-            if is_claude5 and any(
+            if is_claude5 and error_message and any(
                 kw in error_message.lower()
                 for kw in ("retention", "provider_data_share", "data sharing", "data share")
             ):
@@ -1010,6 +1017,12 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if "effort" in model_parameters:
             additional_model_fields["thinking"] = {"type": "adaptive"}
             additional_model_fields["output_config"] = {"effort": model_parameters["effort"]}
+            # Claude 5 rejects non-default sampling params. The family yaml does
+            # not expose them, but drop any that reach here through callers that
+            # bypass the SDK's parameter-rule filtering (e.g. direct _invoke).
+            inference_config.pop("temperature", None)
+            inference_config.pop("topP", None)
+            additional_model_fields.pop("top_k", None)
 
         # process reasoning related parameters, construct nested reasoning_config structure
         if "reasoning_type" in model_parameters and "effort" not in model_parameters:

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -770,7 +770,11 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
             assistant_prompt_message = AssistantPromptMessage(content=reasoning_prefix + text, tool_calls=tool_calls)
         else:
-            assistant_prompt_message = AssistantPromptMessage(content=reasoning_prefix + response_content[0]["text"])
+            # A reasoning-only Converse response (e.g. max_tokens exhausted during
+            # the thinking phase) leaves the filtered list empty; guard the index
+            # so we surface the folded <think> prefix instead of an IndexError.
+            text = response_content[0]["text"] if response_content else ""
+            assistant_prompt_message = AssistantPromptMessage(content=reasoning_prefix + text)
 
         # calculate num tokens
         if response["usage"]:

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -328,7 +328,14 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             region_prefix = None
             cross_region = model_parameters.pop('cross-region', 'disabled')
 
-            if cross_region in ('geographic', 'global'):
+            if model_ids.is_claude5_model(model_id):
+                # Claude 5 models are profile-only (us./global.) — dedicated
+                # resolution that bypasses the legacy whitelist. See model_ids.
+                try:
+                    model_id = model_ids.resolve_claude5_profile_id(model_id, cross_region, region_name)
+                except ValueError as e:
+                    raise InvokeError(str(e))
+            elif cross_region in ('geographic', 'global'):
                 # Cross-region inference enabled
                 prefer_global = (cross_region == 'global')
                 region_prefix = model_ids.get_region_area(region_name, prefer_global=prefer_global)
@@ -795,8 +802,15 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         if "anthropic_beta" in model_parameters:
             additional_model_fields["anthropic_beta"] = list(map(lambda v:v.strip(), model_parameters["anthropic_beta"].strip().split(",")))
 
+        # Claude 5 generation models (Sonnet 5 / Fable 5): adaptive thinking is
+        # always on; depth is controlled by `effort` (replaces budget_tokens).
+        # Only the 'anthropic claude 5' family yaml exposes this parameter.
+        if "effort" in model_parameters:
+            additional_model_fields["thinking"] = {"type": "adaptive"}
+            additional_model_fields["output_config"] = {"effort": model_parameters["effort"]}
+
         # process reasoning related parameters, construct nested reasoning_config structure
-        if "reasoning_type" in model_parameters:
+        if "reasoning_type" in model_parameters and "effort" not in model_parameters:
             reasoning_type = model_parameters["reasoning_type"]
             if reasoning_type:
                 reasoning_config = {

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -1626,6 +1626,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             'GPT-5.5': 'gpt-5-5',
             'GPT-5.4': 'gpt-5-4',
             # Claude models
+            # Claude 5 generation models
+            'Sonnet 5': 'claude-5-sonnet',
+            'Fable 5': 'claude-5-fable',
             'Claude 4.8 Opus': 'claude-4-8-opus',
             'Claude 4.7 Opus': 'claude-4-7-opus',
             'Claude 4.0 Sonnet': 'claude-4-sonnet',

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -122,6 +122,129 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         logger.info(f"current model id: {model_id} did not support by Converse API")
         return None
 
+    # ------------------------------------------------------------------
+    # Claude 5 (Sonnet 5 / Fable 5) refusal handling
+    # The models' safety classifiers block requests (materially more frequent
+    # on Fable 5). The model card documents stop_reason "refusal" for the
+    # native Messages API; the Converse StopReason enum has no "refusal"
+    # (live-verified) — a classifier block is expected to surface as
+    # "content_filtered", with native stop_details available only when
+    # additionalModelResponseFieldPaths requests it. Both signals are checked;
+    # Task 7 live verification prunes this set.
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
+    # ------------------------------------------------------------------
+    CLAUDE5_REFUSAL_STOP_REASONS = ("refusal", "content_filtered")
+    CLAUDE5_RESPONSE_FIELD_PATHS = ["/stop_details"]
+    CLAUDE5_FALLBACK_MODEL_NAME = "Claude 4.8 Opus"
+
+    @staticmethod
+    def _is_claude5_refusal(stop_reason, additional_fields) -> bool:
+        """True when a Converse outcome is a Claude 5 safety-classifier block."""
+        if stop_reason in BedrockLargeLanguageModel.CLAUDE5_REFUSAL_STOP_REASONS:
+            return True
+        if additional_fields and additional_fields.get("stop_details"):
+            return True
+        return False
+
+    @staticmethod
+    def _extract_refusal_detail(response: dict) -> str:
+        """Best-effort extraction of refusal category/explanation from a Converse response."""
+        try:
+            fields = response.get("additionalModelResponseFields") or {}
+            details = fields.get("stop_details") or fields.get("stopDetails") or {}
+            category = details.get("category")
+            explanation = details.get("explanation")
+            parts = [p for p in (category, explanation) if p]
+            if parts:
+                return "; ".join(parts)
+        except Exception:  # noqa: BLE001 - diagnostics only, never fail here
+            pass
+        return "no further details provided by the API"
+
+    @staticmethod
+    def _claude5_refusal_error(model_id: str, detail: str, fallback_attempted: bool) -> InvokeError:
+        if fallback_attempted:
+            hint = (
+                "The refusal occurred after partial output was already streamed, "
+                "so automatic fallback to Claude 4.8 Opus was not possible."
+            )
+        else:
+            hint = (
+                "Enable 'Refusal Fallback to Claude 4.8 Opus' to retry refused "
+                "requests automatically, or rephrase the request."
+            )
+        return InvokeError(
+            f"{model_id} refused this request via its safety classifiers "
+            f"({detail}). {hint}"
+        )
+
+    @staticmethod
+    def _wrap_claude5_stream(stream_gen, fallback_factory, model_id):
+        """
+        Wrap a Claude 5 converse stream to handle safety-classifier refusals.
+
+        - Refusal BEFORE any content chunk was yielded: if fallback_factory is
+          provided, silently restart on the fallback stream; otherwise raise.
+        - Refusal AFTER content was yielded: always raise (chunks cannot be
+          retracted from the Dify stream).
+        """
+        saw_content = False
+        for chunk in stream_gen:
+            delta = chunk.delta
+            finish_reason = delta.finish_reason if delta else None
+            if finish_reason in BedrockLargeLanguageModel.CLAUDE5_REFUSAL_STOP_REASONS:
+                detail = f"stop reason: {finish_reason}; see plugin logs"
+                if not saw_content and fallback_factory is not None:
+                    logger.warning(
+                        f"[REFUSAL FALLBACK] {model_id} refused before producing output; "
+                        f"restarting stream on Claude 4.8 Opus"
+                    )
+                    yield from fallback_factory()
+                    return
+                raise BedrockLargeLanguageModel._claude5_refusal_error(
+                    model_id, detail, fallback_attempted=saw_content
+                )
+            if delta and delta.message and delta.message.content:
+                saw_content = True
+            yield chunk
+
+    @staticmethod
+    def _fold_reasoning_content(content: list) -> tuple[list, str]:
+        """
+        Split a non-streaming Converse content list into non-reasoning blocks and
+        a ``<think>`` prefix built from any ``reasoningContent`` blocks.
+
+        Adaptive-thinking models may return reasoningContent blocks in
+        non-streaming responses; folding them into <think> text (mirrors the
+        streaming handler) avoids crashing on unknown block shapes downstream.
+
+        :return: (content without reasoning blocks, reasoning_prefix)
+        """
+        reasoning_texts = [
+            block["reasoningContent"]["reasoningText"]["text"]
+            for block in content
+            if "reasoningContent" in block
+            and "reasoningText" in block.get("reasoningContent", {})
+            and "text" in block["reasoningContent"]["reasoningText"]
+        ]
+        filtered = [b for b in content if "reasoningContent" not in b]
+        reasoning_prefix = f"<think>\n{''.join(reasoning_texts)}\n</think>\n" if reasoning_texts else ""
+        return filtered, reasoning_prefix
+
+    @staticmethod
+    def _claude5_fallback_call_inputs(parameters: dict, credentials: dict) -> tuple[dict, dict, str]:
+        """Build (params, credentials, model_id) for the Opus 4.8 fallback call."""
+        fallback_model_id = model_ids.get_claude5_fallback_model_id(parameters["modelId"])
+        fb_params = {**parameters, "modelId": fallback_model_id}
+        # stop_details paths are Claude-5-specific; drop for the fallback model
+        fb_params.pop("additionalModelResponseFieldPaths", None)
+        fb_credentials = {**credentials}
+        fb_credentials["model_parameters"] = {
+            **credentials.get("model_parameters", {}),
+            "model_name": BedrockLargeLanguageModel.CLAUDE5_FALLBACK_MODEL_NAME,
+        }
+        return fb_params, fb_credentials, fallback_model_id
+
     def _code_block_mode_wrapper(
             self,
             model: str,
@@ -389,6 +512,11 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         system_cache_checkpoint = model_parameters.pop("system_cache_checkpoint", False)
         latest_two_messages_cache_checkpoint = model_parameters.pop("latest_two_messages_cache_checkpoint", False)
         logger.info(f"---cache_checkpoints--- system: {system_cache_checkpoint}, penultimate: {latest_two_messages_cache_checkpoint}")
+
+        # Claude 5 refusal fallback (pop BEFORE parameter conversion)
+        refusal_fallback = model_parameters.pop("refusal_fallback", True)
+        is_claude5 = model_ids.is_claude5_profile_id(model_info["model"])
+
         model_id = model_info["model"]
         logger.debug(f"Model: {model_id}, Cache checkpoints - System: {system_cache_checkpoint}, Penultimate: {latest_two_messages_cache_checkpoint}")
 
@@ -418,6 +546,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             "inferenceConfig": inference_config,
             "additionalModelRequestFields": additional_model_fields,
         }
+
+        if is_claude5:
+            parameters["additionalModelResponseFieldPaths"] = self.CLAUDE5_RESPONSE_FIELD_PATHS
 
         # Bedrock native Structured Outputs via Converse API outputConfig.
         # When a user-defined JSON schema is provided (from Dify's structured output UI),
@@ -494,12 +625,59 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
 
             if stream:
                 response = bedrock_client.converse_stream(**parameters)
-                return self._handle_converse_stream_response(
+                stream_gen = self._handle_converse_stream_response(
                     model_info["model"], credentials, response, prompt_messages
                 )
+                if is_claude5:
+                    fallback_factory = None
+                    if refusal_fallback:
+                        def fallback_factory():
+                            fb_params, fb_credentials, fb_id = self._claude5_fallback_call_inputs(
+                                parameters, credentials
+                            )
+                            # [ADV] runs during generator iteration, outside this
+                            # method's try/except — map ClientError here too
+                            try:
+                                fb_response = bedrock_client.converse_stream(**fb_params)
+                            except ClientError as ex:
+                                error_code = ex.response["Error"]["Code"]
+                                raise self._map_client_to_invoke_error(
+                                    error_code, f"{error_code}: {ex.response['Error']['Message']}"
+                                )
+                            return self._handle_converse_stream_response(
+                                fb_id, fb_credentials, fb_response, prompt_messages
+                            )
+
+                    return self._wrap_claude5_stream(
+                        stream_gen, fallback_factory, parameters["modelId"]
+                    )
+                return stream_gen
             else:
                 logger.info(f"converse: {parameters}")
                 response = bedrock_client.converse(**parameters)
+
+                # Claude 5: safety-classifier block (content_filtered / stop_details)
+                if is_claude5 and self._is_claude5_refusal(
+                    response.get("stopReason"), response.get("additionalModelResponseFields")
+                ):
+                    detail = self._extract_refusal_detail(response)
+                    if refusal_fallback:
+                        fb_params, fb_credentials, fallback_model_id = (
+                            self._claude5_fallback_call_inputs(parameters, credentials)
+                        )
+                        logger.warning(
+                            f"[REFUSAL FALLBACK] {parameters['modelId']} refused ({detail}); "
+                            f"retrying with {fallback_model_id}"
+                        )
+                        response = bedrock_client.converse(**fb_params)
+                        # [ADV] hand off with fallback identity so pricing/model
+                        # reporting reflect Opus 4.8, not the refused Claude 5 model
+                        return self._handle_converse_response(
+                            fallback_model_id, fb_credentials, response, prompt_messages
+                        )
+                    raise self._claude5_refusal_error(
+                        parameters["modelId"], detail, fallback_attempted=False
+                    )
 
                 # Log cache usage metrics if available
                 if "usage" in response:
@@ -532,7 +710,23 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 return self._handle_converse_response(model_info["model"], credentials, response, prompt_messages)
         except ClientError as ex:
             error_code = ex.response["Error"]["Code"]
-            full_error_msg = f"{error_code}: {ex.response['Error']['Message']}"
+            error_message = ex.response["Error"]["Message"]
+            full_error_msg = f"{error_code}: {error_message}"
+            # Fable 5 requires account-level data-retention opt-in; surface
+            # actionable guidance instead of the raw ValidationException.
+            if is_claude5 and any(
+                kw in error_message.lower()
+                for kw in ("retention", "provider_data_share", "data sharing", "data share")
+            ):
+                raise InvokeBadRequestError(
+                    f"{full_error_msg}\n"
+                    "Claude Fable 5 requires opting in to provider data sharing: set your "
+                    "account's data retention mode to 'provider_data_share' via the Bedrock "
+                    "Data Retention API (no console UI at launch). See the Data Retention "
+                    "section of the model card: https://docs.aws.amazon.com/bedrock/latest/"
+                    "userguide/model-card-anthropic-claude-fable-5.html . "
+                    "The Dify plugin does not change account settings."
+                )
             raise self._map_client_to_invoke_error(error_code, full_error_msg)
         except (EndpointConnectionError, NoRegionError, ServiceNotInRegionError) as ex:
             raise InvokeConnectionError(str(ex))
@@ -556,6 +750,10 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         :return: full response chunk generator result
         """
         response_content = response["output"]["message"]["content"]
+        # Adaptive-thinking models may return reasoningContent blocks in
+        # non-streaming responses; fold them into <think> text (mirrors the
+        # streaming handler) instead of crashing on unknown block shapes.
+        response_content, reasoning_prefix = self._fold_reasoning_content(response_content)
         # transform assistant message to prompt message
         if response["stopReason"] == "tool_use":
             tool_calls = []
@@ -570,9 +768,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             )
             tool_calls.append(tool_call)
 
-            assistant_prompt_message = AssistantPromptMessage(content=text, tool_calls=tool_calls)
+            assistant_prompt_message = AssistantPromptMessage(content=reasoning_prefix + text, tool_calls=tool_calls)
         else:
-            assistant_prompt_message = AssistantPromptMessage(content=response_content[0]["text"])
+            assistant_prompt_message = AssistantPromptMessage(content=reasoning_prefix + response_content[0]["text"])
 
         # calculate num tokens
         if response["usage"]:
@@ -1582,6 +1780,10 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         """
         # Extract the model family from the model ID and check individual models first
         if "anthropic.claude" in model_id:
+            # Claude 5 generation models have a distinct parameter surface
+            if model_ids.is_claude5_profile_id(model_id):
+                return (model_schema.model == "anthropic claude 5" or
+                       model_schema.model.startswith("claude-5-"))
             return (model_schema.model == "anthropic claude" or
                    model_schema.model.startswith("claude-"))
         elif "amazon.nova" in model_id:

--- a/models/bedrock/models/llm/model_configurations/claude-5-fable.yaml
+++ b/models/bedrock/models/llm/model_configurations/claude-5-fable.yaml
@@ -1,0 +1,19 @@
+model: claude-5-fable
+label:
+  en_US: Claude Fable 5
+icon: icon_s_en.svg
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+pricing:
+  input: '0.01'
+  output: '0.05'
+  unit: '0.001'
+  currency: USD

--- a/models/bedrock/models/llm/model_configurations/claude-5-sonnet.yaml
+++ b/models/bedrock/models/llm/model_configurations/claude-5-sonnet.yaml
@@ -1,0 +1,19 @@
+model: claude-5-sonnet
+label:
+  en_US: Claude Sonnet 5
+icon: icon_s_en.svg
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+pricing:
+  input: '0.003'
+  output: '0.015'
+  unit: '0.001'
+  currency: USD

--- a/models/bedrock/models/llm/model_ids.py
+++ b/models/bedrock/models/llm/model_ids.py
@@ -7,6 +7,10 @@ Based on AWS documentation:
 """
 
 BEDROCK_MODEL_IDS = {
+    'anthropic claude 5': {
+        'Sonnet 5': 'anthropic.claude-sonnet-5',
+        'Fable 5': 'anthropic.claude-fable-5',
+    },
     'anthropic claude': {
         'Claude 4.8 Opus': 'anthropic.claude-opus-4-8',
         'Claude 4.7 Opus': 'anthropic.claude-opus-4-7',
@@ -129,3 +133,91 @@ def get_region_area(region_name, prefer_global=False):
     }
 
     return area_mapping.get(prefix, None)
+
+
+# Claude 5 generation models are invocable ONLY through inference profiles
+# (inferenceTypesSupported == [INFERENCE_PROFILE]; live-verified — bare-ID
+# converse returns ValidationException) and, unlike earlier Claude models,
+# only 'us' and 'global' profiles exist — there are no eu./apac. geo
+# profiles. See the model cards:
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
+CLAUDE5_PROFILE_PREFIXES = {
+    'anthropic.claude-sonnet-5': ('us', 'global'),
+    'anthropic.claude-fable-5': ('us', 'global'),
+}
+
+CLAUDE5_REFUSAL_FALLBACK_BASE_ID = 'anthropic.claude-opus-4-8'
+
+# All cross-region inference profile geo prefixes in use on Bedrock
+# (jp./au. exist for Opus 4.7/4.8-era models).
+_PROFILE_PREFIXES = ('global.', 'us.', 'eu.', 'apac.', 'jp.', 'au.')
+
+
+def strip_profile_prefix(model_id):
+    """Remove a leading cross-region profile prefix if present."""
+    for prefix in _PROFILE_PREFIXES:
+        if model_id.startswith(prefix):
+            return model_id[len(prefix):]
+    return model_id
+
+
+def is_claude5_model(model_id):
+    """True if model_id is a bare Claude 5 generation base model ID."""
+    return model_id in CLAUDE5_PROFILE_PREFIXES
+
+
+def is_claude5_profile_id(model_id):
+    """True if model_id is a Claude 5 base ID, optionally profile-prefixed."""
+    return strip_profile_prefix(model_id) in CLAUDE5_PROFILE_PREFIXES
+
+
+def resolve_claude5_profile_id(model_id, cross_region, region_name):
+    """
+    Resolve the inference profile ID for a Claude 5 model.
+
+    :param model_id: bare base model ID (e.g. 'anthropic.claude-sonnet-5')
+    :param cross_region: 'global' or 'geographic'
+    :param region_name: AWS region of the caller (e.g. 'us-east-1')
+    :return: profile-prefixed model ID
+    :raises ValueError: when the combination cannot be served, with a
+        user-actionable message
+    """
+    # GovCloud is a separate AWS partition — commercial global./us. profile
+    # IDs are not valid there.
+    if region_name.startswith('us-gov-'):
+        raise ValueError(
+            f"{model_id} is not available in AWS GovCloud ({region_name}). "
+            f"Claude 5 inference profiles exist only in commercial regions."
+        )
+    allowed = CLAUDE5_PROFILE_PREFIXES[model_id]
+    if cross_region == 'global':
+        # Claude 5 global profiles are available from virtually all commercial
+        # regions — deliberately bypass the legacy get_region_area whitelist.
+        return f"global.{model_id}"
+    if cross_region == 'geographic':
+        area = get_region_area(region_name)
+        # The US geo profile serves Canadian source regions (per model card)
+        if area is None and region_name.startswith('ca-'):
+            area = 'us'
+        if area in allowed:
+            return f"{area}.{model_id}"
+        raise ValueError(
+            f"{model_id} has no '{area or region_name}' geographic inference profile. "
+            f"From {region_name} this model supports only Global cross-region inference — "
+            f"set Cross-Region Inference to 'global'."
+        )
+    raise ValueError(
+        f"{model_id} can only be invoked through an inference profile. "
+        f"Set Cross-Region Inference to 'global' (recommended) or 'geographic'."
+    )
+
+
+def get_claude5_fallback_model_id(profile_model_id):
+    """
+    Map a (possibly profile-prefixed) Claude 5 model ID to the Claude 4.8 Opus
+    fallback ID with the same profile prefix.
+    """
+    base = strip_profile_prefix(profile_model_id)
+    prefix = profile_model_id[: len(profile_model_id) - len(base)]
+    return f"{prefix}{CLAUDE5_REFUSAL_FALLBACK_BASE_ID}"

--- a/models/bedrock/readme/README_zh_Hans.md
+++ b/models/bedrock/readme/README_zh_Hans.md
@@ -33,6 +33,16 @@ After installing the plugin, configure the Amazon Bedrock credentials within the
 
 
 
+## Claude 5 系列模型（Sonnet 5 / Fable 5）
+
+“Anthropic Claude 5” 条目提供 Claude Sonnet 5（`anthropic.claude-sonnet-5`）与 Claude Fable 5（`anthropic.claude-fable-5`）。与之前的 Claude 世代相比：
+
+- **仅支持推理配置文件调用。** 只能通过 `us.`（美国/加拿大区域）或 `global.` 跨区域推理配置文件调用——不支持裸模型 ID 的按需调用，也没有 `eu.`/`apac.` 地理配置文件。插件根据“跨区域推理”选项自动解析；非美国区域请选择 `global`。
+- **自适应思考始终开启**，无法关闭。思考深度由 Effort 参数（`low`/`medium`/`high`/`xhigh`/`max`）控制，取代思考预算。这两个模型不支持调节采样参数（temperature / top_p / top_k），因此不再暴露。
+- **拒答与回落。** 请求可能被安全分类器拒绝（`stop_reason: refusal`，Fable 5 概率明显更高）。默认开启“拒答回落”时，插件会自动用 Claude 4.8 Opus 重试同一请求；流式输出已产生内容后发生的拒绝无法回落，将直接报错。
+- **Fable 5 前置条件：数据保留 opt-in。** 调用 Fable 5 前，AWS 账户必须通过 Bedrock Data Retention API 将数据保留模式设置为 `provider_data_share`（上线初期无控制台入口）。详见 [Fable 5 模型卡](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html)。插件不会修改账户设置。
+- **价格说明。** 展示价格为 Global 跨区域费率（Sonnet 5 每百万 token $3/$15，Fable 5 $10/$50）。Geo/区域内调用约贵 10%。Prompt 缓存读写费率无法体现在 Dify 费用统计中，请以 AWS 账单为准。
+
 ## Issue Feedback | 问题反馈
 
 For more detailed information, please refer to [aws-sample/dify-aws-tool](https://github.com/aws-samples/dify-aws-tool/), which contains multiple workflows for reference.

--- a/models/bedrock/tests/conftest.py
+++ b/models/bedrock/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Make the plugin root importable so `models.llm.llm` (namespace package),
+# `provider.*`, and `utils.*` resolve exactly as they do at plugin runtime.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/models/bedrock/tests/test_claude5_cache_config.py
+++ b/models/bedrock/tests/test_claude5_cache_config.py
@@ -1,0 +1,45 @@
+"""Unit tests for cache_config: Claude 5 registration and global. prefix handling."""
+import importlib.util
+from pathlib import Path
+
+_CACHE_CONFIG_PATH = (
+    Path(__file__).resolve().parent.parent / "models" / "llm" / "cache_config.py"
+)
+_spec = importlib.util.spec_from_file_location("cache_config", _CACHE_CONFIG_PATH)
+cache_config = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cache_config)
+
+
+class TestClaude5CacheRegistration:
+    def test_sonnet5_supported_with_min_4096(self):
+        assert cache_config.is_cache_supported("anthropic.claude-sonnet-5")
+        cfg = cache_config.get_cache_config("anthropic.claude-sonnet-5")
+        assert cfg["min_tokens"] == 4096
+        assert cfg["supported_fields"] == ["system", "messages", "tools"]
+
+    def test_fable5_supported_with_min_1024(self):
+        assert cache_config.is_cache_supported("anthropic.claude-fable-5")
+        cfg = cache_config.get_cache_config("anthropic.claude-fable-5")
+        assert cfg["min_tokens"] == 1024
+        assert cfg["supported_fields"] == ["system", "messages", "tools"]
+
+
+class TestGlobalPrefixStripping:
+    def test_global_prefixed_claude5(self):
+        assert cache_config.is_cache_supported("global.anthropic.claude-sonnet-5")
+        cfg = cache_config.get_cache_config("global.anthropic.claude-fable-5")
+        assert cfg["min_tokens"] == 1024
+
+    def test_global_prefixed_existing_model(self):
+        # Regression: global. profiles previously fell through to defaults
+        assert cache_config.is_cache_supported("global.anthropic.claude-opus-4-8")
+        cfg = cache_config.get_cache_config("global.anthropic.claude-opus-4-8")
+        assert cfg["min_tokens"] == 4096
+
+    def test_us_prefix_still_works(self):
+        assert cache_config.is_cache_supported("us.anthropic.claude-sonnet-5")
+
+    def test_jp_au_prefixes_stripped(self):
+        # jp./au. profiles exist for Opus 4.7/4.8-era models
+        assert cache_config.is_cache_supported("jp.anthropic.claude-opus-4-8")
+        assert cache_config.is_cache_supported("au.anthropic.claude-opus-4-8")

--- a/models/bedrock/tests/test_claude5_llm_params.py
+++ b/models/bedrock/tests/test_claude5_llm_params.py
@@ -1,0 +1,74 @@
+"""Unit tests for Claude 5 parameter conversion and region resolution in llm.py.
+
+Imports models.llm.llm as a namespace package (requires dify_plugin from the
+plugin venv — run via `uv run`). Pure methods are exercised without
+instantiating the model class.
+"""
+import importlib
+
+import pytest
+
+llm_mod = importlib.import_module("models.llm.llm")
+model_ids = importlib.import_module("models.llm.model_ids")
+
+BedrockLLM = llm_mod.BedrockLargeLanguageModel
+
+
+class TestEffortConversion:
+    def _convert(self, params, stop=None):
+        # The method never touches self — call unbound with None.
+        return BedrockLLM._convert_converse_api_model_parameters(None, params, stop)
+
+    def test_effort_maps_to_adaptive_thinking_and_output_config(self):
+        inference_config, additional = self._convert(
+            {"max_tokens": 4096, "effort": "xhigh"}
+        )
+        assert additional["thinking"] == {"type": "adaptive"}
+        assert additional["output_config"] == {"effort": "xhigh"}
+        assert inference_config["maxTokens"] == 4096
+        # Claude 5 yaml never exposes sampling params; nothing must leak in
+        assert "temperature" not in inference_config
+        assert "topP" not in inference_config
+
+    def test_no_effort_no_thinking_injection(self):
+        # Other families don't send effort — their fields must be untouched
+        inference_config, additional = self._convert(
+            {"max_tokens": 1024, "temperature": 0.5}
+        )
+        assert "thinking" not in additional
+        assert "output_config" not in additional
+        assert inference_config["temperature"] == 0.5
+
+    def test_effort_with_legacy_reasoning_ignores_reasoning(self):
+        # Defensive: if both ever arrive, effort (Claude 5) wins and the
+        # legacy budget config must not be emitted alongside it.
+        _, additional = self._convert(
+            {"max_tokens": 4096, "effort": "high", "reasoning_type": True,
+             "reasoning_budget": 2048}
+        )
+        assert additional["thinking"] == {"type": "adaptive"}
+        assert "reasoning_config" not in additional
+
+
+class TestClaude5RegionResolutionInGetModelInfo:
+    def _get_model_info(self, model_name, cross_region, region):
+        params = {"model_name": model_name, "cross-region": cross_region}
+        credentials = {"aws_region": region}
+        return BedrockLLM._get_model_info(None, "anthropic claude 5", credentials, params), params
+
+    def test_global_resolution(self):
+        info, _ = self._get_model_info("Sonnet 5", "global", "eu-central-1")
+        assert info["model"] == "global.anthropic.claude-sonnet-5"
+        assert info["support_tool_use"] is True
+
+    def test_geographic_us(self):
+        info, _ = self._get_model_info("Fable 5", "geographic", "us-west-2")
+        assert info["model"] == "us.anthropic.claude-fable-5"
+
+    def test_geographic_eu_raises_actionable_error(self):
+        with pytest.raises(llm_mod.InvokeError, match="global"):
+            self._get_model_info("Sonnet 5", "geographic", "eu-central-1")
+
+    def test_cross_region_param_is_consumed(self):
+        _, params = self._get_model_info("Sonnet 5", "global", "us-east-1")
+        assert "cross-region" not in params

--- a/models/bedrock/tests/test_claude5_llm_params.py
+++ b/models/bedrock/tests/test_claude5_llm_params.py
@@ -49,6 +49,18 @@ class TestEffortConversion:
         assert additional["thinking"] == {"type": "adaptive"}
         assert "reasoning_config" not in additional
 
+    def test_effort_drops_sampling_params(self):
+        # Claude 5 rejects non-default sampling params; if a caller bypasses
+        # the yaml surface and sends them alongside effort, they must be dropped.
+        inference_config, additional = self._convert(
+            {"max_tokens": 4096, "effort": "high", "temperature": 0.7,
+             "top_p": 0.9, "top_k": 40}
+        )
+        assert "temperature" not in inference_config
+        assert "topP" not in inference_config
+        assert "top_k" not in additional
+        assert additional["thinking"] == {"type": "adaptive"}
+
 
 class TestClaude5RegionResolutionInGetModelInfo:
     def _get_model_info(self, model_name, cross_region, region):

--- a/models/bedrock/tests/test_claude5_model_ids.py
+++ b/models/bedrock/tests/test_claude5_model_ids.py
@@ -1,0 +1,106 @@
+"""Unit tests for Claude 5 (Sonnet 5 / Fable 5) helpers in model_ids.py.
+
+model_ids.py has no third-party imports, so we load it directly by path —
+no dify_plugin or boto3 required.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODEL_IDS_PATH = (
+    Path(__file__).resolve().parent.parent / "models" / "llm" / "model_ids.py"
+)
+_spec = importlib.util.spec_from_file_location("model_ids", _MODEL_IDS_PATH)
+model_ids = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(model_ids)
+
+SONNET5 = "anthropic.claude-sonnet-5"
+FABLE5 = "anthropic.claude-fable-5"
+
+
+class TestRegistry:
+    def test_family_registered(self):
+        family = model_ids.BEDROCK_MODEL_IDS["anthropic claude 5"]
+        assert family["Sonnet 5"] == SONNET5
+        assert family["Fable 5"] == FABLE5
+
+    def test_get_model_id(self):
+        assert model_ids.get_model_id("anthropic claude 5", "Sonnet 5") == SONNET5
+        assert model_ids.get_model_id("anthropic claude 5", "Fable 5") == FABLE5
+
+
+class TestIsClaude5:
+    def test_bare_ids(self):
+        assert model_ids.is_claude5_model(SONNET5)
+        assert model_ids.is_claude5_model(FABLE5)
+
+    def test_other_models_are_not_claude5(self):
+        assert not model_ids.is_claude5_model("anthropic.claude-opus-4-8")
+        assert not model_ids.is_claude5_model("anthropic.claude-sonnet-4-6")
+
+    def test_profile_ids(self):
+        assert model_ids.is_claude5_profile_id(f"global.{SONNET5}")
+        assert model_ids.is_claude5_profile_id(f"us.{FABLE5}")
+        assert model_ids.is_claude5_profile_id(SONNET5)
+        assert not model_ids.is_claude5_profile_id("global.anthropic.claude-opus-4-8")
+
+
+class TestResolveProfileId:
+    @pytest.mark.parametrize("region", [
+        "us-east-1", "eu-central-1", "ap-northeast-1", "sa-east-1",
+    ])
+    def test_global_works_from_any_region(self, region):
+        # global must bypass the legacy 5-region whitelist entirely
+        assert (
+            model_ids.resolve_claude5_profile_id(SONNET5, "global", region)
+            == f"global.{SONNET5}"
+        )
+
+    @pytest.mark.parametrize("region", ["us-east-1", "us-west-2"])
+    def test_geographic_us_regions(self, region):
+        assert (
+            model_ids.resolve_claude5_profile_id(FABLE5, "geographic", region)
+            == f"us.{FABLE5}"
+        )
+
+    @pytest.mark.parametrize("region", ["ca-central-1", "ca-west-1"])
+    def test_geographic_canada_maps_to_us_profile(self, region):
+        # Per the model card, the US geo profile serves CA source regions
+        assert (
+            model_ids.resolve_claude5_profile_id(SONNET5, "geographic", region)
+            == f"us.{SONNET5}"
+        )
+
+    @pytest.mark.parametrize("region", ["eu-central-1", "eu-west-1", "ap-northeast-1"])
+    def test_geographic_unsupported_regions_raise(self, region):
+        with pytest.raises(ValueError, match="Global"):
+            model_ids.resolve_claude5_profile_id(SONNET5, "geographic", region)
+
+    def test_disabled_raises(self):
+        with pytest.raises(ValueError, match="inference profile"):
+            model_ids.resolve_claude5_profile_id(SONNET5, "disabled", "us-east-1")
+
+    def test_unknown_cross_region_value_raises(self):
+        with pytest.raises(ValueError):
+            model_ids.resolve_claude5_profile_id(SONNET5, "", "us-east-1")
+
+    @pytest.mark.parametrize("cross_region", ["global", "geographic"])
+    def test_govcloud_rejected(self, cross_region):
+        # GovCloud is a separate partition — commercial profile IDs are invalid
+        with pytest.raises(ValueError, match="GovCloud"):
+            model_ids.resolve_claude5_profile_id(SONNET5, cross_region, "us-gov-west-1")
+
+
+class TestFallbackId:
+    def test_global_prefix_preserved(self):
+        assert (
+            model_ids.get_claude5_fallback_model_id(f"global.{FABLE5}")
+            == "global.anthropic.claude-opus-4-8"
+        )
+
+    def test_us_prefix_preserved(self):
+        assert (
+            model_ids.get_claude5_fallback_model_id(f"us.{SONNET5}")
+            == "us.anthropic.claude-opus-4-8"
+        )

--- a/models/bedrock/tests/test_claude5_refusal.py
+++ b/models/bedrock/tests/test_claude5_refusal.py
@@ -1,0 +1,122 @@
+"""Unit tests for Claude 5 refusal detection and fallback stream wrapper."""
+import importlib
+
+import pytest
+
+llm_mod = importlib.import_module("models.llm.llm")
+
+from dify_plugin.entities.model.llm import LLMResultChunk, LLMResultChunkDelta
+from dify_plugin.entities.model.message import AssistantPromptMessage
+
+BedrockLLM = llm_mod.BedrockLargeLanguageModel
+
+
+def _chunk(content="", finish_reason=None):
+    return LLMResultChunk(
+        model="global.anthropic.claude-fable-5",
+        prompt_messages=[],
+        delta=LLMResultChunkDelta(
+            index=0,
+            message=AssistantPromptMessage(content=content),
+            finish_reason=finish_reason,
+        ),
+    )
+
+
+class TestRefusalDetection:
+    def test_content_filtered_is_refusal(self):
+        # Converse StopReason enum has no "refusal" — classifier blocks are
+        # expected to surface as content_filtered (live-verified enum)
+        assert BedrockLLM._is_claude5_refusal("content_filtered", None)
+
+    def test_native_refusal_string_still_detected(self):
+        assert BedrockLLM._is_claude5_refusal("refusal", None)
+
+    def test_stop_details_signal(self):
+        assert BedrockLLM._is_claude5_refusal(
+            "end_turn", {"stop_details": {"category": "cyber"}}
+        )
+
+    def test_normal_completion_not_refusal(self):
+        # Live-verified: stop_details is null on normal completion
+        assert not BedrockLLM._is_claude5_refusal("end_turn", {"stop_details": None})
+        assert not BedrockLLM._is_claude5_refusal("end_turn", None)
+        assert not BedrockLLM._is_claude5_refusal("tool_use", {})
+
+
+class TestExtractRefusalDetail:
+    def test_reads_additional_model_response_fields(self):
+        response = {
+            "stopReason": "content_filtered",
+            "additionalModelResponseFields": {
+                "stop_details": {"category": "cyber", "explanation": "blocked"}
+            },
+        }
+        detail = BedrockLLM._extract_refusal_detail(response)
+        assert "cyber" in detail
+
+    def test_missing_details_returns_placeholder(self):
+        detail = BedrockLLM._extract_refusal_detail({"stopReason": "content_filtered"})
+        assert isinstance(detail, str) and detail  # non-empty, never raises
+
+
+class TestWrapClaude5Stream:
+    def test_passthrough_when_no_refusal(self):
+        inner = iter([_chunk("hello"), _chunk("", finish_reason="end_turn")])
+        out = list(BedrockLLM._wrap_claude5_stream(inner, None, "global.anthropic.claude-fable-5"))
+        assert [c.delta.message.content for c in out] == ["hello", ""]
+
+    @pytest.mark.parametrize("reason", ["refusal", "content_filtered"])
+    def test_pre_content_refusal_restarts_on_fallback(self, reason):
+        inner = iter([_chunk("", finish_reason=reason)])
+        fallback_chunks = [_chunk("fallback answer"), _chunk("", finish_reason="end_turn")]
+        out = list(BedrockLLM._wrap_claude5_stream(
+            inner, lambda: iter(fallback_chunks), "global.anthropic.claude-fable-5"
+        ))
+        assert out == fallback_chunks  # refusal chunk swallowed, fallback streamed
+
+    def test_pre_content_refusal_without_fallback_raises(self):
+        inner = iter([_chunk("", finish_reason="content_filtered")])
+        with pytest.raises(llm_mod.InvokeError, match="refus"):
+            list(BedrockLLM._wrap_claude5_stream(inner, None, "global.anthropic.claude-fable-5"))
+
+    def test_mid_stream_refusal_raises_even_with_fallback(self):
+        inner = iter([_chunk("partial"), _chunk("", finish_reason="content_filtered")])
+        gen = BedrockLLM._wrap_claude5_stream(
+            inner, lambda: iter([_chunk("never")]), "global.anthropic.claude-fable-5"
+        )
+        assert next(gen).delta.message.content == "partial"
+        with pytest.raises(llm_mod.InvokeError, match="refus"):
+            list(gen)
+
+    def test_thinking_content_counts_as_content(self):
+        # <think> text is user-visible; a refusal after it is mid-stream
+        inner = iter([_chunk("<think>\nreasoning"), _chunk("", finish_reason="content_filtered")])
+        gen = BedrockLLM._wrap_claude5_stream(
+            inner, lambda: iter([_chunk("never")]), "global.anthropic.claude-fable-5"
+        )
+        next(gen)
+        with pytest.raises(llm_mod.InvokeError):
+            list(gen)
+
+
+class TestNonStreamReasoningContent:
+    def test_reasoning_block_does_not_crash(self):
+        response = {
+            "stopReason": "end_turn",
+            "output": {"message": {"content": [
+                {"reasoningContent": {"reasoningText": {"text": "thinking...", "signature": "sig"}}},
+                {"text": "The answer is 391."},
+            ]}},
+            "usage": {"inputTokens": 10, "outputTokens": 20},
+        }
+        # _handle_converse_response calls _calc_response_usage (needs real
+        # credentials plumbing) — test the block-filtering logic directly by
+        # invoking the method with a minimal fake and asserting no exception
+        # up to the usage call, or refactor the filtering into a static
+        # helper _fold_reasoning_content(content) and test that:
+        content, prefix = BedrockLLM._fold_reasoning_content(
+            response["output"]["message"]["content"]
+        )
+        assert prefix.startswith("<think>")
+        assert all("reasoningContent" not in b for b in content)

--- a/models/bedrock/tests/test_claude5_refusal.py
+++ b/models/bedrock/tests/test_claude5_refusal.py
@@ -137,6 +137,21 @@ class TestNonStreamReasoningContent:
         # with an empty filtered list it must fall back to "" rather than index [0].
         assert (filtered[0]["text"] if filtered else "") == ""
 
+    def test_malformed_reasoning_blocks_do_not_crash(self):
+        # reasoningContent present but None / non-dict shapes must not raise
+        # TypeError; malformed reasoning blocks are dropped from the fold and
+        # (being unusable) filtered out of the content list too.
+        content_list = [
+            {"reasoningContent": None},
+            {"reasoningContent": "bogus"},
+            {"reasoningContent": {"reasoningText": None}},
+            {"reasoningContent": {"reasoningText": {"text": 123}}},
+            {"text": "answer"},
+        ]
+        filtered, prefix = BedrockLLM._fold_reasoning_content(content_list)
+        assert prefix == ""  # no valid reasoning text extracted
+        assert filtered == [{"text": "answer"}]
+
 
 class TestClaude5FallbackCallInputs:
     def _inputs(self):

--- a/models/bedrock/tests/test_claude5_refusal.py
+++ b/models/bedrock/tests/test_claude5_refusal.py
@@ -120,3 +120,60 @@ class TestNonStreamReasoningContent:
         )
         assert prefix.startswith("<think>")
         assert all("reasoningContent" not in b for b in content)
+
+    def test_reasoning_only_content_yields_empty_filtered_list(self):
+        # max_tokens exhausted during the thinking phase: the response has a
+        # reasoning block but NO text block. Folding must yield an empty
+        # filtered list plus a <think> prefix — the exact precondition under
+        # which the plain-text else-branch of _handle_converse_response used to
+        # crash with IndexError on response_content[0].
+        content_list = [
+            {"reasoningContent": {"reasoningText": {"text": "still thinking...", "signature": "sig"}}},
+        ]
+        filtered, prefix = BedrockLLM._fold_reasoning_content(content_list)
+        assert filtered == []
+        assert prefix.startswith("<think>")
+        # Mirror the guarded else-branch expression from _handle_converse_response:
+        # with an empty filtered list it must fall back to "" rather than index [0].
+        assert (filtered[0]["text"] if filtered else "") == ""
+
+
+class TestClaude5FallbackCallInputs:
+    def _inputs(self):
+        parameters = {
+            "modelId": "global.anthropic.claude-fable-5",
+            "additionalModelResponseFieldPaths": ["/stop_details"],
+            "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+        }
+        credentials = {
+            "aws_region": "us-east-1",
+            "model_parameters": {"model_name": "Fable 5"},
+        }
+        return parameters, credentials
+
+    def test_fallback_inputs_shape(self):
+        parameters, credentials = self._inputs()
+        fb_params, fb_credentials, fallback_model_id = (
+            BedrockLLM._claude5_fallback_call_inputs(parameters, credentials)
+        )
+
+        # global. profile prefix preserved on the Opus 4.8 fallback id
+        assert fallback_model_id == "global.anthropic.claude-opus-4-8"
+        assert fb_params["modelId"] == "global.anthropic.claude-opus-4-8"
+
+        # stop_details field paths are Claude-5-specific; dropped for fallback
+        assert "additionalModelResponseFieldPaths" not in fb_params
+
+        # credentials re-priced as Opus 4.8
+        assert fb_credentials["model_parameters"]["model_name"] == "Claude 4.8 Opus"
+
+        # unrelated keys pass through unchanged
+        assert fb_params["messages"] == parameters["messages"]
+
+    def test_original_inputs_not_mutated(self):
+        parameters, credentials = self._inputs()
+        BedrockLLM._claude5_fallback_call_inputs(parameters, credentials)
+
+        assert parameters["modelId"] == "global.anthropic.claude-fable-5"
+        assert parameters["additionalModelResponseFieldPaths"] == ["/stop_details"]
+        assert credentials["model_parameters"]["model_name"] == "Fable 5"


### PR DESCRIPTION
## Summary

Adds a new **"Anthropic Claude 5"** model family to the Bedrock plugin with Claude Sonnet 5 (`anthropic.claude-sonnet-5`) and Claude Fable 5 (`anthropic.claude-fable-5`).

### Key behaviors

- **Inference-profile-only invocation.** Claude 5 models cannot be invoked by bare model ID (`inferenceTypesSupported: [INFERENCE_PROFILE]`, verified live). The plugin resolves `us.` / `global.` profile IDs from the *Cross-Region Inference* setting; `global` works from virtually all commercial regions (bypasses the legacy region whitelist), `geographic` is limited to US/Canada. GovCloud regions are rejected with an actionable error (separate partition).
- **Adaptive thinking via `effort`.** Thinking is always on for these models; depth is controlled by a new `effort` parameter (`low`–`max`, default `high`) sent as `additionalModelRequestFields = {"thinking": {"type": "adaptive"}, "output_config": {"effort": ...}}`. Sampling params (temperature / top_p / top_k) are rejected by these models, so they are not exposed.
- **Refusal detection + automatic fallback to Claude 4.8 Opus.** Live-verified refusal shape: `stopReason: content_filtered` plus `additionalModelResponseFields.stop_details = {"type": "refusal", "category": ..., "explanation": ...}` (returned only when `additionalModelResponseFieldPaths=["/stop_details"]` is requested — the plugin always requests it for Claude 5). Detection is dual-signal (`content_filtered`/`refusal` stop reason OR non-null `stop_details`). With *Refusal Fallback* enabled (default), the identical request is retried on Claude 4.8 Opus with the same profile prefix; the fallback response is **priced and reported as Claude 4.8 Opus** (credentials/model-identity override), and fallback API errors go through the same ClientError → InvokeError mapping. Mid-stream refusals after content was already emitted raise instead (chunks cannot be retracted). Limitation: custom inference profile (ARN) invocations keep their existing behavior — no refusal fallback.
- **Fable 5 data-retention prerequisite.** Fable 5 requires account-level opt-in to `provider_data_share` via the Bedrock Data Retention API; matching ValidationExceptions are rewrapped with actionable guidance.
- **Bugfix: cache-config profile-prefix stripping.** `is_cache_supported`/`get_cache_config` previously stripped only `us.`/`eu.`/`apac.`, silently disabling prompt-cache checkpoints for every `global.` (and `jp.`/`au.`) profile invocation — including existing models like Opus 4.8. Now all six prefixes strip correctly (strictly enabling; regression-tested).
- **Defensive `reasoningContent` handling** in non-streaming responses: reasoning blocks fold into `<think>` text (mirrors the streaming path) instead of crashing, including reasoning-only responses (e.g. max_tokens exhausted during thinking).

### Housekeeping

- Plugin version → **0.0.74** (rebased on top of #3389's 0.0.73).
- New `tests/` suite: 51 unit tests (`uv run --with pytest pytest tests/ -v`), no AWS credentials required.

## Why a separate "Anthropic Claude 5" family instead of extending "Anthropic Claude"

In this plugin, a model family yaml defines a single shared parameter surface for every model in its dropdown. Claude 5's parameter surface is not a superset or subset of the existing family's — it is **contradictory** on both sides, so one family cannot serve both without misconfiguring one generation:

- **Parameters the old family exposes that Claude 5 must NOT have:** `temperature` / `top_p` / `top_k` are rejected by the Claude 5 API (non-default values fail), and `reasoning_type` / `reasoning_budget` (budget-token thinking) don't exist on these models — adaptive thinking is always on. Keeping Claude 5 in the old family would show users five controls that either break requests or silently do nothing.
- **Parameters Claude 5 needs that would be wrong on the old family:** `effort` (low/medium/high/xhigh/max, replacing the thinking budget), a redefined `cross-region` (Claude 5 is inference-profile-only — `us.`/`global.` exist, no `eu.`/`apac.`, and *disabled* is not a valid choice, unlike every older Claude model which supports on-demand bare-ID invocation), and `refusal_fallback`. Adding these to the shared family would surface meaningless toggles on Sonnet 4.6 / Opus 4.8 / etc.
- **Different fixed properties:** context size (1M native vs 200K + beta header on the old family — the old family's `anthropic_beta: context-1m-2025-08-07` default is meaningless for Claude 5), max_tokens ceiling (128K), and per-model pricing.

Since parameter rules, defaults, and help text live at the family level in yaml (not per model), a separate `anthropic claude 5` family is the smallest change that gives both generations a correct UI. It also keeps the blast radius small: the legacy family's yaml and code paths are untouched, so existing configured apps cannot regress. The same generational split is why `_model_id_matches_schema` routes `*.anthropic.claude-sonnet-5`/`-fable-5` custom inference profiles to the new family — otherwise they would inherit temperature/top_k from the legacy schema.

## Verification

### Live API verification (us-east-1)

- Sonnet 5 `global.`/`us.` from us-east-1 and `global.` from eu-west-1: `end_turn` ✅; tool use → `tool_use` ✅; streaming event sequence ✅; `xhigh`/`max` effort accepted ✅
- Fable 5 `global.`: `end_turn` ✅; real refusal probe captured the documented shape ✅
- Opus 4.8 fallback target accepts the forwarded adaptive-thinking/effort fields and answers the refusal-triggering prompt with `end_turn` ✅

### Dify UI verification (local Dify, plugin via remote debug, v0.0.74)

Model provider list showing the new **Anthropic Claude 5** family (1000K context, vision/document) alongside the existing families, plugin at 0.0.74:

<img width="2560" height="1222" alt="model-list" src="https://github.com/user-attachments/assets/6978c25b-df28-44a0-be30-d29988bbaf93" />

Model Settings panel — Sonnet 5 / Fable 5 dropdown, Cross-Region Inference (global), Max Tokens 8192, Effort (default high), Refusal Fallback to Claude 4.8 Opus (default true), cache checkpoints; note there are **no temperature/top_p/top_k** controls by design:

<img width="930" height="614" alt="2-models" src="https://github.com/user-attachments/assets/1f721cc7-0228-4edb-99e4-491cb0817dbe" />

<img width="933" height="581" alt="config" src="https://github.com/user-attachments/assets/0d0b52af-ba5e-4fef-a860-6e35aa7f4c1d" />

End-to-end chatflow driven by two Claude 5 nodes (Fable 5 intent node + Sonnet 5 translate node), both completing successfully:

<img width="2250" height="1222" alt="工作正常" src="https://github.com/user-attachments/assets/7ae295bc-7b34-4964-8649-f697c041ad2f" />

### Pre/post comparison harness (terminal)

A single harness script drove the real plugin code path (public `invoke()` → profile resolution → parameter conversion → Converse → response handling → pricing) in two worktrees: **pre** = `main` (0.0.72), **post** = this branch (0.0.74). Every expectation is asserted mechanically in code.

<details>
<summary><b>pre (0.0.72): 5/5 expected, 5 n/a — Claude 5 absent, old-family regression guard passes</b></summary>

```
[S1] ✅ EXPECTED (pre)  |  Family registry + Claude 5 yaml params
     obs : present=False; schema=None
[S2] ✅ EXPECTED (pre)  |  Cache-config global. prefix-strip bugfix
     obs : is_cache_supported('global.anthropic.claude-opus-4-8') = False   <-- the bug
[S3] ✅ EXPECTED (pre)  |  Effort -> adaptive thinking + output_config
     obs : additionalModelRequestFields = {} (effort ignored=True)
[S4] ✅ EXPECTED (pre)  |  Region resolution: geographic from eu-central-1
     obs : family in registry=False
[S5] ✅ EXPECTED (pre)  |  Regression guard (old Claude family)
     obs : model=global.anthropic.claude-opus-4-8; text='OK'; total_price=$0.000180
[S6-S10] — n/a in this env (family absent in 0.0.72)
totals: ✅ 5 expected   ❌ 0 unexpected   — 5 n/a
```
</details>

<details>
<summary><b>post (0.0.74): 10/10 expected — incl. live refusal fallback billed as Opus 4.8</b></summary>

```
[S1] ✅ EXPECTED (post) |  Family registry + Claude 5 yaml params
     obs : present=True; effort opts=[high,low,max,medium,xhigh] default=high;
           model_name opts=[Fable 5, Sonnet 5]; sampling-params-present=[]
[S2] ✅ EXPECTED (post) |  Cache-config global. prefix-strip bugfix
     obs : is_cache_supported('global.anthropic.claude-opus-4-8') = True    <-- fixed
[S3] ✅ EXPECTED (post) |  Effort -> adaptive thinking + output_config
     obs : {'thinking': {'type': 'adaptive'}, 'output_config': {'effort': 'high'}}
[S4] ✅ EXPECTED (post) |  Region resolution: geographic from eu-central-1
     obs : InvokeError: "...has no 'eu' geographic inference profile... set
           Cross-Region Inference to 'global'."
[S5] ✅ EXPECTED (post) |  Regression guard (old Claude family)
     obs : identical to pre — model=global.anthropic.claude-opus-4-8; text='OK'
[S6] ✅ EXPECTED (post) |  Sonnet 5 non-stream
     obs : model=global.anthropic.claude-sonnet-5; text='OK';
           unit_price(in/out)=0.003/0.015; total_price=$0.000108
[S7] ✅ EXPECTED (post) |  Sonnet 5 streaming
     obs : chunk_count=5; finish=end_turn; text~='1, 2, 3, 4, 5'
[S8] ✅ EXPECTED (post) |  Fable 5 non-stream
     obs : model=global.anthropic.claude-fable-5; unit_price(in/out)=0.01/0.05
[S9] ✅ EXPECTED (post) |  Refusal fallback ON (flagship)
     obs : FALLBACK fired -> model=global.anthropic.claude-opus-4-8;
           unit_price(in/out)=0.005/0.025 (billed as Opus 4.8)
[S10] ✅ EXPECTED (post) |  Refusal fallback OFF
     obs : InvokeError: "global.anthropic.claude-fable-5 refused this request
           via its safety classifiers (cyber; ...)"
totals: ✅ 10 expected   ❌ 0 unexpected
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

