### PR TITLE
docs(outlook): clarify oauth setup permissions

### DIFF
--- a/triggers/outlook_trigger/README.md
+++ b/triggers/outlook_trigger/README.md
@@ -12,15 +12,21 @@ The field remains secret-style in Dify for compatibility with existing saved con
 
 1. Enter [Azure Portal](https://portal.azure.com/#home), head to `App Registrations` and create a new application.
 
+![Azure Entra ID](./_assets/images/register_application_01.png)
+
 Fill with a name and choose the supported account type that matches your tenant policy.
 For company-only access, choose single tenant and use the Directory tenant ID in Dify.
 For organization-account multi-tenant access, choose accounts in any organizational directory and enter `organizations` in Dify.
 Use the personal Microsoft accounts option only when personal accounts are required, then enter `common` in Dify.
 Click `Register`.
 
+![Azure Entra ID](./_assets/images/register_application_02.png)
+
 2. Copy the `Application (client) ID` from the `Overview` page.
 Copy the `Directory (tenant) ID` too if you chose single tenant.
 Generate a new client secret in the `Certificates & secrets` page and copy the value.
+
+![Azure Entra ID](./_assets/images/get_credentials.png)
 
 3. Configure API permissions.
 Go to the `API permissions` section.
@@ -34,12 +40,16 @@ Grant admin consent if your organization requires it.
 
 4. Install this plugin in Dify and open configuration page.
 
+![Dify](./_assets/images/config_oauth_01.png)
+
 Fill in the `Client ID`, `Client Secret`, and `Tenant ID` fields.
 The `Tenant ID` value should match your account type choice: your tenant ID or domain, `organizations`, or `common`.
 
 Copy the `redirect_url` from this dialog, then return to the Azure Entra ID page.
 Go to the `Authentication` page, select `Web` as the platform type, and paste the `redirect_url` into the `Redirect URIs` field.
 Click `Save`.
+
+![Dify](./_assets/images/config_oauth_02.png)
 
 Now you can go back to the Dify plugin configuration page and click `Save and authorize` to initiate the OAuth flow.
 

--- a/triggers/outlook_trigger/README.md
+++ b/triggers/outlook_trigger/README.md
@@ -12,35 +12,37 @@ The field remains secret-style in Dify for compatibility with existing saved con
 
 1. Enter [Azure Portal](https://portal.azure.com/#home), head to `App Registrations` and create a new application.
 
-![Azure Entra ID](./_assets/images/register_application_01.png)
-
 Fill with a name and choose the supported account type that matches your tenant policy.
 For company-only access, choose single tenant and use the Directory tenant ID in Dify.
 For organization-account multi-tenant access, choose accounts in any organizational directory and enter `organizations` in Dify.
 Use the personal Microsoft accounts option only when personal accounts are required, then enter `common` in Dify.
 Click `Register`.
 
-![Azure Entra ID](./_assets/images/register_application_02.png)
-
 2. Copy the `Application (client) ID` from the `Overview` page.
 Copy the `Directory (tenant) ID` too if you chose single tenant.
 Generate a new client secret in the `Certificates & secrets` page and copy the value.
 
-![Azure Entra ID](./_assets/images/get_credentials.png)
+3. Configure API permissions.
+Go to the `API permissions` section.
+Add these Microsoft Graph delegated permissions:
 
-3. Install this plugin in Dify and open configuration page.
+- `Mail.Read` (delegated)
+- `offline_access` (delegated)
 
-![Dify](./_assets/images/config_oauth_01.png)
+No application permissions are required.
+Grant admin consent if your organization requires it.
+
+4. Install this plugin in Dify and open configuration page.
 
 Fill in the `Client ID`, `Client Secret`, and `Tenant ID` fields.
 The `Tenant ID` value should match your account type choice: your tenant ID or domain, `organizations`, or `common`.
 
-You'll get a `redirect_url` in this dialog, copy it and go back to the Azure Entra ID page, head to `Authentication` page, select `Web` as the platform type, add paste the `redirect_url` in the `Redirect URIs` field. Click `Save`.
-
-![Dify](./_assets/images/config_oauth_02.png)
+You'll get a `redirect_url` in this dialog, copy it and go back to the Azure Entra ID page, head to `Authentication` page, select `Web` as the platform type, and paste the `redirect_url` in the `Redirect URIs` field.
+Click `Save`.
 
 Now you can go back to the Dify plugin configuration page and click `Save and authorize` to initiate the OAuth flow.
 
-This plugin will redirect you to the Microsoft login page, login with your Microsoft account and grant the permissions to the application.
+This plugin will redirect you to the Microsoft login page.
+Log in with your Microsoft account and grant the requested delegated permissions.
 
 Then you can use this plugin in a workflow to trigger it when you receive an email.

--- a/triggers/outlook_trigger/README.md
+++ b/triggers/outlook_trigger/README.md
@@ -37,7 +37,8 @@ Grant admin consent if your organization requires it.
 Fill in the `Client ID`, `Client Secret`, and `Tenant ID` fields.
 The `Tenant ID` value should match your account type choice: your tenant ID or domain, `organizations`, or `common`.
 
-You'll get a `redirect_url` in this dialog, copy it and go back to the Azure Entra ID page, head to `Authentication` page, select `Web` as the platform type, and paste the `redirect_url` in the `Redirect URIs` field.
+Copy the `redirect_url` from this dialog, then return to the Azure Entra ID page.
+Go to the `Authentication` page, select `Web` as the platform type, and paste the `redirect_url` into the `Redirect URIs` field.
 Click `Save`.
 
 Now you can go back to the Dify plugin configuration page and click `Save and authorize` to initiate the OAuth flow.

--- a/triggers/outlook_trigger/readme/README_ja_JP.md
+++ b/triggers/outlook_trigger/readme/README_ja_JP.md
@@ -12,35 +12,36 @@
 
 1. [Azure Portal](https://portal.azure.com/#home)にアクセスし、`App Registrations`に移動して新しいアプリケーションを作成します。
 
-![Azure Entra ID](./_assets/images/register_application_01.png)
-
 名前を入力し、テナントのセキュリティポリシーに合うサポート対象アカウントタイプを選択します。
 自社のみのアクセスにする場合は、シングルテナントを選択し、Dify に Directory tenant ID を入力します。
 組織アカウントのマルチテナントアクセスにする場合は、任意の組織ディレクトリのアカウントを選択し、Dify に `organizations` を入力します。
 個人の Microsoft アカウントが必要な場合だけ、個人アカウントを含むオプションを選択し、Dify に `common` を入力します。
 `Register`をクリックします。
 
-![Azure Entra ID](./_assets/images/register_application_02.png)
-
 2. `Overview`ページから`Application (client) ID`をコピーします。
 シングルテナントを選択した場合は、`Directory (tenant) ID`もコピーします。
 `Certificates & secrets`ページで新しいクライアントシークレットを生成し、値をコピーします。
 
-![Azure Entra ID](./_assets/images/get_credentials.png)
+3. API 権限を設定します。
+`API permissions`ページに移動します。
+次の Microsoft Graph 委任権限を追加します。
 
-3. Difyでこのプラグインをインストールして、設定ページを開きます。
+- `Mail.Read`（委任）
+- `offline_access`（委任）
 
-![Dify](./_assets/images/config_oauth_01.png)
+アプリケーション権限は不要です。
+組織で管理者の同意が必要な場合は、admin consent を付与します。
+
+4. Difyでこのプラグインをインストールして、設定ページを開きます。
 
 `Client ID`、`Client Secret`、`Tenant ID`フィールドに入力します。
 `Tenant ID`は、選択したアカウントタイプに合わせて、テナントIDまたはドメイン、`organizations`、`common`のいずれかにします。
 
 このダイアログで`redirect_url`が表示されるので、それをコピーしてAzure Entra IDページに戻り、`Authentication`ページに移動し、プラットフォームタイプとして`Web`を選択し、`Redirect URIs`フィールドに`redirect_url`を貼り付けます。`Save`をクリックします。
 
-![Dify](./_assets/images/config_oauth_02.png)
-
 これで、Difyプラグイン設定ページに戻り、`Save and authorize`をクリックしてOAuthフローを開始できます。
 
-このプラグインはMicrosoftログインページにリダイレクトされるので、Microsoftアカウントでログインし、アプリケーションに権限を付与します。
+このプラグインはMicrosoftログインページにリダイレクトします。
+Microsoftアカウントでログインし、要求された委任権限を付与します。
 
 これで、このプラグインをワークフローで使用して、メールを受信したときにトリガーできます。

--- a/triggers/outlook_trigger/readme/README_ja_JP.md
+++ b/triggers/outlook_trigger/readme/README_ja_JP.md
@@ -37,7 +37,10 @@
 `Client ID`、`Client Secret`、`Tenant ID`フィールドに入力します。
 `Tenant ID`は、選択したアカウントタイプに合わせて、テナントIDまたはドメイン、`organizations`、`common`のいずれかにします。
 
-このダイアログで`redirect_url`が表示されるので、それをコピーしてAzure Entra IDページに戻り、`Authentication`ページに移動し、プラットフォームタイプとして`Web`を選択し、`Redirect URIs`フィールドに`redirect_url`を貼り付けます。`Save`をクリックします。
+このダイアログに表示される`redirect_url`をコピーします。
+Azure Entra IDページに戻り、`Authentication`ページに移動します。
+プラットフォームの種類として`Web`を選択し、`Redirect URIs`フィールドにコピーした`redirect_url`を貼り付けます。
+最後に`Save`をクリックします。
 
 これで、Difyプラグイン設定ページに戻り、`Save and authorize`をクリックしてOAuthフローを開始できます。
 

--- a/triggers/outlook_trigger/readme/README_ja_JP.md
+++ b/triggers/outlook_trigger/readme/README_ja_JP.md
@@ -12,15 +12,21 @@
 
 1. [Azure Portal](https://portal.azure.com/#home)にアクセスし、`App Registrations`に移動して新しいアプリケーションを作成します。
 
+![Azure Entra ID](./_assets/images/register_application_01.png)
+
 名前を入力し、テナントのセキュリティポリシーに合うサポート対象アカウントタイプを選択します。
 自社のみのアクセスにする場合は、シングルテナントを選択し、Dify に Directory tenant ID を入力します。
 組織アカウントのマルチテナントアクセスにする場合は、任意の組織ディレクトリのアカウントを選択し、Dify に `organizations` を入力します。
 個人の Microsoft アカウントが必要な場合だけ、個人アカウントを含むオプションを選択し、Dify に `common` を入力します。
 `Register`をクリックします。
 
+![Azure Entra ID](./_assets/images/register_application_02.png)
+
 2. `Overview`ページから`Application (client) ID`をコピーします。
 シングルテナントを選択した場合は、`Directory (tenant) ID`もコピーします。
 `Certificates & secrets`ページで新しいクライアントシークレットを生成し、値をコピーします。
+
+![Azure Entra ID](./_assets/images/get_credentials.png)
 
 3. API 権限を設定します。
 `API permissions`ページに移動します。
@@ -34,6 +40,8 @@
 
 4. Difyでこのプラグインをインストールして、設定ページを開きます。
 
+![Dify](./_assets/images/config_oauth_01.png)
+
 `Client ID`、`Client Secret`、`Tenant ID`フィールドに入力します。
 `Tenant ID`は、選択したアカウントタイプに合わせて、テナントIDまたはドメイン、`organizations`、`common`のいずれかにします。
 
@@ -41,6 +49,8 @@
 Azure Entra IDページに戻り、`Authentication`ページに移動します。
 プラットフォームの種類として`Web`を選択し、`Redirect URIs`フィールドにコピーした`redirect_url`を貼り付けます。
 最後に`Save`をクリックします。
+
+![Dify](./_assets/images/config_oauth_02.png)
 
 これで、Difyプラグイン設定ページに戻り、`Save and authorize`をクリックしてOAuthフローを開始できます。
 

--- a/triggers/outlook_trigger/readme/README_zh_Hans.md
+++ b/triggers/outlook_trigger/readme/README_zh_Hans.md
@@ -12,15 +12,21 @@
 
 1. 进入 [Azure Portal](https://portal.azure.com/#home)，前往 `App Registrations` 并创建新应用程序。
 
+![Azure Entra ID](./_assets/images/register_application_01.png)
+
 填写名称，并根据租户安全策略选择支持的账户类型。
 如果只允许本公司访问，选择单租户，并在 Dify 中填写 Directory tenant ID。
 如果允许多企业组织账号访问，选择任意组织目录账号，并在 Dify 中填写 `organizations`。
 只有确实需要个人 Microsoft 账号时，才选择包含个人账号的选项，并在 Dify 中填写 `common`。
 点击 `Register`。
 
+![Azure Entra ID](./_assets/images/register_application_02.png)
+
 2. 从 `Overview` 页面复制 `Application (client) ID`。
 如果选择了单租户，也复制 `Directory (tenant) ID`。
 在 `Certificates & secrets` 页面生成新的客户端密钥并复制该值。
+
+![Azure Entra ID](./_assets/images/get_credentials.png)
 
 3. 配置 API 权限。
 进入 `API permissions` 页面。
@@ -34,12 +40,16 @@
 
 4. 在 Dify 中安装此插件并打开配置页面。
 
+![Dify](./_assets/images/config_oauth_01.png)
+
 填写 `Client ID`、`Client Secret` 和 `Tenant ID` 字段。
 `Tenant ID` 应与账户类型选择一致：租户 ID 或域名、`organizations` 或 `common`。
 
 复制此对话框中显示的 `redirect_url`，然后返回 Azure Entra ID 页面。
 前往 `Authentication` 页面，选择 `Web` 作为平台类型，并在 `Redirect URIs` 字段中粘贴该 `redirect_url`。
 点击 `Save`。
+
+![Dify](./_assets/images/config_oauth_02.png)
 
 现在您可以返回 Dify 插件配置页面并点击 `Save and authorize` 以启动 OAuth 流程。
 

--- a/triggers/outlook_trigger/readme/README_zh_Hans.md
+++ b/triggers/outlook_trigger/readme/README_zh_Hans.md
@@ -12,35 +12,36 @@
 
 1. 进入 [Azure Portal](https://portal.azure.com/#home)，前往 `App Registrations` 并创建新应用程序。
 
-![Azure Entra ID](./_assets/images/register_application_01.png)
-
 填写名称，并根据租户安全策略选择支持的账户类型。
 如果只允许本公司访问，选择单租户，并在 Dify 中填写 Directory tenant ID。
 如果允许多企业组织账号访问，选择任意组织目录账号，并在 Dify 中填写 `organizations`。
 只有确实需要个人 Microsoft 账号时，才选择包含个人账号的选项，并在 Dify 中填写 `common`。
 点击 `Register`。
 
-![Azure Entra ID](./_assets/images/register_application_02.png)
-
 2. 从 `Overview` 页面复制 `Application (client) ID`。
 如果选择了单租户，也复制 `Directory (tenant) ID`。
 在 `Certificates & secrets` 页面生成新的客户端密钥并复制该值。
 
-![Azure Entra ID](./_assets/images/get_credentials.png)
+3. 配置 API 权限。
+进入 `API permissions` 页面。
+添加以下 Microsoft Graph 委托权限：
 
-3. 在 Dify 中安装此插件并打开配置页面。
+- `Mail.Read`（委托）
+- `offline_access`（委托）
 
-![Dify](./_assets/images/config_oauth_01.png)
+不需要添加应用程序权限。
+如果您的组织要求管理员同意，请授予 admin consent。
+
+4. 在 Dify 中安装此插件并打开配置页面。
 
 填写 `Client ID`、`Client Secret` 和 `Tenant ID` 字段。
 `Tenant ID` 应与账户类型选择一致：租户 ID 或域名、`organizations` 或 `common`。
 
 您将在此对话框中获得 `redirect_url`，复制它并返回 Azure Entra ID 页面，前往 `Authentication` 页面，选择 `Web` 作为平台类型，在 `Redirect URIs` 字段中粘贴 `redirect_url`。点击 `Save`。
 
-![Dify](./_assets/images/config_oauth_02.png)
-
 现在您可以返回 Dify 插件配置页面并点击 `Save and authorize` 以启动 OAuth 流程。
 
-此插件将重定向您到 Microsoft 登录页面，使用您的 Microsoft 账户登录并授予应用程序权限。
+此插件将重定向您到 Microsoft 登录页面。
+请使用您的 Microsoft 账户登录并授予所请求的委托权限。
 
 然后您可以在工作流中使用此插件,在收到电子邮件时触发它。

--- a/triggers/outlook_trigger/readme/README_zh_Hans.md
+++ b/triggers/outlook_trigger/readme/README_zh_Hans.md
@@ -37,11 +37,13 @@
 填写 `Client ID`、`Client Secret` 和 `Tenant ID` 字段。
 `Tenant ID` 应与账户类型选择一致：租户 ID 或域名、`organizations` 或 `common`。
 
-您将在此对话框中获得 `redirect_url`，复制它并返回 Azure Entra ID 页面，前往 `Authentication` 页面，选择 `Web` 作为平台类型，在 `Redirect URIs` 字段中粘贴 `redirect_url`。点击 `Save`。
+复制此对话框中显示的 `redirect_url`，然后返回 Azure Entra ID 页面。
+前往 `Authentication` 页面，选择 `Web` 作为平台类型，并在 `Redirect URIs` 字段中粘贴该 `redirect_url`。
+点击 `Save`。
 
 现在您可以返回 Dify 插件配置页面并点击 `Save and authorize` 以启动 OAuth 流程。
 
-此插件将重定向您到 Microsoft 登录页面。
+此插件将您重定向到 Microsoft 登录页面。
 请使用您的 Microsoft 账户登录并授予所请求的委托权限。
 
 然后您可以在工作流中使用此插件,在收到电子邮件时触发它。


### PR DESCRIPTION
## Summary

- List the required Outlook trigger Microsoft Graph delegated permissions: `Mail.Read` and `offline_access`.
- Remove local screenshot references that render as 404 on the marketplace.
- Keep the English, Simplified Chinese, and Japanese setup docs aligned.

## Validation

- `git diff --check`
- Docs-only change; tests not run.