### PR TITLE
feat(notion): return retrieve_page image blocks as files output

### DIFF
--- a/tools/notion/manifest.yaml
+++ b/tools/notion/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 type: plugin
 author: langgenius
 name: notion

--- a/tools/notion/tests/test_retrieve_page.py
+++ b/tools/notion/tests/test_retrieve_page.py
@@ -17,6 +17,16 @@ class _Response:
         if self.status_code >= 400:
             raise Exception(f"HTTP {self.status_code}")
 
+    def iter_content(self, chunk_size=8192):
+        for i in range(0, len(self.content), chunk_size):
+            yield self.content[i : i + chunk_size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
 
 class _MessageToolMixin:
     def create_text_message(self, value):
@@ -99,6 +109,16 @@ def test_guess_image_mime_type_falls_back_to_url_extension():
     assert _guess_image_mime_type(response, "https://example.com/photo.gif?X-Amz=abc") == "image/gif"
 
 
+def test_guess_image_mime_type_falls_back_when_content_type_is_generic():
+    response = _Response(headers={"Content-Type": "application/octet-stream"})
+    assert _guess_image_mime_type(response, "https://example.com/photo.jpg") == "image/jpeg"
+
+
+def test_guess_image_mime_type_falls_back_when_content_type_is_not_an_image():
+    response = _Response(headers={"Content-Type": "text/html"})
+    assert _guess_image_mime_type(response, "https://example.com/photo.jpg") == "image/jpeg"
+
+
 def test_guess_image_mime_type_falls_back_to_default():
     response = _Response(headers={})
     assert _guess_image_mime_type(response, "https://example.com/no-extension") == "image/png"
@@ -116,8 +136,9 @@ def test_image_block_is_downloaded_and_returned_as_blob_message(monkeypatch):
     blocks = [_image_block("block-1", "https://s3.example.com/path/photo.png?X-Amz=abc", caption="A photo")]
     retrieve_page = _patch_notion(monkeypatch, blocks)
 
-    def fake_get(url, timeout=None):
+    def fake_get(url, timeout=None, stream=None):
         assert url == "https://s3.example.com/path/photo.png?X-Amz=abc"
+        assert stream is True
         return _Response(content=b"pngbytes", headers={"Content-Type": "image/png"})
 
     monkeypatch.setattr(retrieve_page.requests, "get", fake_get)
@@ -162,7 +183,7 @@ def test_max_images_limits_downloads_and_reports_skipped(monkeypatch):
     monkeypatch.setattr(
         retrieve_page.requests,
         "get",
-        lambda url, timeout=None: _Response(content=b"x", headers={"Content-Type": "image/png"}),
+        lambda url, timeout=None, stream=None: _Response(content=b"x", headers={"Content-Type": "image/png"}),
     )
 
     messages = list(_tool()._invoke({"page_id": "page-123", "max_images": 1}))
@@ -179,7 +200,7 @@ def test_failed_image_download_does_not_crash_others(monkeypatch):
     ]
     retrieve_page = _patch_notion(monkeypatch, blocks)
 
-    def fake_get(url, timeout=None):
+    def fake_get(url, timeout=None, stream=None):
         if "broken" in url:
             raise Exception("connection reset")
         return _Response(content=b"okbytes", headers={"Content-Type": "image/png"})
@@ -208,3 +229,62 @@ def test_page_without_images_yields_no_blob_messages(monkeypatch):
     messages = list(_tool()._invoke({"page_id": "page-123"}))
 
     assert not [m for m in messages if m["type"] == "blob"]
+
+
+def test_image_over_max_size_via_content_length_header_is_skipped(monkeypatch):
+    blocks = [_image_block("block-1", "https://s3.example.com/huge.png")]
+    retrieve_page = _patch_notion(monkeypatch, blocks)
+    monkeypatch.setattr(retrieve_page, "DEFAULT_MAX_IMAGE_SIZE", 10)
+
+    def fake_get(url, timeout=None, stream=None):
+        return _Response(
+            content=b"x" * 20,
+            headers={"Content-Type": "image/png", "Content-Length": "20"},
+        )
+
+    monkeypatch.setattr(retrieve_page.requests, "get", fake_get)
+
+    messages = list(_tool()._invoke({"page_id": "page-123"}))
+
+    assert not [m for m in messages if m["type"] == "blob"]
+    summary = next(m for m in messages if m["type"] == "text" and m["value"].startswith("Downloaded"))
+    assert summary["value"] == "Downloaded 0 image(s), 1 failed"
+
+
+def test_image_over_max_size_without_content_length_is_aborted_mid_stream(monkeypatch):
+    blocks = [_image_block("block-1", "https://s3.example.com/huge.png")]
+    retrieve_page = _patch_notion(monkeypatch, blocks)
+    monkeypatch.setattr(retrieve_page, "DEFAULT_MAX_IMAGE_SIZE", 10)
+
+    def fake_get(url, timeout=None, stream=None):
+        return _Response(content=b"x" * 20, headers={"Content-Type": "image/png"})
+
+    monkeypatch.setattr(retrieve_page.requests, "get", fake_get)
+
+    messages = list(_tool()._invoke({"page_id": "page-123"}))
+
+    assert not [m for m in messages if m["type"] == "blob"]
+
+
+def test_cumulative_size_limit_stops_further_downloads(monkeypatch):
+    blocks = [
+        _image_block("block-1", "https://s3.example.com/a.png"),
+        _image_block("block-2", "https://s3.example.com/b.png"),
+        _image_block("block-3", "https://s3.example.com/c.png"),
+    ]
+    retrieve_page = _patch_notion(monkeypatch, blocks)
+    monkeypatch.setattr(retrieve_page, "DEFAULT_MAX_IMAGE_SIZE", 10)
+    monkeypatch.setattr(retrieve_page, "DEFAULT_MAX_CUMULATIVE_IMAGE_SIZE", 15)
+
+    monkeypatch.setattr(
+        retrieve_page.requests,
+        "get",
+        lambda url, timeout=None, stream=None: _Response(content=b"x" * 10, headers={"Content-Type": "image/png"}),
+    )
+
+    messages = list(_tool()._invoke({"page_id": "page-123"}))
+
+    blob_messages = [m for m in messages if m["type"] == "blob"]
+    assert len(blob_messages) == 1
+    summary = next(m for m in messages if m["type"] == "text" and m["value"].startswith("Downloaded"))
+    assert summary["value"] == "Downloaded 1 image(s), 2 failed"

--- a/tools/notion/tests/test_retrieve_page.py
+++ b/tools/notion/tests/test_retrieve_page.py
@@ -1,0 +1,210 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.retrieve_page import RetrievePageTool, _guess_image_filename, _guess_image_mime_type
+
+
+class _Response:
+    def __init__(self, content=b"binarydata", headers=None, status_code=200):
+        self.content = content
+        self.headers = headers or {}
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+
+class _MessageToolMixin:
+    def create_text_message(self, value):
+        return {"type": "text", "value": value}
+
+    def create_json_message(self, value):
+        return {"type": "json", "value": value}
+
+    def create_blob_message(self, blob, meta=None):
+        return {"type": "blob", "blob": blob, "meta": meta}
+
+
+def _tool():
+    tool = object.__new__(RetrievePageTool)
+    tool.runtime = SimpleNamespace(credentials={"integration_token": "secret-token"})
+    for name in ("create_text_message", "create_json_message", "create_blob_message"):
+        setattr(tool, name, getattr(_MessageToolMixin, name).__get__(tool, RetrievePageTool))
+    return tool
+
+
+def _page_data():
+    return {
+        "id": "page-123",
+        "created_time": "2024-01-01T00:00:00.000Z",
+        "last_edited_time": "2024-01-02T00:00:00.000Z",
+        "archived": False,
+        "properties": {
+            "Name": {"type": "title", "title": [{"plain_text": "My Page"}]},
+        },
+    }
+
+
+def _image_block(block_id, url, caption=""):
+    return {
+        "id": block_id,
+        "type": "image",
+        "has_children": False,
+        "image": {
+            "type": "file",
+            "file": {"url": url},
+            "caption": [{"plain_text": caption}] if caption else [],
+        },
+    }
+
+
+def _paragraph_block(block_id, text):
+    return {
+        "id": block_id,
+        "type": "paragraph",
+        "has_children": False,
+        "paragraph": {"rich_text": [{"plain_text": text}]},
+    }
+
+
+def _patch_notion(monkeypatch, blocks):
+    from tools import retrieve_page
+    from tools.notion_client import NotionClient
+
+    monkeypatch.setattr(NotionClient, "retrieve_page", lambda self, page_id: _page_data())
+    monkeypatch.setattr(
+        NotionClient,
+        "retrieve_block_children",
+        lambda self, block_id, page_size=100, start_cursor=None: {
+            "results": blocks,
+            "has_more": False,
+            "next_cursor": None,
+        },
+    )
+    monkeypatch.setattr(NotionClient, "format_page_url", lambda self, page_id: f"https://notion.so/{page_id}")
+    return retrieve_page
+
+
+def test_guess_image_mime_type_prefers_content_type_header():
+    response = _Response(headers={"Content-Type": "image/jpeg; charset=binary"})
+    assert _guess_image_mime_type(response, "https://example.com/photo.jpg") == "image/jpeg"
+
+
+def test_guess_image_mime_type_falls_back_to_url_extension():
+    response = _Response(headers={})
+    assert _guess_image_mime_type(response, "https://example.com/photo.gif?X-Amz=abc") == "image/gif"
+
+
+def test_guess_image_mime_type_falls_back_to_default():
+    response = _Response(headers={})
+    assert _guess_image_mime_type(response, "https://example.com/no-extension") == "image/png"
+
+
+def test_guess_image_filename_uses_url_path_segment():
+    assert _guess_image_filename("https://example.com/a/b/photo.png?X-Amz=abc", "block-1", "image/png") == "photo.png"
+
+
+def test_guess_image_filename_falls_back_to_block_id():
+    assert _guess_image_filename("https://example.com/", "block-1", "image/jpeg") == "block-1.jpg"
+
+
+def test_image_block_is_downloaded_and_returned_as_blob_message(monkeypatch):
+    blocks = [_image_block("block-1", "https://s3.example.com/path/photo.png?X-Amz=abc", caption="A photo")]
+    retrieve_page = _patch_notion(monkeypatch, blocks)
+
+    def fake_get(url, timeout=None):
+        assert url == "https://s3.example.com/path/photo.png?X-Amz=abc"
+        return _Response(content=b"pngbytes", headers={"Content-Type": "image/png"})
+
+    monkeypatch.setattr(retrieve_page.requests, "get", fake_get)
+
+    messages = list(_tool()._invoke({"page_id": "page-123"}))
+
+    blob_messages = [m for m in messages if m["type"] == "blob"]
+    assert len(blob_messages) == 1
+    assert blob_messages[0]["blob"] == b"pngbytes"
+    assert blob_messages[0]["meta"] == {"mime_type": "image/png", "filename": "photo.png"}
+
+    json_message = next(m for m in messages if m["type"] == "json")
+    image_block = json_message["value"]["content"][0]
+    assert image_block["url"] == "https://s3.example.com/path/photo.png?X-Amz=abc"
+    assert image_block["caption"] == "A photo"
+
+
+def test_include_content_false_skips_image_download(monkeypatch):
+    blocks = [_image_block("block-1", "https://s3.example.com/path/photo.png")]
+    retrieve_page = _patch_notion(monkeypatch, blocks)
+
+    def fake_get(*args, **kwargs):
+        raise AssertionError("Should not download images when include_content is False")
+
+    monkeypatch.setattr(retrieve_page.requests, "get", fake_get)
+
+    messages = list(_tool()._invoke({"page_id": "page-123", "include_content": False}))
+
+    assert not [m for m in messages if m["type"] == "blob"]
+    json_message = next(m for m in messages if m["type"] == "json")
+    assert "content" not in json_message["value"]
+
+
+def test_max_images_limits_downloads_and_reports_skipped(monkeypatch):
+    blocks = [
+        _image_block("block-1", "https://s3.example.com/a.png"),
+        _image_block("block-2", "https://s3.example.com/b.png"),
+        _image_block("block-3", "https://s3.example.com/c.png"),
+    ]
+    retrieve_page = _patch_notion(monkeypatch, blocks)
+
+    monkeypatch.setattr(
+        retrieve_page.requests,
+        "get",
+        lambda url, timeout=None: _Response(content=b"x", headers={"Content-Type": "image/png"}),
+    )
+
+    messages = list(_tool()._invoke({"page_id": "page-123", "max_images": 1}))
+
+    assert len([m for m in messages if m["type"] == "blob"]) == 1
+    json_message = next(m for m in messages if m["type"] == "json")
+    assert json_message["value"]["images_skipped"] == 2
+
+
+def test_failed_image_download_does_not_crash_others(monkeypatch):
+    blocks = [
+        _image_block("block-1", "https://s3.example.com/broken.png"),
+        _image_block("block-2", "https://s3.example.com/ok.png"),
+    ]
+    retrieve_page = _patch_notion(monkeypatch, blocks)
+
+    def fake_get(url, timeout=None):
+        if "broken" in url:
+            raise Exception("connection reset")
+        return _Response(content=b"okbytes", headers={"Content-Type": "image/png"})
+
+    monkeypatch.setattr(retrieve_page.requests, "get", fake_get)
+
+    messages = list(_tool()._invoke({"page_id": "page-123"}))
+
+    blob_messages = [m for m in messages if m["type"] == "blob"]
+    assert len(blob_messages) == 1
+    assert blob_messages[0]["blob"] == b"okbytes"
+
+    summary = next(m for m in messages if m["type"] == "text" and m["value"].startswith("Downloaded"))
+    assert summary["value"] == "Downloaded 1 image(s), 1 failed"
+
+
+def test_page_without_images_yields_no_blob_messages(monkeypatch):
+    blocks = [_paragraph_block("block-1", "Just text, no images here")]
+    retrieve_page = _patch_notion(monkeypatch, blocks)
+
+    def fake_get(*args, **kwargs):
+        raise AssertionError("Should not attempt any download when there are no images")
+
+    monkeypatch.setattr(retrieve_page.requests, "get", fake_get)
+
+    messages = list(_tool()._invoke({"page_id": "page-123"}))
+
+    assert not [m for m in messages if m["type"] == "blob"]

--- a/tools/notion/tools/retrieve_page.py
+++ b/tools/notion/tools/retrieve_page.py
@@ -15,6 +15,9 @@ DEFAULT_MAX_API_CALLS = 500
 DEFAULT_MAX_IMAGES = 20
 DEFAULT_IMAGE_DOWNLOAD_TIMEOUT = 30
 DEFAULT_IMAGE_MIME_TYPE = "image/png"
+DEFAULT_MAX_IMAGE_SIZE = 15 * 1024 * 1024  # 15MB per image
+DEFAULT_MAX_CUMULATIVE_IMAGE_SIZE = 100 * 1024 * 1024  # 100MB per retrieval
+IMAGE_DOWNLOAD_CHUNK_SIZE = 8192
 
 # Block types whose "children" are separate pages/databases, not nested content
 # of the current page. Recursing into them would silently pull in arbitrary
@@ -123,17 +126,26 @@ class RetrievePageTool(Tool):
                 # signed URLs, so we must fetch them now rather than later.
                 images_downloaded = 0
                 images_failed = 0
+                total_downloaded_bytes = 0
                 for image in collected_images:
+                    if total_downloaded_bytes >= DEFAULT_MAX_CUMULATIVE_IMAGE_SIZE:
+                        images_failed += 1
+                        continue
                     try:
-                        response = requests.get(image["url"], timeout=DEFAULT_IMAGE_DOWNLOAD_TIMEOUT)
-                        response.raise_for_status()
-                        mime_type = _guess_image_mime_type(response, image["url"])
-                        filename = _guess_image_filename(image["url"], image["block_id"], mime_type)
+                        blob, mime_type, filename = _download_image(
+                            image["url"],
+                            image["block_id"],
+                            max_bytes=min(
+                                DEFAULT_MAX_IMAGE_SIZE,
+                                DEFAULT_MAX_CUMULATIVE_IMAGE_SIZE - total_downloaded_bytes,
+                            ),
+                        )
                         yield self.create_blob_message(
-                            blob=response.content,
+                            blob=blob,
                             meta={"mime_type": mime_type, "filename": filename},
                         )
                         images_downloaded += 1
+                        total_downloaded_bytes += len(blob)
                     except Exception:
                         images_failed += 1
                 if images_downloaded or images_failed:
@@ -361,12 +373,34 @@ def _coerce_positive_int(value: Any, default: int) -> int:
     return max(coerced, 0)
 
 
+def _download_image(url: str, block_id: str, max_bytes: int) -> tuple[bytes, str, str]:
+    """Stream-download an image, aborting once it exceeds max_bytes so a single
+    huge or malicious response can't exhaust the plugin's memory budget."""
+    with requests.get(url, timeout=DEFAULT_IMAGE_DOWNLOAD_TIMEOUT, stream=True) as response:
+        response.raise_for_status()
+
+        content_length = response.headers.get("Content-Length")
+        if content_length and int(content_length) > max_bytes:
+            raise ValueError(f"Image at {url} exceeds the {max_bytes}-byte download limit")
+
+        content = bytearray()
+        for chunk in response.iter_content(chunk_size=IMAGE_DOWNLOAD_CHUNK_SIZE):
+            content.extend(chunk)
+            if len(content) > max_bytes:
+                raise ValueError(f"Image at {url} exceeds the {max_bytes}-byte download limit")
+
+        mime_type = _guess_image_mime_type(response, url)
+        filename = _guess_image_filename(url, block_id, mime_type)
+        return bytes(content), mime_type, filename
+
+
 def _guess_image_mime_type(response: requests.Response, url: str) -> str:
     """Determine mime type from the response's Content-Type header, falling back
-    to guessing from the URL's file extension, then a hardcoded default."""
+    to guessing from the URL's file extension when the header is missing, generic,
+    or not an image type, then a hardcoded default."""
     content_type = response.headers.get("Content-Type", "")
-    mime_type = content_type.split(";")[0].strip()
-    if mime_type:
+    mime_type = content_type.split(";")[0].strip().lower()
+    if mime_type and mime_type != "application/octet-stream" and mime_type.startswith("image/"):
         return mime_type
     guessed_type, _ = mimetypes.guess_type(urlparse(url).path)
     return guessed_type or DEFAULT_IMAGE_MIME_TYPE

--- a/tools/notion/tools/retrieve_page.py
+++ b/tools/notion/tools/retrieve_page.py
@@ -1,6 +1,8 @@
+import mimetypes
 import time
 from collections.abc import Generator
 from typing import Any, Dict, List
+from urllib.parse import urlparse
 import requests
 
 from dify_plugin import Tool
@@ -10,6 +12,9 @@ from tools.notion_client import NotionClient
 
 DEFAULT_MAX_DEPTH = 5
 DEFAULT_MAX_API_CALLS = 500
+DEFAULT_MAX_IMAGES = 20
+DEFAULT_IMAGE_DOWNLOAD_TIMEOUT = 30
+DEFAULT_IMAGE_MIME_TYPE = "image/png"
 
 # Block types whose "children" are separate pages/databases, not nested content
 # of the current page. Recursing into them would silently pull in arbitrary
@@ -51,6 +56,9 @@ class RetrievePageTool(Tool):
         # max_api_calls must be at least 1 so the initial page fetch can run.
         if max_api_calls < 1:
             max_api_calls = 1
+        max_images = _coerce_positive_int(
+            tool_parameters.get("max_images"), DEFAULT_MAX_IMAGES
+        )
 
         # Validate parameters
         if not page_id:
@@ -76,12 +84,14 @@ class RetrievePageTool(Tool):
                 formatted_page = self._format_page_data(client, page_data)
 
                 budget = _FetchBudget(max_api_calls=max_api_calls)
+                collected_images: List[Dict[str, Any]] = []
                 # Retrieve page content if requested
                 if include_content:
                     try:
                         all_blocks = self._fetch_all_children(client, page_id, budget)
                         formatted_page["content"] = self._format_blocks(
-                            client, all_blocks, budget, depth=0, max_depth=max_depth
+                            client, all_blocks, budget, collected_images,
+                            depth=0, max_depth=max_depth, max_images=max_images,
                         )
                     except requests.HTTPError as e:
                         # If we can't get the content, just return the page data
@@ -99,11 +109,38 @@ class RetrievePageTool(Tool):
                     formatted_page["fetch_truncated_reason"] = (
                         f"max_api_calls={max_api_calls} exceeded; increase the limit or raise max_depth with care."
                     )
+                if len(collected_images) > max_images:
+                    formatted_page["images_skipped"] = len(collected_images) - max_images
+                    collected_images = collected_images[:max_images]
 
                 # Return results
                 title = formatted_page.get("title", "Untitled")
                 yield self.create_text_message(f"Retrieved page: {title}")
                 yield self.create_json_message(formatted_page)
+
+                # Download image blocks so they surface in the tool's `files`
+                # output. Notion image URLs are short-lived (~1 hour) S3
+                # signed URLs, so we must fetch them now rather than later.
+                images_downloaded = 0
+                images_failed = 0
+                for image in collected_images:
+                    try:
+                        response = requests.get(image["url"], timeout=DEFAULT_IMAGE_DOWNLOAD_TIMEOUT)
+                        response.raise_for_status()
+                        mime_type = _guess_image_mime_type(response, image["url"])
+                        filename = _guess_image_filename(image["url"], image["block_id"], mime_type)
+                        yield self.create_blob_message(
+                            blob=response.content,
+                            meta={"mime_type": mime_type, "filename": filename},
+                        )
+                        images_downloaded += 1
+                    except Exception:
+                        images_failed += 1
+                if images_downloaded or images_failed:
+                    yield self.create_text_message(
+                        f"Downloaded {images_downloaded} image(s)"
+                        + (f", {images_failed} failed" if images_failed else "")
+                    )
 
             except requests.HTTPError as e:
                 if e.response.status_code == 404:
@@ -203,8 +240,10 @@ class RetrievePageTool(Tool):
         client: NotionClient,
         blocks: List[Dict[str, Any]],
         budget: "_FetchBudget",
+        collected_images: List[Dict[str, Any]],
         depth: int = 0,
         max_depth: int = DEFAULT_MAX_DEPTH,
+        max_images: int = DEFAULT_MAX_IMAGES,
     ) -> List[Dict[str, Any]]:
         """Format block content for the response, recursing into nested children."""
         formatted_blocks = []
@@ -278,6 +317,13 @@ class RetrievePageTool(Tool):
 
                 formatted_block["caption"] = caption_text
                 formatted_block["url"] = image_url
+
+                if image_url:
+                    collected_images.append({
+                        "block_id": block_id,
+                        "url": image_url,
+                        "caption": caption_text,
+                    })
             else:
                 # For unsupported block types, just include the type
                 formatted_block["text"] = f"<{block_type} block>"
@@ -294,7 +340,8 @@ class RetrievePageTool(Tool):
                     try:
                         child_blocks = self._fetch_all_children(client, block_id, budget)
                         formatted_block["children"] = self._format_blocks(
-                            client, child_blocks, budget, depth=depth + 1, max_depth=max_depth
+                            client, child_blocks, budget, collected_images,
+                            depth=depth + 1, max_depth=max_depth, max_images=max_images,
                         )
                     except requests.HTTPError as e:
                         # Record per-block failure but keep the rest of the page intact
@@ -312,3 +359,25 @@ def _coerce_positive_int(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         return default
     return max(coerced, 0)
+
+
+def _guess_image_mime_type(response: requests.Response, url: str) -> str:
+    """Determine mime type from the response's Content-Type header, falling back
+    to guessing from the URL's file extension, then a hardcoded default."""
+    content_type = response.headers.get("Content-Type", "")
+    mime_type = content_type.split(";")[0].strip()
+    if mime_type:
+        return mime_type
+    guessed_type, _ = mimetypes.guess_type(urlparse(url).path)
+    return guessed_type or DEFAULT_IMAGE_MIME_TYPE
+
+
+def _guess_image_filename(url: str, block_id: str, mime_type: str) -> str:
+    """Derive a filename from the URL path, falling back to the block ID with
+    an extension guessed from the mime type."""
+    path = urlparse(url).path
+    filename = path.rstrip("/").split("/")[-1] if path else ""
+    if filename:
+        return filename
+    extension = mimetypes.guess_extension(mime_type) or ".png"
+    return f"{block_id}{extension}"

--- a/tools/notion/tools/retrieve_page.yaml
+++ b/tools/notion/tools/retrieve_page.yaml
@@ -14,7 +14,7 @@ description:
     pt_BR: Recuperar uma página do Notion pelo seu ID
     ja_JP: ID で Notion ページを取得します
     zh_Hant: 通過 ID 獲取 Notion 頁面
-  llm: Retrieve a Notion page by its ID. Returns page content (recursively including nested child blocks like toggles, callouts, and list sub-items), properties, and metadata. The page must be shared with your integration. Large or deeply nested pages may take several seconds and multiple API calls; use max_depth / max_api_calls to cap cost. The response includes api_calls_made, total_blocks_fetched, and elapsed_seconds for observability, and sets fetch_truncated=true when the budget was hit.
+  llm: Retrieve a Notion page by its ID. Returns page content (recursively including nested child blocks like toggles, callouts, and list sub-items), properties, and metadata. The page must be shared with your integration. Large or deeply nested pages may take several seconds and multiple API calls; use max_depth / max_api_calls to cap cost. The response includes api_calls_made, total_blocks_fetched, and elapsed_seconds for observability, and sets fetch_truncated=true when the budget was hit. Image blocks found in the content are also downloaded and returned as files (array[file]), up to max_images, so they can be passed directly to vision-capable models.
 parameters:
   - name: page_id
     type: string
@@ -86,6 +86,24 @@ parameters:
       ja_JP: "1 回の取得で発行する Notion API 呼び出し数の上限。Notion のレート制限は約 3 req/sec のため、500 回で最大約 3 分かかります。厳しいタイムアウト要件があれば下げてください。上限到達時は部分結果を fetch_truncated=true 付きで返します。"
       zh_Hant: "單次擷取允許的 Notion API 呼叫次數上限。Notion 速率限制約 3 req/sec，500 次約 3 分鐘；可依 SLA 調低。達到上限時回傳部分內容並標記 fetch_truncated=true。"
     llm_description: Safety cap on total Notion API calls for this retrieval. Default 500 (~3 min at Notion's rate limit). If exceeded, the response returns partial content with fetch_truncated=true. Lower this when running in latency-sensitive contexts.
+    form: llm
+  - name: max_images
+    type: number
+    required: false
+    default: 20
+    label:
+      en_US: Max Images
+      zh_Hans: 最大图片数
+      pt_BR: Máximo de Imagens
+      ja_JP: 最大画像数
+      zh_Hant: 最大圖片數
+    human_description:
+      en_US: "Safety cap on the number of image blocks downloaded and returned as files per retrieval. Images beyond this limit are still listed in the content JSON but are not downloaded."
+      zh_Hans: "单次请求下载并作为文件返回的图片块数量上限。超出上限的图片仍会列在内容 JSON 中，但不会被下载。"
+      pt_BR: "Limite de segurança para o número de blocos de imagem baixados e retornados como arquivos por recuperação. Imagens além deste limite ainda são listadas no JSON de conteúdo, mas não são baixadas."
+      ja_JP: "1 回の取得で画像ブロックをダウンロードしファイルとして返す数の上限。上限を超えた画像はコンテンツ JSON には引き続き掲載されますが、ダウンロードは行われません。"
+      zh_Hant: "單次擷取下載並作為檔案回傳的圖片區塊數量上限。超出上限的圖片仍會列在內容 JSON 中，但不會被下載。"
+    llm_description: Safety cap on the number of image blocks downloaded and returned as files for this retrieval. Default 20. Images beyond this limit remain listed in the content JSON (url/caption) but are not downloaded as files.
     form: llm
 extra:
   python:


### PR DESCRIPTION
## Summary

Fixes #3415

`retrieve_page` only exposed image blocks as plain JSON (`{"type": "image", "url": "...", "caption": "..."}`) inside the `content` array, so the tool's reserved `files` (array[file]) output was always empty. Notion's image URLs are short-lived (~1 hour) S3 presigned URLs, so consuming them (e.g. feeding an LLM Vision node) required a manual "extract URL from JSON → HTTP Request → Iteration" workaround in every workflow.

This PR downloads image blocks inline (while the signed URL is still valid) and emits them via `create_blob_message`, so they land directly in the tool's `files` output. The existing `content` JSON structure (`type`/`url`/`caption`) is unchanged — this is purely additive.

- Added `max_images` parameter (default 20) capping how many images are downloaded per retrieval; images beyond the cap stay listed in `content` but aren't downloaded, and the count is reported as `images_skipped` in the JSON output.
- Per-image download failures are caught individually and don't fail the whole tool call; a summary text message reports how many succeeded/failed.
- `include_content=false` skips image collection entirely (no `_format_blocks` call), so no extra downloads happen.
- mime type is read from the response's `Content-Type` header, falling back to guessing from the URL extension, then a hardcoded default; filename is taken from the URL path, falling back to the block ID.

## Change Type

- [x] Non-LLM plugin (tools, extensions, datasource, etc.)

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| `files` output always empty; image URLs only reachable via manual JSON parsing + HTTP Request + Iteration | `files` output contains the downloaded images directly, ready for an LLM Vision node or any other file-consuming node |

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.12 → 0.0.13
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — no dependency changes were needed for this change; `pyproject.toml`/`uv.lock` are untouched.

## Testing

- [x] Local deployment — Dify version: manually verified end-to-end in a real Dify instance (retrieve_page now returns downloaded images in `files`, confirmed working with an LLM Vision node)
- Added `tools/notion/tests/test_retrieve_page.py` (10 tests, all passing) covering: image block download → blob message + `files` output, `include_content=false` skipping downloads, `max_images` capping + `images_skipped` reporting, per-image download failure isolation, and mime-type/filename fallback logic. These tests run automatically in this repo's `pre-pr-check-per-plugin` CI workflow.
