### PR TITLE
feat(aihubmix): align with Anthropic official plugin v0.3.24

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.36
+version: 0.0.37
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/_position.yaml
+++ b/models/aihubmix/models/llm/_position.yaml
@@ -1,3 +1,16 @@
+- gpt-5.6-sol
+- gpt-5.6-luna
+- gpt-5.6-terra
+- grok-4.5
+- claude-sonnet-5
+- glm-5.2
+- claude-fable-5
+- claude-opus-4-8
+- claude-opus-4-8-think
+- hy3
+- doubao-seed-2-1-pro
+- doubao-seed-2-1-turbo
+- grok-build-0.1
 - qwen3.7-max
 - gemini-3.5-flash
 - grok-4.3

--- a/models/aihubmix/models/llm/anthropic.py
+++ b/models/aihubmix/models/llm/anthropic.py
@@ -1351,12 +1351,14 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             return []
 
         if isinstance(message.content, str):
+            if not message.content.strip():
+                return []
             return [self._create_assistant_text_content(message.content)]
 
         return [
             self._create_assistant_text_content(content.data)
             for content in message.content
-            if isinstance(content, TextPromptMessageContent)
+            if isinstance(content, TextPromptMessageContent) and content.data and content.data.strip()
         ]
 
     def _create_tool_use_content(self, tool_call: AssistantPromptMessage.ToolCall) -> dict:

--- a/models/aihubmix/models/llm/anthropic.py
+++ b/models/aihubmix/models/llm/anthropic.py
@@ -53,9 +53,17 @@ ANTHROPIC_BLOCK_MODE_PROMPT = 'You should always follow the instructions and out
 
 
 class PromptCachingHandler:
-    def __init__(self, prompt_messages: Sequence[PromptMessage], enable_system_cache: bool = False):
+    CACHE_CONTROL_TYPE = "ephemeral"
+
+    def __init__(
+        self,
+        prompt_messages: Sequence[PromptMessage],
+        enable_system_cache: bool = False,
+        cache_control: Optional[dict[str, str]] = None,
+    ):
         self.prompt_messages = prompt_messages
         self.enable_system_cache = enable_system_cache
+        self._cache_control = cache_control or {"type": self.CACHE_CONTROL_TYPE}
 
     def get_system_prompt(self) -> Union[str, list[dict]]:
         system_components = []
@@ -84,9 +92,9 @@ class PromptCachingHandler:
                     cached_content = part[len('<cache>'):-len('</cache>')]
                     if cached_content:
                         system_components.append({
-                "type": "text",
+                            "type": "text",
                             "text": cached_content,
-                "cache_control": {"type": "ephemeral"}
+                            "cache_control": self._cache_control,
                         })
                 elif part:
                     system_components.append({
@@ -106,10 +114,8 @@ class PromptCachingHandler:
         return system
 
     # --- Pricing Helpers -------------------------------------------------
-    # Cache write incurs a 25% premium (1.25×) on the written tokens
-    # Cache read receives a 90% discount (0.1×) on the read tokens
-
-    CACHE_WRITE_MULTIPLIER: float = 1.25
+    CACHE_WRITE_5M_MULTIPLIER: float = 1.25
+    CACHE_WRITE_1H_MULTIPLIER: float = 2.0
     CACHE_READ_MULTIPLIER: float = 0.1
 
     @classmethod
@@ -118,20 +124,17 @@ class PromptCachingHandler:
         base_prompt_tokens: int,
         cache_creation_input_tokens: int = 0,
         cache_read_input_tokens: int = 0,
+        cache_creation_5m_input_tokens: int = 0,
+        cache_creation_1h_input_tokens: int = 0,
+        cache_creation_fallback_multiplier: float = CACHE_WRITE_5M_MULTIPLIER,
     ) -> int:
-        """Return billing-adjusted prompt tokens.
-
-        Args:
-            base_prompt_tokens: The raw prompt tokens counted by the API.
-            cache_creation_input_tokens: Tokens written to cache in this request.
-            cache_read_input_tokens: Tokens read from cache in this request.
-        Returns:
-            int: Adjusted prompt tokens to be billed.
-        """
         adjusted = base_prompt_tokens
 
-        if cache_creation_input_tokens > 0:
-            adjusted += int(cache_creation_input_tokens * cls.CACHE_WRITE_MULTIPLIER)
+        if cache_creation_5m_input_tokens > 0 or cache_creation_1h_input_tokens > 0:
+            adjusted += int(cache_creation_5m_input_tokens * cls.CACHE_WRITE_5M_MULTIPLIER)
+            adjusted += int(cache_creation_1h_input_tokens * cls.CACHE_WRITE_1H_MULTIPLIER)
+        elif cache_creation_input_tokens > 0:
+            adjusted += int(cache_creation_input_tokens * cache_creation_fallback_multiplier)
 
         if cache_read_input_tokens > 0:
             adjusted += int(cache_read_input_tokens * cls.CACHE_READ_MULTIPLIER)
@@ -140,17 +143,90 @@ class PromptCachingHandler:
 
 
 class AnthropicLargeLanguageModel(LargeLanguageModel):
+    PROMPT_CACHING_TTL_PARAMETER = "prompt_caching_ttl"
+    VALID_PROMPT_CACHING_TTLS = {"5m", "1h"}
+
+    ADAPTIVE_THINKING_MODELS: tuple[str, ...] = (
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+        "claude-fable-5",
+    )
+    ALWAYS_ON_ADAPTIVE_THINKING_MODELS: tuple[str, ...] = (
+        "claude-fable-5",
+    )
+    TASK_BUDGET_SUPPORTED_MODELS: tuple[str, ...] = (
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-fable-5",
+    )
+    ADAPTIVE_THINKING_DEFAULT_ON_MODELS: tuple[str, ...] = (
+        "claude-sonnet-5",
+    )
+
     def __init__(self, model_schemas=None):
         super().__init__(model_schemas or [])
         self.previous_thinking_blocks = []
         self.previous_redacted_thinking_blocks = []
-        # Flag to indicate whether tool definitions should include cache_control
         self._tool_cache_enabled = False
         self._system_cache_enabled = False
         self._image_cache_enabled = False
         self._document_cache_enabled = False
         self._tool_results_cache_enabled = False
         self._message_flow_cache_threshold: int = 0
+        self._prompt_cache_ttl: Optional[str] = None
+
+    def _resolve_prompt_cache_ttl(
+        self,
+        model: str,
+        model_parameters: dict[str, Any],
+    ) -> Optional[str]:
+        ttl = model_parameters.pop(self.PROMPT_CACHING_TTL_PARAMETER, None)
+        if isinstance(ttl, str) and ttl in self.VALID_PROMPT_CACHING_TTLS:
+            return ttl
+        return None
+
+    def _cache_control(self) -> dict[str, str]:
+        cc = {"type": PromptCachingHandler.CACHE_CONTROL_TYPE}
+        if self._prompt_cache_ttl:
+            cc["ttl"] = self._prompt_cache_ttl
+        return cc
+
+    def _cache_write_fallback_multiplier(self) -> float:
+        if self._prompt_cache_ttl == "1h":
+            return PromptCachingHandler.CACHE_WRITE_1H_MULTIPLIER
+        return PromptCachingHandler.CACHE_WRITE_5M_MULTIPLIER
+
+    @staticmethod
+    def _get_cache_creation_input_tokens_by_ttl(usage: Any) -> tuple[int, int]:
+        cache_creation = getattr(usage, "cache_creation", None)
+        if not cache_creation:
+            return 0, 0
+        if isinstance(cache_creation, Mapping):
+            return (
+                int(cache_creation.get("ephemeral_5m_input_tokens") or 0),
+                int(cache_creation.get("ephemeral_1h_input_tokens") or 0),
+            )
+        return (
+            int(getattr(cache_creation, "ephemeral_5m_input_tokens", 0) or 0),
+            int(getattr(cache_creation, "ephemeral_1h_input_tokens", 0) or 0),
+        )
+
+    def _uses_adaptive_thinking(self, model: str) -> bool:
+        model_id = (model or "").lower()
+        return any(model_id.startswith(prefix) for prefix in self.ADAPTIVE_THINKING_MODELS)
+
+    def _has_always_on_adaptive_thinking(self, model: str) -> bool:
+        model_id = (model or "").lower()
+        return any(model_id.startswith(prefix) for prefix in self.ALWAYS_ON_ADAPTIVE_THINKING_MODELS)
+
+    def _has_adaptive_thinking_default_on(self, model: str) -> bool:
+        model_id = (model or "").lower()
+        return any(model_id.startswith(prefix) for prefix in self.ADAPTIVE_THINKING_DEFAULT_ON_MODELS)
+
+    def _supports_task_budget(self, model: str) -> bool:
+        model_id = (model or "").lower()
+        return any(model_id.startswith(prefix) for prefix in self.TASK_BUDGET_SUPPORTED_MODELS)
 
     def _invoke(
         self,
@@ -230,19 +306,66 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             else:
                 model_parameters["max_tokens"] = 4096
 
-        thinking = model_parameters.pop("thinking", False)
+        _THINKING_SENTINEL = object()
+        thinking = model_parameters.pop("thinking", _THINKING_SENTINEL)
+        thinking_was_set = thinking is not _THINKING_SENTINEL
+        if thinking is _THINKING_SENTINEL:
+            thinking = False
         thinking_budget = model_parameters.pop("thinking_budget", 1024)
         context_1m = model_parameters.pop("context_1m", False)
-        
-        if thinking:
-            extra_model_kwargs["thinking"] = {
-                "type": "enabled",
-                "budget_tokens": thinking_budget
-            }
+
+        uses_adaptive_thinking = self._uses_adaptive_thinking(model)
+        always_on_adaptive_thinking = self._has_always_on_adaptive_thinking(model)
+        adaptive_thinking_default_on = self._has_adaptive_thinking_default_on(model)
+        thinking_display = model_parameters.pop(
+            "thinking_display",
+            "omitted" if uses_adaptive_thinking else "summarized",
+        )
+        effort = model_parameters.pop("effort", None)
+        task_budget = int(model_parameters.pop("task_budget", 0) or 0)
+
+        if uses_adaptive_thinking:
             for key in ("temperature", "top_p", "top_k"):
                 model_parameters.pop(key, None)
 
-        if context_1m:
+            if always_on_adaptive_thinking:
+                extra_model_kwargs["thinking"] = {
+                    "type": "adaptive",
+                    "display": thinking_display or "omitted",
+                }
+            elif thinking:
+                extra_model_kwargs["thinking"] = {
+                    "type": "adaptive",
+                    "display": thinking_display or "omitted",
+                }
+            elif adaptive_thinking_default_on and thinking_was_set:
+                extra_model_kwargs["thinking"] = {"type": "disabled"}
+
+            output_config: dict[str, Any] = {}
+            if effort:
+                output_config["effort"] = effort
+            if task_budget >= 20000 and self._supports_task_budget(model):
+                output_config["task_budget"] = {
+                    "type": "tokens",
+                    "total": task_budget,
+                }
+                extra_headers["anthropic-beta"] = (
+                    extra_headers["anthropic-beta"] + ",task-budgets-2026-03-13"
+                    if "anthropic-beta" in extra_headers
+                    else "task-budgets-2026-03-13"
+                )
+            if output_config:
+                extra_model_kwargs["output_config"] = output_config
+        else:
+            if thinking:
+                extra_model_kwargs["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": thinking_budget,
+                }
+                for key in ("temperature", "top_p", "top_k"):
+                    model_parameters.pop(key, None)
+
+        if context_1m and not uses_adaptive_thinking:
             if "anthropic-beta" in extra_headers:
                 extra_headers["anthropic-beta"] += ",context-1m-2025-08-07"
             else:
@@ -255,18 +378,13 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             else:
                 extra_headers["anthropic-beta"] = "output-128k-2025-02-19"
 
-        if model == "claude-3-7-sonnet-20250219" and tools:
-            if "anthropic-beta" in extra_headers:
-                extra_headers["anthropic-beta"] += ",token-efficient-tools-2025-02-19"
-            else:
-                extra_headers["anthropic-beta"] = "token-efficient-tools-2025-02-19"
-
         if stop:
             extra_model_kwargs["stop_sequences"] = stop
         if user:
             extra_model_kwargs["metadata"] = completion_create_params.Metadata(
                 user_id=user
             )
+        self._prompt_cache_ttl = self._resolve_prompt_cache_ttl(model, model_parameters)
         self._tool_cache_enabled = model_parameters.pop("prompt_caching_tool_definitions", True)
         self._system_cache_enabled = model_parameters.pop("prompt_caching_system_message", True)
         self._image_cache_enabled = model_parameters.pop("prompt_caching_images", True)
@@ -511,7 +629,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             "name": tool.name,
             "description": tool.description,
             "input_schema": input_schema,
-            **({"cache_control": {"type": "ephemeral"}} if getattr(self, "_tool_cache_enabled", False) else {}),
+            **({"cache_control": self._cache_control()} if getattr(self, "_tool_cache_enabled", False) else {}),
         }
 
     def _transform_chat_json_prompts(
@@ -529,21 +647,26 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         """
         Transform json prompts
         """
+        stop = stop or []
         if "```\n" not in stop:
             stop.append("```\n")
         if "\n```" not in stop:
             stop.append("\n```")
+        # Adaptive-thinking models reject assistant prefill with 400 -- rely on system prompt only.
+        supports_prefill = not self._uses_adaptive_thinking(model)
+
         if len(prompt_messages) > 0 and isinstance(
             prompt_messages[0], SystemPromptMessage
         ):
             prompt_messages[0] = SystemPromptMessage(
                 content=ANTHROPIC_BLOCK_MODE_PROMPT.replace(
-                    "{{instructions}}", prompt_messages[0].content
+                    "{{instructions}}", str(prompt_messages[0].content)
                 ).replace("{{block}}", response_format)
             )
-            prompt_messages.append(
-                AssistantPromptMessage(content=f"\n```{response_format}")
-            )
+            if supports_prefill:
+                prompt_messages.append(
+                    AssistantPromptMessage(content=f"\n```{response_format}")
+                )
         else:
             prompt_messages.insert(
                 0,
@@ -554,9 +677,10 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     ).replace("{{block}}", response_format)
                 ),
             )
-            prompt_messages.append(
-                AssistantPromptMessage(content=f"\n```{response_format}")
-            )
+            if supports_prefill:
+                prompt_messages.append(
+                    AssistantPromptMessage(content=f"\n```{response_format}")
+                )
 
     def get_num_tokens(
         self,
@@ -598,10 +722,13 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 break
         
         if has_thinking_blocks:
-            count_tokens_args["thinking"] = {
-                "type": "enabled",
-                "budget_tokens": 4096
-            }
+            if self._uses_adaptive_thinking(model):
+                count_tokens_args["thinking"] = {"type": "adaptive"}
+            else:
+                count_tokens_args["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": 4096,
+                }
         
         if system:
             count_tokens_args["system"] = system
@@ -674,16 +801,14 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 assistant_prompt_message.tool_calls.append(tool_call)
         
         prompt_tokens = (
-            response.usage
-            and response.usage.input_tokens
-            or self.get_num_tokens(
+            response.usage.input_tokens if response.usage else
+            self.get_num_tokens(
                 model=model, credentials=credentials, prompt_messages=prompt_messages
             )
         )
         completion_tokens = (
-            response.usage
-            and response.usage.output_tokens
-            or self.get_num_tokens(
+            response.usage.output_tokens if response.usage else
+            self.get_num_tokens(
                 model=model,
                 credentials=credentials,
                 prompt_messages=[assistant_prompt_message],
@@ -693,16 +818,24 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         # Adjust prompt tokens for cache operations
         cache_creation_input_tokens = 0
         cache_read_input_tokens = 0
+        cache_creation_5m_input_tokens = 0
+        cache_creation_1h_input_tokens = 0
         if response.usage:
             if hasattr(response.usage, "cache_creation_input_tokens") and response.usage.cache_creation_input_tokens:
                 cache_creation_input_tokens = response.usage.cache_creation_input_tokens
             if hasattr(response.usage, "cache_read_input_tokens") and response.usage.cache_read_input_tokens:
                 cache_read_input_tokens = response.usage.cache_read_input_tokens
+            cache_creation_5m_input_tokens, cache_creation_1h_input_tokens = (
+                self._get_cache_creation_input_tokens_by_ttl(response.usage)
+            )
 
         adjusted_prompt_tokens = PromptCachingHandler.calc_adjusted_prompt_tokens(
             prompt_tokens,
             cache_creation_input_tokens,
             cache_read_input_tokens,
+            cache_creation_5m_input_tokens,
+            cache_creation_1h_input_tokens,
+            self._cache_write_fallback_multiplier(),
         )
 
         usage = super()._calc_response_usage(
@@ -744,7 +877,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         
         current_tool_name = None
         current_tool_id = None
-        current_tool_params = ""
+        tool_params_by_id: dict[str, str] = {}
         
         if not any(isinstance(msg, ToolPromptMessage) for msg in prompt_messages):
             self.previous_thinking_blocks = []
@@ -756,7 +889,9 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         # Cache token tracking
         cache_creation_input_tokens = 0
         cache_read_input_tokens = 0
-        
+        cache_creation_5m_input_tokens = 0
+        cache_creation_1h_input_tokens = 0
+
         for chunk in response:
             logging.info(f"Anthropic API Stream Response Chunk: {chunk.model_dump_json()}")
             if isinstance(chunk, MessageStartEvent):
@@ -767,6 +902,9 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                         cache_creation_input_tokens = chunk.message.usage.cache_creation_input_tokens
                     if hasattr(chunk.message.usage, "cache_read_input_tokens") and chunk.message.usage.cache_read_input_tokens:
                         cache_read_input_tokens = chunk.message.usage.cache_read_input_tokens
+                    cache_creation_5m_input_tokens, cache_creation_1h_input_tokens = (
+                        self._get_cache_creation_input_tokens_by_ttl(chunk.message.usage)
+                    )
             elif hasattr(chunk, "type") and chunk.type == "content_block_start":
                 if hasattr(chunk, "content_block"):
                     content_block = chunk.content_block
@@ -776,6 +914,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                         current_tool_id = getattr(content_block, 'id', None)
                         
                         if current_tool_name and current_tool_id:
+                            tool_params_by_id[current_tool_id] = ""
                             tool_call = AssistantPromptMessage.ToolCall(
                                 id=current_tool_id,
                                 type="function",
@@ -799,17 +938,17 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 if hasattr(chunk.delta, "type") and chunk.delta.type == "input_json_delta":
                     if hasattr(chunk.delta, "partial_json"):
                         partial_json = chunk.delta.partial_json
-                        if partial_json:
-                            current_tool_params += partial_json
-                            
+                        if partial_json and current_tool_id and current_tool_id in tool_params_by_id:
+                            tool_params_by_id[current_tool_id] += partial_json
+
                             for tc in tool_calls:
                                 if tc.id == current_tool_id:
-                                    tc.function.arguments = current_tool_params
+                                    tc.function.arguments = tool_params_by_id[current_tool_id]
                                     break
                 
                 if chunk.index != current_block_index:
-                    if current_block_type == "thinking" and current_block_index is not None:
-                        assistant_prompt_message = AssistantPromptMessage(content="\n</think>")
+                    if current_block_type in ("thinking", "redacted_thinking") and current_block_index is not None:
+                        assistant_prompt_message = AssistantPromptMessage(content="\n</think>\n\n")
                         yield LLMResultChunk(
                             model=return_model,
                             prompt_messages=prompt_messages,
@@ -892,9 +1031,12 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     cache_creation_input_tokens = chunk.usage.cache_creation_input_tokens
                 if hasattr(chunk.usage, "cache_read_input_tokens") and chunk.usage.cache_read_input_tokens:
                     cache_read_input_tokens = chunk.usage.cache_read_input_tokens
+                cache_creation_5m_input_tokens, cache_creation_1h_input_tokens = (
+                    self._get_cache_creation_input_tokens_by_ttl(chunk.usage)
+                )
             elif isinstance(chunk, MessageStopEvent):
-                if current_block_type == "thinking" and current_block_index is not None:
-                    assistant_prompt_message = AssistantPromptMessage(content="\n</think>")
+                if current_block_type in ("thinking", "redacted_thinking") and current_block_index is not None:
+                    assistant_prompt_message = AssistantPromptMessage(content="\n</think>\n\n")
                     yield LLMResultChunk(
                         model=return_model,
                         prompt_messages=prompt_messages,
@@ -903,12 +1045,13 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                         ),
                     )
                 
-                if current_tool_name and current_tool_id and current_tool_params and not tool_calls:
+                fallback_params = tool_params_by_id.get(current_tool_id or "", "")
+                if current_tool_name and current_tool_id and fallback_params and not tool_calls:
                     fallback_tool_call = AssistantPromptMessage.ToolCall(
                         id=current_tool_id,
                         type="function",
                         function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                            name=current_tool_name, arguments=current_tool_params
+                            name=current_tool_name, arguments=fallback_params
                         ),
                     )
                     tool_calls.append(fallback_tool_call)
@@ -923,6 +1066,9 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     input_tokens,
                     cache_creation_input_tokens,
                     cache_read_input_tokens,
+                    cache_creation_5m_input_tokens,
+                    cache_creation_1h_input_tokens,
+                    self._cache_write_fallback_multiplier(),
                 )
                 
                 usage = super()._calc_response_usage(
@@ -979,8 +1125,9 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         making the code more maintainable and following Fluent Python principles.
         """
         caching_handler = PromptCachingHandler(
-            prompt_messages, 
-            enable_system_cache=self._system_cache_enabled
+            prompt_messages,
+            enable_system_cache=self._system_cache_enabled,
+            cache_control=self._cache_control(),
         )
         system = caching_handler.get_system_prompt()
         
@@ -1043,7 +1190,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 "content": [{
                     "type": "text",
                     "text": text,
-                    "cache_control": {"type": "ephemeral"}
+                    "cache_control": self._cache_control(),
                 }]
             }
         return {"role": "user", "content": text}
@@ -1085,7 +1232,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             "text": content.data
         }
         if self._should_cache_text(content.data):
-            result["cache_control"] = {"type": "ephemeral"}
+            result["cache_control"] = self._cache_control()
         return result
     
     def _create_image_content(self, content: ImagePromptMessageContent) -> dict:
@@ -1110,7 +1257,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         }
         
         if self._image_cache_enabled:
-            result["cache_control"] = {"type": "ephemeral"}
+            result["cache_control"] = self._cache_control()
         
         return result
     
@@ -1165,7 +1312,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         }
         
         if self._document_cache_enabled:
-            result["cache_control"] = {"type": "ephemeral"}
+            result["cache_control"] = self._cache_control()
         
         return result
     
@@ -1186,18 +1333,32 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             content.extend(self.previous_thinking_blocks)
             content.extend(self.previous_redacted_thinking_blocks)
         
-        # Process tool calls or content
+        # Dify stores assistant text and tool calls separately; Anthropic expects the next
+        # user tool_result message to immediately follow the assistant tool_use turn.
+        # Keep assistant prose before tool_use so no text lands between tool_use and tool_result.
+        # https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
+        content.extend(self._create_assistant_text_contents(message))
         if message.tool_calls:
             content.extend(
                 self._create_tool_use_content(tool_call)
                 for tool_call in message.tool_calls
             )
-        elif message.content:
-            if isinstance(message.content, str):
-                content.append(self._create_assistant_text_content(message.content))
-        
+
         return {"role": "assistant", "content": content}
     
+    def _create_assistant_text_contents(self, message: AssistantPromptMessage) -> list[dict]:
+        if not message.content:
+            return []
+
+        if isinstance(message.content, str):
+            return [self._create_assistant_text_content(message.content)]
+
+        return [
+            self._create_assistant_text_content(content.data)
+            for content in message.content
+            if isinstance(content, TextPromptMessageContent)
+        ]
+
     def _create_tool_use_content(self, tool_call: AssistantPromptMessage.ToolCall) -> dict:
         """Create tool use content dict."""
         result = {
@@ -1208,7 +1369,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         }
         
         if self._tool_results_cache_enabled:
-            result["cache_control"] = {"type": "ephemeral"}
+            result["cache_control"] = self._cache_control()
         
         return result
     
@@ -1218,7 +1379,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             return {
                 "type": "text",
                 "text": text,
-                "cache_control": {"type": "ephemeral"}
+                "cache_control": self._cache_control(),
             }
         return {"type": "text", "text": text}
     
@@ -1231,7 +1392,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         }
         
         if self._tool_results_cache_enabled:
-            tool_result_content["cache_control"] = {"type": "ephemeral"}
+            tool_result_content["cache_control"] = self._cache_control()
         
         return {
             "role": "user",

--- a/models/aihubmix/models/llm/anthropic.py
+++ b/models/aihubmix/models/llm/anthropic.py
@@ -658,9 +658,16 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         if len(prompt_messages) > 0 and isinstance(
             prompt_messages[0], SystemPromptMessage
         ):
+            raw = prompt_messages[0].content
+            if isinstance(raw, list):
+                instructions = "\n".join(
+                    c.data for c in raw if isinstance(c, TextPromptMessageContent)
+                )
+            else:
+                instructions = str(raw or "")
             prompt_messages[0] = SystemPromptMessage(
                 content=ANTHROPIC_BLOCK_MODE_PROMPT.replace(
-                    "{{instructions}}", str(prompt_messages[0].content)
+                    "{{instructions}}", instructions
                 ).replace("{{block}}", response_format)
             )
             if supports_prefill:

--- a/models/aihubmix/models/llm/claude-fable-5.yaml
+++ b/models/aihubmix/models/llm/claude-fable-5.yaml
@@ -1,28 +1,17 @@
-model: claude-opus-4-7-think
+model: claude-fable-5
 label:
-  en_US: Claude Opus 4.7 Thinking
+  en_US: Claude Fable 5
 model_type: llm
 features:
   - agent-thought
+  - vision
   - tool-call
   - stream-tool-call
-  - multi-tool-call
-  - vision
   - document
 model_properties:
   mode: chat
   context_size: 1000000
 parameter_rules:
-  - name: thinking
-    label:
-      zh_Hans: 自适应推理
-      en_US: Adaptive Thinking
-    type: boolean
-    default: true
-    required: false
-    help:
-      zh_Hans: 启用自适应推理（adaptive thinking）。Claude Opus 4.7 仅支持 adaptive 模式，不再支持设置 thinking_budget。推理深度由 Effort 参数控制。此 -think 变体默认开启。
-      en_US: Enable adaptive thinking. Claude Opus 4.7 only supports adaptive mode; thinking_budget is no longer supported. Thinking depth is controlled by the Effort parameter. This -think variant defaults to enabled.
   - name: thinking_display
     label:
       zh_Hans: 推理内容展示
@@ -34,8 +23,9 @@ parameter_rules:
       - omitted
       - summarized
     help:
-      zh_Hans: 响应中推理内容的展示方式。omitted 为官方默认值（响应中不返回 thinking 文本）；summarized 返回摘要化的推理过程，便于在前端展示思考进度。
-      en_US: How thinking content is exposed in the response. `omitted` is the official default (thinking text not returned); `summarized` returns summarized reasoning so clients can display progress.
+      zh_Hans: Claude Fable 5 的 adaptive thinking 始终开启。此参数仅控制响应中推理内容的展示方式：omitted 为官方默认值（响应中不返回 thinking 文本）；summarized 返回摘要化的推理过程，便于在前端展示思考进度。
+      en_US: |
+        Claude Fable 5 always runs with adaptive thinking. This only controls how thinking content is exposed in the response: `omitted` is the official default (thinking text not returned); `summarized` returns summarized reasoning so clients can display progress.
   - name: effort
     label:
       zh_Hans: 推理投入等级
@@ -74,21 +64,12 @@ parameter_rules:
         · ≥20000: enabled and the `task-budgets-2026-03-13` beta header is attached automatically. Overly tight budgets can cause the model to wrap up prematurely.
   - name: max_tokens
     use_template: max_tokens
-    default: 8192
+    required: true
+    default: 128000
     min: 1
-    max: 32000
+    max: 128000
   - name: response_format
-    label:
-      zh_Hans: 回复格式
-      en_US: Response Format
-    type: string
-    required: false
-    options:
-      - text
-      - json_object
-      - json_schema
-  - name: json_schema
-    use_template: json_schema
+    use_template: response_format
   - name: prompt_caching_message_flow
     label:
       zh_Hans: 大消息自动缓存阈值
@@ -114,56 +95,56 @@ parameter_rules:
       en_US: Controls prompt caching cache_control.ttl. 5m is the default duration; 1h extends cache lifetime but has a higher cache write cost.
   - name: prompt_caching_system_message
     label:
-      zh_Hans: 系统提示缓存
+      zh_Hans: 缓存系统消息
       en_US: Cache System Message
     type: boolean
     default: true
     required: false
     help:
-      zh_Hans: 开启后自动为系统提示添加缓存控制。
-      en_US: Automatically add cache_control to the system message.
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
   - name: prompt_caching_images
     label:
-      zh_Hans: 图片缓存
+      zh_Hans: 缓存图片
       en_US: Cache Images
     type: boolean
     default: true
     required: false
     help:
-      zh_Hans: 开启后自动为图片添加缓存控制。
-      en_US: Automatically add cache_control to image content blocks.
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
   - name: prompt_caching_documents
     label:
-      zh_Hans: 文档缓存
+      zh_Hans: 缓存文档
       en_US: Cache Documents
     type: boolean
     default: true
     required: false
     help:
-      zh_Hans: 开启后自动为文档添加缓存控制。
-      en_US: Automatically add cache_control to document content blocks.
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
   - name: prompt_caching_tool_definitions
     label:
-      zh_Hans: 工具定义缓存
+      zh_Hans: 缓存工具定义
       en_US: Cache Tool Definitions
     type: boolean
     default: true
     required: false
     help:
-      zh_Hans: 开启后自动为工具定义添加缓存控制。
-      en_US: Automatically add cache_control to tool definitions.
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
   - name: prompt_caching_tool_results
     label:
-      zh_Hans: 工具结果缓存
+      zh_Hans: 缓存工具结果
       en_US: Cache Tool Results
     type: boolean
     default: true
     required: false
     help:
-      zh_Hans: 开启后自动为工具调用结果添加缓存控制。
-      en_US: Automatically add cache_control to tool result content blocks.
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
 pricing:
-  input: '5'
-  output: '25'
+  input: '11'
+  output: '55'
   unit: '0.000001'
   currency: USD

--- a/models/aihubmix/models/llm/claude-haiku-4-5.yaml
+++ b/models/aihubmix/models/llm/claude-haiku-4-5.yaml
@@ -8,9 +8,10 @@ features:
   - stream-tool-call
   - multi-tool-call
   - vision
+  - document
 model_properties:
   mode: chat
-  context_size: 204800
+  context_size: 200000
 parameter_rules:
   - name: thinking
     label:
@@ -52,6 +53,79 @@ parameter_rules:
       - json_schema
   - name: json_schema
     use_template: json_schema
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_ttl
+    label:
+      zh_Hans: 缓存有效期
+      en_US: Cache TTL
+    type: string
+    default: 5m
+    required: true
+    options:
+      - 5m
+      - 1h
+    help:
+      zh_Hans: 控制 prompt caching 的 cache_control.ttl。5m 为默认有效期；1h 可延长缓存有效期，但缓存写入成本更高。
+      en_US: Controls prompt caching cache_control.ttl. 5m is the default duration; 1h extends cache lifetime but has a higher cache write cost.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 系统提示缓存
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 开启后自动为系统提示添加缓存控制。
+      en_US: Automatically add cache_control to the system message.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 图片缓存
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 开启后自动为图片添加缓存控制。
+      en_US: Automatically add cache_control to image content blocks.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 文档缓存
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 开启后自动为文档添加缓存控制。
+      en_US: Automatically add cache_control to document content blocks.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 工具定义缓存
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 开启后自动为工具定义添加缓存控制。
+      en_US: Automatically add cache_control to tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 工具结果缓存
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 开启后自动为工具调用结果添加缓存控制。
+      en_US: Automatically add cache_control to tool result content blocks.
 pricing:
   input: '1.1'
   output: '5.5'

--- a/models/aihubmix/models/llm/claude-opus-4-5-think.yaml
+++ b/models/aihubmix/models/llm/claude-opus-4-5-think.yaml
@@ -8,6 +8,7 @@ features:
   - stream-tool-call
   - multi-tool-call
   - vision
+  - document
 model_properties:
   mode: chat
   context_size: 200000

--- a/models/aihubmix/models/llm/claude-opus-4-5.yaml
+++ b/models/aihubmix/models/llm/claude-opus-4-5.yaml
@@ -8,6 +8,7 @@ features:
   - stream-tool-call
   - multi-tool-call
   - vision
+  - document
 model_properties:
   mode: chat
   context_size: 200000

--- a/models/aihubmix/models/llm/claude-opus-4-6-think.yaml
+++ b/models/aihubmix/models/llm/claude-opus-4-6-think.yaml
@@ -10,7 +10,7 @@ features:
   - vision
 model_properties:
   mode: chat
-  context_size: 200000
+  context_size: 1000000
 parameter_rules:
   - name: temperature
     use_template: temperature

--- a/models/aihubmix/models/llm/claude-opus-4-6.yaml
+++ b/models/aihubmix/models/llm/claude-opus-4-6.yaml
@@ -10,7 +10,7 @@ features:
   - document
 model_properties:
   mode: chat
-  context_size: 200000
+  context_size: 1000000
 parameter_rules:
   - name: thinking
     label:

--- a/models/aihubmix/models/llm/claude-opus-4-7.yaml
+++ b/models/aihubmix/models/llm/claude-opus-4-7.yaml
@@ -8,12 +8,73 @@ features:
   - stream-tool-call
   - multi-tool-call
   - vision
+  - document
 model_properties:
   mode: chat
-  context_size: 200000
+  context_size: 1000000
 parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 自适应推理
+      en_US: Adaptive Thinking
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 启用自适应推理（adaptive thinking）。Claude Opus 4.7 仅支持 adaptive 模式，不再支持设置 thinking_budget。推理深度由 Effort 参数控制。
+      en_US: Enable adaptive thinking. Claude Opus 4.7 only supports adaptive mode; thinking_budget is no longer supported. Thinking depth is controlled by the Effort parameter.
+  - name: thinking_display
+    label:
+      zh_Hans: 推理内容展示
+      en_US: Thinking Display
+    type: string
+    default: summarized
+    required: false
+    options:
+      - omitted
+      - summarized
+    help:
+      zh_Hans: 响应中推理内容的展示方式。omitted 为官方默认值（响应中不返回 thinking 文本）；summarized 返回摘要化的推理过程，便于在前端展示思考进度。
+      en_US: How thinking content is exposed in the response. `omitted` is the official default (thinking text not returned); `summarized` returns summarized reasoning so clients can display progress.
+  - name: effort
+    label:
+      zh_Hans: 推理投入等级
+      en_US: Effort
+    type: string
+    default: high
+    required: false
+    options:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    help:
+      zh_Hans: 通过 output_config.effort 控制智能/token 消耗的权衡。xhigh 推荐用于编码与智能体场景，high 是智能敏感场景的最低建议值；low 与 medium 适合延迟或成本敏感场景。
+      en_US: Controls the intelligence vs. token cost trade-off via output_config.effort. Use `xhigh` for coding and agentic tasks; `high` is the minimum recommendation for intelligence-sensitive tasks; `low`/`medium` for latency- or cost-sensitive tasks.
+  - name: task_budget
+    label:
+      zh_Hans: 任务预算
+      en_US: Task Budget
+    type: int
+    default: 0
+    min: 0
+    max: 1000000
+    required: false
+    help:
+      zh_Hans: |
+        跨完整智能体循环（推理+工具调用+工具结果+最终输出）下发给模型的建议性 token 预算。这是"建议"（模型可见并据此自我调度），不是硬上限；真正的硬上限由 max_tokens 控制。
+        · 0（默认）：不发送该字段 → 模型看不到预算倒计时，按 max_tokens 自由发挥，适合质量优先的开放式任务。这不是"无上限"，而是"不启用预算建议"。
+        · <20000：插件会静默忽略（API 要求最小 20000，避免 400）。
+        · ≥20000：启用并自动追加 beta 头 `task-budgets-2026-03-13`；预算过紧可能导致模型潦草收尾。
+      en_US: |
+        Advisory token budget visible to the model across the full agentic loop (thinking + tool calls + tool results + final output). This is advisory — the hard per-request cap is `max_tokens`.
+        · 0 (default): field is not sent → model runs without a countdown, bounded only by `max_tokens`. Recommended for open-ended agentic tasks where quality matters more than speed. "0" means "no budget hint", NOT "unlimited".
+        · <20000: silently ignored by the plugin (API requires a minimum of 20000 and would otherwise return 400).
+        · ≥20000: enabled and the `task-budgets-2026-03-13` beta header is attached automatically. Overly tight budgets can cause the model to wrap up prematurely.
   - name: max_tokens
     use_template: max_tokens
+    required: true
     default: 128000
     min: 1
     max: 128000
@@ -39,6 +100,19 @@ parameter_rules:
     help:
       zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
       en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_ttl
+    label:
+      zh_Hans: 缓存有效期
+      en_US: Cache TTL
+    type: string
+    default: 5m
+    required: true
+    options:
+      - 5m
+      - 1h
+    help:
+      zh_Hans: 控制 prompt caching 的 cache_control.ttl。5m 为默认有效期；1h 可延长缓存有效期，但缓存写入成本更高。
+      en_US: Controls prompt caching cache_control.ttl. 5m is the default duration; 1h extends cache lifetime but has a higher cache write cost.
   - name: prompt_caching_system_message
     label:
       zh_Hans: 系统提示缓存

--- a/models/aihubmix/models/llm/claude-opus-4-8-think.yaml
+++ b/models/aihubmix/models/llm/claude-opus-4-8-think.yaml
@@ -1,6 +1,6 @@
-model: claude-opus-4-7-think
+model: claude-opus-4-8-think
 label:
-  en_US: Claude Opus 4.7 Thinking
+  en_US: Claude Opus 4.8 Thinking
 model_type: llm
 features:
   - agent-thought
@@ -21,8 +21,8 @@ parameter_rules:
     default: true
     required: false
     help:
-      zh_Hans: 启用自适应推理（adaptive thinking）。Claude Opus 4.7 仅支持 adaptive 模式，不再支持设置 thinking_budget。推理深度由 Effort 参数控制。此 -think 变体默认开启。
-      en_US: Enable adaptive thinking. Claude Opus 4.7 only supports adaptive mode; thinking_budget is no longer supported. Thinking depth is controlled by the Effort parameter. This -think variant defaults to enabled.
+      zh_Hans: 启用自适应推理（adaptive thinking）。Claude Opus 4.8 仅支持 adaptive 模式，不再支持设置 thinking_budget。推理深度由 Effort 参数控制。此 -think 变体默认开启。
+      en_US: Enable adaptive thinking. Claude Opus 4.8 only supports adaptive mode; thinking_budget is no longer supported. Thinking depth is controlled by the Effort parameter. This -think variant defaults to enabled.
   - name: thinking_display
     label:
       zh_Hans: 推理内容展示

--- a/models/aihubmix/models/llm/claude-opus-4-8.yaml
+++ b/models/aihubmix/models/llm/claude-opus-4-8.yaml
@@ -1,13 +1,13 @@
-model: claude-opus-4-7-think
+model: claude-opus-4-8
 label:
-  en_US: Claude Opus 4.7 Thinking
+  en_US: Claude Opus 4.8
 model_type: llm
 features:
   - agent-thought
+  - vision
   - tool-call
   - stream-tool-call
   - multi-tool-call
-  - vision
   - document
 model_properties:
   mode: chat
@@ -18,11 +18,11 @@ parameter_rules:
       zh_Hans: 自适应推理
       en_US: Adaptive Thinking
     type: boolean
-    default: true
+    default: false
     required: false
     help:
-      zh_Hans: 启用自适应推理（adaptive thinking）。Claude Opus 4.7 仅支持 adaptive 模式，不再支持设置 thinking_budget。推理深度由 Effort 参数控制。此 -think 变体默认开启。
-      en_US: Enable adaptive thinking. Claude Opus 4.7 only supports adaptive mode; thinking_budget is no longer supported. Thinking depth is controlled by the Effort parameter. This -think variant defaults to enabled.
+      zh_Hans: 启用自适应推理（adaptive thinking）。Claude Opus 4.8 仅支持 adaptive 模式，不再支持设置 thinking_budget。推理深度由 Effort 参数控制。
+      en_US: Enable adaptive thinking. Claude Opus 4.8 only supports adaptive mode; thinking_budget is no longer supported. Thinking depth is controlled by the Effort parameter.
   - name: thinking_display
     label:
       zh_Hans: 推理内容展示
@@ -74,9 +74,10 @@ parameter_rules:
         · ≥20000: enabled and the `task-budgets-2026-03-13` beta header is attached automatically. Overly tight budgets can cause the model to wrap up prematurely.
   - name: max_tokens
     use_template: max_tokens
-    default: 8192
+    required: true
+    default: 128000
     min: 1
-    max: 32000
+    max: 128000
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/models/aihubmix/models/llm/claude-sonnet-5.yaml
+++ b/models/aihubmix/models/llm/claude-sonnet-5.yaml
@@ -1,0 +1,145 @@
+model: claude-sonnet-5
+label:
+  en_US: Claude Sonnet 5
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 自适应推理
+      en_US: Adaptive Thinking
+    type: boolean
+    default: true
+    required: true
+    help:
+      zh_Hans: |
+        Claude Sonnet 5 默认启用自适应推理，推理深度由 Effort 参数控制。
+        开启此项时，插件会发送 `thinking.type=adaptive`，并按"推理内容展示"返回或省略推理内容。
+        关闭此项时，插件会显式发送 `thinking.type=disabled`，完全关闭推理以获得最低延迟与成本。
+      en_US: |
+        Claude Sonnet 5 runs adaptive thinking by default; depth is controlled by the Effort parameter.
+        When enabled, the plugin sends `thinking.type=adaptive` and uses Thinking Display to return or omit thinking content.
+        When disabled, the plugin explicitly sends `thinking.type=disabled` to completely turn off reasoning for the lowest latency and cost.
+  - name: thinking_display
+    label:
+      zh_Hans: 推理内容展示
+      en_US: Thinking Display
+    type: string
+    default: omitted
+    required: true
+    options:
+      - omitted
+      - summarized
+    help:
+      zh_Hans: 响应中推理内容的展示方式。omitted 为官方默认值（响应中不返回 thinking 文本）；summarized 返回摘要化的推理过程，便于在前端展示思考进度。
+      en_US: How thinking content is exposed in the response. `omitted` is the official default (thinking text not returned); `summarized` returns summarized reasoning so clients can display progress.
+  - name: effort
+    label:
+      zh_Hans: 推理投入等级
+      en_US: Effort
+    type: string
+    default: high
+    required: true
+    options:
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    help:
+      zh_Hans: 通过 output_config.effort 控制智能/token 消耗的权衡。high 是官方默认值，适合复杂推理、编码与智能体场景；xhigh 适合最困难的长程编码与智能体任务；low 与 medium 适合延迟或成本敏感场景。
+      en_US: Controls the intelligence vs. token cost trade-off via output_config.effort. `high` is the official default for complex reasoning, coding, and agentic tasks; use `xhigh` for the hardest long-running coding and agentic tasks; use `low`/`medium` for latency- or cost-sensitive workloads.
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    default: 128000
+    min: 1
+    max: 128000
+  - name: response_format
+    use_template: response_format
+  - name: prompt_caching_message_flow
+    label:
+      zh_Hans: 大消息自动缓存阈值
+      en_US: Cache Message Flow Threshold
+    type: int
+    default: 0
+    required: false
+    help:
+      zh_Hans: 当用户或助手消息的单词数超过此阈值时，自动为该消息添加缓存控制。0 表示禁用。
+      en_US: If a user or assistant message exceeds this word count, add cache_control automatically. 0 disables the feature.
+  - name: prompt_caching_ttl
+    label:
+      zh_Hans: 缓存有效期
+      en_US: Cache TTL
+    type: string
+    default: 5m
+    required: true
+    options:
+      - 5m
+      - 1h
+    help:
+      zh_Hans: 控制 prompt caching 的 cache_control.ttl。5m 为默认有效期；1h 可延长缓存有效期，但缓存写入成本更高。
+      en_US: Controls prompt caching cache_control.ttl. 5m is the default duration; 1h extends cache lifetime but has a higher cache write cost.
+  - name: prompt_caching_system_message
+    label:
+      zh_Hans: 缓存系统消息
+      en_US: Cache System Message
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用系统消息的提示缓存。<cache></cache>中的内容将自动缓存。
+      en_US: Enable prompt caching for system messages. Content within <cache></cache> will be cached.
+  - name: prompt_caching_images
+    label:
+      zh_Hans: 缓存图片
+      en_US: Cache Images
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用图片的提示缓存。
+      en_US: Enable prompt caching for images.
+  - name: prompt_caching_documents
+    label:
+      zh_Hans: 缓存文档
+      en_US: Cache Documents
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用文档的提示缓存。
+      en_US: Enable prompt caching for documents.
+  - name: prompt_caching_tool_definitions
+    label:
+      zh_Hans: 缓存工具定义
+      en_US: Cache Tool Definitions
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具定义的提示缓存。
+      en_US: Enable prompt caching for tool definitions.
+  - name: prompt_caching_tool_results
+    label:
+      zh_Hans: 缓存工具结果
+      en_US: Cache Tool Results
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 启用工具结果的提示缓存。
+      en_US: Enable prompt caching for tool results.
+pricing:
+  input: '2'
+  output: '10'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/doubao-seed-2-1-pro.yaml
+++ b/models/aihubmix/models/llm/doubao-seed-2-1-pro.yaml
@@ -1,0 +1,60 @@
+model: doubao-seed-2-1-pro
+label:
+  en_US: Doubao Seed 2.1 Pro
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+  - vision
+  - video
+model_properties:
+  mode: chat
+  context_size: 256000
+parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: thinking_budget
+    label:
+      zh_Hans: 推理预算
+      en_US: Thinking Budget
+    type: int
+    default: 1024
+    min: 0
+    max: 32000
+    required: false
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.9295'
+  output: '4.6475'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/doubao-seed-2-1-turbo.yaml
+++ b/models/aihubmix/models/llm/doubao-seed-2-1-turbo.yaml
@@ -1,0 +1,60 @@
+model: doubao-seed-2-1-turbo
+label:
+  en_US: Doubao Seed 2.1 Turbo
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+  - vision
+  - video
+model_properties:
+  mode: chat
+  context_size: 256000
+parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: thinking_budget
+    label:
+      zh_Hans: 推理预算
+      en_US: Thinking Budget
+    type: int
+    default: 1024
+    min: 0
+    max: 32000
+    required: false
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.46475'
+  output: '2.32375'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/glm-5.2.yaml
+++ b/models/aihubmix/models/llm/glm-5.2.yaml
@@ -1,0 +1,58 @@
+model: glm-5.2
+label:
+  en_US: GLM 5.2
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: thinking_budget
+    label:
+      zh_Hans: 推理预算
+      en_US: Thinking Budget
+    type: int
+    default: 1024
+    min: 0
+    max: 32000
+    required: false
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '1.1268'
+  output: '3.9438'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/gpt-5.6-luna.yaml
+++ b/models/aihubmix/models/llm/gpt-5.6-luna.yaml
@@ -1,0 +1,91 @@
+model: gpt-5.6-luna
+label:
+  en_US: GPT 5.6 Luna
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 1050000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理努力程度
+      en_US: Reasoning Effort
+    type: string
+    help:
+      zh_Hans: GPT-5.6 支持 none、low、medium、high、xhigh 和 max，默认值为 medium。
+      en_US: GPT-5.6 supports none, low, medium, high, xhigh, and max, defaulting to medium.
+    required: false
+    default: medium
+    options:
+      - none
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+  - name: reasoning_mode
+    label:
+      zh_Hans: 推理模式
+      en_US: Reasoning Mode
+    type: string
+    help:
+      zh_Hans: 标准模式平衡质量与延迟；Pro 模式会投入更多模型计算。
+      en_US: Standard mode balances quality and latency; Pro mode applies more model work.
+    required: false
+    default: standard
+    options:
+      - standard
+      - pro
+  - name: verbosity
+    label:
+      zh_Hans: 详细程度
+      en_US: Verbosity
+    type: string
+    help:
+      zh_Hans: 约束模型响应的详细程度。较低的值将产生更简洁的响应，而较高的值将产生更详细的响应。支持的值包括 low、medium 和 high
+      en_US: Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high
+    required: false
+    default: medium
+    options:
+      - low
+      - medium
+      - high
+  - name: enable_stream
+    label:
+      zh_Hans: 流式响应
+      en_US: Streaming
+    type: boolean
+    help:
+      zh_Hans: GPT-5 系列模型流式输出需要 KYC 验证，若想跳过这个限制使用模型，请关闭流式响应。
+      en_US: GPT-5 series models require KYC validation for streaming output, if you want to use the models without this limitation, please turn off streaming responses.
+    required: true
+    default: true
+pricing:
+  input: '1'
+  output: '6'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/gpt-5.6-sol.yaml
+++ b/models/aihubmix/models/llm/gpt-5.6-sol.yaml
@@ -1,0 +1,91 @@
+model: gpt-5.6-sol
+label:
+  en_US: GPT 5.6 Sol
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 1050000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理努力程度
+      en_US: Reasoning Effort
+    type: string
+    help:
+      zh_Hans: GPT-5.6 支持 none、low、medium、high、xhigh 和 max，默认值为 medium。
+      en_US: GPT-5.6 supports none, low, medium, high, xhigh, and max, defaulting to medium.
+    required: false
+    default: medium
+    options:
+      - none
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+  - name: reasoning_mode
+    label:
+      zh_Hans: 推理模式
+      en_US: Reasoning Mode
+    type: string
+    help:
+      zh_Hans: 标准模式平衡质量与延迟；Pro 模式会投入更多模型计算。
+      en_US: Standard mode balances quality and latency; Pro mode applies more model work.
+    required: false
+    default: standard
+    options:
+      - standard
+      - pro
+  - name: verbosity
+    label:
+      zh_Hans: 详细程度
+      en_US: Verbosity
+    type: string
+    help:
+      zh_Hans: 约束模型响应的详细程度。较低的值将产生更简洁的响应，而较高的值将产生更详细的响应。支持的值包括 low、medium 和 high
+      en_US: Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high
+    required: false
+    default: medium
+    options:
+      - low
+      - medium
+      - high
+  - name: enable_stream
+    label:
+      zh_Hans: 流式响应
+      en_US: Streaming
+    type: boolean
+    help:
+      zh_Hans: GPT-5 系列模型流式输出需要 KYC 验证，若想跳过这个限制使用模型，请关闭流式响应。
+      en_US: GPT-5 series models require KYC validation for streaming output, if you want to use the models without this limitation, please turn off streaming responses.
+    required: true
+    default: true
+pricing:
+  input: '5'
+  output: '30'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/gpt-5.6-terra.yaml
+++ b/models/aihubmix/models/llm/gpt-5.6-terra.yaml
@@ -1,0 +1,91 @@
+model: gpt-5.6-terra
+label:
+  en_US: GPT 5.6 Terra
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 1050000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理努力程度
+      en_US: Reasoning Effort
+    type: string
+    help:
+      zh_Hans: GPT-5.6 支持 none、low、medium、high、xhigh 和 max，默认值为 medium。
+      en_US: GPT-5.6 supports none, low, medium, high, xhigh, and max, defaulting to medium.
+    required: false
+    default: medium
+    options:
+      - none
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+  - name: reasoning_mode
+    label:
+      zh_Hans: 推理模式
+      en_US: Reasoning Mode
+    type: string
+    help:
+      zh_Hans: 标准模式平衡质量与延迟；Pro 模式会投入更多模型计算。
+      en_US: Standard mode balances quality and latency; Pro mode applies more model work.
+    required: false
+    default: standard
+    options:
+      - standard
+      - pro
+  - name: verbosity
+    label:
+      zh_Hans: 详细程度
+      en_US: Verbosity
+    type: string
+    help:
+      zh_Hans: 约束模型响应的详细程度。较低的值将产生更简洁的响应，而较高的值将产生更详细的响应。支持的值包括 low、medium 和 high
+      en_US: Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high
+    required: false
+    default: medium
+    options:
+      - low
+      - medium
+      - high
+  - name: enable_stream
+    label:
+      zh_Hans: 流式响应
+      en_US: Streaming
+    type: boolean
+    help:
+      zh_Hans: GPT-5 系列模型流式输出需要 KYC 验证，若想跳过这个限制使用模型，请关闭流式响应。
+      en_US: GPT-5 series models require KYC validation for streaming output, if you want to use the models without this limitation, please turn off streaming responses.
+    required: true
+    default: true
+pricing:
+  input: '2.5'
+  output: '15'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/grok-4.5.yaml
+++ b/models/aihubmix/models/llm/grok-4.5.yaml
@@ -1,0 +1,58 @@
+model: grok-4.5
+label:
+  en_US: Grok 4.5
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理努力程度
+      en_US: Reasoning Effort
+    type: string
+    help:
+      zh_Hans: 控制模型的推理强度。none 为关闭思考，low/medium/high 为推荐值。
+      en_US: Controls the model's reasoning intensity. none disables thinking, low/medium/high are recommended.
+    required: false
+    default: high
+    options:
+      - none
+      - low
+      - medium
+      - high
+  - name: temperature
+    use_template: temperature
+    default: 1.0
+    min: 0.0
+    max: 2.0
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 131072
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '2'
+  output: '6'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/grok-build-0.1.yaml
+++ b/models/aihubmix/models/llm/grok-build-0.1.yaml
@@ -1,0 +1,59 @@
+model: grok-build-0.1
+label:
+  en_US: Grok Build 0.1
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 256000
+parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。
+      en_US: Controls the model's thinking capability.
+  - name: thinking_budget
+    label:
+      zh_Hans: 推理预算
+      en_US: Thinking Budget
+    type: int
+    default: 1024
+    min: 0
+    max: 10000
+    required: false
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 131072
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '1'
+  output: '2'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/hy3.yaml
+++ b/models/aihubmix/models/llm/hy3.yaml
@@ -1,0 +1,58 @@
+model: hy3
+label:
+  en_US: Hunyuan 3
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+model_properties:
+  mode: chat
+  context_size: 256000
+parameter_rules:
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: false
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。开启后使用深度推理模式。
+      en_US: Controls the model's thinking capability. Enables deep reasoning when turned on.
+  - name: thinking_budget
+    label:
+      zh_Hans: 推理预算
+      en_US: Thinking Budget
+    type: int
+    default: 1024
+    min: 0
+    max: 32000
+    required: false
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 8192
+    min: 1
+    max: 128000
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.1562'
+  output: '0.6248'
+  unit: '0.000001'
+  currency: USD


### PR DESCRIPTION
## Summary

- **Adaptive Thinking**: support `thinking.type=adaptive` for opus-4-7/4-8, sonnet-5, fable-5 (always-on); auto-remove temperature/top_p for adaptive models
- **output_config**: effort (low~max) + task_budget (≥20000 with beta header `task-budgets-2026-03-13`)
- **Prompt Caching TTL**: 5m (default, 1.25x write) / 1h (2.0x write) with per-tier billing in both streaming and non-streaming paths
- **7 bug fixes**: assistant message content loss (elif→collect both), multi-tool stream param cross-contamination (str→dict), redacted_thinking close tag, JSON prefill adaptive guard, count_tokens adaptive branch, streaming TTL cache-split lookup, token fallback zero-value bug
- **13 new models**: claude-opus-4-8(-think), claude-sonnet-5, claude-fable-5, gpt-5.6-sol/luna/terra, grok-4.5, glm-5.2, hy3, doubao-seed-2-1-pro/turbo, grok-build-0.1
- **7 YAML updates**: context_size corrections (opus-4-6/4-7: 200K→1M, haiku-4-5: 204800→200000), document feature, prompt_caching params

## Test plan

- [x] Python syntax check (`ast.parse`) — passed
- [x] All 189 YAML files validated against `AIModelEntity` schema — 0 failures
- [x] API direct test: adaptive thinking (opus-4-7), always-on (fable-5), disabled (sonnet-5)
- [x] API direct test: output_config effort + task_budget with beta header
- [x] API direct test: cache TTL 1h with per-tier cache_creation breakdown
- [x] API direct test: multi-tool call (2 tools, no param cross-contamination)
- [x] API direct test: gpt-5.6-sol new model
- [x] API direct test: opus-4-6 regression (non-adaptive model unchanged)
- [x] Local Dify community edition: plugin registration, model list, basic conversation
- [x] Line-by-line diff with Anthropic official plugin v0.3.24 — confirmed aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)