### PR TITLE
feat(aihubmix): add qwen3.7-plus/step-3.7-flash and fix hy3 reasoning control

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.37
+version: 0.0.38
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/_position.yaml
+++ b/models/aihubmix/models/llm/_position.yaml
@@ -12,6 +12,7 @@
 - doubao-seed-2-1-turbo
 - grok-build-0.1
 - qwen3.7-max
+- qwen3.7-plus
 - gemini-3.5-flash
 - grok-4.3
 - gpt-5.5
@@ -102,6 +103,7 @@
 - coding-minimax-m2.7
 - coding-minimax-m2.7-highspeed
 - o3
+- step-3.7-flash
 - step-3.5-flash
 - glm-4.6
 - kimi-for-coding-free

--- a/models/aihubmix/models/llm/hy3.yaml
+++ b/models/aihubmix/models/llm/hy3.yaml
@@ -11,34 +11,21 @@ model_properties:
   mode: chat
   context_size: 256000
 parameter_rules:
-  - name: thinking
+  - name: reasoning_effort
     label:
-      zh_Hans: 推理模式
-      en_US: Thinking Mode
-    type: boolean
-    default: false
+      zh_Hans: 推理深度
+      en_US: Reasoning Effort
+    type: string
     required: false
+    default: none
+    options:
+      - none
+      - low
+      - medium
+      - high
     help:
-      zh_Hans: 控制模型的推理能力。开启后使用深度推理模式。
-      en_US: Controls the model's thinking capability. Enables deep reasoning when turned on.
-  - name: thinking_budget
-    label:
-      zh_Hans: 推理预算
-      en_US: Thinking Budget
-    type: int
-    default: 1024
-    min: 0
-    max: 32000
-    required: false
-  - name: temperature
-    use_template: temperature
-  - name: top_p
-    use_template: top_p
-  - name: max_tokens
-    use_template: max_tokens
-    default: 8192
-    min: 1
-    max: 128000
+      zh_Hans: 控制推理深度。none 关闭思考；low 轻量推理（速度快，适合简单任务）、medium 平衡（适合日常适中复杂任务）、high 深度推理（延迟与成本最高，适合高难度数学/编程/复杂逻辑）。
+      en_US: Controls reasoning depth. none disables thinking; low = lightweight (fast, simple tasks), medium = balanced (everyday tasks), high = deep reasoning (highest latency/cost, for hard math/coding/logic).
   - name: response_format
     label:
       zh_Hans: 回复格式
@@ -52,7 +39,7 @@ parameter_rules:
   - name: json_schema
     use_template: json_schema
 pricing:
-  input: '0.1562'
-  output: '0.6248'
-  unit: '0.000001'
+  input: "0.1562"
+  output: "0.6248"
+  unit: "0.000001"
   currency: USD

--- a/models/aihubmix/models/llm/qwen3.7-plus.yaml
+++ b/models/aihubmix/models/llm/qwen3.7-plus.yaml
@@ -1,0 +1,42 @@
+model: qwen3.7-plus
+label:
+  en_US: Qwen3.7 Plus
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+  - vision
+  - video
+model_properties:
+  mode: chat
+  context_size: 1014784
+parameter_rules:
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 深度思考
+      en_US: Deep Thinking
+    help:
+      zh_Hans: 是否开启深度思考模式，开启后模型会先进行推理再给出回答。
+      en_US: Whether to enable deep thinking mode. When enabled, the model will reason before answering.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '2'
+  output: '8'
+  unit: '0.000001'
+  currency: RMB

--- a/models/aihubmix/models/llm/step-3.7-flash.yaml
+++ b/models/aihubmix/models/llm/step-3.7-flash.yaml
@@ -1,0 +1,46 @@
+model: step-3.7-flash
+label:
+  en_US: Step 3.7 Flash
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+  - vision
+  - video
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: medium
+    options:
+      - low
+      - medium
+      - high
+    help:
+      zh_Hans: "根据任务复杂度选择合适档位。low 适合简单问答、摘要、改写、信息抽取；medium 默认推荐，适合一般推理和多步骤任务；high 适合复杂推理、数学、规划、代码分析。"
+      en_US: "Select effort by task complexity. low: simple Q&A, summary, rewrite, extraction; medium: default for general reasoning and multi-step tasks; high: complex reasoning, math, planning, code analysis."
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '1.35'
+  output: '8.1'
+  unit: '0.000001'
+  currency: RMB


### PR DESCRIPTION
## Summary

Two aihubmix model-catalog updates bundled together:

- **fix(hy3): switch Hunyuan thinking control to `reasoning_effort`.** The aihubmix gateway rejects a boolean `thinking` field for Hunyuan (hy3) with HTTP 400. 
- **feat: add `qwen3.7-plus` and `step-3.7-flash` models.** Both are multi-modal (vision + video) chat models with tool-call / stream-tool-call / multi-tool-call support, `response_format` (text / json_object / json_schema) and a `json_schema` template rule. `qwen3.7-plus` exposes an `enable_thinking` boolean (default off); `step-3.7-flash` exposes a `reasoning_effort` string (`low`/`medium`/`high`, default `medium`). Registered both in `_position.yaml`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — `0.0.37` → `0.0.38`
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — no dependency changes were needed for this change; `pyproject.toml` / `uv.lock` are untouched. (aihubmix already declares `dify_plugin>=0.9.0` from #3422.)

## Testing

- [x] Local deployment — Dify version: 1.15.0
- [ ] SaaS (cloud.dify.ai)
