### PR TITLE
feat(volcengine): add DeepSeek V4, GLM-5.2, Doubao-Seed-2.1 models and extend reasoning_effort support

### DIFF
--- a/models/volcengine/manifest.yaml
+++ b/models/volcengine/manifest.yaml
@@ -33,4 +33,4 @@ resource:
       text_embedding: false
       tts: false
 type: plugin
-version: 0.0.11
+version: 0.0.12

--- a/models/volcengine/models/llm/_position.yaml
+++ b/models/volcengine/models/llm/_position.yaml
@@ -1,3 +1,6 @@
+- doubao-seed-evolving-latest-version
+- doubao-seed-2-1-pro-260628
+- doubao-seed-2-1-turbo-260628
 - doubao-seed-2-0-pro-260215
 - doubao-seed-2-0-lite-260215
 - doubao-seed-2-0-mini-260215
@@ -6,6 +9,7 @@
 - doubao-seedance-1-5-pro-251215
 - doubao-seedream-5-0-260128
 - doubao-seed-1-8-251228
+- glm-5-2-260617
 - glm-4-7-251222
 - doubao-seed-code-preview-251028
 - doubao-seed-1-6-lite-251015
@@ -18,6 +22,6 @@
 - doubao-1-5-pro-32k-character-250715
 - doubao-1-5-pro-32k-character-250228
 - doubao-1-5-lite-32k-250115
+- deepseek-v4-pro-260425
+- deepseek-v4-flash-260425
 - deepseek-v3-2-251201
-- deepseek-v3-1-terminus
-- deepseek-v3-250324

--- a/models/volcengine/models/llm/deepseek-v3-1-terminus.yaml
+++ b/models/volcengine/models/llm/deepseek-v3-1-terminus.yaml
@@ -17,3 +17,4 @@ parameter_rules:
     use_template: top_p
   - name: max_tokens
     use_template: max_tokens
+deprecated: true

--- a/models/volcengine/models/llm/deepseek-v3-250324.yaml
+++ b/models/volcengine/models/llm/deepseek-v3-250324.yaml
@@ -17,3 +17,4 @@ parameter_rules:
     use_template: top_p
   - name: max_tokens
     use_template: max_tokens
+deprecated: true

--- a/models/volcengine/models/llm/deepseek-v4-flash-260425.yaml
+++ b/models/volcengine/models/llm/deepseek-v4-flash-260425.yaml
@@ -1,0 +1,35 @@
+model: deepseek-v4-flash-260425
+label:
+  en_US: deepseek-v4-flash-260425
+  zh_Hans: deepseek-v4-flash-260425
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: medium
+    options:
+      - minimal
+      - low
+      - medium
+      - high
+      - max
+    help:
+      zh_Hans: 控制思维链长度，平衡效果、时延与成本。minimal 关闭思考直接回答；low 轻量思考侧重快速响应；medium 均衡模式；high 深度分析处理复杂问题；max 最高程度思考适配高难度推理任务。
+      en_US: Controls chain-of-thought length to balance quality, latency, and cost. minimal answers directly without thinking; low favors fast response; medium is balanced; high enables deep analysis; max maximizes reasoning for hardest tasks.
+pricing:
+  input: "1"
+  output: "2"
+  unit: "0.000001"
+  currency: RMB

--- a/models/volcengine/models/llm/deepseek-v4-pro-260425.yaml
+++ b/models/volcengine/models/llm/deepseek-v4-pro-260425.yaml
@@ -1,0 +1,35 @@
+model: deepseek-v4-pro-260425
+label:
+  en_US: deepseek-v4-pro-260425
+  zh_Hans: deepseek-v4-pro-260425
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: medium
+    options:
+      - minimal
+      - low
+      - medium
+      - high
+      - max
+    help:
+      zh_Hans: 控制思维链长度，平衡效果、时延与成本。minimal 关闭思考直接回答；low 轻量思考侧重快速响应；medium 均衡模式；high 深度分析处理复杂问题；max 最高程度思考适配高难度推理任务。
+      en_US: Controls chain-of-thought length to balance quality, latency, and cost. minimal answers directly without thinking; low favors fast response; medium is balanced; high enables deep analysis; max maximizes reasoning for hardest tasks.
+pricing:
+  input: "12"
+  output: "24"
+  unit: "0.000001"
+  currency: RMB

--- a/models/volcengine/models/llm/doubao-seed-2-1-pro-260628.yaml
+++ b/models/volcengine/models/llm/doubao-seed-2-1-pro-260628.yaml
@@ -1,0 +1,36 @@
+model: doubao-seed-2-1-pro-260628
+label:
+  en_US: doubao-seed-2-1-pro-260628
+  zh_Hans: doubao-seed-2-1-pro-260628
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - video
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - minimal
+      - low
+      - medium
+      - high
+    help:
+      zh_Hans: 控制思维链长度，平衡效果、时延与成本。minimal 关闭思考直接回答；low 轻量思考侧重快速响应；medium 均衡模式；high 深度分析处理复杂问题。
+      en_US: Controls chain-of-thought length to balance quality, latency, and cost. minimal answers directly without thinking; low favors fast response; medium is balanced; high enables deep analysis for complex problems.
+pricing:
+  input: "6"
+  output: "30"
+  unit: "0.000001"
+  currency: RMB

--- a/models/volcengine/models/llm/doubao-seed-2-1-turbo-260628.yaml
+++ b/models/volcengine/models/llm/doubao-seed-2-1-turbo-260628.yaml
@@ -1,0 +1,36 @@
+model: doubao-seed-2-1-turbo-260628
+label:
+  en_US: doubao-seed-2-1-turbo-260628
+  zh_Hans: doubao-seed-2-1-turbo-260628
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - video
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - minimal
+      - low
+      - medium
+      - high
+    help:
+      zh_Hans: 控制思维链长度，平衡效果、时延与成本。minimal 关闭思考直接回答；low 轻量思考侧重快速响应；medium 均衡模式；high 深度分析处理复杂问题。
+      en_US: Controls chain-of-thought length to balance quality, latency, and cost. minimal answers directly without thinking; low favors fast response; medium is balanced; high enables deep analysis for complex problems.
+pricing:
+  input: "3"
+  output: "15"
+  unit: "0.000001"
+  currency: RMB

--- a/models/volcengine/models/llm/doubao-seed-evolving-latest-version.yaml
+++ b/models/volcengine/models/llm/doubao-seed-evolving-latest-version.yaml
@@ -1,0 +1,36 @@
+model: doubao-seed-evolving-latest-version
+label:
+  en_US: doubao-seed-evolving-latest-version
+  zh_Hans: doubao-seed-evolving-latest-version
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - video
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - minimal
+      - low
+      - medium
+      - high
+    help:
+      zh_Hans: 控制思维链长度，平衡效果、时延与成本。minimal 关闭思考直接回答；low 轻量思考侧重快速响应；medium 均衡模式；high 深度分析处理复杂问题。
+      en_US: Controls chain-of-thought length to balance quality, latency, and cost. minimal answers directly without thinking; low favors fast response; medium is balanced; high enables deep analysis for complex problems.
+pricing:
+  input: "6"
+  output: "30"
+  unit: "0.000001"
+  currency: RMB

--- a/models/volcengine/models/llm/glm-5-2-260617.yaml
+++ b/models/volcengine/models/llm/glm-5-2-260617.yaml
@@ -1,0 +1,33 @@
+model: glm-5-2-260617
+label:
+  en_US: glm-5-2-260617
+  zh_Hans: glm-5-2-260617
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: max
+    options:
+      - none
+      - high
+      - max
+    help:
+      zh_Hans: 控制思维链长度，平衡效果、时延与成本。none 关闭思考；high 深度分析处理复杂问题；max 最高程度思考适配高难度推理任务。
+      en_US: Controls chain-of-thought length to balance quality, latency, and cost. none disables thinking; high enables deep analysis; max maximizes reasoning for hardest tasks.
+pricing:
+  input: "8"
+  output: "28"
+  unit: "0.000001"
+  currency: RMB

--- a/models/volcengine/models/llm/llm.py
+++ b/models/volcengine/models/llm/llm.py
@@ -229,7 +229,9 @@ class ChatCompletionRequest(RequestModel):
     stop: list[str] | None = None
     user: str | None = None
     thinking: ChatThinking | None = None
-    reasoning_effort: Literal["minimal"] | None = None
+    reasoning_effort: (
+        Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"] | None
+    ) = None
     tools: list[ChatTool] | None = None
     tool_choice: ChatToolChoice | None = None
     parallel_tool_calls: bool | None = None
@@ -714,7 +716,7 @@ def build_chat_completion_request(
     stream_options: ChatStreamOptions | None = None,
 ) -> ChatCompletionRequest:
     thinking: ChatThinking | None = None
-    reasoning_effort: Literal["minimal"] | None = None
+    reasoning_effort = None
     thinking_type = model_parameters.get("thinking")
     if thinking_type:
         thinking = build_model(
@@ -724,6 +726,10 @@ def build_chat_completion_request(
         )
         if thinking_type == "disabled":
             reasoning_effort = "minimal"
+
+    effort = model_parameters.get("reasoning_effort")
+    if effort:
+        reasoning_effort = effort
 
     return build_model(
         ChatCompletionRequest,

--- a/models/volcengine/tests/test_llm_call.py
+++ b/models/volcengine/tests/test_llm_call.py
@@ -19,8 +19,6 @@ from dify_plugin.integration.run import PluginRunner
 UNAVAILABLE_IN_CI = {
     "doubao-seed-1-6-lite-251015",
     "doubao-1-5-pro-32k-character-250228",
-    "deepseek-v3-1-terminus",
-    "deepseek-v3-250324",
 }
 
 


### PR DESCRIPTION
## Summary

Add the latest Volcengine Ark models and extend `reasoning_effort` so the new reasoning models can be controlled end-to-end.

- **New models**
  - `deepseek-v4-pro-260425`, `deepseek-v4-flash-260425` (1M context)
  - `glm-5-2-260617` (1M context)
  - `doubao-seed-2-1-pro-260628` (vision + video, 256K context)
  - `doubao-seed-2-1-turbo-260628`
  - `doubao-seed-evolving-latest-version`
- **Deprecations**: mark `deepseek-v3-1-terminus` and `deepseek-v3-250324` as `deprecated: true` (superseded by DeepSeek V4) and drop them from the CI unavailable set.
- **Reasoning effort**
  - Expand the `reasoning_effort` `Literal` from `["minimal"]` to the full ladder `none / minimal / low / medium / high / xhigh / max`.
  - Read `reasoning_effort` from `model_parameters` in `build_chat_completion_request` instead of only inferring `minimal` from `thinking=disabled`, so per-model option sets (e.g. GLM-5.2 `none/high/max`, Doubao-Seed-2.1-Pro `minimal/low/medium/high`) are honored.
- **Version**: bump `manifest.yaml` `0.0.11` -> `0.0.12`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

> Note: this plugin is on the newer SDK line — `dify-plugin>=0.9.1` is declared in `models/volcengine/pyproject.toml` and locked in `models/volcengine/uv.lock`.

## Testing

- [x] Local deployment — Dify version: 1.16.0-rc1
- [ ] SaaS (cloud.dify.ai)

Pre-merge checks performed in this workspace:

- All 6 new YAML files follow the existing Volcengine LLM schema (`model`, `label`, `model_type`, `features`, `model_properties`, `parameter_rules`, `pricing`).
- `_position.yaml` lists every presented model exactly once; the two deprecated V3 entries are removed from the position list and flagged `deprecated: true` in their own YAMLs.
- `manifest.yaml` version bumped to `0.0.12`.
- `llm.py` type-only change: `reasoning_effort` `Literal` widened and the parameter is now read from `model_parameters`; existing `thinking=disabled -> minimal` behavior preserved.

Live model calls and Dify registration are left for the maintainer/local environment checklist above.
