### PR TITLE
fix(tavily): change include_answer and include_raw_content defaults f…

### DIFF
--- a/tools/tavily/manifest.yaml
+++ b/tools/tavily/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
 - search
 type: plugin
-version: 0.1.10
+version: 0.1.11

--- a/tools/tavily/pyproject.toml
+++ b/tools/tavily/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tavily"
-version = "0.1.10"
+version = "0.1.11"
 description = "A powerful AI-native search engine and web content extraction tool for Dify"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tools/tavily/tools/tavily_search.yaml
+++ b/tools/tavily/tools/tavily_search.yaml
@@ -186,7 +186,7 @@ parameters:
     required: false
     type: boolean
   - name: include_answer
-    default: false
+    default: "false"
     form: form
     human_description:
       en_US: Include a short answer to the original query in the response. Use 'basic' or 'true' for a quick answer or 'advanced' for a more detailed, comprehensive answer.
@@ -215,7 +215,7 @@ parameters:
     required: false
     type: select
   - name: include_raw_content
-    default: false
+    default: "false"
     form: form
     human_description:
       en_US: Include the cleaned and parsed HTML content of each search result. Use 'markdown' for markdown format or 'text' for plain text.

--- a/tools/tavily/uv.lock
+++ b/tools/tavily/uv.lock
@@ -940,7 +940,7 @@ wheels = [
 
 [[package]]
 name = "tavily"
-version = "0.1.10"
+version = "0.1.11"
 source = { virtual = "." }
 dependencies = [
     { name = "dify-plugin" },


### PR DESCRIPTION
…rom boolean to string

## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->
Resolves #2780


## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
| <img width="781" height="401" alt="image" src="https://github.com/user-attachments/assets/0bcb242c-e563-4d5d-aa93-020a75b3d680" /> <img width="1148" height="216" alt="image" src="https://github.com/user-attachments/assets/9a8fc51b-6126-4b2a-a1f3-467de4995278" /> |   <img width="425" height="164" alt="image" src="https://github.com/user-attachments/assets/4966e194-40d6-4189-82d4-413ffbc20563" /> |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [x] SaaS (cloud.dify.ai)
