### PR TITLE
feat(siliconflow): add reasoning_effort parameter to deepseek-v4-flash/pro

### DIFF
--- a/models/siliconflow/manifest.yaml
+++ b/models/siliconflow/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.58
+version: 0.0.59
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/siliconflow/models/llm/deepseek-v4-flash.yaml
+++ b/models/siliconflow/models/llm/deepseek-v4-flash.yaml
@@ -60,6 +60,18 @@ parameter_rules:
     help:
       zh_Hans: 是否开启思考模式。
       en_US: Whether to enable thinking mode.
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    help:
+      zh_Hans: 仅在思考模式（enable_thinking 为 true）下生效，控制推理强度。high 为默认强度，max 为最大强度。
+      en_US: Effective only in thinking mode (enable_thinking is true). Controls reasoning effort. high is the default effort, max is the maximum effort.
+    required: false
+    options:
+      - high
+      - max
 pricing:
   input: "1"
   output: "2"

--- a/models/siliconflow/models/llm/deepseek-v4-pro.yaml
+++ b/models/siliconflow/models/llm/deepseek-v4-pro.yaml
@@ -60,6 +60,18 @@ parameter_rules:
     help:
       zh_Hans: 是否开启思考模式。
       en_US: Whether to enable thinking mode.
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    help:
+      zh_Hans: 仅在思考模式（enable_thinking 为 true）下生效，控制推理强度。high 为默认强度，max 为最大强度。
+      en_US: Effective only in thinking mode (enable_thinking is true). Controls reasoning effort. high is the default effort, max is the maximum effort.
+    required: false
+    options:
+      - high
+      - max
 pricing:
   input: "3"
   output: "6"


### PR DESCRIPTION
## Summary

SiliconFlow recently added a `reasoning_effort` parameter for their hosted DeepSeek V4 models, letting callers control reasoning depth when thinking mode is on. This is a DeepSeek-V4-specific addition on their platform — I confirmed the API surface directly with SiliconFlow support before implementing.

This change surfaces that parameter in the siliconflow plugin:

- **New parameter** `reasoning_effort` on `deepseek-v4-flash` and `deepseek-v4-pro`, type `string` with options `high` (default) / `max`. Effective only when `enable_thinking=true`.
- Bilingual labels/help (`zh_Hans` / `en_US`) matching the existing `enable_thinking` rule style.
- Bump siliconflow plugin version `0.0.58` -> `0.0.59`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

> Note: this plugin is on the newer SDK line — `dify-plugin>=0.9.0` is declared in `models/siliconflow/pyproject.toml` and locked in `models/siliconflow/uv.lock`.

## Testing

- [x] Local deployment — Dify version: 1.16.0-rc1
- [ ] SaaS (cloud.dify.ai)

