### PR TITLE
feat(volcengine): add doubao-seed-2-0-lite-260428 model

### DIFF
--- a/models/volcengine/manifest.yaml
+++ b/models/volcengine/manifest.yaml
@@ -33,4 +33,4 @@ resource:
       text_embedding: false
       tts: false
 type: plugin
-version: 0.0.12
+version: 0.0.13

--- a/models/volcengine/models/llm/_position.yaml
+++ b/models/volcengine/models/llm/_position.yaml
@@ -3,6 +3,7 @@
 - doubao-seed-2-1-turbo-260628
 - doubao-seed-2-0-pro-260215
 - doubao-seed-2-0-lite-260215
+- doubao-seed-2-0-lite-260428
 - doubao-seed-2-0-mini-260215
 - doubao-seed-2-0-code-preview-260215
 - doubao-seedance-2-0-260128

--- a/models/volcengine/models/llm/doubao-seed-2-0-lite-260428.yaml
+++ b/models/volcengine/models/llm/doubao-seed-2-0-lite-260428.yaml
@@ -1,0 +1,36 @@
+model: doubao-seed-2-0-lite-260428
+label:
+  en_US: doubao-seed-2-0-lite-260428
+  zh_Hans: doubao-seed-2-0-lite-260428
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - video
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - minimal
+      - low
+      - medium
+      - high
+    help:
+      zh_Hans: 控制思维链长度，平衡效果、时延与成本。minimal 关闭思考直接回答；low 轻量思考侧重快速响应；medium 均衡模式；high 深度分析处理复杂问题。
+      en_US: Controls chain-of-thought length to balance quality, latency, and cost. minimal answers directly without thinking; low favors fast response; medium is balanced; high enables deep analysis for complex problems.
+pricing:
+  input: "0.6"
+  output: "3.6"
+  unit: "0.000001"
+  currency: RMB


### PR DESCRIPTION
## Summary

Add new Volcengine model `doubao-seed-2-0-lite-260428` with multimodal and reasoning capabilities.

- **New model**: `doubao-seed-2-0-lite-260428` — 262K context, vision + video + tool-call support
- **Reasoning control**: uses `reasoning_effort` parameter (`minimal`/`low`/`medium`/`high`, default `high`) instead of boolean `thinking` toggle
- **Features**: `agent-thought`, `vision`, `video`, `tool-call`, `multi-tool-call`, `stream-tool-call`
- **Pricing**: input ¥0.6/M, output ¥3.6/M
- **Version**: bump `manifest.yaml` `0.0.12` → `0.0.13`

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.9.1` is declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [x] Local deployment — Dify version: 1.16.0-rc1
- [ ] SaaS (cloud.dify.ai)

> Note: Live model calls and Dify registration are left for the maintainer/local environment checklist above.