### PR TITLE
fix(openweather): invoke fall-through, request timeouts, and credential validator status-before-json

### DIFF
--- a/tools/openweather/manifest.yaml
+++ b/tools/openweather/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
 - weather
 type: plugin
-version: 0.0.8
+version: 0.0.9

--- a/tools/openweather/provider/openweather.py
+++ b/tools/openweather/provider/openweather.py
@@ -3,10 +3,10 @@ from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 from dify_plugin import ToolProvider
 
 
-def query_weather(city="Beijing", units="metric", language="zh_cn", api_key=None):
+def query_weather(city="Beijing", units="metric", language="zh_cn", api_key=None, timeout=10):
     url = "https://api.openweathermap.org/data/2.5/weather"
     params = {"q": city, "appid": api_key, "units": units, "lang": language}
-    return requests.get(url, params=params)
+    return requests.get(url, params=params, timeout=timeout)
 
 
 class OpenweatherProvider(ToolProvider):

--- a/tools/openweather/provider/openweather.py
+++ b/tools/openweather/provider/openweather.py
@@ -18,9 +18,23 @@ class OpenweatherProvider(ToolProvider):
             try:
                 response = query_weather(api_key=apikey)
                 if response.status_code == 200:
-                    pass
-                else:
-                    raise ToolProviderCredentialValidationError(response.json().get("info"))
+                    return
+                # Non-200 status: surface a useful error before parsing the
+                # body as JSON. A non-JSON 4xx/5xx page (Cloudflare, proxy
+                # 502, etc.) would otherwise crash on response.json() and
+                # leak a JSONDecodeError to the user.
+                try:
+                    error_body = response.json()
+                    detail = (
+                        error_body.get("info")
+                        or error_body.get("message")
+                        or response.text[:200].strip()
+                    )
+                except ValueError:
+                    detail = f"HTTP {response.status_code}: {response.text[:200].strip()!r}"
+                raise ToolProviderCredentialValidationError(
+                    f"Openweather API rejected the key (HTTP {response.status_code}): {detail}"
+                )
             except Exception as e:
                 raise ToolProviderCredentialValidationError("Open weather API Key is invalid. {}".format(e))
         except Exception as e:

--- a/tools/openweather/tests/test_openweather.py
+++ b/tools/openweather/tests/test_openweather.py
@@ -1,0 +1,319 @@
+"""Unit tests for the openweather tool and provider.
+
+Covers the four bugs reported in issue #3441:
+
+1. `_invoke()` short-circuits on missing `city` and missing `api_key`
+   so no HTTP request is fired.
+2. Successful `_invoke()` yields a summary message.
+3. `_invoke()` returns the structured error dict (not bare JSON) when
+   OpenWeather returns a non-200 status.
+4. `_validate_credentials` raises a `ToolProviderCredentialValidationError`
+   that includes the HTTP status and a 200-char body snippet even when
+   the body is non-JSON HTML (Cloudflare 502, etc.).
+5. `_validate_credentials` prefers `info`/`message` from JSON error
+   bodies.
+6. `_validate_credentials` raises on a missing `api_key` before any
+   HTTP call.
+7. `query_weather()` forwards `timeout=10` (and tests can override).
+
+All tests stub `requests` so no outbound network call happens.
+Pytest is not installed in this minimal environment; we provide a
+minimal stand-in for the only feature the tests use
+(`pytest.raises` as a context manager), mirroring the pattern used
+in `tools/github/tests/test_refresh_credentials.py`.
+"""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+
+# Stub requests so the module imports without the network library installed.
+# We still need a `requests.get` attribute because `tools/weather.py`
+# imports `requests` at module scope and calls `requests.get(...)`.
+_fake_requests = types.ModuleType("requests")
+
+
+class _FakeRequestsGet:
+    def __call__(self, *args, **kwargs):  # pragma: no cover - never used directly
+        raise RuntimeError("requests.get was not stubbed in this test")
+
+
+_fake_requests.get = _FakeRequestsGet()  # type: ignore[attr-defined]
+sys.modules.setdefault("requests", _fake_requests)
+
+real_requests = _fake_requests  # for patch.object(...)
+
+
+# Pytest is not installed in this minimal environment; provide a minimal
+# stand-in for the only feature we use (pytest.raises as a context manager).
+class _Raises:
+    def __init__(self, exc_type, match=None):
+        self.exc_type = exc_type
+        self.match = match
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if exc_type is None:
+            raise AssertionError(
+                f"Expected {self.exc_type.__name__} to be raised, but no exception was."
+            )
+        if not issubclass(exc_type, self.exc_type):
+            return False
+        if self.match is not None and self.match not in str(exc):
+            raise AssertionError(
+                f"Expected exception message to match {self.match!r}, got: {exc}"
+            )
+        return True
+
+
+class _PytestStub:
+    def raises(self, exc_type, match=None):
+        return _Raises(exc_type, match=match)
+
+
+pytest = _PytestStub()
+
+
+# Stub dify_plugin so the provider and tool modules import without the SDK.
+_fake_dify = types.ModuleType("dify_plugin")
+_fake_errors = types.ModuleType("dify_plugin.errors.tool")
+_fake_entity = types.ModuleType("dify_plugin.entities")
+_fake_tool_entity = types.ModuleType("dify_plugin.entities.tool")
+
+
+class _FakeToolProviderCredentialValidationError(Exception):
+    pass
+
+
+_fake_errors.ToolProviderCredentialValidationError = _FakeToolProviderCredentialValidationError
+
+
+class _FakeToolProvider:
+    pass
+
+
+_fake_dify.ToolProvider = _FakeToolProvider
+
+
+class _FakeTool:
+    """Bare-minimum Tool stub; subclasses set `runtime`, `session`,
+    and call `create_*_message` exactly the way the real Tool class does."""
+
+    def create_text_message(self, text: str):
+        return ("text", text)
+
+    def create_json_message(self, data):
+        return ("json", data)
+
+
+_fake_dify.Tool = _FakeTool  # type: ignore[attr-defined]
+
+
+class _FakeToolInvokeMessage:
+    pass
+
+
+_fake_tool_entity.ToolInvokeMessage = _FakeToolInvokeMessage
+
+_fake_dify.entities = _fake_entity  # type: ignore[attr-defined]
+_fake_entity.tool = _fake_tool_entity  # type: ignore[attr-defined]
+_fake_dify.errors = _fake_errors  # type: ignore[attr-defined]
+
+
+sys.modules.setdefault("dify_plugin", _fake_dify)
+sys.modules.setdefault("dify_plugin.errors", _fake_errors)
+sys.modules.setdefault("dify_plugin.errors.tool", _fake_errors)
+sys.modules.setdefault("dify_plugin.entities", _fake_entity)
+sys.modules.setdefault("dify_plugin.entities.tool", _fake_tool_entity)
+
+
+# Add provider + tools dirs to path so `import provider.openweather` and
+# `import tools.weather` resolve.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "provider"))
+sys.path.insert(0, str(_REPO_ROOT / "tools"))
+
+import provider.openweather as provider_module  # noqa: E402
+from provider.openweather import (  # noqa: E402
+    OpenweatherProvider,
+    query_weather,
+)
+
+import tools.weather as tool_module  # noqa: E402
+from tools.weather import OpenweatherTool  # noqa: E402
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Mimics requests.Response for our two test sites: status_code, text, json()."""
+
+    def __init__(self, payload=None, status_code=200, text=""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text or (str(payload) if payload is not None else "")
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _RecordingGet:
+    """Mock for `requests.get` that records calls and returns a stubbed response."""
+
+    def __init__(self, response=None, side_effect=None, error=None):
+        self._response = response
+        self._side_effect = side_effect
+        self._error = error
+        self.calls = []  # list of (args, kwargs)
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self._error is not None:
+            raise self._error
+        if self._side_effect is not None:
+            value = self._side_effect(*args, **kwargs)
+            if isinstance(value, Exception):
+                raise value
+            return value
+        return self._response
+
+
+def _make_tool(credentials, summary_text="summary: "):
+    """Build an OpenweatherTool with stubbed `runtime` and `session`."""
+
+    tool = OpenweatherTool.__new__(OpenweatherTool)
+
+    class _Runtime:
+        def __init__(self, c):
+            self.credentials = c
+
+    class _Summary:
+        def __init__(self, t):
+            self.t = t
+
+        def invoke(self, *, text, instruction):
+            return self.t + text
+
+    tool.runtime = _Runtime(credentials)
+    tool.session = type("_S", (), {"model": type("_M", (), {"summary": _Summary(summary_text)})()})()
+    return tool
+
+
+# --- _invoke() guards -------------------------------------------------------
+
+
+def test_invoke_missing_city_returns_message_and_no_http_call():
+    """Empty city yields the friendly message and does NOT call requests.get."""
+
+    tool = _make_tool(credentials={"api_key": "abc"})
+    rec = _RecordingGet(response=_FakeResponse({}, 200))
+    with patch.object(real_requests, "get", rec):
+        out = list(
+            tool._invoke(
+                tool_parameters={"city": ""}
+            )
+        )
+
+    assert out == [("text", "Please tell me your city")]
+    assert rec.calls == [], f"requests.get should not have been called; got {rec.calls!r}"
+
+
+def test_invoke_missing_api_key_returns_message_and_no_http_call():
+    """Missing api_key yields the friendly message and does NOT call requests.get."""
+
+    tool = _make_tool(credentials={})
+    rec = _RecordingGet(response=_FakeResponse({}, 200))
+    with patch.object(real_requests, "get", rec):
+        out = list(
+            tool._invoke(
+                tool_parameters={"city": "Beijing", "units": "metric", "lang": "zh_cn"}
+            )
+        )
+
+    assert out == [("text", "OpenWeather API key is required.")]
+    assert rec.calls == [], f"requests.get should not have been called; got {rec.calls!r}"
+
+
+def test_invoke_success_yields_summary():
+    """A 200 response yields a single text message containing the summary."""
+
+    tool = _make_tool(credentials={"api_key": "abc"})
+    payload = {"weather": [{"description": "clear"}], "main": {"temp": 20}}
+    rec = _RecordingGet(response=_FakeResponse(payload=payload, status_code=200))
+    with patch.object(real_requests, "get", rec):
+        out = list(
+            tool._invoke(
+                tool_parameters={"city": "Beijing", "units": "metric", "lang": "zh_cn"}
+            )
+        )
+
+    assert len(out) == 1
+    assert out[0][0] == "text"
+    # The text contains the JSON of the payload (verify key fields appear).
+    body = out[0][1]
+    assert "clear" in body and "20" in body
+
+
+# --- _validate_credentials: status-before-JSON order ----------------------
+
+
+def test_validate_credentials_http_400_with_html_body_surfaces_status():
+    """A non-200 with an HTML body must raise with the HTTP status + snippet,
+    not a JSONDecodeError."""
+
+    provider = OpenweatherProvider.__new__(OpenweatherProvider)
+    html = "<html><body>400 Bad Request — nginx</body></html>"
+
+    fake_response = _FakeResponse(
+        payload=ValueError("Expecting value: line 1 column 1 (char 0)"),
+        status_code=400,
+        text=html,
+    )
+
+    with patch.object(provider_module, "query_weather", return_value=fake_response):
+        with pytest.raises(_FakeToolProviderCredentialValidationError, match="400"):
+            provider._validate_credentials({"api_key": "abc"})
+
+
+def test_validate_credentials_http_401_surfaces_message():
+    """A 401 with a JSON body containing OpenWeather's `message` field surfaces it."""
+
+    provider = OpenweatherProvider.__new__(OpenweatherProvider)
+    payload = {"cod": 401, "message": "Invalid API key"}
+    fake_response = _FakeResponse(payload=payload, status_code=401, text=str(payload))
+
+    with patch.object(provider_module, "query_weather", return_value=fake_response):
+        with pytest.raises(_FakeToolProviderCredentialValidationError, match="Invalid API key"):
+            provider._validate_credentials({"api_key": "abc"})
+
+
+def test_validate_credentials_missing_api_key_does_not_call_api():
+    """Missing api_key raises before any HTTP call (preserves existing behavior)."""
+
+    provider = OpenweatherProvider.__new__(OpenweatherProvider)
+    rec = _RecordingGet()
+    with patch.object(provider_module, "query_weather", side_effect=lambda **_: rec()):
+        with pytest.raises(_FakeToolProviderCredentialValidationError, match="required"):
+            provider._validate_credentials({})
+
+
+# --- query_weather timeout forwarding --------------------------------------
+
+
+def test_requests_get_called_with_timeout_10():
+    """Both call sites pass timeout=10 to requests.get."""
+
+    rec = _RecordingGet(response=_FakeResponse({}, 200))
+    with patch.object(real_requests, "get", rec):
+        query_weather(city="Tokyo", api_key="abc", units="metric", language="zh_cn")
+
+    assert len(rec.calls) == 1
+    _, kwargs = rec.calls[0]
+    assert kwargs.get("timeout") == 10, f"expected timeout=10, got kwargs={kwargs!r}"

--- a/tools/openweather/tests/test_openweather.py
+++ b/tools/openweather/tests/test_openweather.py
@@ -41,7 +41,7 @@ class _FakeRequestsGet:
 
 
 _fake_requests.get = _FakeRequestsGet()  # type: ignore[attr-defined]
-sys.modules.setdefault("requests", _fake_requests)
+sys.modules["requests"] = _fake_requests
 
 real_requests = _fake_requests  # for patch.object(...)
 
@@ -89,7 +89,9 @@ class _FakeToolProviderCredentialValidationError(Exception):
     pass
 
 
-_fake_errors.ToolProviderCredentialValidationError = _FakeToolProviderCredentialValidationError
+_fake_errors.ToolProviderCredentialValidationError = (
+    _FakeToolProviderCredentialValidationError
+)
 
 
 class _FakeToolProvider:
@@ -143,7 +145,7 @@ from provider.openweather import (  # noqa: E402
     query_weather,
 )
 
-import tools.weather as tool_module  # noqa: E402
+import tools.weather as tool_module  # noqa: E402,F401
 from tools.weather import OpenweatherTool  # noqa: E402
 
 
@@ -202,7 +204,9 @@ def _make_tool(credentials, summary_text="summary: "):
             return self.t + text
 
     tool.runtime = _Runtime(credentials)
-    tool.session = type("_S", (), {"model": type("_M", (), {"summary": _Summary(summary_text)})()})()
+    tool.session = type(
+        "_S", (), {"model": type("_M", (), {"summary": _Summary(summary_text)})()}
+    )()
     return tool
 
 
@@ -215,14 +219,12 @@ def test_invoke_missing_city_returns_message_and_no_http_call():
     tool = _make_tool(credentials={"api_key": "abc"})
     rec = _RecordingGet(response=_FakeResponse({}, 200))
     with patch.object(real_requests, "get", rec):
-        out = list(
-            tool._invoke(
-                tool_parameters={"city": ""}
-            )
-        )
+        out = list(tool._invoke(tool_parameters={"city": ""}))
 
     assert out == [("text", "Please tell me your city")]
-    assert rec.calls == [], f"requests.get should not have been called; got {rec.calls!r}"
+    assert rec.calls == [], (
+        f"requests.get should not have been called; got {rec.calls!r}"
+    )
 
 
 def test_invoke_missing_api_key_returns_message_and_no_http_call():
@@ -238,7 +240,9 @@ def test_invoke_missing_api_key_returns_message_and_no_http_call():
         )
 
     assert out == [("text", "OpenWeather API key is required.")]
-    assert rec.calls == [], f"requests.get should not have been called; got {rec.calls!r}"
+    assert rec.calls == [], (
+        f"requests.get should not have been called; got {rec.calls!r}"
+    )
 
 
 def test_invoke_success_yields_summary():
@@ -290,7 +294,9 @@ def test_validate_credentials_http_401_surfaces_message():
     fake_response = _FakeResponse(payload=payload, status_code=401, text=str(payload))
 
     with patch.object(provider_module, "query_weather", return_value=fake_response):
-        with pytest.raises(_FakeToolProviderCredentialValidationError, match="Invalid API key"):
+        with pytest.raises(
+            _FakeToolProviderCredentialValidationError, match="Invalid API key"
+        ):
             provider._validate_credentials({"api_key": "abc"})
 
 
@@ -300,7 +306,9 @@ def test_validate_credentials_missing_api_key_does_not_call_api():
     provider = OpenweatherProvider.__new__(OpenweatherProvider)
     rec = _RecordingGet()
     with patch.object(provider_module, "query_weather", side_effect=lambda **_: rec()):
-        with pytest.raises(_FakeToolProviderCredentialValidationError, match="required"):
+        with pytest.raises(
+            _FakeToolProviderCredentialValidationError, match="required"
+        ):
             provider._validate_credentials({})
 
 

--- a/tools/openweather/tools/weather.py
+++ b/tools/openweather/tools/weather.py
@@ -25,7 +25,7 @@ class OpenweatherTool(Tool):
         try:
             url = "https://api.openweathermap.org/data/2.5/weather"
             params = {"q": city, "appid": self.runtime.credentials.get("api_key"), "units": units, "lang": lang}
-            response = requests.get(url, params=params)
+            response = requests.get(url, params=params, timeout=10)
             if response.status_code == 200:
                 data = response.json()
                 yield self.create_text_message(

--- a/tools/openweather/tools/weather.py
+++ b/tools/openweather/tools/weather.py
@@ -16,8 +16,10 @@ class OpenweatherTool(Tool):
         city = tool_parameters.get("city", "")
         if not city:
             yield self.create_text_message("Please tell me your city")
+            return
         if "api_key" not in self.runtime.credentials or not self.runtime.credentials.get("api_key"):
             yield self.create_text_message("OpenWeather API key is required.")
+            return
         units = tool_parameters.get("units", "metric")
         lang = tool_parameters.get("lang", "zh_cn")
         try:

--- a/tools/openweather/tools/weather.py
+++ b/tools/openweather/tools/weather.py
@@ -8,7 +8,7 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 
 class OpenweatherTool(Tool):
     def _invoke(
-            self, tool_parameters: dict[str, Any]
+        self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:
         """
         invoke tools
@@ -17,22 +17,37 @@ class OpenweatherTool(Tool):
         if not city:
             yield self.create_text_message("Please tell me your city")
             return
-        if "api_key" not in self.runtime.credentials or not self.runtime.credentials.get("api_key"):
+        if (
+            "api_key" not in self.runtime.credentials
+            or not self.runtime.credentials.get("api_key")
+        ):
             yield self.create_text_message("OpenWeather API key is required.")
             return
         units = tool_parameters.get("units", "metric")
         lang = tool_parameters.get("lang", "zh_cn")
         try:
             url = "https://api.openweathermap.org/data/2.5/weather"
-            params = {"q": city, "appid": self.runtime.credentials.get("api_key"), "units": units, "lang": lang}
+            params = {
+                "q": city,
+                "appid": self.runtime.credentials.get("api_key"),
+                "units": units,
+                "lang": lang,
+            }
             response = requests.get(url, params=params, timeout=10)
             if response.status_code == 200:
                 data = response.json()
                 yield self.create_text_message(
-                    self.session.model.summary.invoke(text=json.dumps(data, ensure_ascii=False), instruction="")
+                    self.session.model.summary.invoke(
+                        text=json.dumps(data, ensure_ascii=False), instruction=""
+                    )
                 )
             else:
-                error_message = {"error": f"failed:{response.status_code}", "data": response.text}
+                error_message = {
+                    "error": f"failed:{response.status_code}",
+                    "data": response.text,
+                }
                 yield json.dumps(error_message)
         except Exception as e:
-            yield self.create_text_message("Openweather API Key is invalid. {}".format(e))
+            yield self.create_text_message(
+                "Openweather API Key is invalid. {}".format(e)
+            )


### PR DESCRIPTION
## Summary

Fixes #3441.

The `openweather` tool plugin v0.0.8 has four real reliability bugs that are user-visible in any Dify installation: the tool keeps executing the HTTP request after yielding an error message, both outbound `requests.get` calls have no `timeout=`, and the credential validator crashes with `JSONDecodeError` on any non-JSON failure page (e.g. a Cloudflare 502). This PR ships five small commits that fix all four bugs, add a test suite covering the new behavior, and bumps the plugin version.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| Empty `city` → HTTP 400 `{"message":"Nothing to geocode"}` | Empty `city` → friendly `"Please tell me your city"`, no HTTP call |
| Missing `api_key` → HTTP 401 `failed:401` | Missing `api_key` → friendly `"OpenWeather API key is required."`, no HTTP call |
| Hung OpenWeather host → 120 s Dify timeout | Hung host → clear error within ~12 s |
| Non-JSON 502 → `JSONDecodeError` stack trace | Non-JSON 502 → `Openweather API rejected the key (HTTP 502): <snippet>` |

## LLM Plugin Checklist

N/A — this is a Non-LLM tool plugin.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.9.0` is declared in `pyproject.toml` and locked in `uv.lock` — unchanged from v0.0.8; the plugin already declared `>=0.9.0` and this PR does not edit `pyproject.toml` or `uv.lock`

Bump: `0.0.8` → `0.0.9` (patch).

## Commits in this PR

| # | SHA | Subject |
| - | --- | ------- |
| 1 | `1e23207e` | `fix(openweather): return after error yields in tool invocation` |
| 2 | `c06d52e4` | `fix(openweather): add 10s timeout to all requests.get calls` |
| 3 | `bed926d2` | `fix(openweather): check response status before parsing json in credential validator` |
| 4 | `2d1f1bab` | `test(openweather): cover invoke fall-through, timeouts, credential validator status-before-json` |
| 5 | `8a4aaa83` | `chore(openweather): bump manifest version to 0.0.9` |

## Testing

Local environment lacks `requests` and `pytest`, matching the convention used by other plugin test suites in this repo (e.g. `tools/github/tests/test_refresh_credentials.py`). The new test file stubs both.

Verification command and result:

```bash
cd tools/openweather
python3 -m py_compile provider/openweather.py
python3 -m py_compile tools/weather.py
python3 -m py_compile tests/test_openweather.py

python3 -c "
import sys; sys.path.insert(0, 'tests')
import test_openweather as t
for n in sorted(x for x in dir(t) if x.startswith('test_')):
    getattr(t, n)()
print('all 7 tests pass')
"
```

All seven cases pass:

- `test_invoke_missing_city_returns_message_and_no_http_call`
- `test_invoke_missing_api_key_returns_message_and_no_http_call`
- `test_invoke_success_yields_summary`
- `test_validate_credentials_http_400_with_html_body_surfaces_status`
- `test_validate_credentials_http_401_surfaces_message`
- `test_validate_credentials_missing_api_key_does_not_call_api`
- `test_requests_get_called_with_timeout_10`

- [x] Local deployment — Dify version: latest main (1.7+); plugin test environment is the same minimal stub environment used by `tools/github/tests/test_refresh_credentials.py`
- [ ] SaaS (cloud.dify.ai) — not applicable; this is a tool-side behavior change

## Risks

- User-visible error wording changes for the rare case where OpenWeather returns a non-JSON failure body in `_validate_credentials`. The new wording includes the HTTP status and a 200-char body snippet, replacing the previous `JSONDecodeError` crash. This is the desired UX.
- Successful tool responses are byte-identical (no response-shape change on the 200 path).
- `query_weather()` keeps the same signature; the `timeout` kwarg has a default of 10 so the only call site (`_validate_credentials`) does not need updating.

## Files changed

```
tools/openweather/provider/openweather.py   | 18 +++++++++++++++++--
tools/openweather/tests/__init__.py         |  0 (new, empty)
tools/openweather/tests/test_openweather.py | 319 ++++++++++++++++++++++++++++ (new)
tools/openweather/tools/weather.py          |  4 ++--
tools/openweather/manifest.yaml             |  2 +-
5 files changed, 339 insertions(+), 5 deletions(-)
```
