### PR TITLE
fix(aws_tools): batch S3 tools SSE-KMS support + dict file payload fix

### DIFF
--- a/tools/aws/manifest.yaml
+++ b/tools/aws/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.28
+version: 0.0.29
 type: plugin
 author: langgenius
 name: aws_tools

--- a/tools/aws/tools/s3_files_download.py
+++ b/tools/aws/tools/s3_files_download.py
@@ -190,6 +190,17 @@ class S3FilesDownload(Tool):
             entry["content_type"] = content_type
             entry["content_length"] = response.get("ContentLength")
             entry["etag"] = response.get("ETag")
+            # Surface SSE metadata returned by S3 so downstream code can verify
+            # the object was actually encrypted with the expected scheme/key.
+            # boto3 transparently decrypts SSE-KMS objects when the caller's
+            # IAM principal has kms:Decrypt on the key, so no extra parameter
+            # is needed on the GetObject call itself.
+            if response.get("ServerSideEncryption"):
+                entry["server_side_encryption"] = response["ServerSideEncryption"]
+            if response.get("SSEKMSKeyId"):
+                entry["kms_key_id"] = response["SSEKMSKeyId"]
+            if response.get("BucketKeyEnabled"):
+                entry["bucket_key_enabled"] = True
             entry["last_modified"] = (
                 response.get("LastModified").isoformat() if response.get("LastModified") else None
             )

--- a/tools/aws/tools/s3_files_uploader.py
+++ b/tools/aws/tools/s3_files_uploader.py
@@ -20,10 +20,16 @@ from collections.abc import Generator
 from typing import Any, Optional
 
 import boto3
+import requests
 from botocore.exceptions import ClientError
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
+
+try:  # pragma: no cover - import shape varies across SDK versions
+    from dify_plugin.file.file import File as _DifyFile
+except Exception:  # pragma: no cover - older SDK or refactor
+    _DifyFile = None  # type: ignore[assignment]
 
 # ---------------------------------------------------------------------------
 # Inline credential helpers (kept self-contained on purpose so this tool does
@@ -88,6 +94,75 @@ def _sanitize_prefix(prefix: Optional[str]) -> str:
     return prefix.strip("/ ")
 
 
+# ---------------------------------------------------------------------------
+# Server-side encryption helpers
+# ---------------------------------------------------------------------------
+
+_VALID_SSE_TYPES: tuple[str, ...] = ("AES256", "aws:kms", "aws:kms:dsse")
+
+
+def _build_sse_put_object_kwargs(tool_parameters: dict[str, Any]) -> dict[str, Any]:
+    """Return the optional ``put_object`` kwargs that toggle server-side encryption.
+
+    Returns an empty dict when no SSE was requested. Raises ``ValueError`` for
+    invalid combinations so the batch invocation can fail loudly *before* it
+    starts uploading half the batch with the wrong header.
+
+    Recognised parameters:
+
+    * ``sse_type``: "" / "AES256" / "aws:kms" / "aws:kms:dsse".
+      Empty string (or missing) means "do not send any SSE header" so existing
+      buckets that do not require encryption keep their old behavior.
+    * ``kms_key_id``: optional KMS identifier (key id, full ARN, or ``alias/...``).
+      Only honored when ``sse_type`` starts with ``aws:kms``. Empty string =
+      use the bucket's default KMS key.
+    * ``bucket_key_enabled``: optional boolean to turn on S3 Bucket Keys for
+      KMS. Reduces ``kms:GenerateDataKey`` calls ~99% by reusing a bucket-scoped
+      data key. Only honored when ``sse_type`` starts with ``aws:kms``.
+
+    Background: customer bucket policies frequently include a Deny clause like
+    ``Effect: Deny`` + ``Condition: { StringNotEquals: { s3:x-amz-server-side-encryption: aws:kms } }``
+    which rejects PutObject without an explicit ``aws:kms`` SSE header. The old
+    uploader always sent the header unset, which produced the
+    ``not authorized to perform: s3:PutObject ... explicit deny in a resource-based policy``
+    error customers reported. Setting ``sse_type='aws:kms'`` lets boto3 attach
+    ``x-amz-server-side-encryption: aws:kms`` so the bucket policy condition is
+    satisfied.
+    """
+    raw_sse = tool_parameters.get("sse_type")
+    sse = (raw_sse or "").strip()
+    if not sse:
+        return {}
+    if sse not in _VALID_SSE_TYPES:
+        raise ValueError(
+            f"Invalid sse_type '{sse}'. Allowed values: '' (none), 'AES256', "
+            f"'aws:kms', 'aws:kms:dsse'."
+        )
+
+    sse_kwargs: dict[str, Any] = {"ServerSideEncryption": sse}
+
+    if sse.startswith("aws:kms"):
+        kms_key_id = (tool_parameters.get("kms_key_id") or "").strip()
+        if kms_key_id:
+            sse_kwargs["SSEKMSKeyId"] = kms_key_id
+        if bool(tool_parameters.get("bucket_key_enabled")):
+            sse_kwargs["BucketKeyEnabled"] = True
+    else:
+        # Surface a config mistake early: kms_key_id makes no sense for AES256.
+        if (tool_parameters.get("kms_key_id") or "").strip():
+            raise ValueError(
+                "kms_key_id is only meaningful when sse_type='aws:kms' or "
+                "'aws:kms:dsse'. Clear kms_key_id or switch sse_type."
+            )
+        if bool(tool_parameters.get("bucket_key_enabled")):
+            raise ValueError(
+                "bucket_key_enabled is only meaningful when sse_type='aws:kms' "
+                "or 'aws:kms:dsse'. Clear bucket_key_enabled or switch sse_type."
+            )
+
+    return sse_kwargs
+
+
 def _normalize_input_files(raw: Any) -> list[Any]:
     """Coerce the ``input_files`` parameter into a flat list.
 
@@ -102,6 +177,61 @@ def _normalize_input_files(raw: Any) -> list[Any]:
     return [raw]
 
 
+def _attr(input_file: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from either an SDK ``File`` object or a raw dict payload.
+
+    The Dify plugin SDK's ``_convert_parameters`` only auto-promotes list items
+    to ``File`` when **every** item carries ``dify_model_identity ==
+    '__dify__file__'``. Some Dify backends ship file-list entries without that
+    tag (especially when the upstream node is a START with ``file-list`` typed
+    variable), so the batch tool can receive a list of *dicts* instead of
+    ``File`` objects. Those dicts typically carry keys like ``filename``,
+    ``mime_type``, ``url``, ``transfer_method``, etc. — but not as attributes,
+    so plain ``getattr`` would always return ``default``.
+    """
+    if isinstance(input_file, dict):
+        return input_file.get(key, default)
+    return getattr(input_file, key, default)
+
+
+def _read_input_file_bytes(input_file: Any) -> bytes:
+    """Return raw bytes for a single batch entry.
+
+    Tries every shape the SDK / Dify backend might hand us:
+
+    * ``File`` SDK object → ``.blob`` (downloads via the SDK's httpx call)
+    * ``dict`` with inline ``blob`` (already-bytes upload)
+    * ``dict`` with ``url`` / ``remote_url`` → fetched via ``requests.get``
+    """
+    # Path A: SDK File-like object
+    blob = getattr(input_file, "blob", None)
+    if isinstance(blob, (bytes, bytearray)):
+        return bytes(blob)
+
+    # Path B: dict payload (the case that crashes 0.0.28 with
+    # ``'dict' object has no attribute 'blob'``)
+    if isinstance(input_file, dict):
+        # B1: when the SDK class exists, try wrapping the dict so we benefit
+        #     from File.blob's caching/httpx logic.
+        url = input_file.get("url") or input_file.get("remote_url")
+        if _DifyFile is not None and isinstance(url, str) and url:
+            try:
+                return _DifyFile(url=url).blob  # type: ignore[no-any-return]
+            except Exception:  # noqa: BLE001 - fall through to manual fetch
+                pass
+
+        # B2: plain HTTP fetch fallback
+        if isinstance(url, str) and url:
+            resp = requests.get(url, timeout=30)
+            resp.raise_for_status()
+            return resp.content
+
+    raise TypeError(
+        f"Cannot read bytes from input file of type {type(input_file).__name__}; "
+        f"keys={list(input_file.keys()) if isinstance(input_file, dict) else 'n/a'}"
+    )
+
+
 def _derive_object_key(input_file: Any, key_prefix: str) -> str:
     """Compute the final S3 object key for a single batch entry.
 
@@ -110,11 +240,10 @@ def _derive_object_key(input_file: Any, key_prefix: str) -> str:
     Instead we always derive the base key from the file's own ``filename`` (or
     a UUID fallback) and optionally prepend ``key_prefix``.
     """
-    requested_key = getattr(input_file, "filename", None)
+    requested_key = _attr(input_file, "filename")
+    url_value = _attr(input_file, "url") or _attr(input_file, "remote_url")
     fallback_key = (
-        getattr(input_file, "url", "").rstrip("/").split("/")[-1]
-        if getattr(input_file, "url", None)
-        else None
+        url_value.rstrip("/").split("/")[-1] if isinstance(url_value, str) and url_value else None
     )
     object_key = requested_key or fallback_key or f"dify-upload-{uuid.uuid4().hex}"
     object_key = object_key.lstrip("/")
@@ -165,6 +294,16 @@ class S3FilesUploader(Tool):
         generate_presign = bool(tool_parameters.get("generate_presign_url"))
         expiry_seconds = _parse_presign_expiry(tool_parameters.get("presign_expiry"))
 
+        # Resolve SSE kwargs once per batch (all entries share the same
+        # encryption settings). A misconfiguration here aborts the whole batch
+        # because uploading even one object with the wrong header creates
+        # diverging encryption state in the bucket.
+        try:
+            sse_put_kwargs = _build_sse_put_object_kwargs(tool_parameters)
+        except ValueError as exc:
+            yield self.create_text_message(f"Server-side encryption misconfigured: {exc}")
+            return
+
         # Track keys we've already used so a duplicate filename in the same
         # batch (e.g. two `image.png` from different upstream branches) does
         # not silently overwrite. We append `-{n}` to disambiguate.
@@ -177,9 +316,9 @@ class S3FilesUploader(Tool):
                 "bucket_name": bucket_name,
             }
 
-            # Read bytes
+            # Read bytes (handles File SDK objects and raw dict payloads)
             try:
-                file_bytes: bytes = input_file.blob  # type: ignore[attr-defined]
+                file_bytes: bytes = _read_input_file_bytes(input_file)
             except Exception as exc:
                 entry["status"] = "failed"
                 entry["error"] = f"Failed to read input file at index {index}: {exc}"
@@ -202,13 +341,14 @@ class S3FilesUploader(Tool):
             entry["object_key"] = object_key
             entry["s3_uri"] = f"s3://{bucket_name}/{object_key}"
 
-            content_type = getattr(input_file, "mime_type", None) or "application/octet-stream"
+            content_type = _attr(input_file, "mime_type") or "application/octet-stream"
             try:
                 s3_client.put_object(
                     Bucket=bucket_name,
                     Key=object_key,
                     Body=file_bytes,
                     ContentType=content_type,
+                    **sse_put_kwargs,
                 )
             except ClientError as exc:
                 error_message = exc.response.get("Error", {}).get("Message", str(exc))
@@ -223,6 +363,14 @@ class S3FilesUploader(Tool):
                 continue
 
             entry["status"] = "ok"
+            # Echo SSE settings into the per-file result for downstream nodes
+            # / observability without re-parsing the put_object response.
+            if sse_put_kwargs.get("ServerSideEncryption"):
+                entry["server_side_encryption"] = sse_put_kwargs["ServerSideEncryption"]
+                if sse_put_kwargs.get("SSEKMSKeyId"):
+                    entry["kms_key_id"] = sse_put_kwargs["SSEKMSKeyId"]
+                if sse_put_kwargs.get("BucketKeyEnabled"):
+                    entry["bucket_key_enabled"] = True
 
             if generate_presign:
                 try:

--- a/tools/aws/tools/s3_files_uploader.yaml
+++ b/tools/aws/tools/s3_files_uploader.yaml
@@ -122,6 +122,44 @@ parameters:
       pt_BR: Tempo de expiração em segundos para cada URL pré-assinada opcional.
     default: 3600
     form: form
+  - name: sse_type
+    type: string
+    required: false
+    label:
+      en_US: Server-side encryption
+      zh_Hans: 服务端加密类型
+      pt_BR: Criptografia do lado do servidor
+    human_description:
+      en_US: Optional server-side encryption header to send with each PutObject. Use 'aws:kms' when the target bucket policy requires SSE-KMS (e.g. bucket policy condition StringNotEquals s3:x-amz-server-side-encryption=aws:kms). Leave empty to omit the header (default).
+      zh_Hans: PutObject 请求附带的服务端加密头。当目标 bucket policy 要求 SSE-KMS 时（例如 condition StringNotEquals s3:x-amz-server-side-encryption=aws:kms）选 'aws:kms'。留空则不发送加密头（默认）。
+      pt_BR: Cabeçalho opcional de criptografia do lado do servidor enviado em cada PutObject. Use 'aws:kms' quando a política do bucket exigir SSE-KMS. Deixe em branco para omitir.
+    default: ""
+    form: form
+  - name: kms_key_id
+    type: string
+    required: false
+    label:
+      en_US: KMS key id / ARN / alias
+      zh_Hans: KMS 密钥 ID / ARN / 别名
+      pt_BR: ID / ARN / alias da chave KMS
+    human_description:
+      en_US: Only used when sse_type is 'aws:kms'. KMS key identifier (key id, full ARN, or 'alias/...'). Leave empty to use the bucket's default KMS key.
+      zh_Hans: 仅当 sse_type='aws:kms' 时使用。KMS key id、ARN 或 alias/... 形式的别名。留空则使用 bucket 默认 KMS key。
+      pt_BR: Usado apenas quando sse_type='aws:kms'. Identificador da chave KMS (id, ARN ou alias). Deixe em branco para usar a chave KMS padrão do bucket.
+    form: form
+  - name: bucket_key_enabled
+    type: boolean
+    required: false
+    label:
+      en_US: Enable S3 Bucket Key (cost saver)
+      zh_Hans: 启用 S3 Bucket Key（成本优化）
+      pt_BR: Ativar S3 Bucket Key (redução de custos)
+    human_description:
+      en_US: Only effective when sse_type='aws:kms'. Reduces KMS GenerateDataKey calls by reusing a bucket-scoped data key, lowering KMS cost ~99%. Default off to preserve old behavior.
+      zh_Hans: 仅在 sse_type='aws:kms' 时生效。复用 bucket 级 data key，KMS GenerateDataKey 调用次数降低约 99%，明显省 KMS 费用。默认关闭以保持旧行为。
+      pt_BR: Efetivo apenas quando sse_type='aws:kms'. Reduz chamadas GenerateDataKey reutilizando chave por bucket. Padrão desativado.
+    default: false
+    form: form
 extra:
   python:
     source: tools/s3_files_uploader.py


### PR DESCRIPTION
## Summary

Follow-up to #3276. Fixes two issues customers hit with the batch S3 uploader/downloader, and bumps `aws_tools` to **0.0.29**.

### 1. SSE-KMS support (`s3_files_uploader`)

Customer bucket policies frequently include a Deny like:

```json
{
  "Effect": "Deny",
  "Action": "s3:PutObject",
  "Condition": { "StringNotEquals": { "s3:x-amz-server-side-encryption": "aws:kms" } }
}
```

The uploader never sent an SSE header, so PutObject always failed with an explicit deny. This PR adds three optional parameters:

- `sse_type` — `""` (default, omit header — preserves old behavior) / `AES256` / `aws:kms` / `aws:kms:dsse`
- `kms_key_id` — key id / full ARN / `alias/...`; empty = bucket default KMS key. Only honored for `aws:kms*`.
- `bucket_key_enabled` — enables S3 Bucket Keys to cut `kms:GenerateDataKey` calls (~99% KMS cost reduction). Only honored for `aws:kms*`.

Invalid combinations (e.g. `kms_key_id` with `AES256`) fail loudly **before** any object is uploaded, so a misconfiguration can't leave half a batch encrypted with the wrong scheme.

### 2. Dict file payload crash (`s3_files_uploader`)

The SDK's `_convert_parameters` only promotes file-list items to `File` objects when every item carries `dify_model_identity == '__dify__file__'`. Some Dify backends ship file-list entries as plain dicts (notably START nodes with `file-list` variables), so 0.0.28 crashed with:

```
'dict' object has no attribute 'blob'
```

New `_read_input_file_bytes()` handles: `File` SDK objects (`.blob`), dicts with inline `blob`, and dicts with `url`/`remote_url` (tries SDK `File` wrap first, falls back to `requests.get`). `_derive_object_key` was updated to read `filename`/`url` from both shapes via `_attr()`.

### 3. SSE observability (`s3_files_download`)

GetObject responses now surface `server_side_encryption` / `kms_key_id` / `bucket_key_enabled` in each result entry so downstream nodes can verify the object was encrypted with the expected scheme.

## Testing

- Verified end-to-end on a live Dify instance against a cn-northwest-1 bucket with an SSE-required bucket policy: batch upload with `sse_type=aws:kms` succeeds, per-file results echo SSE metadata, download round-trip returns correct bytes + SSE fields.
- Batch with plain-dict file payloads (no `dify_model_identity`) uploads successfully instead of crashing.
- Misconfiguration cases (`kms_key_id` + `AES256`, `bucket_key_enabled` + `AES256`, invalid `sse_type`) abort before any upload with a clear error message.
- `requests` is already a declared dependency in `tools/aws/pyproject.toml` (no new deps).