### PR TITLE
fix(gemini): preserve text system prompt parts

### DIFF
--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.1
+version: 0.9.2

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -505,6 +505,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         :return: list of Gemini Content objects ready for use
         """
         contents = []
+        system_parts = []
+        structured_system_parts = []
+        system_strings = []
         file_part_factory = GeminiFilePartFactory(
             genai_client=genai_client,
             file_server_url_prefix=file_server_url_prefix,
@@ -513,6 +516,25 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         )
 
         for msg in prompt_messages:
+            if isinstance(msg, SystemPromptMessage):
+                if isinstance(msg.content, str):
+                    if msg.content:
+                        system_strings.append(msg.content)
+                        system_parts.append(types.Part.from_text(text=msg.content))
+                    continue
+
+                if isinstance(msg.content, list) and all(
+                    isinstance(part, TextPromptMessageContent) for part in msg.content
+                ):
+                    parts = [
+                        types.Part.from_text(text=part.data)
+                        for part in msg.content
+                        if part.data
+                    ]
+                    system_parts.extend(parts)
+                    structured_system_parts.extend(parts)
+                    continue
+
             content = self._format_message_to_gemini_content(
                 msg,
                 genai_client,
@@ -521,7 +543,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 model_parameters,
                 file_part_factory,
             )
-            if not content:
+            if not content or not content.parts:
                 continue
 
             # Merge consecutive messages with same role for proper alternation
@@ -529,6 +551,20 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 contents[-1].parts.extend(content.parts)
             else:
                 contents.append(content)
+
+        if contents:
+            if len(system_parts) == 1 and len(system_strings) == 1:
+                config.system_instruction = system_strings[0]
+            elif system_parts:
+                config.system_instruction = types.Content(parts=system_parts)
+        elif structured_system_parts:
+            # Preserve the legacy list-as-user fallback without emitting empty turns.
+            if system_strings:
+                config.system_instruction = system_strings[-1]
+            contents.append(types.Content(role="user", parts=structured_system_parts))
+        elif system_strings:
+            config.system_instruction = system_strings[-1]
+
         return contents
 
     def _format_message_to_gemini_content(
@@ -628,41 +664,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             return types.Content(role="model", parts=parts)
 
         elif isinstance(message, SystemPromptMessage):
-            # String content -> system instruction
-            if isinstance(message.content, str):
-                if isinstance(config.system_instruction, types.Content):
-                    if message.content:
-                        config.system_instruction.parts.append(
-                            types.Part.from_text(text=message.content)
-                        )
-                else:
-                    config.system_instruction = message.content
-                return None
-
-            # List content -> convert to user message (Files[] compatibility)
             if isinstance(message.content, list):
-                if message.content and all(
-                    isinstance(part, TextPromptMessageContent)
-                    for part in message.content
-                ):
-                    parts = build_parts(message.content)
-                    if parts:
-                        if isinstance(config.system_instruction, types.Content):
-                            config.system_instruction.parts.extend(parts)
-                        elif config.system_instruction:
-                            config.system_instruction = types.Content(
-                                parts=[
-                                    types.Part.from_text(
-                                        text=config.system_instruction
-                                    ),
-                                    *parts,
-                                ]
-                            )
-                        else:
-                            config.system_instruction = types.Content(parts=parts)
-                        return None
-                    return types.Content(role="user", parts=parts)
                 return types.Content(role="user", parts=build_parts(message.content))
+            return None
 
         elif isinstance(message, ToolPromptMessage):
             return types.Content(

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -507,7 +507,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         message_contents = []
         system_parts = []
         system_strings = []
-        has_multimodal_system = False
+        has_structured_system_fallback = False
         file_part_factory = GeminiFilePartFactory(
             genai_client=genai_client,
             file_server_url_prefix=file_server_url_prefix,
@@ -523,23 +523,25 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                         system_parts.append(types.Part.from_text(text=msg.content))
                     continue
 
-                if isinstance(msg.content, list) and all(
-                    isinstance(part, TextPromptMessageContent) for part in msg.content
+                if (
+                    isinstance(msg.content, list)
+                    and msg.content
+                    and all(
+                        isinstance(part, TextPromptMessageContent) and part.data
+                        for part in msg.content
+                    )
                 ):
                     parts = [
-                        types.Part.from_text(text=part.data)
-                        for part in msg.content
-                        if part.data
+                        types.Part.from_text(text=part.data) for part in msg.content
                     ]
                     system_parts.extend(parts)
-                    if parts:
-                        message_contents.append(
-                            (types.Content(role="user", parts=parts), True)
-                        )
+                    message_contents.append(
+                        (types.Content(role="user", parts=parts), True)
+                    )
                     continue
 
                 if isinstance(msg.content, list):
-                    has_multimodal_system = True
+                    has_structured_system_fallback = True
 
             content = self._format_message_to_gemini_content(
                 msg,
@@ -559,7 +561,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             if not is_structured_system
         ]
         promote_structured_system = (
-            not has_multimodal_system
+            not has_structured_system_fallback
             and ordinary_contents
             and ordinary_contents[0].role == "user"
         )

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -635,6 +635,14 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
 
             # List content -> convert to user message (Files[] compatibility)
             if isinstance(message.content, list):
+                if message.content and all(
+                    isinstance(part, TextPromptMessageContent)
+                    for part in message.content
+                ):
+                    config.system_instruction = types.Content(
+                        parts=build_parts(message.content)
+                    )
+                    return None
                 return types.Content(role="user", parts=build_parts(message.content))
 
         elif isinstance(message, ToolPromptMessage):

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -630,7 +630,13 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         elif isinstance(message, SystemPromptMessage):
             # String content -> system instruction
             if isinstance(message.content, str):
-                config.system_instruction = message.content
+                if isinstance(config.system_instruction, types.Content):
+                    if message.content:
+                        config.system_instruction.parts.append(
+                            types.Part.from_text(text=message.content)
+                        )
+                else:
+                    config.system_instruction = message.content
                 return None
 
             # List content -> convert to user message (Files[] compatibility)
@@ -639,10 +645,23 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     isinstance(part, TextPromptMessageContent)
                     for part in message.content
                 ):
-                    config.system_instruction = types.Content(
-                        parts=build_parts(message.content)
-                    )
-                    return None
+                    parts = build_parts(message.content)
+                    if parts:
+                        if isinstance(config.system_instruction, types.Content):
+                            config.system_instruction.parts.extend(parts)
+                        elif config.system_instruction:
+                            config.system_instruction = types.Content(
+                                parts=[
+                                    types.Part.from_text(
+                                        text=config.system_instruction
+                                    ),
+                                    *parts,
+                                ]
+                            )
+                        else:
+                            config.system_instruction = types.Content(parts=parts)
+                        return None
+                    return types.Content(role="user", parts=parts)
                 return types.Content(role="user", parts=build_parts(message.content))
 
         elif isinstance(message, ToolPromptMessage):
@@ -1062,6 +1081,8 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     if isinstance(config.system_instruction, types.Content)
                     else [types.Part.from_text(text=config.system_instruction)]
                 )
+                if isinstance(config.system_instruction, types.Content):
+                    config.system_instruction = None
                 contents = [
                     types.Content(
                         role="user",

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -1071,6 +1071,8 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
     ) -> Union[LLMResult, Generator[LLMResultChunk]]:
         # Validate and adjust feature compatibility
         model_parameters = self._validate_feature_compatibility(model_parameters, tools)
+        if model == "gemini-2.5-flash-image":
+            model_parameters[_DISABLE_SYSTEM_PROMOTION] = True
 
         # == InitConfig == #
 

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -1057,10 +1057,15 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         if not contents:
             if config.system_instruction:
                 # When only system instruction is provided, add it as a user message
+                instruction_parts = (
+                    config.system_instruction.parts
+                    if isinstance(config.system_instruction, types.Content)
+                    else [types.Part.from_text(text=config.system_instruction)]
+                )
                 contents = [
                     types.Content(
                         role="user",
-                        parts=[types.Part.from_text(text=config.system_instruction)],
+                        parts=instruction_parts,
                     )
                 ]
             else:

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -504,10 +504,10 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         :param model_parameters: model parameters dictionary
         :return: list of Gemini Content objects ready for use
         """
-        contents = []
+        message_contents = []
         system_parts = []
-        structured_system_parts = []
         system_strings = []
+        has_multimodal_system = False
         file_part_factory = GeminiFilePartFactory(
             genai_client=genai_client,
             file_server_url_prefix=file_server_url_prefix,
@@ -532,8 +532,14 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                         if part.data
                     ]
                     system_parts.extend(parts)
-                    structured_system_parts.extend(parts)
+                    if parts:
+                        message_contents.append(
+                            (types.Content(role="user", parts=parts), True)
+                        )
                     continue
+
+                if isinstance(msg.content, list):
+                    has_multimodal_system = True
 
             content = self._format_message_to_gemini_content(
                 msg,
@@ -545,25 +551,37 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             )
             if not content or not content.parts:
                 continue
+            message_contents.append((content, False))
 
+        ordinary_contents = [
+            content
+            for content, is_structured_system in message_contents
+            if not is_structured_system
+        ]
+        promote_structured_system = (
+            not has_multimodal_system
+            and ordinary_contents
+            and ordinary_contents[0].role == "user"
+        )
+
+        if promote_structured_system:
+            selected_contents = ordinary_contents
+            if len(system_parts) == 1 and len(system_strings) == 1:
+                config.system_instruction = system_strings[0]
+            elif system_parts:
+                config.system_instruction = types.Content(parts=system_parts)
+        else:
+            selected_contents = [content for content, _ in message_contents]
+            if system_strings:
+                config.system_instruction = system_strings[-1]
+
+        contents = []
+        for content in selected_contents:
             # Merge consecutive messages with same role for proper alternation
             if contents and contents[-1].role == content.role:
                 contents[-1].parts.extend(content.parts)
             else:
                 contents.append(content)
-
-        if contents:
-            if len(system_parts) == 1 and len(system_strings) == 1:
-                config.system_instruction = system_strings[0]
-            elif system_parts:
-                config.system_instruction = types.Content(parts=system_parts)
-        elif structured_system_parts:
-            # Preserve the legacy list-as-user fallback without emitting empty turns.
-            if system_strings:
-                config.system_instruction = system_strings[-1]
-            contents.append(types.Content(role="user", parts=structured_system_parts))
-        elif system_strings:
-            config.system_instruction = system_strings[-1]
 
         return contents
 

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -48,6 +48,7 @@ IMAGE_GENERATION_MODELS = {"gemini-2.5-flash-image", "gemini-3-pro-image-preview
 
 # https://ai.google.dev/gemini-api/docs/thought-signatures#faqs
 DEFAULT_THOUGHT_SIGNATURE: bytes = b"skip_thought_signature_validator"
+_DISABLE_SYSTEM_PROMOTION = "_disable_system_promotion"
 
 
 class GoogleLargeLanguageModel(LargeLanguageModel):
@@ -569,10 +570,11 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         promote_structured_system = (
             has_text_system_parts
             and not has_structured_system_fallback
+            and not (model_parameters or {}).get(_DISABLE_SYSTEM_PROMOTION)
             and last_system_string != ""
             and ordinary_contents
             and ordinary_contents[0][1]
-            and ordinary_contents[0][0].parts
+            and all(content.parts for content, _ in ordinary_contents)
         )
 
         if promote_structured_system:
@@ -995,6 +997,30 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             tool_calls=function_calls,  # type: ignore
         )
         return message
+
+    def _code_block_mode_wrapper(
+        self,
+        model: str,
+        credentials: dict,
+        prompt_messages: list[PromptMessage],
+        model_parameters: dict,
+        tools: Optional[list[PromptMessageTool]] = None,
+        stop: Optional[list[str]] = None,
+        stream: bool = True,
+        user: Optional[str] = None,
+    ) -> Union[LLMResult, Generator[LLMResultChunk]]:
+        if model_parameters.get("response_format"):
+            model_parameters[_DISABLE_SYSTEM_PROMOTION] = True
+        return super()._code_block_mode_wrapper(
+            model=model,
+            credentials=credentials,
+            prompt_messages=prompt_messages,
+            model_parameters=model_parameters,
+            tools=tools,
+            stop=stop,
+            stream=stream,
+            user=user,
+        )
 
     def _invoke(
         self,

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -506,7 +506,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         """
         message_contents = []
         system_parts = []
-        system_strings = []
+        scalar_system_part_indexes = []
+        last_system_string = None
+        has_text_system_parts = False
         has_structured_system_fallback = False
         file_part_factory = GeminiFilePartFactory(
             genai_client=genai_client,
@@ -518,8 +520,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         for msg in prompt_messages:
             if isinstance(msg, SystemPromptMessage):
                 if isinstance(msg.content, str):
+                    last_system_string = msg.content
                     if msg.content:
-                        system_strings.append(msg.content)
+                        scalar_system_part_indexes.append(len(system_parts))
                         system_parts.append(types.Part.from_text(text=msg.content))
                     continue
 
@@ -531,12 +534,13 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                         for part in msg.content
                     )
                 ):
+                    has_text_system_parts = True
                     parts = [
                         types.Part.from_text(text=part.data) for part in msg.content
                     ]
                     system_parts.extend(parts)
                     message_contents.append(
-                        (types.Content(role="user", parts=parts), True)
+                        (types.Content(role="user", parts=parts), True, False)
                     )
                     continue
 
@@ -551,31 +555,44 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 model_parameters,
                 file_part_factory,
             )
-            if not content or not content.parts:
+            if not content:
                 continue
-            message_contents.append((content, False))
+            message_contents.append(
+                (content, False, isinstance(msg, UserPromptMessage))
+            )
 
         ordinary_contents = [
-            content
-            for content, is_structured_system in message_contents
+            (content, is_user_message)
+            for content, is_structured_system, is_user_message in message_contents
             if not is_structured_system
         ]
         promote_structured_system = (
-            not has_structured_system_fallback
+            has_text_system_parts
+            and not has_structured_system_fallback
+            and last_system_string != ""
             and ordinary_contents
-            and ordinary_contents[0].role == "user"
+            and ordinary_contents[0][1]
+            and ordinary_contents[0][0].parts
         )
 
         if promote_structured_system:
-            selected_contents = ordinary_contents
-            if len(system_parts) == 1 and len(system_strings) == 1:
-                config.system_instruction = system_strings[0]
-            elif system_parts:
-                config.system_instruction = types.Content(parts=system_parts)
+            selected_contents = [
+                content
+                for content, is_structured_system, _ in message_contents
+                if not is_structured_system
+            ]
+            superseded_scalar_parts = set(scalar_system_part_indexes[:-1])
+            config.system_instruction = types.Content(
+                parts=[
+                    part
+                    for index, part in enumerate(system_parts)
+                    if index not in superseded_scalar_parts
+                ]
+            )
         else:
-            selected_contents = [content for content, _ in message_contents]
-            if system_strings:
-                config.system_instruction = system_strings[-1]
+            selected_contents = [content for content, _, _ in message_contents]
+            if last_system_string is not None:
+                config.system_instruction = last_system_string
 
         contents = []
         for content in selected_contents:

--- a/models/gemini/models/tests/test_document_filtering.py
+++ b/models/gemini/models/tests/test_document_filtering.py
@@ -370,7 +370,8 @@ class TestDocumentFilteringUnit:
                 )
 
             # Should be filtered out
-            assert not contents, f"Failed for {format_ext}"
+            assert len(contents) == 1
+            assert len(contents[0].parts) == 0, f"Failed for {format_ext}"
 
     def test_unsupported_extensions_filtered(self):
         """Test that documents with unsupported extensions are filtered out."""
@@ -395,7 +396,8 @@ class TestDocumentFilteringUnit:
                 )
 
             # Should be filtered out
-            assert not contents, f"Failed for extension {ext}"
+            assert len(contents) == 1
+            assert len(contents[0].parts) == 0, f"Failed for extension {ext}"
 
     def test_case_insensitive_extension_filtering(self):
         """Test that extension filtering is case-insensitive."""
@@ -420,7 +422,8 @@ class TestDocumentFilteringUnit:
                 )
 
             # Should be filtered regardless of case
-            assert not contents, f"Failed for case variant {ext}"
+            assert len(contents) == 1
+            assert len(contents[0].parts) == 0, f"Failed for case variant {ext}"
 
     def test_mixed_supported_unsupported_documents(self):
         """Test filtering with mixed supported and unsupported documents."""
@@ -514,7 +517,8 @@ class TestDocumentFilteringUnit:
             )
 
         # All content filtered out
-        assert not contents
+        assert len(contents) == 1
+        assert len(contents[0].parts) == 0
 
     def test_none_mime_type_handling(self):
         """Test handling of documents with None mime_type."""

--- a/models/gemini/models/tests/test_document_filtering.py
+++ b/models/gemini/models/tests/test_document_filtering.py
@@ -370,8 +370,7 @@ class TestDocumentFilteringUnit:
                 )
 
             # Should be filtered out
-            assert len(contents) == 1
-            assert len(contents[0].parts) == 0, f"Failed for {format_ext}"
+            assert not contents, f"Failed for {format_ext}"
 
     def test_unsupported_extensions_filtered(self):
         """Test that documents with unsupported extensions are filtered out."""
@@ -396,8 +395,7 @@ class TestDocumentFilteringUnit:
                 )
 
             # Should be filtered out
-            assert len(contents) == 1
-            assert len(contents[0].parts) == 0, f"Failed for extension {ext}"
+            assert not contents, f"Failed for extension {ext}"
 
     def test_case_insensitive_extension_filtering(self):
         """Test that extension filtering is case-insensitive."""
@@ -422,8 +420,7 @@ class TestDocumentFilteringUnit:
                 )
 
             # Should be filtered regardless of case
-            assert len(contents) == 1
-            assert len(contents[0].parts) == 0, f"Failed for case variant {ext}"
+            assert not contents, f"Failed for case variant {ext}"
 
     def test_mixed_supported_unsupported_documents(self):
         """Test filtering with mixed supported and unsupported documents."""
@@ -517,8 +514,7 @@ class TestDocumentFilteringUnit:
             )
 
         # All content filtered out
-        assert len(contents) == 1
-        assert len(contents[0].parts) == 0
+        assert not contents
 
     def test_none_mime_type_handling(self):
         """Test handling of documents with None mime_type."""

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -524,6 +524,44 @@ class TestBuildGeminiContents:
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "Hello"
 
+    def test_multiple_text_system_messages_preserve_all_parts(self):
+        messages = [
+            SystemPromptMessage(content="First instruction."),
+            SystemPromptMessage(
+                content=[TextPromptMessageContent(data="Second instruction.")]
+            ),
+            UserPromptMessage(content="Hello"),
+            SystemPromptMessage(
+                content=[TextPromptMessageContent(data="Third instruction.")]
+            ),
+        ]
+
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=messages,
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert [part.text for part in self.mock_config.system_instruction.parts] == [
+            "First instruction.",
+            "Second instruction.",
+            "Third instruction.",
+        ]
+        assert [part.text for part in contents[0].parts] == ["Hello"]
+
+    def test_empty_text_system_part_keeps_config_empty(self):
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=[
+                SystemPromptMessage(content=[TextPromptMessageContent(data="")]),
+                UserPromptMessage(content="Hello"),
+            ],
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert self.mock_config.system_instruction is None
+        assert [part.text for part in contents[0].parts] == ["Hello"]
+
     def test_system_only_text_parts_reach_generation(self):
         mock_client = Mock()
 
@@ -549,6 +587,12 @@ class TestBuildGeminiContents:
             "First instruction.",
             "Second instruction.",
         ]
+        assert (
+            mock_client.models.generate_content_stream.call_args.kwargs[
+                "config"
+            ].system_instruction
+            is None
+        )
 
     def test_system_message_with_multimodal_content(self):
         """Test that system messages with list content are converted to user messages"""

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -668,6 +668,67 @@ class TestBuildGeminiContents:
         assert request["config"].system_instruction == "Policy"
         assert [part.text for part in request["contents"][0].parts] == ["Task"]
 
+    @pytest.mark.parametrize(
+        "empty_message",
+        [
+            UserPromptMessage(content=""),
+            UserPromptMessage(
+                content=[
+                    DocumentPromptMessageContent(
+                        format="docx",
+                        base64_data="dGVzdA==",
+                        mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    )
+                ]
+            ),
+        ],
+    )
+    def test_later_empty_turn_disables_text_system_promotion(self, empty_message):
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=[
+                UserPromptMessage(content="Question"),
+                AssistantPromptMessage(content="Answer"),
+                SystemPromptMessage(
+                    content=[TextPromptMessageContent(data="Later policy")]
+                ),
+                empty_message,
+            ],
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert self.mock_config.system_instruction is None
+        assert [content.role for content in contents] == ["user", "model", "user"]
+        assert [part.text for part in contents[-1].parts] == ["Later policy"]
+
+    def test_structured_output_keeps_legacy_system_fallback(self):
+        mock_client = Mock()
+
+        with (
+            patch("models.llm.llm.genai.Client", return_value=mock_client),
+            patch.object(self.llm, "_handle_generate_response"),
+        ):
+            self.llm._code_block_mode_wrapper(
+                model="gemini-pro",
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[
+                    SystemPromptMessage(content=[TextPromptMessageContent(data="")]),
+                    SystemPromptMessage(
+                        content=[TextPromptMessageContent(data="Task")]
+                    ),
+                    UserPromptMessage(content="Question"),
+                ],
+                model_parameters={"response_format": "JSON"},
+                stream=False,
+            )
+
+        request = mock_client.models.generate_content.call_args.kwargs
+        assert isinstance(request["config"].system_instruction, str)
+        assert [part.text for part in request["contents"][0].parts] == [
+            "Task",
+            "Question\n```JSON\n",
+        ]
+
     def test_text_system_fallback_keeps_user_before_assistant(self):
         contents = self.llm._build_gemini_contents(
             prompt_messages=[

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -628,6 +628,22 @@ class TestBuildGeminiContents:
         assert request["config"].system_instruction == "Policy"
         assert [part.text for part in request["contents"][0].parts] == ["Task"]
 
+    def test_text_system_fallback_keeps_user_before_assistant(self):
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=[
+                SystemPromptMessage(
+                    content=[TextPromptMessageContent(data="Instruction")]
+                ),
+                AssistantPromptMessage(content="Answer"),
+            ],
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert self.mock_config.system_instruction is None
+        assert [content.role for content in contents] == ["user", "model"]
+        assert [part.text for part in contents[0].parts] == ["Instruction"]
+
     def test_system_message_with_multimodal_content(self):
         """Test that system messages with list content are converted to user messages"""
         messages = [
@@ -640,7 +656,9 @@ class TestBuildGeminiContents:
                         mime_type="image/png",
                     ),
                 ]
-            )
+            ),
+            SystemPromptMessage(content=[TextPromptMessageContent(data="After image")]),
+            UserPromptMessage(content="Question"),
         ]
 
         # Mock the file upload since we have multimodal content
@@ -663,9 +681,12 @@ class TestBuildGeminiContents:
 
         assert len(contents) == 1
         assert contents[0].role == "user"
-        assert len(contents[0].parts) == 2
+        assert self.mock_config.system_instruction is None
+        assert len(contents[0].parts) == 4
         assert contents[0].parts[0].text == "System context with image:"
         assert contents[0].parts[1].file_data.file_uri == "gs://test-file-uri"
+        assert contents[0].parts[2].text == "After image"
+        assert contents[0].parts[3].text == "Question"
 
     def test_tool_message(self):
         """Test conversion of tool prompt messages"""

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -524,6 +524,35 @@ class TestBuildGeminiContents:
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "Hello"
 
+    def test_image_model_keeps_text_system_parts_as_user_content(self):
+        mock_client = Mock()
+
+        with (
+            patch("models.llm.llm.genai.Client", return_value=mock_client),
+            patch.object(self.llm, "_handle_generate_response"),
+        ):
+            self.llm._generate(
+                model="gemini-2.5-flash-image",
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[
+                    SystemPromptMessage(
+                        content=[
+                            TextPromptMessageContent(data="Keep the subject centered.")
+                        ]
+                    ),
+                    UserPromptMessage(content="Draw a red fox."),
+                ],
+                model_parameters={},
+                stream=False,
+            )
+
+        request = mock_client.models.generate_content.call_args.kwargs
+        assert request["config"].system_instruction is None
+        assert [part.text for part in request["contents"][0].parts] == [
+            "Keep the subject centered.",
+            "Draw a red fox.",
+        ]
+
     def test_multiple_text_system_messages_keep_last_scalar(self):
         messages = [
             SystemPromptMessage(content="First instruction."),

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -524,7 +524,7 @@ class TestBuildGeminiContents:
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "Hello"
 
-    def test_multiple_text_system_messages_preserve_all_parts(self):
+    def test_multiple_text_system_messages_keep_last_scalar(self):
         messages = [
             SystemPromptMessage(content="First instruction."),
             SystemPromptMessage(content="Second instruction."),
@@ -544,12 +544,31 @@ class TestBuildGeminiContents:
         )
 
         assert [part.text for part in self.mock_config.system_instruction.parts] == [
-            "First instruction.",
             "Second instruction.",
             "Third instruction.",
             "Fourth instruction.",
         ]
         assert [part.text for part in contents[0].parts] == ["Hello"]
+
+    def test_empty_scalar_system_clears_previous_instruction_on_fallback(self):
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=[
+                SystemPromptMessage(content="Policy"),
+                SystemPromptMessage(content=""),
+                SystemPromptMessage(
+                    content=[
+                        TextPromptMessageContent(data=""),
+                        TextPromptMessageContent(data="Task"),
+                    ]
+                ),
+                UserPromptMessage(content="Question"),
+            ],
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert self.mock_config.system_instruction == ""
+        assert [part.text for part in contents[0].parts] == ["Task", "Question"]
 
     def test_empty_text_system_part_keeps_config_empty(self):
         contents = self.llm._build_gemini_contents(
@@ -664,6 +683,41 @@ class TestBuildGeminiContents:
         assert self.mock_config.system_instruction is None
         assert [content.role for content in contents] == ["user", "model"]
         assert [part.text for part in contents[0].parts] == ["Instruction"]
+
+    def test_text_system_fallback_keeps_tool_response_with_user_content(self):
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=[
+                SystemPromptMessage(
+                    content=[TextPromptMessageContent(data="Instruction")]
+                ),
+                ToolPromptMessage(
+                    name="lookup",
+                    content="Result",
+                    tool_call_id="call-1",
+                ),
+            ],
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert self.mock_config.system_instruction is None
+        assert [part.text for part in contents[0].parts[:1]] == ["Instruction"]
+        assert contents[0].parts[1].function_response.name == "lookup"
+
+    def test_empty_user_keeps_scalar_system_request_shape(self):
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=[
+                SystemPromptMessage(content="Policy"),
+                UserPromptMessage(content=""),
+            ],
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert self.mock_config.system_instruction == "Policy"
+        assert len(contents) == 1
+        assert contents[0].role == "user"
+        assert contents[0].parts == []
 
     def test_system_message_with_multimodal_content(self):
         """Test that system messages with list content are converted to user messages"""

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -564,6 +564,27 @@ class TestBuildGeminiContents:
         assert self.mock_config.system_instruction is None
         assert [part.text for part in contents[0].parts] == ["Hello"]
 
+    def test_partially_empty_text_system_keeps_user_fallback(self):
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=[
+                SystemPromptMessage(
+                    content=[
+                        TextPromptMessageContent(data=""),
+                        TextPromptMessageContent(data="Instruction"),
+                    ]
+                ),
+                UserPromptMessage(content="Question"),
+            ],
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert self.mock_config.system_instruction is None
+        assert [part.text for part in contents[0].parts] == [
+            "Instruction",
+            "Question",
+        ]
+
     def test_system_only_text_parts_reach_generation(self):
         mock_client = Mock()
 

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -498,6 +498,32 @@ class TestBuildGeminiContents:
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "Hello"
 
+    def test_system_message_with_text_parts_as_instruction(self):
+        """Test that text-only system message parts stay system instructions"""
+        messages = [
+            SystemPromptMessage(
+                content=[
+                    TextPromptMessageContent(data="You are a helpful assistant."),
+                    TextPromptMessageContent(data="Keep answers concise."),
+                ]
+            ),
+            UserPromptMessage(content="Hello"),
+        ]
+
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=messages,
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert [part.text for part in self.mock_config.system_instruction.parts] == [
+            "You are a helpful assistant.",
+            "Keep answers concise.",
+        ]
+        assert len(contents) == 1
+        assert contents[0].role == "user"
+        assert contents[0].parts[0].text == "Hello"
+
     def test_system_message_with_multimodal_content(self):
         """Test that system messages with list content are converted to user messages"""
         messages = [

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -524,6 +524,32 @@ class TestBuildGeminiContents:
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "Hello"
 
+    def test_system_only_text_parts_reach_generation(self):
+        mock_client = Mock()
+
+        with patch("models.llm.llm.genai.Client", return_value=mock_client):
+            self.llm._generate(
+                model="gemini-2.0-flash",
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[
+                    SystemPromptMessage(
+                        content=[
+                            TextPromptMessageContent(data="First instruction."),
+                            TextPromptMessageContent(data="Second instruction."),
+                        ]
+                    )
+                ],
+                model_parameters={},
+            )
+
+        contents = mock_client.models.generate_content_stream.call_args.kwargs[
+            "contents"
+        ]
+        assert [part.text for part in contents[0].parts] == [
+            "First instruction.",
+            "Second instruction.",
+        ]
+
     def test_system_message_with_multimodal_content(self):
         """Test that system messages with list content are converted to user messages"""
         messages = [

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -527,12 +527,13 @@ class TestBuildGeminiContents:
     def test_multiple_text_system_messages_preserve_all_parts(self):
         messages = [
             SystemPromptMessage(content="First instruction."),
+            SystemPromptMessage(content="Second instruction."),
             SystemPromptMessage(
-                content=[TextPromptMessageContent(data="Second instruction.")]
+                content=[TextPromptMessageContent(data="Third instruction.")]
             ),
             UserPromptMessage(content="Hello"),
             SystemPromptMessage(
-                content=[TextPromptMessageContent(data="Third instruction.")]
+                content=[TextPromptMessageContent(data="Fourth instruction.")]
             ),
         ]
 
@@ -546,6 +547,7 @@ class TestBuildGeminiContents:
             "First instruction.",
             "Second instruction.",
             "Third instruction.",
+            "Fourth instruction.",
         ]
         assert [part.text for part in contents[0].parts] == ["Hello"]
 
@@ -593,6 +595,38 @@ class TestBuildGeminiContents:
             ].system_instruction
             is None
         )
+
+    @pytest.mark.parametrize(
+        "empty_message",
+        [
+            UserPromptMessage(content=""),
+            SystemPromptMessage(content=[]),
+        ],
+    )
+    def test_empty_turn_keeps_legacy_system_only_roles(self, empty_message):
+        mock_client = Mock()
+
+        with (
+            patch("models.llm.llm.genai.Client", return_value=mock_client),
+            patch.object(self.llm, "_handle_generate_response"),
+        ):
+            self.llm._generate(
+                model="gemini-2.0-flash",
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[
+                    SystemPromptMessage(content="Policy"),
+                    SystemPromptMessage(
+                        content=[TextPromptMessageContent(data="Task")]
+                    ),
+                    empty_message,
+                ],
+                model_parameters={},
+                stream=False,
+            )
+
+        request = mock_client.models.generate_content.call_args.kwargs
+        assert request["config"].system_instruction == "Policy"
+        assert [part.text for part in request["contents"][0].parts] == ["Task"]
 
     def test_system_message_with_multimodal_content(self):
         """Test that system messages with list content are converted to user messages"""


### PR DESCRIPTION
## Summary

Fixes #3448.

Dify can emit plain-text system prompts as lists of `TextPromptMessageContent` parts.
The Gemini plugin currently recognizes only string system prompts, so it silently sends those lists as user content.
When no structured system list requires legacy fallback and the first effective ordinary turn is a non-empty `UserPromptMessage`, this patch collects fully populated text-only list system messages and the last non-empty scalar system prompt into one `system_instruction` while preserving message and part order.
A tool response does not qualify for promotion merely because Gemini represents it with `role=user`.
When the first effective ordinary turn is model or tool content, or any system list is empty, partially empty, or contains non-text content, structured system lists retain their legacy user role and original position.
Scalar system prompts retain exact legacy last-write-wins behavior, including a trailing empty scalar clearing an earlier value.
This keeps the compatibility release from changing system-only, model-first, tool-first, empty-turn, or mixed multimodal request shapes.
Any empty or fully filtered ordinary turn disables promotion and retains its legacy zero-part `Content` shape.
Structured-output requests retain `origin/main` system-message roles because the SDK code-block wrapper mutates prompts before provider conversion.
Lists containing empty or non-text parts retain the existing user-message fallback, so this compatibility patch introduces no new validation errors.
Gemini 2.5 Flash Image retains this fallback because the Developer API rejects system instructions for that model.
This patch is mutually exclusive with the stricter alternative in #3451, tracked by #3449.
The plugin version is bumped from `0.9.1` to `0.9.2`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable because this change only affects request conversion.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Message flow (system messages, user ↔ assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [x] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

The existing `dify-plugin>=0.9.0` dependency and lockfile are unchanged.

## Testing

- [ ] Local deployment — Dify version:
- [ ] SaaS (cloud.dify.ai)

Automated checks were run from the locked plugin environment.

- `uv run --frozen python -m pytest -m 'not integration'`: `156 passed, 15 skipped, 5 deselected`.
- `uv run --frozen ruff check models/llm/llm.py models/tests/test_llm.py models/tests/test_document_filtering.py`: passed.
- `uv run --frozen ruff format --check models/llm/llm.py models/tests/test_llm.py models/tests/test_document_filtering.py`: passed.
