### PR TITLE
feat(gemini): enforce system instruction semantics

### DIFF
--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.1
+version: 0.10.0

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -511,9 +511,11 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             if not isinstance(msg, SystemPromptMessage):
                 continue
 
+            if not msg.content:
+                continue
+
             if isinstance(msg.content, str):
-                if msg.content:
-                    system_parts.append(types.Part.from_text(text=msg.content))
+                system_parts.append(types.Part.from_text(text=msg.content))
                 continue
 
             for part in msg.content:
@@ -1068,6 +1070,8 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     if isinstance(config.system_instruction, types.Content)
                     else [types.Part.from_text(text=config.system_instruction)]
                 )
+                if isinstance(config.system_instruction, types.Content):
+                    config.system_instruction = None
                 contents = [
                     types.Content(
                         role="user",

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -548,7 +548,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 model_parameters,
                 file_part_factory,
             )
-            if not content:
+            if not content or not content.parts:
                 continue
 
             # Merge consecutive messages with same role for proper alternation
@@ -1063,26 +1063,10 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         # Handle empty contents scenario (e.g., only system instruction provided)
         # Gemini API requires at least one content in the conversation
         if not contents:
-            if config.system_instruction:
-                # When only system instruction is provided, add it as a user message
-                instruction_parts = (
-                    config.system_instruction.parts
-                    if isinstance(config.system_instruction, types.Content)
-                    else [types.Part.from_text(text=config.system_instruction)]
-                )
-                if isinstance(config.system_instruction, types.Content):
-                    config.system_instruction = None
-                contents = [
-                    types.Content(
-                        role="user",
-                        parts=instruction_parts,
-                    )
-                ]
-            else:
-                raise InvokeBadRequestError(
-                    "No valid content to send to Gemini API. "
-                    "Please provide at least one user message with content."
-                )
+            raise InvokeBadRequestError(
+                "No valid content to send to Gemini API. "
+                "Please provide at least one user message with content."
+            )
 
         if stream:
             response = genai_client.models.generate_content_stream(

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -1060,12 +1060,11 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
 
         # == InvokeModel == #
 
-        # Handle empty contents scenario (e.g., only system instruction provided)
-        # Gemini API requires at least one content in the conversation
-        if not contents:
+        # Gemini requires the conversation to start with user content.
+        if not contents or contents[0].role != "user":
             raise InvokeBadRequestError(
                 "No valid content to send to Gemini API. "
-                "Please provide at least one user message with content."
+                "Please start with a non-empty user message."
             )
 
         if stream:

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -506,6 +506,28 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         """
         contents = []
         system_parts = []
+
+        for msg in prompt_messages:
+            if not isinstance(msg, SystemPromptMessage):
+                continue
+
+            if isinstance(msg.content, str):
+                if msg.content:
+                    system_parts.append(types.Part.from_text(text=msg.content))
+                continue
+
+            for part in msg.content:
+                if not isinstance(part, TextPromptMessageContent):
+                    raise InvokeBadRequestError(
+                        "Gemini system instructions support text only. "
+                        "Move files to a user message."
+                    )
+                if part.data:
+                    system_parts.append(types.Part.from_text(text=part.data))
+
+        if system_parts:
+            config.system_instruction = types.Content(parts=system_parts)
+
         file_part_factory = GeminiFilePartFactory(
             genai_client=genai_client,
             file_server_url_prefix=file_server_url_prefix,
@@ -515,19 +537,6 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
 
         for msg in prompt_messages:
             if isinstance(msg, SystemPromptMessage):
-                if isinstance(msg.content, str):
-                    if msg.content:
-                        system_parts.append(types.Part.from_text(text=msg.content))
-                    continue
-
-                for part in msg.content:
-                    if not isinstance(part, TextPromptMessageContent):
-                        raise InvokeBadRequestError(
-                            "Gemini system instructions support text only. "
-                            "Move files to a user message."
-                        )
-                    if part.data:
-                        system_parts.append(types.Part.from_text(text=part.data))
                 continue
 
             content = self._format_message_to_gemini_content(
@@ -546,8 +555,6 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             else:
                 contents.append(content)
 
-        if system_parts:
-            config.system_instruction = types.Content(parts=system_parts)
         return contents
 
     def _format_message_to_gemini_content(
@@ -1056,10 +1063,15 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         if not contents:
             if config.system_instruction:
                 # When only system instruction is provided, add it as a user message
+                instruction_parts = (
+                    config.system_instruction.parts
+                    if isinstance(config.system_instruction, types.Content)
+                    else [types.Part.from_text(text=config.system_instruction)]
+                )
                 contents = [
                     types.Content(
                         role="user",
-                        parts=[types.Part.from_text(text=config.system_instruction)],
+                        parts=instruction_parts,
                     )
                 ]
             else:

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -1024,6 +1024,22 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator[LLMResultChunk]]:
         self._validate_prompt_messages(prompt_messages)
+        if (
+            model_parameters.get("response_format")
+            and prompt_messages
+            and isinstance(prompt_messages[0], SystemPromptMessage)
+            and isinstance(prompt_messages[0].content, list)
+        ):
+            # Give the SDK a scalar to wrap without replacing structured parts.
+            prompt_messages.insert(
+                0,
+                SystemPromptMessage(
+                    content=(
+                        "Please output a valid "
+                        f"{model_parameters['response_format']} object."
+                    )
+                ),
+            )
         return super()._code_block_mode_wrapper(
             model=model,
             credentials=credentials,

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -488,20 +488,30 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             config.tools.append(self._convert_tools_to_gemini_tool(tools))
 
     @staticmethod
-    def _validate_prompt_messages(prompt_messages: list[PromptMessage]) -> None:
+    def _validate_prompt_messages(
+        model: str, prompt_messages: list[PromptMessage]
+    ) -> None:
+        has_system_instruction = False
         for message in prompt_messages:
-            if (
-                isinstance(message, SystemPromptMessage)
-                and isinstance(message.content, list)
-                and any(
-                    not isinstance(part, TextPromptMessageContent)
-                    for part in message.content
-                )
-            ):
-                raise InvokeBadRequestError(
-                    "Gemini system instructions support text only. "
-                    "Move files to a user message."
-                )
+            if not isinstance(message, SystemPromptMessage) or not message.content:
+                continue
+            if isinstance(message.content, str):
+                has_system_instruction = True
+                continue
+            for part in message.content:
+                if not isinstance(part, TextPromptMessageContent):
+                    raise InvokeBadRequestError(
+                        "Gemini system instructions support text only. "
+                        "Move files to a user message."
+                    )
+                if part.data:
+                    has_system_instruction = True
+
+        if model == "gemini-2.5-flash-image" and has_system_instruction:
+            raise InvokeBadRequestError(
+                "gemini-2.5-flash-image does not support system instructions. "
+                "Move the instruction to a user message."
+            )
 
         def has_content(message: PromptMessage) -> bool:
             if isinstance(message, ToolPromptMessage):
@@ -1023,7 +1033,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         stream: bool = True,
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator[LLMResultChunk]]:
-        self._validate_prompt_messages(prompt_messages)
+        self._validate_prompt_messages(model, prompt_messages)
         if (
             model_parameters.get("response_format")
             and prompt_messages
@@ -1098,7 +1108,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         stream: bool = True,
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator[LLMResultChunk]]:
-        self._validate_prompt_messages(prompt_messages)
+        self._validate_prompt_messages(model, prompt_messages)
 
         # Validate and adjust feature compatibility
         model_parameters = self._validate_feature_compatibility(model_parameters, tools)

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -162,6 +162,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             InvokeConnectionError: [errors.APIError, errors.ClientError],
             InvokeServerUnavailableError: [errors.ServerError],
             InvokeBadRequestError: [
+                InvokeBadRequestError,
                 errors.ClientError,
                 errors.UnknownFunctionCallArgumentError,
                 errors.UnsupportedFunctionError,
@@ -485,6 +486,73 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
 
         if tools:
             config.tools.append(self._convert_tools_to_gemini_tool(tools))
+
+    @staticmethod
+    def _validate_prompt_messages(prompt_messages: list[PromptMessage]) -> None:
+        for message in prompt_messages:
+            if (
+                isinstance(message, SystemPromptMessage)
+                and isinstance(message.content, list)
+                and any(
+                    not isinstance(part, TextPromptMessageContent)
+                    for part in message.content
+                )
+            ):
+                raise InvokeBadRequestError(
+                    "Gemini system instructions support text only. "
+                    "Move files to a user message."
+                )
+
+        def has_content(message: PromptMessage) -> bool:
+            if isinstance(message, ToolPromptMessage):
+                return True
+            if isinstance(message, AssistantPromptMessage) and message.tool_calls:
+                return True
+
+            content = message.content
+            if isinstance(content, str):
+                if isinstance(message, AssistantPromptMessage):
+                    content = re.sub(
+                        r"^<think>.*?</think>\s*",
+                        "",
+                        content,
+                        count=1,
+                        flags=re.DOTALL,
+                    )
+                return bool(content)
+
+            if not content:
+                return False
+
+            for part in content:
+                if not isinstance(part, TextPromptMessageContent):
+                    if GeminiFilePartFactory.is_supported(part):
+                        return True
+                    continue
+                text = part.data
+                if isinstance(message, AssistantPromptMessage):
+                    text = re.sub(
+                        r"^<think>.*?</think>\s*",
+                        "",
+                        text,
+                        count=1,
+                        flags=re.DOTALL,
+                    )
+                if text:
+                    return True
+            return False
+
+        for message in prompt_messages:
+            if isinstance(message, SystemPromptMessage) or not has_content(message):
+                continue
+            if isinstance(message, UserPromptMessage):
+                return
+            break
+
+        raise InvokeBadRequestError(
+            "No valid content to send to Gemini API. "
+            "Please start with a non-empty user message."
+        )
 
     def _build_gemini_contents(
         self,
@@ -944,6 +1012,29 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         )
         return message
 
+    def _code_block_mode_wrapper(
+        self,
+        model: str,
+        credentials: dict,
+        prompt_messages: list[PromptMessage],
+        model_parameters: dict,
+        tools: Optional[list[PromptMessageTool]] = None,
+        stop: Optional[list[str]] = None,
+        stream: bool = True,
+        user: Optional[str] = None,
+    ) -> Union[LLMResult, Generator[LLMResultChunk]]:
+        self._validate_prompt_messages(prompt_messages)
+        return super()._code_block_mode_wrapper(
+            model=model,
+            credentials=credentials,
+            prompt_messages=prompt_messages,
+            model_parameters=model_parameters,
+            tools=tools,
+            stop=stop,
+            stream=stream,
+            user=user,
+        )
+
     def _invoke(
         self,
         model: str,
@@ -991,6 +1082,8 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         stream: bool = True,
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator[LLMResultChunk]]:
+        self._validate_prompt_messages(prompt_messages)
+
         # Validate and adjust feature compatibility
         model_parameters = self._validate_feature_compatibility(model_parameters, tools)
 

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -505,6 +505,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         :return: list of Gemini Content objects ready for use
         """
         contents = []
+        system_parts = []
         file_part_factory = GeminiFilePartFactory(
             genai_client=genai_client,
             file_server_url_prefix=file_server_url_prefix,
@@ -513,10 +514,25 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         )
 
         for msg in prompt_messages:
+            if isinstance(msg, SystemPromptMessage):
+                if isinstance(msg.content, str):
+                    if msg.content:
+                        system_parts.append(types.Part.from_text(text=msg.content))
+                    continue
+
+                for part in msg.content:
+                    if not isinstance(part, TextPromptMessageContent):
+                        raise InvokeBadRequestError(
+                            "Gemini system instructions support text only. "
+                            "Move files to a user message."
+                        )
+                    if part.data:
+                        system_parts.append(types.Part.from_text(text=part.data))
+                continue
+
             content = self._format_message_to_gemini_content(
                 msg,
                 genai_client,
-                config,
                 file_server_url_prefix,
                 model_parameters,
                 file_part_factory,
@@ -529,13 +545,15 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 contents[-1].parts.extend(content.parts)
             else:
                 contents.append(content)
+
+        if system_parts:
+            config.system_instruction = types.Content(parts=system_parts)
         return contents
 
     def _format_message_to_gemini_content(
         self,
         message: PromptMessage,
         genai_client: genai.Client,
-        config: types.GenerateContentConfig,
         file_server_url_prefix: str | None = None,
         model_parameters: Mapping[str, Any] | None = None,
         file_part_factory: GeminiFilePartFactory | None = None,
@@ -545,7 +563,6 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
 
         :param message: one PromptMessage
         :param genai_client: Google GenAI client
-        :param config: GenerateContentConfig object
         :param file_server_url_prefix: optional file server URL prefix
         :param model_parameters: model parameters dictionary
         :return: Gemini Content representation of message
@@ -626,16 +643,6 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 return None
 
             return types.Content(role="model", parts=parts)
-
-        elif isinstance(message, SystemPromptMessage):
-            # String content -> system instruction
-            if isinstance(message.content, str):
-                config.system_instruction = message.content
-                return None
-
-            # List content -> convert to user message (Files[] compatibility)
-            if isinstance(message.content, list):
-                return types.Content(role="user", parts=build_parts(message.content))
 
         elif isinstance(message, ToolPromptMessage):
             return types.Content(

--- a/models/gemini/models/tests/test_document_filtering.py
+++ b/models/gemini/models/tests/test_document_filtering.py
@@ -370,8 +370,7 @@ class TestDocumentFilteringUnit:
                 )
 
             # Should be filtered out
-            assert len(contents) == 1
-            assert len(contents[0].parts) == 0, f"Failed for {format_ext}"
+            assert not contents, f"Failed for {format_ext}"
 
     def test_unsupported_extensions_filtered(self):
         """Test that documents with unsupported extensions are filtered out."""
@@ -396,8 +395,7 @@ class TestDocumentFilteringUnit:
                 )
 
             # Should be filtered out
-            assert len(contents) == 1
-            assert len(contents[0].parts) == 0, f"Failed for extension {ext}"
+            assert not contents, f"Failed for extension {ext}"
 
     def test_case_insensitive_extension_filtering(self):
         """Test that extension filtering is case-insensitive."""
@@ -422,8 +420,7 @@ class TestDocumentFilteringUnit:
                 )
 
             # Should be filtered regardless of case
-            assert len(contents) == 1
-            assert len(contents[0].parts) == 0, f"Failed for case variant {ext}"
+            assert not contents, f"Failed for case variant {ext}"
 
     def test_mixed_supported_unsupported_documents(self):
         """Test filtering with mixed supported and unsupported documents."""
@@ -517,8 +514,7 @@ class TestDocumentFilteringUnit:
             )
 
         # All content filtered out
-        assert len(contents) == 1
-        assert len(contents[0].parts) == 0
+        assert not contents
 
     def test_none_mime_type_handling(self):
         """Test handling of documents with None mime_type."""

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -537,6 +537,30 @@ class TestBuildGeminiContents:
         assert self.mock_config.system_instruction is None
         assert [part.text for part in contents[0].parts] == ["Hello"]
 
+    def test_image_model_rejects_system_instruction_before_client_creation(self):
+        with patch("models.llm.llm.genai.Client") as client_factory:
+            with pytest.raises(
+                InvokeBadRequestError,
+                match="gemini-2.5-flash-image does not support system instructions",
+            ):
+                self.llm._generate(
+                    model="gemini-2.5-flash-image",
+                    credentials={"google_api_key": "test-key"},
+                    prompt_messages=[
+                        SystemPromptMessage(
+                            content=[
+                                TextPromptMessageContent(
+                                    data="Keep the subject centered."
+                                )
+                            ]
+                        ),
+                        UserPromptMessage(content="Draw a red fox."),
+                    ],
+                    model_parameters={},
+                )
+
+        client_factory.assert_not_called()
+
     @pytest.mark.parametrize(
         "extra_messages",
         [

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -542,15 +542,20 @@ class TestBuildGeminiContents:
         [
             [],
             [UserPromptMessage(content="")],
+            [AssistantPromptMessage(content="Answer")],
+            [
+                AssistantPromptMessage(content="Answer"),
+                UserPromptMessage(content="Question"),
+            ],
         ],
     )
-    def test_system_without_user_content_is_rejected(self, extra_messages):
+    def test_system_without_leading_user_content_is_rejected(self, extra_messages):
         mock_client = Mock()
 
         with patch("models.llm.llm.genai.Client", return_value=mock_client):
             with pytest.raises(
                 InvokeBadRequestError,
-                match="at least one user message with content",
+                match="start with a non-empty user message",
             ):
                 self.llm._generate(
                     model="gemini-2.0-flash",

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -524,6 +524,32 @@ class TestBuildGeminiContents:
         assert len(contents) == 1
         assert contents[0].parts[0].text == "Hello"
 
+    def test_system_only_text_parts_reach_generation(self):
+        mock_client = Mock()
+
+        with patch("models.llm.llm.genai.Client", return_value=mock_client):
+            self.llm._generate(
+                model="gemini-2.0-flash",
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[
+                    SystemPromptMessage(
+                        content=[
+                            TextPromptMessageContent(data="First instruction."),
+                            TextPromptMessageContent(data="Second instruction."),
+                        ]
+                    )
+                ],
+                model_parameters={},
+            )
+
+        contents = mock_client.models.generate_content_stream.call_args.kwargs[
+            "contents"
+        ]
+        assert [part.text for part in contents[0].parts] == [
+            "First instruction.",
+            "Second instruction.",
+        ]
+
     def test_multiple_system_messages_are_combined(self):
         messages = [
             SystemPromptMessage(content="First instruction."),
@@ -549,6 +575,15 @@ class TestBuildGeminiContents:
     def test_system_message_with_multimodal_content(self):
         """Test that multimodal system messages fail instead of becoming user messages"""
         messages = [
+            UserPromptMessage(
+                content=[
+                    ImagePromptMessageContent(
+                        format="png",
+                        base64_data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+                        mime_type="image/png",
+                    )
+                ]
+            ),
             SystemPromptMessage(
                 content=[
                     TextPromptMessageContent(data="System context with image:"),
@@ -558,7 +593,7 @@ class TestBuildGeminiContents:
                         mime_type="image/png",
                     ),
                 ]
-            )
+            ),
         ]
 
         # Mock the file upload since we have multimodal content
@@ -572,7 +607,11 @@ class TestBuildGeminiContents:
         mock_client.files.upload.return_value = mock_file
         mock_client.files.get.return_value = mock_file
 
-        with patch("tempfile.NamedTemporaryFile"), patch("os.unlink"):
+        with (
+            patch("models.llm.llm.file_cache", MemoryFileCache()),
+            patch("tempfile.NamedTemporaryFile"),
+            patch("os.unlink"),
+        ):
             with pytest.raises(
                 InvokeBadRequestError,
                 match="Gemini system instructions support text only",

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -537,37 +537,37 @@ class TestBuildGeminiContents:
         assert self.mock_config.system_instruction is None
         assert [part.text for part in contents[0].parts] == ["Hello"]
 
-    def test_system_only_text_parts_reach_generation(self):
+    @pytest.mark.parametrize(
+        "extra_messages",
+        [
+            [],
+            [UserPromptMessage(content="")],
+        ],
+    )
+    def test_system_without_user_content_is_rejected(self, extra_messages):
         mock_client = Mock()
 
         with patch("models.llm.llm.genai.Client", return_value=mock_client):
-            self.llm._generate(
-                model="gemini-2.0-flash",
-                credentials={"google_api_key": "test-key"},
-                prompt_messages=[
-                    SystemPromptMessage(
-                        content=[
-                            TextPromptMessageContent(data="First instruction."),
-                            TextPromptMessageContent(data="Second instruction."),
-                        ]
-                    )
-                ],
-                model_parameters={},
-            )
+            with pytest.raises(
+                InvokeBadRequestError,
+                match="at least one user message with content",
+            ):
+                self.llm._generate(
+                    model="gemini-2.0-flash",
+                    credentials={"google_api_key": "test-key"},
+                    prompt_messages=[
+                        SystemPromptMessage(
+                            content=[
+                                TextPromptMessageContent(data="First instruction."),
+                                TextPromptMessageContent(data="Second instruction."),
+                            ]
+                        ),
+                        *extra_messages,
+                    ],
+                    model_parameters={},
+                )
 
-        contents = mock_client.models.generate_content_stream.call_args.kwargs[
-            "contents"
-        ]
-        assert [part.text for part in contents[0].parts] == [
-            "First instruction.",
-            "Second instruction.",
-        ]
-        assert (
-            mock_client.models.generate_content_stream.call_args.kwargs[
-                "config"
-            ].system_instruction
-            is None
-        )
+        mock_client.models.generate_content_stream.assert_not_called()
 
     def test_multiple_system_messages_are_combined(self):
         messages = [

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -544,6 +544,13 @@ class TestBuildGeminiContents:
             [UserPromptMessage(content="")],
             [AssistantPromptMessage(content="Answer")],
             [
+                ToolPromptMessage(
+                    name="lookup",
+                    content="Result",
+                    tool_call_id="call-1",
+                )
+            ],
+            [
                 AssistantPromptMessage(content="Answer"),
                 UserPromptMessage(content="Question"),
             ],
@@ -573,6 +580,149 @@ class TestBuildGeminiContents:
                 )
 
         mock_client.models.generate_content_stream.assert_not_called()
+
+    def test_model_first_is_rejected_before_later_file_upload(self):
+        mock_client = Mock()
+
+        with patch("models.llm.llm.genai.Client", return_value=mock_client):
+            with pytest.raises(
+                InvokeBadRequestError,
+                match="start with a non-empty user message",
+            ):
+                self.llm._generate(
+                    model="gemini-2.0-flash",
+                    credentials={"google_api_key": "test-key"},
+                    prompt_messages=[
+                        AssistantPromptMessage(content="Answer"),
+                        UserPromptMessage(
+                            content=[
+                                ImagePromptMessageContent(
+                                    format="png",
+                                    base64_data="aGVsbG8=",
+                                    mime_type="image/png",
+                                )
+                            ]
+                        ),
+                    ],
+                    model_parameters={},
+                )
+
+        mock_client.files.upload.assert_not_called()
+
+    def test_model_first_tool_call_is_rejected_before_arguments_are_parsed(self):
+        with pytest.raises(
+            InvokeBadRequestError,
+            match="start with a non-empty user message",
+        ):
+            self.llm._generate(
+                model="gemini-2.0-flash",
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[
+                    AssistantPromptMessage(
+                        content="",
+                        tool_calls=[
+                            AssistantPromptMessage.ToolCall(
+                                id="call-1",
+                                type="function",
+                                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                                    name="lookup",
+                                    arguments="{",
+                                ),
+                            )
+                        ],
+                    ),
+                    UserPromptMessage(content="Question"),
+                ],
+                model_parameters={},
+            )
+
+    def test_filtered_user_does_not_hide_model_first_tool_call(self):
+        with pytest.raises(
+            InvokeBadRequestError,
+            match="start with a non-empty user message",
+        ):
+            self.llm._generate(
+                model="gemini-2.0-flash",
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[
+                    UserPromptMessage(
+                        content=[
+                            DocumentPromptMessageContent(
+                                format="docx",
+                                base64_data="dGVzdA==",
+                                mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                            )
+                        ]
+                    ),
+                    AssistantPromptMessage(
+                        content="",
+                        tool_calls=[
+                            AssistantPromptMessage.ToolCall(
+                                id="call-1",
+                                type="function",
+                                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                                    name="lookup",
+                                    arguments="{",
+                                ),
+                            )
+                        ],
+                    ),
+                ],
+                model_parameters={},
+            )
+
+    def test_bad_request_mapping_preserves_error_type(self):
+        error = self.llm._transform_invoke_error(
+            InvokeBadRequestError("Invalid prompt")
+        )
+
+        assert isinstance(error, InvokeBadRequestError)
+
+    def test_code_block_wrapper_rejects_multimodal_system_before_conversion(self):
+        messages = [
+            SystemPromptMessage(
+                content=[
+                    TextPromptMessageContent(data="Instruction"),
+                    ImagePromptMessageContent(
+                        format="png",
+                        base64_data="aGVsbG8=",
+                        mime_type="image/png",
+                    ),
+                ]
+            ),
+            UserPromptMessage(content="Question"),
+        ]
+
+        with patch.object(self.llm, "_invoke") as mock_invoke:
+            with pytest.raises(
+                InvokeBadRequestError,
+                match="system instructions support text only",
+            ):
+                self.llm._code_block_mode_wrapper(
+                    model="gemini-pro",
+                    credentials={"google_api_key": "test-key"},
+                    prompt_messages=messages,
+                    model_parameters={"response_format": "JSON"},
+                )
+
+        mock_invoke.assert_not_called()
+
+    def test_code_block_wrapper_rejects_system_only_prompt(self):
+        with patch.object(self.llm, "_invoke") as mock_invoke:
+            with pytest.raises(
+                InvokeBadRequestError,
+                match="start with a non-empty user message",
+            ):
+                self.llm._code_block_mode_wrapper(
+                    model="gemini-pro",
+                    credentials={"google_api_key": "test-key"},
+                    prompt_messages=[
+                        SystemPromptMessage(content="Instruction"),
+                    ],
+                    model_parameters={"response_format": "JSON"},
+                )
+
+        mock_invoke.assert_not_called()
 
     def test_multiple_system_messages_are_combined(self):
         messages = [

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -524,6 +524,19 @@ class TestBuildGeminiContents:
         assert len(contents) == 1
         assert contents[0].parts[0].text == "Hello"
 
+    def test_empty_system_message_is_ignored(self):
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=[
+                SystemPromptMessage(),
+                UserPromptMessage(content="Hello"),
+            ],
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert self.mock_config.system_instruction is None
+        assert [part.text for part in contents[0].parts] == ["Hello"]
+
     def test_system_only_text_parts_reach_generation(self):
         mock_client = Mock()
 
@@ -549,6 +562,12 @@ class TestBuildGeminiContents:
             "First instruction.",
             "Second instruction.",
         ]
+        assert (
+            mock_client.models.generate_content_stream.call_args.kwargs[
+                "config"
+            ].system_instruction
+            is None
+        )
 
     def test_multiple_system_messages_are_combined(self):
         messages = [

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -671,12 +671,22 @@ class TestBuildGeminiContents:
                 model_parameters={},
             )
 
-    def test_bad_request_mapping_preserves_error_type(self):
-        error = self.llm._transform_invoke_error(
-            InvokeBadRequestError("Invalid prompt")
-        )
-
-        assert isinstance(error, InvokeBadRequestError)
+    def test_public_invoke_preserves_bad_request_error_type(self):
+        with patch.object(
+            self.llm,
+            "_validate_and_filter_model_parameters",
+            return_value={},
+        ):
+            with pytest.raises(InvokeBadRequestError):
+                next(
+                    self.llm.invoke(
+                        model="gemini-pro",
+                        credentials={"google_api_key": "test-key"},
+                        prompt_messages=[
+                            SystemPromptMessage(content="Instruction"),
+                        ],
+                    )
+                )
 
     def test_code_block_wrapper_rejects_multimodal_system_before_conversion(self):
         messages = [

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -734,6 +734,38 @@ class TestBuildGeminiContents:
 
         mock_invoke.assert_not_called()
 
+    def test_code_block_wrapper_preserves_text_system_parts(self):
+        mock_client = Mock()
+
+        with (
+            patch("models.llm.llm.genai.Client", return_value=mock_client),
+            patch.object(self.llm, "_handle_generate_response"),
+        ):
+            self.llm._code_block_mode_wrapper(
+                model="gemini-pro",
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[
+                    SystemPromptMessage(
+                        content=[
+                            TextPromptMessageContent(data="First instruction."),
+                            TextPromptMessageContent(data="Second instruction."),
+                        ]
+                    ),
+                    UserPromptMessage(content="Question"),
+                ],
+                model_parameters={"response_format": "JSON"},
+                stream=False,
+            )
+
+        instruction = mock_client.models.generate_content.call_args.kwargs[
+            "config"
+        ].system_instruction
+        assert [part.text for part in instruction.parts[1:]] == [
+            "First instruction.",
+            "Second instruction.",
+        ]
+        assert "TextPromptMessageContent" not in instruction.parts[0].text
+
     def test_multiple_system_messages_are_combined(self):
         messages = [
             SystemPromptMessage(content="First instruction."),

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -17,6 +17,7 @@ from dify_plugin.entities.model.message import (
     UserPromptMessage,
     VideoPromptMessageContent,
 )
+from dify_plugin.errors.model import InvokeBadRequestError
 from google.genai import types
 from models.llm.file_parts import (
     FILE_DOWNLOAD_TIMEOUT_SECONDS,
@@ -297,7 +298,6 @@ class TestContentConversion:
             self.llm._format_message_to_gemini_content(
                 message=invalid_message,
                 genai_client=self.mock_client,
-                config=self.mock_config,
             )
 
     def test_file_upload_with_caching(self):
@@ -493,13 +493,61 @@ class TestBuildGeminiContents:
         )
 
         # System message should set config.system_instruction, not appear in contents
-        assert self.mock_config.system_instruction == "You are a helpful assistant"
+        assert [part.text for part in self.mock_config.system_instruction.parts] == [
+            "You are a helpful assistant"
+        ]
         assert len(contents) == 1
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "Hello"
 
+    def test_system_message_with_text_parts_as_instruction(self):
+        messages = [
+            SystemPromptMessage(
+                content=[
+                    TextPromptMessageContent(data="You are a helpful assistant."),
+                    TextPromptMessageContent(data="Keep answers concise."),
+                ]
+            ),
+            UserPromptMessage(content="Hello"),
+        ]
+
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=messages,
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert [part.text for part in self.mock_config.system_instruction.parts] == [
+            "You are a helpful assistant.",
+            "Keep answers concise.",
+        ]
+        assert len(contents) == 1
+        assert contents[0].parts[0].text == "Hello"
+
+    def test_multiple_system_messages_are_combined(self):
+        messages = [
+            SystemPromptMessage(content="First instruction."),
+            UserPromptMessage(content="Hello"),
+            SystemPromptMessage(
+                content=[TextPromptMessageContent(data="Second instruction.")]
+            ),
+        ]
+
+        contents = self.llm._build_gemini_contents(
+            prompt_messages=messages,
+            genai_client=self.mock_client,
+            config=self.mock_config,
+        )
+
+        assert [part.text for part in self.mock_config.system_instruction.parts] == [
+            "First instruction.",
+            "Second instruction.",
+        ]
+        assert len(contents) == 1
+        assert contents[0].parts[0].text == "Hello"
+
     def test_system_message_with_multimodal_content(self):
-        """Test that system messages with list content are converted to user messages"""
+        """Test that multimodal system messages fail instead of becoming user messages"""
         messages = [
             SystemPromptMessage(
                 content=[
@@ -525,17 +573,17 @@ class TestBuildGeminiContents:
         mock_client.files.get.return_value = mock_file
 
         with patch("tempfile.NamedTemporaryFile"), patch("os.unlink"):
-            contents = self.llm._build_gemini_contents(
-                prompt_messages=messages,
-                genai_client=mock_client,
-                config=self.mock_config,
-            )
+            with pytest.raises(
+                InvokeBadRequestError,
+                match="Gemini system instructions support text only",
+            ):
+                self.llm._build_gemini_contents(
+                    prompt_messages=messages,
+                    genai_client=mock_client,
+                    config=self.mock_config,
+                )
 
-        assert len(contents) == 1
-        assert contents[0].role == "user"
-        assert len(contents[0].parts) == 2
-        assert contents[0].parts[0].text == "System context with image:"
-        assert contents[0].parts[1].file_data.file_uri == "gs://test-file-uri"
+        mock_client.files.upload.assert_not_called()
 
     def test_tool_message(self):
         """Test conversion of tool prompt messages"""
@@ -661,7 +709,9 @@ class TestBuildGeminiContents:
         )
 
         # System message sets instruction, not in contents
-        assert self.mock_config.system_instruction == "You are a helpful assistant"
+        assert [part.text for part in self.mock_config.system_instruction.parts] == [
+            "You are a helpful assistant"
+        ]
 
         # Should have 5 contents after processing
         assert len(contents) == 5


### PR DESCRIPTION
## Summary

Fixes #3449.

Dify can emit system prompts as structured text parts, but the Gemini plugin currently demotes every list-valued system prompt to user content.
This change collects all non-empty text system messages into one Gemini `system_instruction` while preserving message order and part boundaries.
It combines multiple system messages instead of allowing the last one to overwrite earlier instructions.
It rejects non-text system content with an actionable `InvokeBadRequestError` because Gemini system instructions are text-only.
It ignores empty system messages and omits empty or fully filtered ordinary turns.
Requests without a leading non-empty user turn raise an actionable error instead of sending an empty or model-first conversation to Gemini.
Tool responses do not qualify as a leading user turn.
Raw prompts are validated before structured-response wrapping, assistant tool-argument parsing, file reads, and file uploads.
This prevents the generic code-block wrapper from stringifying unsupported system content or synthesizing a user turn that bypasses provider validation.
Text-only structured system parts also remain separate through successful structured-response wrapping.
Fully filtered user turns are ignored by leading-turn validation.
Provider validation failures remain `InvokeBadRequestError` at the public invoke boundary.
It also removes configuration mutation from the generic per-message formatter.
Gemini 2.5 Flash Image system prompts are rejected before client creation because the Developer API does not enable developer instructions for that model.
This change is mutually exclusive with the compatibility alternative in #3450, tracked by #3448.
The behavior change is reflected by a minor version bump from `0.9.1` to `0.10.0`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable because this change only affects request conversion and validation.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Message flow (system messages, user ↔ assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [x] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

The existing `dify-plugin>=0.9.0` dependency and lockfile are unchanged.

## Testing

- [ ] Local deployment — Dify version:
- [ ] SaaS (cloud.dify.ai)

Automated checks were run from the locked plugin environment.

- `uv run --frozen python -m pytest -m 'not integration'`: `157 passed, 15 skipped, 5 deselected`.
- `uv run --frozen ruff check models/llm/llm.py models/tests/test_llm.py`: passed.
- `uv run --frozen ruff format --check models/llm/llm.py models/tests/test_llm.py`: passed.
