### PR TITLE
fix(openai): restore gpt-4.1-nano predefined model entries

### DIFF
--- a/models/openai/manifest.yaml
+++ b/models/openai/manifest.yaml
@@ -1,4 +1,4 @@
-version: 1.0.0
+version: 1.0.1
 type: plugin
 author: "langgenius"
 name: "openai"

--- a/models/openai/models/llm/_position.yaml
+++ b/models/openai/models/llm/_position.yaml
@@ -28,8 +28,10 @@
 - gpt-audio-mini-2025-12-15
 - gpt-4.1
 - gpt-4.1-mini
+- gpt-4.1-nano
 - gpt-4.1-2025-04-14
 - gpt-4.1-mini-2025-04-14
+- gpt-4.1-nano-2025-04-14
 - gpt-4o-mini
 - gpt-4o-2024-08-06
 - gpt-4o-2024-11-20

--- a/models/openai/models/llm/gpt-4.1-nano-2025-04-14.yaml
+++ b/models/openai/models/llm/gpt-4.1-nano-2025-04-14.yaml
@@ -1,0 +1,47 @@
+model: gpt-4.1-nano-2025-04-14
+label:
+  zh_Hans: gpt-4.1-nano-2025-04-14
+  en_US: gpt-4.1-nano-2025-04-14
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 1047576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: presence_penalty
+    use_template: presence_penalty
+  - name: frequency_penalty
+    use_template: frequency_penalty
+  - name: max_tokens
+    use_template: max_tokens
+    default: 512
+    min: 1
+    max: 32768
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.10'
+  output: '0.40'
+  unit: '0.000001'
+  currency: USD

--- a/models/openai/models/llm/gpt-4.1-nano.yaml
+++ b/models/openai/models/llm/gpt-4.1-nano.yaml
@@ -1,0 +1,47 @@
+model: gpt-4.1-nano
+label:
+  zh_Hans: gpt-4.1-nano
+  en_US: gpt-4.1-nano
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 1047576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: presence_penalty
+    use_template: presence_penalty
+  - name: frequency_penalty
+    use_template: frequency_penalty
+  - name: max_tokens
+    use_template: max_tokens
+    default: 512
+    min: 1
+    max: 32768
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.10'
+  output: '0.40'
+  unit: '0.000001'
+  currency: USD

--- a/models/openai/pyproject.toml
+++ b/models/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify-openai"
-version = "1.0.0"
+version = "1.0.1"
 description = "OpenAI models for Dify"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/models/openai/tests/test_catalog.py
+++ b/models/openai/tests/test_catalog.py
@@ -38,8 +38,6 @@ REMOVED_MODELS = {
     "gpt-4-turbo",
     "gpt-4-turbo-2024-04-09",
     "gpt-4-turbo-preview",
-    "gpt-4.1-nano",
-    "gpt-4.1-nano-2025-04-14",
     "gpt-4o",
     "gpt-4o-2024-05-13",
     "gpt-4o-audio-preview",
@@ -159,8 +157,8 @@ def test_version_one_is_consistent_and_documented() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
-    assert manifest["version"] == "1.0.0"
-    assert project["project"]["version"] == "1.0.0"
+    assert manifest["version"] == "1.0.1"
+    assert project["project"]["version"] == "1.0.1"
     assert "Version 1.0 is a major rewrite" in readme
     permissions = manifest["resource"]["permission"]["model"]
     assert permissions["enabled"] is True

--- a/models/openai/uv.lock
+++ b/models/openai/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-openai"
-version = "1.0.0"
+version = "1.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "dify-plugin" },


### PR DESCRIPTION
## Summary

Fixes #3447.

The v1.0 rewrite ([#3419](https://github.com/langgenius/dify-official-plugins/pull/3419), commit `0c57704c`) flagged a breaking change that "removes deprecated model entries," but `gpt-4.1-nano` is not deprecated — it is still listed on OpenAI's pricing page and is a supported base model for fine-tuning. The two related YAMLs were removed accidentally and the rest of the `4.1` family was kept intact.

This restores the missing predefined model entries so that fine-tuned models based on `gpt-4.1-nano` can be validated, enumerated, and added to the catalog again.

### Changes

- Restore `models/openai/models/llm/gpt-4.1-nano.yaml` from `0c57704c^:models/openai/models/llm/gpt-4.1-nano.yaml` (identical structure to `gpt-4.1-mini.yaml`, with `pricing.input: 0.10`, `pricing.output: 0.40` per OpenAI's published rates).
- Restore `models/openai/models/llm/gpt-4.1-nano-2025-04-14.yaml` from the same commit.
- Add the two models to `models/openai/models/llm/_position.yaml` in the `gpt-4.1` cluster, mirroring the existing `gpt-4.1` / `gpt-4.1-2025-04-14` / `gpt-4.1-mini` / `gpt-4.1-mini-2025-04-14` ordering.
- Remove `"gpt-4.1-nano"` and `"gpt-4.1-nano-2025-04-14"` from the `REMOVED_MODELS` set in `tests/test_catalog.py` so the catalog test asserts they are present.
- Bump `manifest.yaml` and `pyproject.toml` from `1.0.0` to `1.0.1` (PATCH: bug fix, backward-compatible). Update the corresponding assertion in `test_version_one_is_consistent_and_documented`.
- Refresh `uv.lock` to reflect the version bump.

### Scope

This PR addresses **only the first of three problems** identified in the issue:

1. Missing `gpt-4.1-nano` schemas — **fixed by this PR**.
2. Misleading error message in `validate_credentials` ("Fine-tuned model ... not found" should describe the actual condition, "no predefined schema for base model ...").
3. Silent drop in `remote_models` (`schema is None: continue`) and the switch from substring matching to exact-key lookup, which now also blocks fine-tunes of `gpt-5`, `gpt-5-mini`, and `gpt-5-nano` dated snapshots.

Problems #2 and #3 are out of scope here because they touch the catalog resolver logic itself and need a design decision (log vs. raise, alias fallback vs. snapshot restore). Happy to follow up with separate PRs if maintainers want to address them.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin only
- [x] LLM and multimodal model plugin

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change</summary>

- [x] Model catalog and parameter rules

</details>

## Version

- [x] `manifest.yaml` and `pyproject.toml` are `1.0.1`.
- [x] `openai>=2.45.0` and `dify_plugin>=0.9.0` are declared and locked.
- [x] `uv.lock` is refreshed (`uv lock`).
- [x] `test_version_one_is_consistent_and_documented` updated to match the new version.

## Testing

- `uv run --frozen pytest tests/test_catalog.py -v` — `7 passed` (the catalog now contains both restored models and `REMOVED_MODELS.isdisjoint(models)` passes).
- `uv run --frozen pytest tests/` — `152 passed`, all failures are in `tests/live/` which require `OPENAI_API_KEY` (expected offline).
- `uv run --frozen ruff check .` — `All checks passed!`.
- `uv lock --check` — clean after `uv lock`.
- Manual end-to-end `validate_credentials` cannot be reproduced without an OpenAI fine-tuned model; the catalog-level guarantee is the strongest offline evidence that `schemas.get(_base_model(remote.id))` will now return the correct schema for `ft:gpt-4.1-nano-2025-04-14:*`.

## Official references

- https://developers.openai.com/api/docs/models
- https://developers.openai.com/api/docs/models/gpt-4.1
- https://developers.openai.com/api/docs/pricing
