### PR TITLE
fix(moonshot): auto-detect the API endpoint when Base URL is left blank

### DIFF
--- a/models/moonshot/manifest.yaml
+++ b/models/moonshot/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.9
+version: 0.1.10

--- a/models/moonshot/models/llm/llm.py
+++ b/models/moonshot/models/llm/llm.py
@@ -23,6 +23,7 @@ from dify_plugin.entities.model.message import (
     UserPromptMessage,
     VideoPromptMessageContent,
 )
+from dify_plugin.errors.model import CredentialsValidateFailedError
 from requests import Response
 
 
@@ -37,6 +38,8 @@ class MoonshotLargeLanguageModel(OAICompatLargeLanguageModel):
         "kimi-k2.7-code-highspeed",
         "kimi-k3",
     }
+    _INTERNATIONAL_ENDPOINT = "https://api.moonshot.ai/v1"
+    _MAINLAND_ENDPOINT = "https://api.moonshot.cn/v1"
 
     def _invoke(
         self,
@@ -122,8 +125,36 @@ class MoonshotLargeLanguageModel(OAICompatLargeLanguageModel):
         return cleaned
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
-        self._add_custom_parameters(credentials)
-        super().validate_credentials(model, credentials)
+        # An explicitly set endpoint_url (including a proxy/gateway URL) is used
+        # as-is with no fallback, so existing configurations stay untouched.
+        if credentials.get("endpoint_url"):
+            self._add_custom_parameters(credentials)
+            super().validate_credentials(model, credentials)
+            return
+
+        # endpoint_url left blank: Moonshot runs two platforms whose API keys are
+        # not interchangeable. Try the international endpoint first (the platform
+        # the plugin's docs point to), then mainland China, and persist whichever
+        # authenticates so later invokes use it directly without re-probing.
+        last_error: CredentialsValidateFailedError | None = None
+        for endpoint_url in (self._INTERNATIONAL_ENDPOINT, self._MAINLAND_ENDPOINT):
+            trial = dict(credentials)
+            trial["endpoint_url"] = endpoint_url
+            self._add_custom_parameters(trial)
+            try:
+                super().validate_credentials(model, trial)
+            except CredentialsValidateFailedError as error:
+                last_error = error
+                continue
+            credentials["endpoint_url"] = endpoint_url
+            self._add_custom_parameters(credentials)
+            return
+
+        # Both endpoints rejected the key: it is genuinely invalid, so surface the
+        # original authentication error (from the mainland attempt, matching the
+        # pre-change default) rather than a synthesized one.
+        if last_error is not None:
+            raise last_error
 
     def get_customizable_model_schema(
         self, model: str, credentials: dict
@@ -173,8 +204,8 @@ class MoonshotLargeLanguageModel(OAICompatLargeLanguageModel):
 
     def _add_custom_parameters(self, credentials: dict) -> None:
         credentials["mode"] = "chat"
-        if "endpoint_url" not in credentials or credentials["endpoint_url"] == "":
-            credentials["endpoint_url"] = "https://api.moonshot.cn/v1"
+        if not credentials.get("endpoint_url"):
+            credentials["endpoint_url"] = self._MAINLAND_ENDPOINT
 
     def _add_function_call(self, model: str, credentials: dict) -> None:
         model_schema = self.get_model_schema(model, credentials)

--- a/models/moonshot/provider/moonshot.yaml
+++ b/models/moonshot/provider/moonshot.yaml
@@ -91,8 +91,8 @@ provider_credential_schema:
   - label:
       en_US: API Base URL
     placeholder:
-      en_US: Base URL, e.g. https://api.moonshot.cn/v1
-      zh_Hans: Base URL, 如：https://api.moonshot.cn/v1
+      en_US: Optional. Leave blank to detect your key's platform automatically; set only to override, e.g. a proxy URL
+      zh_Hans: 选填。留空将根据密钥自动选择平台；仅在需要覆盖时填写，如代理地址
     required: false
     type: text-input
     variable: endpoint_url

--- a/models/moonshot/provider/moonshot.yaml
+++ b/models/moonshot/provider/moonshot.yaml
@@ -91,8 +91,8 @@ provider_credential_schema:
   - label:
       en_US: API Base URL
     placeholder:
-      en_US: Optional. Leave blank to detect your key's platform automatically; set only to override, e.g. a proxy URL
-      zh_Hans: 选填。留空将根据密钥自动选择平台；仅在需要覆盖时填写，如代理地址
+      en_US: Optional — leave blank to auto-detect, or set to override.
+      zh_Hans: 选填 — 留空自动检测，或填写以覆盖。
     required: false
     type: text-input
     variable: endpoint_url

--- a/models/moonshot/tests/test_llm.py
+++ b/models/moonshot/tests/test_llm.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import yaml
+from dify_plugin import OAICompatLargeLanguageModel
 from dify_plugin.entities.model import (
     AIModelEntity,
     ModelFeature,
@@ -16,6 +17,7 @@ from dify_plugin.entities.model.message import (
     UserPromptMessage,
     VideoPromptMessageContent,
 )
+from dify_plugin.errors.model import CredentialsValidateFailedError
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -317,3 +319,84 @@ def test_json_schema_is_sent_to_api():
     }
     assert "json_schema" not in request
     assert chunks[0].delta.message.content == '{"answer":"ok"}'
+
+
+INTERNATIONAL = "https://api.moonshot.ai/v1"
+MAINLAND = "https://api.moonshot.cn/v1"
+
+
+def _base_validate_accepting(valid_endpoint, attempts):
+    """A fake OAICompat base validate_credentials that authenticates only for
+    valid_endpoint and records every endpoint it was called with."""
+
+    def _validate(self, model, credentials):
+        attempts.append(credentials.get("endpoint_url"))
+        if credentials.get("endpoint_url") != valid_endpoint:
+            raise CredentialsValidateFailedError(
+                f"401 invalid_authentication_error for {credentials.get('endpoint_url')}"
+            )
+
+    return _validate
+
+
+def test_blank_endpoint_resolves_to_international_and_persists():
+    llm = _llm()
+    credentials = {"api_key": "intl-key"}
+    attempts = []
+    with patch.object(
+        OAICompatLargeLanguageModel,
+        "validate_credentials",
+        _base_validate_accepting(INTERNATIONAL, attempts),
+    ):
+        llm.validate_credentials("moonshot-v1-8k", credentials)
+
+    assert credentials["endpoint_url"] == INTERNATIONAL
+    assert attempts[0] == INTERNATIONAL  # international tried first
+
+
+def test_blank_endpoint_resolves_to_mainland_and_persists():
+    llm = _llm()
+    credentials = {"api_key": "cn-key"}
+    attempts = []
+    with patch.object(
+        OAICompatLargeLanguageModel,
+        "validate_credentials",
+        _base_validate_accepting(MAINLAND, attempts),
+    ):
+        llm.validate_credentials("moonshot-v1-8k", credentials)
+
+    assert credentials["endpoint_url"] == MAINLAND
+    assert attempts == [INTERNATIONAL, MAINLAND]  # international first, then mainland
+
+
+def test_blank_endpoint_invalid_key_surfaces_original_error_and_persists_nothing():
+    llm = _llm()
+    credentials = {"api_key": "bad-key"}
+    attempts = []
+    with patch.object(
+        OAICompatLargeLanguageModel,
+        "validate_credentials",
+        _base_validate_accepting("neither", attempts),
+    ):
+        with pytest.raises(CredentialsValidateFailedError) as excinfo:
+            llm.validate_credentials("moonshot-v1-8k", credentials)
+
+    assert attempts == [INTERNATIONAL, MAINLAND]  # both tried
+    assert MAINLAND in str(excinfo.value)  # original mainland 401 surfaced, not synthesized
+    assert not credentials.get("endpoint_url")  # nothing persisted on failure
+
+
+def test_explicit_endpoint_is_used_as_is_with_no_fallback():
+    llm = _llm()
+    proxy = "https://proxy.internal.example/v1"
+    credentials = {"api_key": "k", "endpoint_url": proxy}
+    attempts = []
+    with patch.object(
+        OAICompatLargeLanguageModel,
+        "validate_credentials",
+        _base_validate_accepting(proxy, attempts),
+    ):
+        llm.validate_credentials("moonshot-v1-8k", credentials)
+
+    assert credentials["endpoint_url"] == proxy  # untouched
+    assert attempts == [proxy]  # exactly one attempt, no fallback probing


### PR DESCRIPTION
## Summary

Fixes #3460.

The Moonshot provider's **API Base URL** field is optional, and when left blank the plugin hardcoded `https://api.moonshot.cn/v1` (mainland China). Users following the plugin's own docs and Marketplace description — which point to `platform.moonshot.ai` (international) — got a key that the default endpoint rejects with a bare `401 invalid_authentication_error` naming neither endpoint nor region. Moonshot runs two platforms whose API keys are **not interchangeable**.

This adds a **validation-only endpoint fallback**: when `endpoint_url` is left blank, credential validation tries `api.moonshot.ai` first, then `api.moonshot.cn`, and **persists whichever authenticates** so subsequent invokes use it directly.

**Validation-only — no per-call cost.** The fallback runs only during `validate_credentials`, never per invoke. The resolved endpoint is written into the credentials, which the plugin runtime returns to the host for persistence, so invokes read it with no extra latency or probing.

**Existing configurations are unaffected.**
- A set `endpoint_url` (including a proxy or gateway URL) is used **as-is** — no fallback runs.
- A blank `endpoint_url` on an install that isn't re-validated still resolves to mainland China at invoke time, exactly as before. No forced reconfiguration.
- The change is purely additive: leaving the field blank now auto-detects the platform instead of silently failing for international keys.

**Why not a region selector.** I first implemented the alternative you might expect — remove the free-text field and add a required region selector, matching the [`models/siliconflow`](https://github.com/langgenius/dify-official-plugins/tree/main/models/siliconflow) house pattern. That branch is [here](https://github.com/dparkmit24/dify-official-plugins/tree/moonshot-region-selector). I rejected it because it **forces every existing Moonshot install to re-configure on upgrade**: a required field with no stored value invalidates existing credentials, and proxy users lose their custom URL, with no migration path. For a fix to a "blank field routes wrong" bug, breaking every existing user seemed like too much. Happy to switch if you'd prefer the consistency.

**Design choices, open to change:**
- **International is tried first**, because the plugin's own docs point users to `platform.moonshot.ai`. Easy to reverse.
- **If both endpoints reject the key**, the original `401` is surfaced rather than a synthesized message — at that point the key really is invalid.
- The `.cn`-only placeholder is updated, since the field is now optional for both platforms.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

**Before** 
<img width="638" height="448" alt="moonshot-before" src="https://github.com/user-attachments/assets/147c9b1f-a1cf-4595-977e-0e6ff4f19fc4" />  

**After**
<img width="641" height="447" alt="moonshot-after" src="https://github.com/user-attachments/assets/3a42ed9c-6553-4990-9167-fc92578d1f73" />

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

Credential validation and endpoint resolution only. No change to model invocation, streaming, tool calling, or model parameters.

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — `0.1.9` → `0.1.10`
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`

> Note: this plugin's `pyproject.toml` declares `dify_plugin>=0.9.1` (unchanged by this PR) and has a `uv.lock`. The constraint in the checklist doesn't match what's here — leaving the box unchecked rather than asserting something inaccurate. Happy to update the pin if that's expected.

## Testing

- [x] Local deployment — Dify version: **1.16.0** (self-hosted, Docker Compose)
- [ ] SaaS (cloud.dify.ai)

Ran the plugin's own suite: **13 passed, 2 live-skipped** (`uv run pytest tests/`), including 4 new cases:
- blank `endpoint_url` + a key valid only on `.ai` → resolves to `.ai`
- blank `endpoint_url` + a key valid only on `.cn` → resolves to `.cn`
- blank + an invalid key → both tried, original `401` surfaced, nothing persisted
- explicit `endpoint_url` → used as-is, exactly one attempt, **no fallback** (the no-regression test)

Also verified in a running self-hosted instance: the built package installs cleanly, existing credentials for other providers are unaffected, and a blank Base URL with an international key validates successfully.

## Changes

- `models/moonshot/models/llm/llm.py` — validation-only two-endpoint fallback; persist the resolved endpoint; `endpoint_url` still honored as an override
- `models/moonshot/provider/moonshot.yaml` — updated placeholder (field otherwise unchanged)
- `models/moonshot/manifest.yaml` — version `0.1.9` → `0.1.10`
- `models/moonshot/tests/test_llm.py` — 4 new tests

---

*Implemented with AI assistance (Claude) using a two-agent workflow, and reviewed by me before submitting.*