### PR TITLE
feat(bedrock): add OpenAI GPT-5.6 (Sol/Terra/Luna) support via bedrock-mantle endpoint

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.74
+version: 0.0.75
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -106,6 +106,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
     # Models that require the bedrock-mantle endpoint with the OpenAI Responses API.
     # These do NOT go through the standard Converse API path.
     _BEDROCK_MANTLE_MODEL_IDS: frozenset = frozenset({
+        "openai.gpt-5.6-sol",
+        "openai.gpt-5.6-terra",
+        "openai.gpt-5.6-luna",
         "openai.gpt-5.5",
         "openai.gpt-5.4",
     })
@@ -1856,6 +1859,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         # Create model name mapping for individual model files
         model_name_mapping = {
             # OpenAI GPT-5.x models (bedrock-mantle endpoint)
+            'GPT-5.6 Sol': 'gpt-5-6-sol',
+            'GPT-5.6 Terra': 'gpt-5-6-terra',
+            'GPT-5.6 Luna': 'gpt-5-6-luna',
             'GPT-5.5': 'gpt-5-5',
             'GPT-5.4': 'gpt-5-4',
             # Claude models
@@ -2133,12 +2139,32 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             params["max_output_tokens"] = model_parameters["max_tokens"]
         if "temperature" in model_parameters:
             params["temperature"] = model_parameters["temperature"]
-        if "top_p" in model_parameters:
-            params["top_p"] = model_parameters["top_p"]
+        # NOTE: top_p is intentionally NOT forwarded on the bedrock-mantle path.
+        # GPT-5.5 / GPT-5.6 reject top_p outright (400 unsupported_parameter), and
+        # even GPT-5.4 rejects it once reasoning is active (which it is by default
+        # here). These are reasoning models driven by reasoning_effort, so top_p
+        # does not apply. It remains in openai.yaml only for the GPT OSS Converse
+        # models, which are handled on a separate code path.
+        # GPT-5.6/5.5/5.4 reasoning models: pass reasoning effort through the
+        # Responses API. Effort values: none, low, medium, high, xhigh, max.
+        reasoning_effort = model_parameters.get("reasoning_effort")
+        if reasoning_effort:
+            params["reasoning"] = {"effort": reasoning_effort}
 
         # Store model_name for pricing calculation, deriving it from model_id if not set.
         credentials_for_pricing = credentials.copy()
-        resolved_model_name = model_name or ("GPT-5.5" if "gpt-5.5" in model_id else "GPT-5.4")
+        if model_name:
+            resolved_model_name = model_name
+        elif "gpt-5.6-sol" in model_id:
+            resolved_model_name = "GPT-5.6 Sol"
+        elif "gpt-5.6-terra" in model_id:
+            resolved_model_name = "GPT-5.6 Terra"
+        elif "gpt-5.6-luna" in model_id:
+            resolved_model_name = "GPT-5.6 Luna"
+        elif "gpt-5.5" in model_id:
+            resolved_model_name = "GPT-5.5"
+        else:
+            resolved_model_name = "GPT-5.4"
         credentials_for_pricing["model_parameters"] = {
             **credentials_for_pricing.get("model_parameters", {}),
             "model_name": resolved_model_name,

--- a/models/bedrock/models/llm/model_configurations/gpt-5-6-luna.yaml
+++ b/models/bedrock/models/llm/model_configurations/gpt-5-6-luna.yaml
@@ -1,0 +1,55 @@
+model: gpt-5-6-luna
+label:
+  en_US: GPT-5.6 Luna
+icon: icon_s_en.svg
+model_type: llm
+features:
+  - vision
+model_properties:
+  mode: chat
+  context_size: 272000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    label:
+      zh_Hans: 最大token数
+      en_US: Max Tokens
+    type: int
+    default: 4096
+    min: 1
+    max: 272000
+    help:
+      zh_Hans: 停止前生成的最大令牌数。
+      en_US: The maximum number of tokens to generate before stopping.
+  - name: temperature
+    use_template: temperature
+    required: false
+    label:
+      zh_Hans: 模型温度
+      en_US: Model Temperature
+    type: float
+    default: 1
+    min: 0.0
+    max: 1.0
+    help:
+      zh_Hans: 生成内容的随机性。
+      en_US: The amount of randomness injected into the response.
+  - name: top_p
+    use_template: top_p
+    label:
+      zh_Hans: Top P
+      en_US: Top P
+    required: false
+    type: float
+    default: 0.999
+    min: 0.000
+    max: 1.000
+    help:
+      zh_Hans: 在核采样中的概率阈值。
+      en_US: The probability threshold in nucleus sampling.
+pricing:
+  input: '0.0011'
+  output: '0.0066'
+  unit: '0.001'
+  currency: USD

--- a/models/bedrock/models/llm/model_configurations/gpt-5-6-sol.yaml
+++ b/models/bedrock/models/llm/model_configurations/gpt-5-6-sol.yaml
@@ -1,0 +1,55 @@
+model: gpt-5-6-sol
+label:
+  en_US: GPT-5.6 Sol
+icon: icon_s_en.svg
+model_type: llm
+features:
+  - vision
+model_properties:
+  mode: chat
+  context_size: 272000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    label:
+      zh_Hans: 最大token数
+      en_US: Max Tokens
+    type: int
+    default: 4096
+    min: 1
+    max: 272000
+    help:
+      zh_Hans: 停止前生成的最大令牌数。
+      en_US: The maximum number of tokens to generate before stopping.
+  - name: temperature
+    use_template: temperature
+    required: false
+    label:
+      zh_Hans: 模型温度
+      en_US: Model Temperature
+    type: float
+    default: 1
+    min: 0.0
+    max: 1.0
+    help:
+      zh_Hans: 生成内容的随机性。
+      en_US: The amount of randomness injected into the response.
+  - name: top_p
+    use_template: top_p
+    label:
+      zh_Hans: Top P
+      en_US: Top P
+    required: false
+    type: float
+    default: 0.999
+    min: 0.000
+    max: 1.000
+    help:
+      zh_Hans: 在核采样中的概率阈值。
+      en_US: The probability threshold in nucleus sampling.
+pricing:
+  input: '0.0055'
+  output: '0.033'
+  unit: '0.001'
+  currency: USD

--- a/models/bedrock/models/llm/model_configurations/gpt-5-6-terra.yaml
+++ b/models/bedrock/models/llm/model_configurations/gpt-5-6-terra.yaml
@@ -1,0 +1,55 @@
+model: gpt-5-6-terra
+label:
+  en_US: GPT-5.6 Terra
+icon: icon_s_en.svg
+model_type: llm
+features:
+  - vision
+model_properties:
+  mode: chat
+  context_size: 272000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    required: true
+    label:
+      zh_Hans: 最大token数
+      en_US: Max Tokens
+    type: int
+    default: 4096
+    min: 1
+    max: 272000
+    help:
+      zh_Hans: 停止前生成的最大令牌数。
+      en_US: The maximum number of tokens to generate before stopping.
+  - name: temperature
+    use_template: temperature
+    required: false
+    label:
+      zh_Hans: 模型温度
+      en_US: Model Temperature
+    type: float
+    default: 1
+    min: 0.0
+    max: 1.0
+    help:
+      zh_Hans: 生成内容的随机性。
+      en_US: The amount of randomness injected into the response.
+  - name: top_p
+    use_template: top_p
+    label:
+      zh_Hans: Top P
+      en_US: Top P
+    required: false
+    type: float
+    default: 0.999
+    min: 0.000
+    max: 1.000
+    help:
+      zh_Hans: 在核采样中的概率阈值。
+      en_US: The probability threshold in nucleus sampling.
+pricing:
+  input: '0.00275'
+  output: '0.0165'
+  unit: '0.001'
+  currency: USD

--- a/models/bedrock/models/llm/model_ids.py
+++ b/models/bedrock/models/llm/model_ids.py
@@ -74,6 +74,9 @@ BEDROCK_MODEL_IDS = {
         'Qwen3 Coder 30B': 'qwen.qwen3-coder-30b-a3b-v1:0'
     },
     'openai': {
+        'GPT-5.6 Sol': 'openai.gpt-5.6-sol',
+        'GPT-5.6 Terra': 'openai.gpt-5.6-terra',
+        'GPT-5.6 Luna': 'openai.gpt-5.6-luna',
         'GPT-5.5': 'openai.gpt-5.5',
         'GPT-5.4': 'openai.gpt-5.4',
         'GPT OSS 120B': 'openai.gpt-oss-120b-1:0',
@@ -92,6 +95,9 @@ def is_support_cross_region(model_id):
         "openai.gpt-oss-20b-1:0",
         "openai.gpt-5.5",
         "openai.gpt-5.4",
+        "openai.gpt-5.6-sol",
+        "openai.gpt-5.6-terra",
+        "openai.gpt-5.6-luna",
     ]
     return model_id not in unsupport_model_list
 

--- a/models/bedrock/models/llm/openai.yaml
+++ b/models/bedrock/models/llm/openai.yaml
@@ -22,6 +22,9 @@ parameter_rules:
     required: true
     default: GPT OSS 20B
     options:
+      - GPT-5.6 Sol
+      - GPT-5.6 Terra
+      - GPT-5.6 Luna
       - GPT-5.5
       - GPT-5.4
       - GPT OSS 120B
@@ -79,6 +82,23 @@ parameter_rules:
     help:
       zh_Hans: 在核采样中的概率阈值。
       en_US: The probability threshold in nucleus sampling.
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理努力程度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: medium
+    options:
+      - none
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    help:
+      zh_Hans: 仅对 GPT-5.6 / GPT-5.5 / GPT-5.4（bedrock-mantle Responses API）生效，控制推理投入程度，默认 medium。GPT OSS 等模型会忽略此参数。
+      en_US: Applies only to GPT-5.6 / GPT-5.5 / GPT-5.4 (bedrock-mantle Responses API) to control reasoning effort, defaulting to medium. Ignored by other models such as GPT OSS.
   - name: response_format
     use_template: response_format
 pricing:


### PR DESCRIPTION
## Summary

- Add **GPT-5.6 Sol**, **GPT-5.6 Terra**, and **GPT-5.6 Luna** as selectable models in the Amazon Bedrock plugin
- Route these models through the `bedrock-mantle` endpoint using the **OpenAI Responses API**, reusing the infrastructure introduced in #3240 for GPT-5.5 / GPT-5.4
- Add a **Reasoning Effort** parameter (`none` / `low` / `medium` / `high` / `xhigh` / `max`) forwarded to the Responses API `reasoning.effort`
- **Do not forward `top_p`** on the bedrock-mantle path — GPT-5.5 / GPT-5.6 reject it, and it is incompatible with `reasoning` even for GPT-5.4

## Background

GPT-5.6 (Sol / Terra / Luna) became generally available on Amazon Bedrock on July 13, 2026. Like GPT-5.5 / GPT-5.4 (added in #3240), these models use the `bedrock-mantle` endpoint with the OpenAI Responses API rather than the `bedrock-runtime` Converse API used by GPT OSS, Claude, etc.

| Model | Positioning | Bedrock model ID |
|---|---|---|
| GPT-5.6 Sol | Most capable (frontier reasoning / agentic) | `openai.gpt-5.6-sol` |
| GPT-5.6 Terra | Balanced, competitive with GPT-5.5 at ~half the cost | `openai.gpt-5.6-terra` |
| GPT-5.6 Luna | Lightweight / lowest cost | `openai.gpt-5.6-luna` |

All three are Responses-API-only, `bedrock-mantle`-only, In-Region only (no cross-region inference), with a 272K-token context window — consistent with the GPT-5.5 / GPT-5.4 path.

## Changes

### `models/bedrock/models/llm/model_ids.py`
- Add `GPT-5.6 Sol` / `GPT-5.6 Terra` / `GPT-5.6 Luna` → `openai.gpt-5.6-sol` / `-terra` / `-luna` to the `openai` section
- Add the three model IDs to the `is_support_cross_region` exclusion list (In-Region only)

### `models/bedrock/models/llm/openai.yaml`
- Add the three GPT-5.6 models to the `model_name` options
- Add a `reasoning_effort` parameter rule (`none` / `low` / `medium` / `high` / `xhigh` / `max`, default `medium`)

### `models/bedrock/models/llm/llm.py`
- Add the three model IDs to `_BEDROCK_MANTLE_MODEL_IDS`
- Add them to the pricing name mapping in `_get_model_specific_pricing`
- Forward `reasoning_effort` to the Responses API as `reasoning={"effort": ...}`
- Stop forwarding `top_p` on the bedrock-mantle path (see Known Limitations)
- Extend the `resolved_model_name` fallback to cover the GPT-5.6 variants

### `models/bedrock/models/llm/model_configurations/gpt-5-6-{sol,terra,luna}.yaml`
- New per-model pricing/config files (context 272K). Pricing is the OpenAI list price for In-Region on-demand inference on Bedrock (`unit: 0.001` per 1K tokens):
  - Sol: input `0.0055` / output `0.033`
  - Terra: input `0.00275` / output `0.0165`
  - Luna: input `0.0011` / output `0.0066`

### `models/bedrock/manifest.yaml`
- Bump plugin version `0.0.74` → `0.0.75`

> No dependency changes: `openai` and `aws-bedrock-token-generator` were already added in #3240.

## Known Limitations

- **`top_p` not forwarded**: GPT-5.5 / GPT-5.6 reject `top_p` (`400 unsupported_parameter`), and `top_p` is mutually exclusive with `reasoning` even on GPT-5.4. Since these are reasoning models driven by `reasoning_effort`, `top_p` is omitted on the mantle path. It remains in `openai.yaml` only for the GPT OSS Converse models (separate code path, unaffected).
- **Cross-region inference**: Not available (In-Region only), per AWS documentation.
- **Regional availability** (verified via the `bedrock-mantle` `/v1/models` endpoint):
  - `us-east-1`, `us-east-2`: all three (Sol / Terra / Luna)
  - `us-west-2`: Terra and Luna only (**Sol not available**)
- **Tool use / image input / structured output**: not supported on this path (same as #3240).

## References

- [GPT-5.6 Sol model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html)
- [GPT-5.6 Terra model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html)
- [GPT-5.6 Luna model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html)
- Builds on #3240 (GPT-5.5 / GPT-5.4 bedrock-mantle support)
