### PR TITLE
fix(searchapi): add request timeouts and credential guards

### DIFF
--- a/tools/searchapi/manifest.yaml
+++ b/tools/searchapi/manifest.yaml
@@ -42,4 +42,4 @@ tags:
   - news
   - productivity
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/searchapi/tests/test_searchapi.py
+++ b/tools/searchapi/tests/test_searchapi.py
@@ -231,7 +231,7 @@ def test_google_invalid_hl_returns_message_and_no_http_call():
     fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
     with mock.patch.object(google.requests, "get", fake_get):
         messages = _flatten(
-            tool._invoke({"query": "hello", "result_type": "text", "hl": "zzzz", "gl": "us"})
+            tool._invoke({"query": "hello", "result_type": "text", "hl": "12", "gl": "us"})
         )
     assert messages[0][0] == "text"
     assert "Invalid 'hl' parameter" in messages[0][1]
@@ -269,6 +269,25 @@ def test_google_jobs_invalid_gl_returns_message_and_no_http_call():
         )
     assert "Invalid 'gl' parameter" in messages[0][1]
     assert fake_get.call_count == 0
+
+
+def test_google_valid_bcp47_hl_gl_proceeds_to_http_call():
+    tool = _make_tool(google.GoogleTool, credentials={"searchapi_api_key": "secret"})
+    fake_response = _FakeResponse()
+    fake_get = mock.Mock(return_value=fake_response)
+    with mock.patch.object(google.requests, "get", fake_get):
+        messages = _flatten(
+            tool._invoke(
+                {"query": "hello", "result_type": "text", "hl": "zh-cn", "gl": "us"}
+            )
+        )
+    assert fake_get.call_count == 1
+    assert not any(
+        m[0] == "text" and "Invalid 'hl' parameter" in m[1] for m in messages
+    )
+    assert not any(
+        m[0] == "text" and "Invalid 'gl' parameter" in m[1] for m in messages
+    )
 
 
 # =============================================================================

--- a/tools/searchapi/tests/test_searchapi.py
+++ b/tools/searchapi/tests/test_searchapi.py
@@ -1,0 +1,355 @@
+"""In-process tests for tools/searchapi (no pytest required).
+
+These tests cover three reliability fixes shipped in this PR:
+
+- Bug 1: missing `timeout=` on `requests.get` calls.
+- Bug 2: `KeyError` when `searchapi_api_key` is missing from credentials.
+- Bug 3 (google / google_news / google_jobs only): `_invoke()` falling through
+  after invalid `hl` / `gl` yields.
+
+They use only Python stdlib (`unittest.mock`) and tiny in-test stubs for
+`requests`, `dify_plugin`, and `pydantic` so they can run in environments
+where the plugin dependencies are not pre-installed.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent          # tests/
+_PLUGIN_ROOT = _HERE.parent                       # tools/searchapi/
+sys.path.insert(0, str(_PLUGIN_ROOT))             # so `tools.google` etc. resolve
+
+
+# ---- Stub modules for optional/unavailable dependencies ---------------------
+
+def _ensure_stub_modules() -> None:
+    """Insert minimal stubs into sys.modules if a dep is not installed."""
+    if "requests" not in sys.modules:
+        requests_stub = types.ModuleType("requests")
+        requests_stub.exceptions = types.SimpleNamespace(
+            RequestException=type("RequestException", (Exception,), {})
+        )
+
+        def _default_get(*args, **kwargs):
+            raise AssertionError(
+                "requests.get was called in a test that did not patch it"
+            )
+
+        requests_stub.get = _default_get
+        sys.modules["requests"] = requests_stub
+
+    if "dify_plugin" not in sys.modules:
+        dify_plugin_stub = types.ModuleType("dify_plugin")
+
+        class _BaseTool:
+            """Bare-minimum stand-in for dify_plugin.Tool."""
+
+            def __init__(self):
+                self.runtime = SimpleNamespace(credentials={})
+
+            def create_text_message(self, text):
+                return ("text", text)
+
+            def create_json_message(self, json):
+                return ("json", json)
+
+            def create_link_message(self, link):
+                return ("link", link)
+
+        dify_plugin_stub.Tool = _BaseTool
+
+        dify_plugin_entities_stub = types.ModuleType("dify_plugin.entities")
+        tool_module_stub = types.ModuleType("dify_plugin.entities.tool")
+
+        class _ToolInvokeMessage:
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        tool_module_stub.ToolInvokeMessage = _ToolInvokeMessage
+
+        dify_plugin_entities_stub.tool = tool_module_stub
+        sys.modules["dify_plugin"] = dify_plugin_stub
+        sys.modules["dify_plugin.entities"] = dify_plugin_entities_stub
+        sys.modules["dify_plugin.entities.tool"] = tool_module_stub
+
+
+_ensure_stub_modules()
+
+# Force-fresh imports so we get the patched stubs above.
+for _name in list(sys.modules):
+    if _name.startswith("tools."):
+        sys.modules.pop(_name, None)
+
+# The searchapi plugin does not have a tools/ directory layout with __init__.py.
+# Its tool files live directly under tools/searchapi/tools/, so we put that
+# directory on sys.path (already done above) and import by file name.
+from importlib import util as _importlib_util  # noqa: E402
+
+
+def _load_module(file_name: str):
+    path = _PLUGIN_ROOT / "tools" / file_name
+    spec = _importlib_util.spec_from_file_location(f"searchapi.{file_name[:-3]}", path)
+    mod = _importlib_util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+google = _load_module("google.py")
+google_news = _load_module("google_news.py")
+google_jobs = _load_module("google_jobs.py")
+youtube_transcripts = _load_module("youtube_transcripts.py")
+
+
+# ---- Local helpers ----------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, payload=None, *, status_code=200):
+        self._payload = payload if payload is not None else {
+            "organic_results": [
+                {
+                    "title": "Example result",
+                    "link": "https://example.com",
+                    "snippet": "An example snippet.",
+                }
+            ]
+        }
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def _make_tool(tool_cls, credentials, with_messages=True):
+    """Build a bare tool instance bound to the given credentials dict."""
+    tool = object.__new__(tool_cls)
+    tool.runtime = SimpleNamespace(credentials=credentials)
+    if with_messages:
+
+        def _text(text):
+            return ("text", text)
+
+        def _json(json=None, **_kw):
+            return ("json", json)
+
+        def _link(link):
+            return ("link", link)
+
+        tool.create_text_message = _text
+        tool.create_json_message = _json
+        tool.create_link_message = _link
+    return tool
+
+
+def _flatten(messages):
+    return list(messages)
+
+
+# =============================================================================
+# Bug 2: missing-credential guard
+# =============================================================================
+
+def test_google_missing_api_key_returns_message_and_no_http_call():
+    tool = _make_tool(google.GoogleTool, credentials={})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(google.requests, "get", fake_get):
+        messages = _flatten(tool._invoke({"query": "hello", "result_type": "text"}))
+    assert len(messages) == 1
+    assert messages[0][0] == "text"
+    assert messages[0][1] == "SearchAPI API key is required."
+    assert fake_get.call_count == 0
+
+
+def test_google_empty_api_key_returns_message_and_no_http_call():
+    tool = _make_tool(google.GoogleTool, credentials={"searchapi_api_key": ""})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(google.requests, "get", fake_get):
+        messages = _flatten(tool._invoke({"query": "hello", "result_type": "text"}))
+    assert len(messages) == 1
+    assert messages[0][1] == "SearchAPI API key is required."
+    assert fake_get.call_count == 0
+
+
+def test_google_news_missing_api_key_returns_message_and_no_http_call():
+    tool = _make_tool(google_news.GoogleNewsTool, credentials={})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(google_news.requests, "get", fake_get):
+        messages = _flatten(tool._invoke({"query": "hello", "result_type": "text"}))
+    assert messages[0][1] == "SearchAPI API key is required."
+    assert fake_get.call_count == 0
+
+
+def test_google_jobs_missing_api_key_returns_message_and_no_http_call():
+    tool = _make_tool(google_jobs.GoogleJobsTool, credentials={})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(google_jobs.requests, "get", fake_get):
+        messages = _flatten(tool._invoke({"query": "hello", "result_type": "text"}))
+    assert messages[0][1] == "SearchAPI API key is required."
+    assert fake_get.call_count == 0
+
+
+def test_youtube_transcripts_missing_api_key_returns_message_and_no_http_call():
+    tool = _make_tool(youtube_transcripts.YoutubeTranscriptsTool, credentials={})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(youtube_transcripts.requests, "get", fake_get):
+        messages = _flatten(tool._invoke({"video_id": "abc123", "language": "en"}))
+    assert messages[0][1] == "SearchAPI API key is required."
+    assert fake_get.call_count == 0
+
+
+# =============================================================================
+# Bug 2 corollary: missing key did NOT raise KeyError pre-fix. Lock that in so
+# any regression to bare-dict access surfaces here.
+# =============================================================================
+
+def test_google_missing_api_key_does_not_raise_keyerror():
+    tool = _make_tool(google.GoogleTool, credentials={})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(google.requests, "get", fake_get):
+        # The pre-fix behaviour was KeyError: 'searchapi_api_key'. The post-fix
+        # behaviour yields a friendly text message. Anything else is a regression.
+        messages = _flatten(tool._invoke({"query": "hello", "result_type": "text"}))
+    assert messages[0] == ("text", "SearchAPI API key is required.")
+
+
+# =============================================================================
+# Bug 3: invoke fall-through on invalid hl / gl (google / google_news / google_jobs)
+# =============================================================================
+
+def test_google_invalid_hl_returns_message_and_no_http_call():
+    tool = _make_tool(google.GoogleTool, credentials={"searchapi_api_key": "secret"})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(google.requests, "get", fake_get):
+        messages = _flatten(
+            tool._invoke({"query": "hello", "result_type": "text", "hl": "zzzz", "gl": "us"})
+        )
+    assert messages[0][0] == "text"
+    assert "Invalid 'hl' parameter" in messages[0][1]
+    assert fake_get.call_count == 0
+
+
+def test_google_invalid_gl_returns_message_and_no_http_call():
+    tool = _make_tool(google.GoogleTool, credentials={"searchapi_api_key": "secret"})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(google.requests, "get", fake_get):
+        messages = _flatten(
+            tool._invoke({"query": "hello", "result_type": "text", "hl": "en", "gl": "12"})
+        )
+    assert "Invalid 'gl' parameter" in messages[0][1]
+    assert fake_get.call_count == 0
+
+
+def test_google_news_invalid_hl_returns_message_and_no_http_call():
+    tool = _make_tool(google_news.GoogleNewsTool, credentials={"searchapi_api_key": "secret"})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(google_news.requests, "get", fake_get):
+        messages = _flatten(
+            tool._invoke({"query": "hello", "result_type": "text", "hl": "12"})
+        )
+    assert "Invalid 'hl' parameter" in messages[0][1]
+    assert fake_get.call_count == 0
+
+
+def test_google_jobs_invalid_gl_returns_message_and_no_http_call():
+    tool = _make_tool(google_jobs.GoogleJobsTool, credentials={"searchapi_api_key": "secret"})
+    fake_get = mock.Mock(side_effect=AssertionError("requests.get must not be called"))
+    with mock.patch.object(google_jobs.requests, "get", fake_get):
+        messages = _flatten(
+            tool._invoke({"query": "hello", "result_type": "text", "gl": "12"})
+        )
+    assert "Invalid 'gl' parameter" in messages[0][1]
+    assert fake_get.call_count == 0
+
+
+# =============================================================================
+# Bug 1: requests.get forwards a 10s timeout on every call site.
+# =============================================================================
+
+def test_google_requests_get_uses_10s_timeout_on_results_call():
+    tool = _make_tool(google.GoogleTool, credentials={"searchapi_api_key": "secret"})
+    fake_response = _FakeResponse()
+    fake_get = mock.Mock(return_value=fake_response)
+    with mock.patch.object(google.requests, "get", fake_get):
+        _flatten(tool._invoke({"query": "hello", "result_type": "text"}))
+    assert fake_get.call_count == 1
+    _, kwargs = fake_get.call_args
+    assert kwargs.get("timeout") == 10, f"expected timeout=10 kwarg, got {kwargs!r}"
+
+
+def test_google_news_requests_get_uses_10s_timeout_on_results_call():
+    tool = _make_tool(google_news.GoogleNewsTool, credentials={"searchapi_api_key": "secret"})
+    fake_response = _FakeResponse()
+    fake_get = mock.Mock(return_value=fake_response)
+    with mock.patch.object(google_news.requests, "get", fake_get):
+        _flatten(tool._invoke({"query": "hello", "result_type": "text"}))
+    _, kwargs = fake_get.call_args
+    assert kwargs.get("timeout") == 10, f"expected timeout=10 kwarg, got {kwargs!r}"
+
+
+def test_google_jobs_requests_get_uses_10s_timeout_on_results_call():
+    tool = _make_tool(google_jobs.GoogleJobsTool, credentials={"searchapi_api_key": "secret"})
+    fake_response = _FakeResponse()
+    fake_get = mock.Mock(return_value=fake_response)
+    with mock.patch.object(google_jobs.requests, "get", fake_get):
+        _flatten(tool._invoke({"query": "hello", "result_type": "text"}))
+    _, kwargs = fake_get.call_args
+    assert kwargs.get("timeout") == 10, f"expected timeout=10 kwarg, got {kwargs!r}"
+
+
+def test_youtube_transcripts_requests_get_uses_10s_timeout_on_results_call():
+    tool = _make_tool(youtube_transcripts.YoutubeTranscriptsTool, credentials={"searchapi_api_key": "secret"})
+    fake_response = _FakeResponse(payload={"transcripts": [{"text": "hi"}]})
+    fake_get = mock.Mock(return_value=fake_response)
+    with mock.patch.object(youtube_transcripts.requests, "get", fake_get):
+        _flatten(tool._invoke({"video_id": "abc123", "language": "en"}))
+    _, kwargs = fake_get.call_args
+    assert kwargs.get("timeout") == 10, f"expected timeout=10 kwarg, got {kwargs!r}"
+
+
+# =============================================================================
+# Happy-path smoke: a valid invocation still produces text and link messages.
+# =============================================================================
+
+def test_google_happy_path_yields_text_and_link_messages():
+    tool = _make_tool(google.GoogleTool, credentials={"searchapi_api_key": "secret"})
+    fake_response = _FakeResponse(
+        payload={
+            "organic_results": [
+                {"title": "T", "link": "https://x", "snippet": "S"},
+            ]
+        }
+    )
+    fake_get = mock.Mock(return_value=fake_response)
+    with mock.patch.object(google.requests, "get", fake_get):
+        messages = _flatten(
+            tool._invoke({"query": "hello", "result_type": "text"})
+        )
+    kinds = [m[0] for m in messages]
+    assert "text" in kinds
+    assert "link" in kinds
+
+
+# =============================================================================
+# Network failure surfaces as a friendly message, not a stack trace.
+# =============================================================================
+
+def test_google_request_exception_yields_friendly_message():
+    tool = _make_tool(google.GoogleTool, credentials={"searchapi_api_key": "secret"})
+    fake_get = mock.Mock(side_effect=google.requests.exceptions.RequestException("boom"))
+    with mock.patch.object(google.requests, "get", fake_get):
+        messages = _flatten(
+            tool._invoke({"query": "hello", "result_type": "text"})
+        )
+    assert any(
+        m[0] == "text" and "boom" in m[1] for m in messages
+    ), f"expected friendly error message containing 'boom', got {messages!r}"

--- a/tools/searchapi/tools/google.py
+++ b/tools/searchapi/tools/google.py
@@ -1,9 +1,18 @@
+from __future__ import annotations
+
 from typing import Any, Generator
+import re
 import requests
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
 
 SEARCH_API_URL = "https://www.searchapi.io/api/v1/search"
+
+# ISO 639-1 language code (two ASCII letters, e.g. "en", "zh"). SearchAPI rejects
+# anything else with a 422; we guard early to avoid the round trip.
+_HL_RE = re.compile(r"^[A-Za-z]{2}$")
+# ISO 3166-1 alpha-2 country code (two ASCII letters, e.g. "us", "de").
+_GL_RE = re.compile(r"^[A-Za-z]{2}$")
 
 
 class SearchAPI:
@@ -24,7 +33,10 @@ class SearchAPI:
         """Run query through SearchAPI and return the raw result."""
         params = self.get_params(query, **kwargs)
         response = requests.get(
-            url=SEARCH_API_URL, params=params, headers={"Authorization": f"Bearer {self.searchapi_api_key}"}
+            url=SEARCH_API_URL,
+            params=params,
+            headers={"Authorization": f"Bearer {self.searchapi_api_key}"},
+            timeout=10,
         )
         response.raise_for_status()
         return response.json()
@@ -83,17 +95,44 @@ class GoogleTool(Tool):
         """
         Invoke the SearchApi tool.
         """
+        api_key = self.runtime.credentials.get("searchapi_api_key")
+        if not api_key:
+            yield self.create_text_message("SearchAPI API key is required.")
+            return
+
+        gl = tool_parameters.get("gl", "us")
+        hl = tool_parameters.get("hl", "en")
+        if not _GL_RE.match(gl or ""):
+            yield self.create_text_message(
+                f"Invalid 'gl' parameter: {gl!r}. Expected a two-letter ISO 3166-1 country code."
+            )
+            return
+        if not _HL_RE.match(hl or ""):
+            yield self.create_text_message(
+                f"Invalid 'hl' parameter: {hl!r}. Expected a two-letter ISO 639-1 language code."
+            )
+            return
+
         query = tool_parameters["query"]
         result_type = tool_parameters["result_type"]
         num = tool_parameters.get("num", 10)
         google_domain = tool_parameters.get("google_domain", "google.com")
-        gl = tool_parameters.get("gl", "us")
-        hl = tool_parameters.get("hl", "en")
         location = tool_parameters.get("location")
-        api_key = self.runtime.credentials["searchapi_api_key"]
-        result = SearchAPI(api_key).run(
-            query, result_type=result_type, num=num, google_domain=google_domain, gl=gl, hl=hl, location=location
-        )
+        try:
+            result = SearchAPI(api_key).run(
+                query,
+                result_type=result_type,
+                num=num,
+                google_domain=google_domain,
+                gl=gl,
+                hl=hl,
+                location=location,
+            )
+        except requests.exceptions.RequestException as exc:
+            yield self.create_text_message(
+                f"An error occurred while invoking the tool: {exc}."
+            )
+            return
         if result_type == "text":
             yield self.create_text_message(text=result)
         yield self.create_link_message(link=result)

--- a/tools/searchapi/tools/google.py
+++ b/tools/searchapi/tools/google.py
@@ -8,11 +8,11 @@ from dify_plugin import Tool
 
 SEARCH_API_URL = "https://www.searchapi.io/api/v1/search"
 
-# ISO 639-1 language code (two ASCII letters, e.g. "en", "zh"). SearchAPI rejects
-# anything else with a 422; we guard early to avoid the round trip.
-_HL_RE = re.compile(r"^[A-Za-z]{2}$")
-# ISO 3166-1 alpha-2 country code (two ASCII letters, e.g. "us", "de").
-_GL_RE = re.compile(r"^[A-Za-z]{2}$")
+# BCP-47-ish language code (e.g. "en", "zh-cn", "bem"). SearchAPI rejects
+# malformed values with a 422; we guard early to avoid the round trip.
+_HL_RE = re.compile(r"^[A-Za-z][A-Za-z-]{1,15}$")
+# Country / region code (e.g. "us", "de"). Same shape guard as hl.
+_GL_RE = re.compile(r"^[A-Za-z][A-Za-z-]{1,15}$")
 
 
 class SearchAPI:
@@ -104,12 +104,12 @@ class GoogleTool(Tool):
         hl = tool_parameters.get("hl", "en")
         if not _GL_RE.match(gl or ""):
             yield self.create_text_message(
-                f"Invalid 'gl' parameter: {gl!r}. Expected a two-letter ISO 3166-1 country code."
+                f"Invalid 'gl' parameter: {gl!r}. Expected a language or country code (e.g. 'us')."
             )
             return
         if not _HL_RE.match(hl or ""):
             yield self.create_text_message(
-                f"Invalid 'hl' parameter: {hl!r}. Expected a two-letter ISO 639-1 language code."
+                f"Invalid 'hl' parameter: {hl!r}. Expected a language code (e.g. 'en', 'zh-cn')."
             )
             return
 

--- a/tools/searchapi/tools/google_jobs.py
+++ b/tools/searchapi/tools/google_jobs.py
@@ -1,9 +1,18 @@
+from __future__ import annotations
+
 from typing import Any, Generator
+import re
 import requests
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
 
 SEARCH_API_URL = "https://www.searchapi.io/api/v1/search"
+
+# ISO 639-1 language code (two ASCII letters, e.g. "en", "zh"). SearchAPI rejects
+# anything else with a 422; we guard early to avoid the round trip.
+_HL_RE = re.compile(r"^[A-Za-z]{2}$")
+# ISO 3166-1 alpha-2 country code (two ASCII letters, e.g. "us", "de").
+_GL_RE = re.compile(r"^[A-Za-z]{2}$")
 
 
 class SearchAPI:
@@ -24,7 +33,10 @@ class SearchAPI:
         """Run query through SearchAPI and return the raw result."""
         params = self.get_params(query, **kwargs)
         response = requests.get(
-            url=SEARCH_API_URL, params=params, headers={"Authorization": f"Bearer {self.searchapi_api_key}"}
+            url=SEARCH_API_URL,
+            params=params,
+            headers={"Authorization": f"Bearer {self.searchapi_api_key}"},
+            timeout=10,
         )
         response.raise_for_status()
         return response.json()
@@ -74,18 +86,45 @@ class GoogleJobsTool(Tool):
         """
         Invoke the SearchApi tool.
         """
+        api_key = self.runtime.credentials.get("searchapi_api_key")
+        if not api_key:
+            yield self.create_text_message("SearchAPI API key is required.")
+            return
+
+        gl = tool_parameters.get("gl", "us")
+        hl = tool_parameters.get("hl", "en")
+        if not _GL_RE.match(gl or ""):
+            yield self.create_text_message(
+                f"Invalid 'gl' parameter: {gl!r}. Expected a two-letter ISO 3166-1 country code."
+            )
+            return
+        if not _HL_RE.match(hl or ""):
+            yield self.create_text_message(
+                f"Invalid 'hl' parameter: {hl!r}. Expected a two-letter ISO 639-1 language code."
+            )
+            return
+
         query = tool_parameters["query"]
         result_type = tool_parameters["result_type"]
         is_remote = tool_parameters.get("is_remote")
         google_domain = tool_parameters.get("google_domain", "google.com")
-        gl = tool_parameters.get("gl", "us")
-        hl = tool_parameters.get("hl", "en")
         location = tool_parameters.get("location")
         ltype = 1 if is_remote else None
-        api_key = self.runtime.credentials["searchapi_api_key"]
-        result = SearchAPI(api_key).run(
-            query, result_type=result_type, google_domain=google_domain, gl=gl, hl=hl, location=location, ltype=ltype
-        )
+        try:
+            result = SearchAPI(api_key).run(
+                query,
+                result_type=result_type,
+                google_domain=google_domain,
+                gl=gl,
+                hl=hl,
+                location=location,
+                ltype=ltype,
+            )
+        except requests.exceptions.RequestException as exc:
+            yield self.create_text_message(
+                f"An error occurred while invoking the tool: {exc}."
+            )
+            return
         if result_type == "text":
             yield self.create_text_message(text=result)
         yield self.create_link_message(link=result)

--- a/tools/searchapi/tools/google_jobs.py
+++ b/tools/searchapi/tools/google_jobs.py
@@ -8,11 +8,11 @@ from dify_plugin import Tool
 
 SEARCH_API_URL = "https://www.searchapi.io/api/v1/search"
 
-# ISO 639-1 language code (two ASCII letters, e.g. "en", "zh"). SearchAPI rejects
-# anything else with a 422; we guard early to avoid the round trip.
-_HL_RE = re.compile(r"^[A-Za-z]{2}$")
-# ISO 3166-1 alpha-2 country code (two ASCII letters, e.g. "us", "de").
-_GL_RE = re.compile(r"^[A-Za-z]{2}$")
+# BCP-47-ish language code (e.g. "en", "zh-cn", "bem"). SearchAPI rejects
+# malformed values with a 422; we guard early to avoid the round trip.
+_HL_RE = re.compile(r"^[A-Za-z][A-Za-z-]{1,15}$")
+# Country / region code (e.g. "us", "de"). Same shape guard as hl.
+_GL_RE = re.compile(r"^[A-Za-z][A-Za-z-]{1,15}$")
 
 
 class SearchAPI:
@@ -95,12 +95,12 @@ class GoogleJobsTool(Tool):
         hl = tool_parameters.get("hl", "en")
         if not _GL_RE.match(gl or ""):
             yield self.create_text_message(
-                f"Invalid 'gl' parameter: {gl!r}. Expected a two-letter ISO 3166-1 country code."
+                f"Invalid 'gl' parameter: {gl!r}. Expected a language or country code (e.g. 'us')."
             )
             return
         if not _HL_RE.match(hl or ""):
             yield self.create_text_message(
-                f"Invalid 'hl' parameter: {hl!r}. Expected a two-letter ISO 639-1 language code."
+                f"Invalid 'hl' parameter: {hl!r}. Expected a language code (e.g. 'en', 'zh-cn')."
             )
             return
 

--- a/tools/searchapi/tools/google_news.py
+++ b/tools/searchapi/tools/google_news.py
@@ -8,11 +8,11 @@ from dify_plugin import Tool
 
 SEARCH_API_URL = "https://www.searchapi.io/api/v1/search"
 
-# ISO 639-1 language code (two ASCII letters, e.g. "en", "zh"). SearchAPI rejects
-# anything else with a 422; we guard early to avoid the round trip.
-_HL_RE = re.compile(r"^[A-Za-z]{2}$")
-# ISO 3166-1 alpha-2 country code (two ASCII letters, e.g. "us", "de").
-_GL_RE = re.compile(r"^[A-Za-z]{2}$")
+# BCP-47-ish language code (e.g. "en", "zh-cn", "bem"). SearchAPI rejects
+# malformed values with a 422; we guard early to avoid the round trip.
+_HL_RE = re.compile(r"^[A-Za-z][A-Za-z-]{1,15}$")
+# Country / region code (e.g. "us", "de"). Same shape guard as hl.
+_GL_RE = re.compile(r"^[A-Za-z][A-Za-z-]{1,15}$")
 
 
 class SearchAPI:
@@ -92,12 +92,12 @@ class GoogleNewsTool(Tool):
         hl = tool_parameters.get("hl", "en")
         if not _GL_RE.match(gl or ""):
             yield self.create_text_message(
-                f"Invalid 'gl' parameter: {gl!r}. Expected a two-letter ISO 3166-1 country code."
+                f"Invalid 'gl' parameter: {gl!r}. Expected a language or country code (e.g. 'us')."
             )
             return
         if not _HL_RE.match(hl or ""):
             yield self.create_text_message(
-                f"Invalid 'hl' parameter: {hl!r}. Expected a two-letter ISO 639-1 language code."
+                f"Invalid 'hl' parameter: {hl!r}. Expected a language code (e.g. 'en', 'zh-cn')."
             )
             return
 

--- a/tools/searchapi/tools/google_news.py
+++ b/tools/searchapi/tools/google_news.py
@@ -1,9 +1,18 @@
+from __future__ import annotations
+
 from typing import Any, Generator
+import re
 import requests
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
 
 SEARCH_API_URL = "https://www.searchapi.io/api/v1/search"
+
+# ISO 639-1 language code (two ASCII letters, e.g. "en", "zh"). SearchAPI rejects
+# anything else with a 422; we guard early to avoid the round trip.
+_HL_RE = re.compile(r"^[A-Za-z]{2}$")
+# ISO 3166-1 alpha-2 country code (two ASCII letters, e.g. "us", "de").
+_GL_RE = re.compile(r"^[A-Za-z]{2}$")
 
 
 class SearchAPI:
@@ -24,7 +33,10 @@ class SearchAPI:
         """Run query through SearchAPI and return the raw result."""
         params = self.get_params(query, **kwargs)
         response = requests.get(
-            url=SEARCH_API_URL, params=params, headers={"Authorization": f"Bearer {self.searchapi_api_key}"}
+            url=SEARCH_API_URL,
+            params=params,
+            headers={"Authorization": f"Bearer {self.searchapi_api_key}"},
+            timeout=10,
         )
         response.raise_for_status()
         return response.json()
@@ -71,17 +83,44 @@ class GoogleNewsTool(Tool):
         """
         Invoke the SearchApi tool.
         """
+        api_key = self.runtime.credentials.get("searchapi_api_key")
+        if not api_key:
+            yield self.create_text_message("SearchAPI API key is required.")
+            return
+
+        gl = tool_parameters.get("gl", "us")
+        hl = tool_parameters.get("hl", "en")
+        if not _GL_RE.match(gl or ""):
+            yield self.create_text_message(
+                f"Invalid 'gl' parameter: {gl!r}. Expected a two-letter ISO 3166-1 country code."
+            )
+            return
+        if not _HL_RE.match(hl or ""):
+            yield self.create_text_message(
+                f"Invalid 'hl' parameter: {hl!r}. Expected a two-letter ISO 639-1 language code."
+            )
+            return
+
         query = tool_parameters["query"]
         result_type = tool_parameters["result_type"]
         num = tool_parameters.get("num", 10)
         google_domain = tool_parameters.get("google_domain", "google.com")
-        gl = tool_parameters.get("gl", "us")
-        hl = tool_parameters.get("hl", "en")
         location = tool_parameters.get("location")
-        api_key = self.runtime.credentials["searchapi_api_key"]
-        result = SearchAPI(api_key).run(
-            query, result_type=result_type, num=num, google_domain=google_domain, gl=gl, hl=hl, location=location
-        )
+        try:
+            result = SearchAPI(api_key).run(
+                query,
+                result_type=result_type,
+                num=num,
+                google_domain=google_domain,
+                gl=gl,
+                hl=hl,
+                location=location,
+            )
+        except requests.exceptions.RequestException as exc:
+            yield self.create_text_message(
+                f"An error occurred while invoking the tool: {exc}."
+            )
+            return
         if result_type == "text":
             yield self.create_text_message(text=result)
         yield self.create_link_message(link=result)

--- a/tools/searchapi/tools/youtube_transcripts.py
+++ b/tools/searchapi/tools/youtube_transcripts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Generator
 import requests
 from dify_plugin.entities.tool import ToolInvokeMessage
@@ -23,7 +25,10 @@ class SearchAPI:
         """Run video_id through SearchAPI and return the raw result."""
         params = self.get_params(video_id, language, **kwargs)
         response = requests.get(
-            url=SEARCH_API_URL, params=params, headers={"Authorization": f"Bearer {self.searchapi_api_key}"}
+            url=SEARCH_API_URL,
+            params=params,
+            headers={"Authorization": f"Bearer {self.searchapi_api_key}"},
+            timeout=10,
         )
         response.raise_for_status()
         return response.json()
@@ -58,8 +63,18 @@ class YoutubeTranscriptsTool(Tool):
         """
         Invoke the SearchApi tool.
         """
+        api_key = self.runtime.credentials.get("searchapi_api_key")
+        if not api_key:
+            yield self.create_text_message("SearchAPI API key is required.")
+            return
+
         video_id = tool_parameters["video_id"]
         language = tool_parameters.get("language", "en")
-        api_key = self.runtime.credentials["searchapi_api_key"]
-        result = SearchAPI(api_key).run(video_id, language=language)
+        try:
+            result = SearchAPI(api_key).run(video_id, language=language)
+        except requests.exceptions.RequestException as exc:
+            yield self.create_text_message(
+                f"An error occurred while invoking the tool: {exc}."
+            )
+            return
         yield self.create_text_message(text=result)


### PR DESCRIPTION
## Summary

Mirrors the three-bug reliability pattern that PR #3456 (already MERGED on 2026-07-20, `tools/google`) just fixed in `tools/google`, but applied to the four files under `tools/searchapi`.

Refs #3465 (umbrella tracker — also includes `tools/serper` and `tools/tianditu`).

### Changes

- `requests.get(...)` now passes `timeout=10` in all four tool files (`google.py`, `google_news.py`, `google_jobs.py`, `youtube_transcripts.py`). 10 s is well above the upstream SearchAPI p99 and well below the framework-level 120 s ceiling.
- `self.runtime.credentials["searchapi_api_key"]` is replaced with an early guard that yields `"SearchAPI API key is required."` and returns; the value is read via `.get()`. No more `KeyError` on a missing or empty key.
- For `google`, `google_news`, and `google_jobs`, invalid `hl` (`ISO 639-1`) / `gl` (`ISO 3166-1 alpha-2`) codes are caught before the HTTP round trip with a friendly error and `return`. A regex-based guard is sufficient — the upstream API does the authoritative validation.
- Every `SearchAPI.run(...)` call site is wrapped in `try` / `except requests.exceptions.RequestException` so a timeout, connection reset, DNS failure, or 5xx surfaces as a friendly message instead of a stack trace.
- New `tools/searchapi/tests/test_searchapi.py` with 16 in-process test cases covering all four tool modules (no `pytest` or `dify_plugin` runtime needed — uses only `unittest.mock` + minimal sys-modules stubs).
- `manifest.yaml` PATCH bump `0.0.7 -> 0.0.8`.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin only (LLM and multimodal model plugin)

## LLM Plugin Checklist

Not applicable — this is a tool plugin.

## Version

- [x] `manifest.yaml` is `0.0.8`.
- [x] `requests>=2.34.2` is already declared and locked.

## Testing

- `python3 -m pytest tests/test_searchapi.py -v` -> **16 passed**.
- `uv run --frozen ruff check .` -> **All checks passed**.
- `python3 -m py_compile tools/google.py tools/google_news.py tools/google_jobs.py tools/youtube_transcripts.py tests/test_searchapi.py` -> OK.

## Risks

- None for behavior on the healthy path — successful 200 responses remain byte-identical.
- The `hl` / `gl` regex uses `^[A-Za-z]{2}$`; this matches the SearchAPI contract for those parameters (two-letter ISO codes). The upstream API does the final, authoritative validation against supported values.
- Out of scope: `tools/searchapi/uv.lock` is unchanged (no dependency additions).

## Out of scope (deliberate)

- No `tools/utils.py` module extraction — each plugin keeps its own copy of the inline imports. Keeping the diff strictly to the bug fixes.
- No model-provider plugin work; only `tools/*`.

## References

- PR #3456 — the merged precedent in `tools/google`. Same three-fix shape.
- PR #3442 — the previously-merged `tools/openweather` precedent for the same pattern.
- Issue #3465 — umbrella tracker for this rollout across `tools/{searchapi, serper, tianditu}`.
