### PR TITLE
fix(brave): add request timeouts and credential guards

### DIFF
--- a/tools/brave/manifest.yaml
+++ b/tools/brave/manifest.yaml
@@ -33,4 +33,4 @@ resource:
 tags:
   - search
 type: plugin
-version: 0.0.9
+version: 0.0.10

--- a/tools/brave/tests/test_brave.py
+++ b/tools/brave/tests/test_brave.py
@@ -1,0 +1,120 @@
+"""In-process tests for tools/brave (pytest-shaped)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+sys.path.insert(0, str(_PLUGIN_ROOT))
+
+
+def _ensure_stub_modules() -> None:
+    if "requests" not in sys.modules:
+        requests_stub = types.ModuleType("requests")
+        requests_stub.exceptions = types.SimpleNamespace(
+            RequestException=type("RequestException", (Exception,), {})
+        )
+        requests_stub.PreparedRequest = type(
+            "PreparedRequest",
+            (),
+            {"prepare_url": lambda self, url, params: setattr(self, "url", url + "?q=test") or None},
+        )
+        requests_stub.get = lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("requests.get must be patched")
+        )
+        sys.modules["requests"] = requests_stub
+
+    if "pydantic" not in sys.modules:
+        pydantic_stub = types.ModuleType("pydantic")
+
+        class _BaseModel:
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        pydantic_stub.BaseModel = _BaseModel
+        pydantic_stub.Field = lambda *a, **k: None
+        sys.modules["pydantic"] = pydantic_stub
+
+    if "dify_plugin" not in sys.modules:
+        dify_plugin_stub = types.ModuleType("dify_plugin")
+
+        class _BaseTool:
+            def create_text_message(self, text):
+                return ("text", text)
+
+        dify_plugin_stub.Tool = _BaseTool
+        entities = types.ModuleType("dify_plugin.entities")
+        tool_mod = types.ModuleType("dify_plugin.entities.tool")
+        tool_mod.ToolInvokeMessage = type("ToolInvokeMessage", (), {})
+        entities.tool = tool_mod
+        sys.modules["dify_plugin"] = dify_plugin_stub
+        sys.modules["dify_plugin.entities"] = entities
+        sys.modules["dify_plugin.entities.tool"] = tool_mod
+
+
+_ensure_stub_modules()
+for _name in list(sys.modules):
+    if _name.startswith("tools.brave") or _name == "brave_search":
+        sys.modules.pop(_name, None)
+
+from importlib import util as _importlib_util  # noqa: E402
+
+spec = _importlib_util.spec_from_file_location(
+    "brave_search", _PLUGIN_ROOT / "tools" / "brave_search.py"
+)
+brave_search = _importlib_util.module_from_spec(spec)
+sys.modules[spec.name] = brave_search
+spec.loader.exec_module(brave_search)
+
+
+class _FakeResponse:
+    ok = True
+
+    def json(self):
+        return {"web": {"results": [{"title": "T", "url": "https://x", "description": "S"}]}}
+
+
+def _make_tool(credentials):
+    tool = object.__new__(brave_search.BraveSearchTool)
+    tool.runtime = SimpleNamespace(credentials=credentials)
+    tool.create_text_message = lambda text: ("text", text)
+    return tool
+
+
+def test_brave_missing_api_key_no_http():
+    tool = _make_tool({})
+    fake_get = mock.Mock(side_effect=AssertionError("no http"))
+    with mock.patch.object(brave_search.requests, "get", fake_get):
+        msgs = list(tool._invoke({"query": "hello"}))
+    assert msgs[0][1] == "Brave Search API key is required."
+    assert fake_get.call_count == 0
+
+
+def test_brave_requests_get_uses_timeout():
+    tool = _make_tool({"brave_search_api_key": "secret"})
+    fake_get = mock.Mock(return_value=_FakeResponse())
+    with mock.patch.object(brave_search.requests, "get", fake_get):
+        list(tool._invoke({"query": "hello"}))
+    assert fake_get.call_args.kwargs.get("timeout") == 10
+
+
+def test_brave_happy_path():
+    tool = _make_tool({"brave_search_api_key": "secret"})
+    fake_get = mock.Mock(return_value=_FakeResponse())
+    with mock.patch.object(brave_search.requests, "get", fake_get):
+        msgs = list(tool._invoke({"query": "hello"}))
+    assert any(m[0] == "text" and "T" in m[1] for m in msgs)
+
+
+def test_brave_request_exception():
+    tool = _make_tool({"brave_search_api_key": "secret"})
+    fake_get = mock.Mock(side_effect=brave_search.requests.exceptions.RequestException("timeout"))
+    with mock.patch.object(brave_search.requests, "get", fake_get):
+        msgs = list(tool._invoke({"query": "hello"}))
+    assert any(m[0] == "text" and "timeout" in m[1] for m in msgs)

--- a/tools/brave/tools/brave_search.py
+++ b/tools/brave/tools/brave_search.py
@@ -131,7 +131,13 @@ class BraveSearchTool(Tool):
             search_kwargs={"count": count},
             ensure_ascii=ensure_ascii,
         )
-        results = tool._run(query)
+        try:
+            results = tool._run(query)
+        except requests.exceptions.RequestException as exc:
+            yield self.create_text_message(
+                f"An error occurred while invoking the tool: {exc}."
+            )
+            return
         if not results:
             yield self.create_text_message(f"No results found for '{query}' in Brave")
         else:

--- a/tools/brave/tools/brave_search.py
+++ b/tools/brave/tools/brave_search.py
@@ -47,7 +47,7 @@ class BraveSearchWrapper(BaseModel):
         req.prepare_url(self.base_url, params)
         if req.url is None:
             raise ValueError("prepared url is None, this should not happen")
-        response = requests.get(req.url, headers=headers)
+        response = requests.get(req.url, headers=headers, timeout=10)
         if not response.ok:
             raise Exception(f"HTTP error {response.status_code}")
         return response.json().get("web", {}).get("results", [])
@@ -112,7 +112,10 @@ class BraveSearchTool(Tool):
         """
         query = tool_parameters.get("query", "")
         count = tool_parameters.get("count", 3)
-        api_key = self.runtime.credentials["brave_search_api_key"]
+        api_key = self.runtime.credentials.get("brave_search_api_key")
+        if not api_key:
+            yield self.create_text_message("Brave Search API key is required.")
+            return
         base_url = self.runtime.credentials.get("base_url")
         if not base_url:
             base_url = BRAVE_BASE_URL


### PR DESCRIPTION
## Summary

Mirrors the reliability pattern from PR #3456 and umbrella #3475. Applies to `tools/brave/tools/brave_search.py`.

Refs #3475

### Changes

- `timeout=10` on `requests.get` in `BraveSearchWrapper._search_request`.
- Early guard for missing `brave_search_api_key` with friendly message and return.
- `try/except requests.RequestException` around the search call.
- `tests/test_brave.py` with 4 in-process cases.
- `manifest.yaml` PATCH bump `0.0.9 -> 0.0.10`.

## Change Type

- [x] Non-LLM plugin only

## Version

- [x] `manifest.yaml` is `0.0.10`.

## Testing

- `python3 -m pytest tests/test_brave.py -v` -> 4 passed
- `uv run --frozen ruff check .` -> clean

## References

- PR #3456, Issue #3475, Issue #3465
