### PR TITLE
fix(judge0ce): add request timeout and credential guard

### DIFF
--- a/tools/judge0ce/manifest.yaml
+++ b/tools/judge0ce/manifest.yaml
@@ -36,4 +36,4 @@ tags:
 - utilities
 - other
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/judge0ce/tests/test_judge0ce.py
+++ b/tools/judge0ce/tests/test_judge0ce.py
@@ -1,0 +1,135 @@
+"""In-process tests for tools/judge0ce (pytest-shaped)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+sys.path.insert(0, str(_PLUGIN_ROOT))
+
+
+def _ensure_stub_modules() -> None:
+    if "requests" not in sys.modules:
+        requests_stub = types.ModuleType("requests")
+        requests_stub.exceptions = types.SimpleNamespace(
+            RequestException=type("RequestException", (Exception,), {})
+        )
+        requests_stub.get = lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("requests.get must be patched")
+        )
+        sys.modules["requests"] = requests_stub
+
+    if "httpx" not in sys.modules:
+        httpx_stub = types.ModuleType("httpx")
+
+        class _Resp:
+            status_code = 201
+
+            def json(self):
+                return {"token": "abc123"}
+
+        httpx_stub.post = lambda *a, **k: _Resp()
+        sys.modules["httpx"] = httpx_stub
+
+    if "dify_plugin" not in sys.modules:
+        dify_plugin_stub = types.ModuleType("dify_plugin")
+
+        class _BaseTool:
+            def create_text_message(self, text):
+                return ("text", text)
+
+        dify_plugin_stub.Tool = _BaseTool
+        entities = types.ModuleType("dify_plugin.entities")
+        tool_mod = types.ModuleType("dify_plugin.entities.tool")
+        tool_mod.ToolInvokeMessage = type("ToolInvokeMessage", (), {})
+        entities.tool = tool_mod
+        sys.modules["dify_plugin"] = dify_plugin_stub
+        sys.modules["dify_plugin.entities"] = entities
+        sys.modules["dify_plugin.entities.tool"] = tool_mod
+
+
+_ensure_stub_modules()
+for _name in list(sys.modules):
+    if _name.startswith("executeCode") or _name.startswith("judge0ce"):
+        sys.modules.pop(_name, None)
+
+from importlib import util as _importlib_util  # noqa: E402
+
+spec = _importlib_util.spec_from_file_location(
+    "executeCode", _PLUGIN_ROOT / "tools" / "executeCode.py"
+)
+executeCode = _importlib_util.module_from_spec(spec)
+sys.modules[spec.name] = executeCode
+spec.loader.exec_module(executeCode)
+
+
+class _PollResponse:
+    status_code = 200
+
+    def json(self):
+        return {
+            "stdout": "hi",
+            "stderr": "",
+            "compile_output": "",
+            "message": "",
+            "status": {"description": "Accepted"},
+            "time": "0.01",
+            "memory": "1024",
+        }
+
+
+def _make_tool(credentials):
+    tool = object.__new__(executeCode.ExecuteCodeTool)
+    tool.runtime = SimpleNamespace(credentials=credentials)
+    tool.create_text_message = lambda text: ("text", text)
+    return tool
+
+
+def _params():
+    return {"language_id": 71, "source_code": "print('hi')", "stdin": ""}
+
+
+def test_judge0ce_missing_api_key_no_http():
+    tool = _make_tool({})
+    fake_get = mock.Mock(side_effect=AssertionError("no http"))
+    with mock.patch.object(executeCode.requests, "get", fake_get):
+        msgs = list(tool._invoke(_params()))
+    assert msgs[0][1] == "Judge0 CE RapidAPI key is required."
+    assert fake_get.call_count == 0
+
+
+def test_judge0ce_requests_get_uses_timeout():
+    tool = _make_tool({"X-RapidAPI-Key": "secret"})
+    fake_get = mock.Mock(return_value=_PollResponse())
+
+    class _SubmitResp:
+        status_code = 201
+
+        def json(self):
+            return {"token": "abc123"}
+
+    with mock.patch.object(executeCode, "post", return_value=_SubmitResp()):
+        with mock.patch.object(executeCode.requests, "get", fake_get):
+            list(tool._invoke(_params()))
+    assert fake_get.call_args.kwargs.get("timeout") == 10
+
+
+def test_judge0ce_happy_path():
+    tool = _make_tool({"X-RapidAPI-Key": "secret"})
+    fake_get = mock.Mock(return_value=_PollResponse())
+
+    class _SubmitResp:
+        status_code = 201
+
+        def json(self):
+            return {"token": "abc123"}
+
+    with mock.patch.object(executeCode, "post", return_value=_SubmitResp()):
+        with mock.patch.object(executeCode.requests, "get", fake_get):
+            msgs = list(tool._invoke(_params()))
+    assert any(m[0] == "text" and "stdout: hi" in m[1] for m in msgs)

--- a/tools/judge0ce/tools/executeCode.py
+++ b/tools/judge0ce/tools/executeCode.py
@@ -13,7 +13,10 @@ class ExecuteCodeTool(Tool):
         """
         invoke tools
         """
-        api_key = self.runtime.credentials["X-RapidAPI-Key"]
+        api_key = self.runtime.credentials.get("X-RapidAPI-Key")
+        if not api_key:
+            yield self.create_text_message("Judge0 CE RapidAPI key is required.")
+            return
         url = "https://judge0-ce.p.rapidapi.com/submissions"
         querystring = {"base64_encoded": "false", "fields": "*"}
         headers = {
@@ -34,11 +37,17 @@ class ExecuteCodeTool(Tool):
         token = response.json()["token"]
         url = f"https://judge0-ce.p.rapidapi.com/submissions/{token}"
         headers = {"X-RapidAPI-Key": api_key}
-        response = requests.get(url, headers=headers)
-        if response.status_code == 200:
-            result = response.json()
+        try:
+            poll_response = requests.get(url, headers=headers, timeout=10)
+        except requests.exceptions.RequestException as exc:
+            yield self.create_text_message(
+                f"An error occurred while invoking the tool: {exc}."
+            )
+            return
+        if poll_response.status_code == 200:
+            result = poll_response.json()
             yield self.create_text_message(
                 text=f"stdout: {result.get('stdout', '')}\nstderr: {result.get('stderr', '')}\ncompile_output: {result.get('compile_output', '')}\nmessage: {result.get('message', '')}\nstatus: {result['status']['description']}\ntime: {result.get('time', '')} seconds\nmemory: {result.get('memory', '')} bytes"
             )
         else:
-            yield self.create_text_message(text=f"Error retrieving submission details: {response.text}")
+            yield self.create_text_message(text=f"Error retrieving submission details: {poll_response.text}")


### PR DESCRIPTION
## Summary

Mirrors PR #3456 reliability pattern for `tools/judge0ce/tools/executeCode.py`.

Refs #3475

### Changes

- `timeout=10` on the submission poll `requests.get`.
- Early guard for missing `X-RapidAPI-Key`.
- `try/except requests.RequestException` on the poll call.
- `tests/test_judge0ce.py` (3 cases). Manifest `0.0.7 -> 0.0.8`.

## Change Type

- [x] Non-LLM plugin only

## Testing

- `python3 -m pytest tests/test_judge0ce.py -v` -> 3 passed

## References

- PR #3456, Issue #3475
