### PR TITLE
feat(gemini): add Gemini 3.6 Flash and 3.5 Flash-Lite

### DIFF
--- a/models/gemini/.env.example
+++ b/models/gemini/.env.example
@@ -2,4 +2,3 @@ INSTALL_METHOD=remote
 REMOTE_INSTALL_URL=debug-plugin.dify.dev:5003
 REMOTE_INSTALL_KEY=********-****-****-****-************
 GEMINI_API_KEY=
-RUN_GEMINI_LIVE=0

--- a/models/gemini/.env.example
+++ b/models/gemini/.env.example
@@ -1,3 +1,5 @@
 INSTALL_METHOD=remote
 REMOTE_INSTALL_URL=debug-plugin.dify.dev:5003
 REMOTE_INSTALL_KEY=********-****-****-****-************
+GEMINI_API_KEY=
+RUN_GEMINI_LIVE=0

--- a/models/gemini/conftest.py
+++ b/models/gemini/conftest.py
@@ -18,5 +18,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
     skipped = pytest.mark.skip(reason="live tests require GEMINI_API_KEY")
     for item in items:
-        if item.get_closest_marker("live") is not None:
+        in_gemini = Path(str(item.path)).resolve().is_relative_to(ROOT)
+        if in_gemini and item.get_closest_marker("live") is not None:
             item.add_marker(skipped)

--- a/models/gemini/conftest.py
+++ b/models/gemini/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from dotenv import load_dotenv
 
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parent
 
 
 def pytest_configure() -> None:
@@ -13,16 +13,10 @@ def pytest_configure() -> None:
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    enabled = (
-        bool(os.getenv("GEMINI_API_KEY", "").strip())
-        and os.getenv("RUN_GEMINI_LIVE") == "1"
-    )
-    if enabled:
+    if os.getenv("GEMINI_API_KEY", "").strip():
         return
 
-    skipped = pytest.mark.skip(
-        reason="live tests require GEMINI_API_KEY and RUN_GEMINI_LIVE=1"
-    )
+    skipped = pytest.mark.skip(reason="live tests require GEMINI_API_KEY")
     for item in items:
         if item.get_closest_marker("live") is not None:
             item.add_marker(skipped)

--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.2
+version: 0.9.3

--- a/models/gemini/models/llm/_position.yaml
+++ b/models/gemini/models/llm/_position.yaml
@@ -1,4 +1,6 @@
+- gemini-3.6-flash
 - gemini-3.5-flash
+- gemini-3.5-flash-lite
 - gemini-3.1-pro-preview
 - gemini-3.1-pro-preview-customtools
 - gemini-3.1-flash-lite

--- a/models/gemini/models/llm/gemini-3.5-flash-lite.yaml
+++ b/models/gemini/models/llm/gemini-3.5-flash-lite.yaml
@@ -1,0 +1,162 @@
+# https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite
+model: gemini-3.5-flash-lite
+label:
+  en_US: Gemini 3.5 Flash-Lite
+model_type: llm
+features:
+  - tool-call
+  - multi-tool-call
+  - agent-thought
+  - vision
+  - stream-tool-call
+  - document
+  - video
+  - audio
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: include_thoughts
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Include thoughts
+      zh_Hans: 返回思考过程
+    help:
+      en_US: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available. Default is false.
+      zh_Hans: 是否返回思考过程。若为 true 则只有模型支持思考且启动思考模式时才返回思考过程。默认为 false。
+  - name: media_resolution
+    type: string
+    required: true
+    default: "Default"
+    options:
+      - Default
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Media resolution
+      zh_Hans: 媒体分辨率
+    help:
+      en_US: |
+        Gemini 3 introduces fine-grained control over multimodal visual processing via the `media_resolution` parameter. Higher resolution improves the model's ability to read small text or recognize fine details, but increases token usage and latency.
+
+        Recommended Settings:
+        - Images: `media_resolution_high` (1120 tokens) - Recommended for most image analysis tasks to ensure best quality.
+        - PDF: `media_resolution_medium` (560 tokens) - Great for document understanding; quality usually saturates at medium.
+        - Video (Regular): `media_resolution_low` or `medium` (70 tokens/frame) - Sufficient for most action recognition and description tasks.
+        - Video (Text-heavy): `media_resolution_high` (280 tokens/frame) - Needed only when use cases involve reading dense text (OCR) or tiny details in video frames.
+
+        Note: If not specified, the model uses the best default value based on the media type.
+      zh_Hans: |
+        Gemini 3 通过 `media_resolution` 参数引入了对多模态视觉处理的精细控制。分辨率越高，模型读取细小文本或识别细微细节的能力就越强，但会增加令牌用量和延迟时间。
+
+        推荐设置：
+        - 图片：`media_resolution_high` (1120 tokens) - 建议用于大多数图片分析任务，以确保获得最佳质量。
+        - PDF：`media_resolution_medium` (560 tokens) - 非常适合文档理解；质量通常在 medium 时达到饱和。
+        - 视频（常规）：`media_resolution_low` 或 `medium` (70 tokens/帧) - 对于大多数动作识别和描述任务来说已经足够。
+        - 视频（文字较多）：`media_resolution_high` (280 tokens/帧) - 仅当用例涉及读取密集文本 (OCR) 或视频帧中的微小细节时才需要。
+
+        注意：如果不指定，模型会根据媒体类型使用最佳默认值。
+  - name: thinking_level
+    type: string
+    required: true
+    default: "Minimal"
+    options:
+      - Minimal
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Thinking level
+      zh_Hans: 思考层级
+    help:
+      en_US: Indicates the thinking level. Default is Minimal.
+      zh_Hans: 思考层级。默认为 Minimal。
+  - name: grounding
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Grounding
+      zh_Hans: 事实核查
+      ja_JP: 事実チェック
+    help:
+      en_US: Grounding with Google Search
+      zh_Hans: Google 事实核查
+      ja_JP: Google 検索に基づいた応答をします。
+  - name: url_context
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: URL context
+      zh_Hans: 链接详情
+      ja_JP: 網羅閲覧
+    help:
+      en_US: Browse the url context
+      zh_Hans: 获取并分析该链接的详细信息，为回答提供参考依据。
+      ja_JP: リンク先の詳細情報を取得し、文脈を理解します。
+  - name: code_execution
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Code execution
+      zh_Hans: 代码执行
+      ja_JP: コード実行
+    help:
+      en_US: Lets Gemini use code to solve complex tasks
+      zh_Hans: 让 Gemini 使用代码来解决复杂任务。
+      ja_JP: Gemini にコードを使って複雑なタスクを解決させましょう。
+  - name: max_output_tokens
+    use_template: max_tokens
+    type: int
+    required: true
+    default: 65536
+    min: 1
+    max: 65536
+    label:
+      en_US: Output length
+      zh_Hans: 输出长度
+    help:
+      en_US: The maximum number of tokens to generate in the response.
+      zh_Hans: 模型单次输出的最大 tokens 数。
+  - name: service_tier
+    type: string
+    required: true
+    default: "standard"
+    options:
+      - flex
+      - standard
+      - priority
+    label:
+      en_US: Service Tier
+      zh_Hans: 推理层级
+    help:
+      en_US: |
+        The inference tier for the request. You can switch between Gemini Standard, Flex, and Priority tiers. Default is Standard.
+        - Flex: Lower cost with the possibility of capacity unavailability.
+        - Standard: Default pricing and availability.
+        - Priority: Higher cost with guaranteed capacity and lower latency.
+        See:
+        - https://ai.google.dev/gemini-api/docs/flex-inference
+        - https://ai.google.dev/gemini-api/docs/priority-inference
+      zh_Hans: |
+        推理层级，可切换 Gemini Standard/Flex/Priority 推理层级，默认为 Standard。
+        - Flex：价格更低，但可能出现容量不可用的情况。
+        - Standard：默认价格和可用性。
+        - Priority：价格更高，但保证容量并提供更低延迟。
+        详见：
+        - https://ai.google.dev/gemini-api/docs/flex-inference
+        - https://ai.google.dev/gemini-api/docs/priority-inference
+  - name: json_schema
+    use_template: json_schema
+# https://ai.google.dev/gemini-api/docs/pricing#gemini-3.5-flash-lite
+pricing:
+  input: '0.30'
+  output: '2.50'
+  unit: '0.000001'
+  currency: USD

--- a/models/gemini/models/llm/gemini-3.6-flash.yaml
+++ b/models/gemini/models/llm/gemini-3.6-flash.yaml
@@ -1,0 +1,162 @@
+# https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash
+model: gemini-3.6-flash
+label:
+  en_US: Gemini 3.6 Flash
+model_type: llm
+features:
+  - tool-call
+  - multi-tool-call
+  - agent-thought
+  - vision
+  - stream-tool-call
+  - document
+  - video
+  - audio
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: include_thoughts
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Include thoughts
+      zh_Hans: 返回思考过程
+    help:
+      en_US: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available. Default is false.
+      zh_Hans: 是否返回思考过程。若为 true 则只有模型支持思考且启动思考模式时才返回思考过程。默认为 false。
+  - name: media_resolution
+    type: string
+    required: true
+    default: "Default"
+    options:
+      - Default
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Media resolution
+      zh_Hans: 媒体分辨率
+    help:
+      en_US: |
+        Gemini 3 introduces fine-grained control over multimodal visual processing via the `media_resolution` parameter. Higher resolution improves the model's ability to read small text or recognize fine details, but increases token usage and latency.
+
+        Recommended Settings:
+        - Images: `media_resolution_high` (1120 tokens) - Recommended for most image analysis tasks to ensure best quality.
+        - PDF: `media_resolution_medium` (560 tokens) - Great for document understanding; quality usually saturates at medium.
+        - Video (Regular): `media_resolution_low` or `medium` (70 tokens/frame) - Sufficient for most action recognition and description tasks.
+        - Video (Text-heavy): `media_resolution_high` (280 tokens/frame) - Needed only when use cases involve reading dense text (OCR) or tiny details in video frames.
+
+        Note: If not specified, the model uses the best default value based on the media type.
+      zh_Hans: |
+        Gemini 3 通过 `media_resolution` 参数引入了对多模态视觉处理的精细控制。分辨率越高，模型读取细小文本或识别细微细节的能力就越强，但会增加令牌用量和延迟时间。
+
+        推荐设置：
+        - 图片：`media_resolution_high` (1120 tokens) - 建议用于大多数图片分析任务，以确保获得最佳质量。
+        - PDF：`media_resolution_medium` (560 tokens) - 非常适合文档理解；质量通常在 medium 时达到饱和。
+        - 视频（常规）：`media_resolution_low` 或 `medium` (70 tokens/帧) - 对于大多数动作识别和描述任务来说已经足够。
+        - 视频（文字较多）：`media_resolution_high` (280 tokens/帧) - 仅当用例涉及读取密集文本 (OCR) 或视频帧中的微小细节时才需要。
+
+        注意：如果不指定，模型会根据媒体类型使用最佳默认值。
+  - name: thinking_level
+    type: string
+    required: true
+    default: "Medium"
+    options:
+      - Minimal
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Thinking level
+      zh_Hans: 思考层级
+    help:
+      en_US: Indicates the thinking level. Default is Medium.
+      zh_Hans: 思考层级。默认为 Medium。
+  - name: grounding
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Grounding
+      zh_Hans: 事实核查
+      ja_JP: 事実チェック
+    help:
+      en_US: Grounding with Google Search
+      zh_Hans: Google 事实核查
+      ja_JP: Google 検索に基づいた応答をします。
+  - name: url_context
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: URL context
+      zh_Hans: 链接详情
+      ja_JP: 網羅閲覧
+    help:
+      en_US: Browse the url context
+      zh_Hans: 获取并分析该链接的详细信息，为回答提供参考依据。
+      ja_JP: リンク先の詳細情報を取得し、文脈を理解します。
+  - name: code_execution
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Code execution
+      zh_Hans: 代码执行
+      ja_JP: コード実行
+    help:
+      en_US: Lets Gemini use code to solve complex tasks
+      zh_Hans: 让 Gemini 使用代码来解决复杂任务。
+      ja_JP: Gemini にコードを使って複雑なタスクを解決させましょう。
+  - name: max_output_tokens
+    use_template: max_tokens
+    type: int
+    required: true
+    default: 65536
+    min: 1
+    max: 65536
+    label:
+      en_US: Output length
+      zh_Hans: 输出长度
+    help:
+      en_US: The maximum number of tokens to generate in the response.
+      zh_Hans: 模型单次输出的最大 tokens 数。
+  - name: service_tier
+    type: string
+    required: true
+    default: "standard"
+    options:
+      - flex
+      - standard
+      - priority
+    label:
+      en_US: Service Tier
+      zh_Hans: 推理层级
+    help:
+      en_US: |
+        The inference tier for the request. You can switch between Gemini Standard, Flex, and Priority tiers. Default is Standard.
+        - Flex: Lower cost with the possibility of capacity unavailability.
+        - Standard: Default pricing and availability.
+        - Priority: Higher cost with guaranteed capacity and lower latency.
+        See:
+        - https://ai.google.dev/gemini-api/docs/flex-inference
+        - https://ai.google.dev/gemini-api/docs/priority-inference
+      zh_Hans: |
+        推理层级，可切换 Gemini Standard/Flex/Priority 推理层级，默认为 Standard。
+        - Flex：价格更低，但可能出现容量不可用的情况。
+        - Standard：默认价格和可用性。
+        - Priority：价格更高，但保证容量并提供更低延迟。
+        详见：
+        - https://ai.google.dev/gemini-api/docs/flex-inference
+        - https://ai.google.dev/gemini-api/docs/priority-inference
+  - name: json_schema
+    use_template: json_schema
+# https://ai.google.dev/gemini-api/docs/pricing#gemini-3.6-flash
+pricing:
+  input: '1.50'
+  output: '7.50'
+  unit: '0.000001'
+  currency: USD

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -45,6 +45,7 @@ from .utils import FileCache
 file_cache = FileCache()
 
 IMAGE_GENERATION_MODELS = {"gemini-2.5-flash-image", "gemini-3-pro-image-preview"}
+NO_SAMPLING_OR_PREFILL_MODELS = {"gemini-3.6-flash", "gemini-3.5-flash-lite"}
 
 # https://ai.google.dev/gemini-api/docs/thought-signatures#faqs
 DEFAULT_THOUGHT_SIGNATURE: bytes = b"skip_thought_signature_validator"
@@ -689,12 +690,17 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             # Handle tool calls
             # https://ai.google.dev/gemini-api/docs/function-calling?hl=zh-cn&example=chart#how-it-works
             if message.tool_calls:
-                call = message.tool_calls[0]
-                _unsafe_part = types.Part.from_function_call(
-                    name=call.function.name, args=json.loads(call.function.arguments)
-                )
-                _unsafe_part.thought_signature = DEFAULT_THOUGHT_SIGNATURE
-                parts.append(_unsafe_part)
+                for call in message.tool_calls:
+                    parts.append(
+                        types.Part(
+                            function_call=types.FunctionCall(
+                                id=call.id,
+                                name=call.function.name,
+                                args=json.loads(call.function.arguments),
+                            ),
+                            thought_signature=DEFAULT_THOUGHT_SIGNATURE,
+                        )
+                    )
 
             # Filter out assistant messages with empty parts to avoid invalid requests
             if not parts:
@@ -713,8 +719,12 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 # https://googleapis.github.io/python-genai/genai.html#genai.types.Content.role
                 role="user",
                 parts=[
-                    types.Part.from_function_response(
-                        name=message.name, response={"response": message.content}
+                    types.Part(
+                        function_response=types.FunctionResponse(
+                            id=message.tool_call_id,
+                            name=message.name,
+                            response={"response": message.content},
+                        )
                     )
                 ],
             )
@@ -944,11 +954,12 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             # representing the [FunctionDeclaration.name] with the parameters and their values.
             if part.function_call:
                 function_call_part: types.FunctionCall = part.function_call
-                # Generate a unique ID since Gemini API doesn't provide one
-                function_call_id = (
-                    f"gemini_call_{function_call_part.name}_{time.time_ns()}"
-                )
-                logging.info(f"Generated function call ID: {function_call_id}")
+                function_call_id = function_call_part.id
+                if not function_call_id:
+                    function_call_id = (
+                        f"gemini_call_{function_call_part.name}_{time.time_ns()}"
+                    )
+                    logging.info(f"Generated function call ID: {function_call_id}")
                 function_call_name = function_call_part.name
                 function_call_args = function_call_part.args
                 if not isinstance(function_call_name, str):
@@ -1071,6 +1082,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
     ) -> Union[LLMResult, Generator[LLMResultChunk]]:
         # Validate and adjust feature compatibility
         model_parameters = self._validate_feature_compatibility(model_parameters, tools)
+        if model in NO_SAMPLING_OR_PREFILL_MODELS:
+            for parameter in ("temperature", "top_p", "top_k"):
+                model_parameters.pop(parameter, None)
         if model == "gemini-2.5-flash-image":
             model_parameters[_DISABLE_SYSTEM_PROMOTION] = True
 
@@ -1164,6 +1178,15 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     "Please provide at least one user message with content."
                 )
 
+        if model in NO_SAMPLING_OR_PREFILL_MODELS:
+            last_nonempty_content = next(
+                (content for content in reversed(contents) if content.parts), None
+            )
+            if not last_nonempty_content or last_nonempty_content.role == "model":
+                raise InvokeBadRequestError(
+                    f"{model} requires a non-empty final user turn"
+                )
+
         if stream:
             response = genai_client.models.generate_content_stream(
                 model=model, contents=contents, config=config
@@ -1221,7 +1244,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             genai_client.models.generate_content(
                 model=model,
                 contents="ping",
-                config=types.GenerateContentConfig(temperature=0, max_output_tokens=20),
+                config=types.GenerateContentConfig(max_output_tokens=20),
             )
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -228,7 +228,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     schema = json.loads(schema)
                 except (TypeError, ValueError) as exc:
                     raise InvokeError("Invalid JSON Schema") from exc
-                config.response_schema = schema
+                config.response_json_schema = schema
 
         if stop:
             config.stop_sequences = stop

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -5,6 +5,7 @@ import re
 import time
 from collections.abc import Generator, Iterator, Sequence
 from contextlib import suppress
+from decimal import Decimal
 from typing import Any, List, Mapping, Optional, Union
 
 from dify_plugin.entities.model import AIModelEntity
@@ -12,6 +13,7 @@ from dify_plugin.entities.model.llm import (
     LLMResult,
     LLMResultChunk,
     LLMResultChunkDelta,
+    LLMUsage,
 )
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
@@ -50,6 +52,10 @@ NO_SAMPLING_OR_PREFILL_MODELS = {"gemini-3.6-flash", "gemini-3.5-flash-lite"}
 # https://ai.google.dev/gemini-api/docs/thought-signatures#faqs
 DEFAULT_THOUGHT_SIGNATURE: bytes = b"skip_thought_signature_validator"
 _DISABLE_SYSTEM_PROMOTION = "_disable_system_promotion"
+_SERVICE_TIER_PRICE_MULTIPLIERS = {
+    "flex": Decimal("0.5"),
+    "priority": Decimal("1.8"),
+}
 
 
 class GoogleLargeLanguageModel(LargeLanguageModel):
@@ -275,6 +281,43 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             )
         if isinstance(service_tier, types.ServiceTier):
             config.service_tier = service_tier
+
+    @staticmethod
+    def _apply_service_tier_pricing(
+        usage: LLMUsage,
+        response: types.GenerateContentResponse,
+        requested_service_tier: types.ServiceTier | str | None = None,
+    ) -> LLMUsage:
+        headers = getattr(getattr(response, "sdk_http_response", None), "headers", None)
+        actual_service_tier = (
+            next(
+                (
+                    str(value).lower()
+                    for name, value in headers.items()
+                    if name.lower() == "x-gemini-service-tier"
+                ),
+                None,
+            )
+            if isinstance(headers, Mapping)
+            else None
+        )
+        requested = (
+            requested_service_tier.value
+            if isinstance(requested_service_tier, types.ServiceTier)
+            else requested_service_tier
+        )
+        multiplier = _SERVICE_TIER_PRICE_MULTIPLIERS.get(
+            actual_service_tier or str(requested or "standard").lower()
+        )
+        if multiplier is None:
+            return usage
+
+        usage.prompt_unit_price *= multiplier
+        usage.prompt_price *= multiplier
+        usage.completion_unit_price *= multiplier
+        usage.completion_price *= multiplier
+        usage.total_price = usage.prompt_price + usage.completion_price
+        return usage
 
     @staticmethod
     def _set_image_config(
@@ -738,6 +781,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         credentials: dict,
         response: types.GenerateContentResponse,
         prompt_messages: list[PromptMessage],
+        requested_service_tier: types.ServiceTier | str | None = None,
     ) -> LLMResult:
         """
         Handle llm response
@@ -779,6 +823,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
         )
+        usage = self._apply_service_tier_pricing(
+            usage, response, requested_service_tier
+        )
 
         # transform response
         return LLMResult(
@@ -795,6 +842,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         response: Iterator[types.GenerateContentResponse],
         prompt_messages: list[PromptMessage],
         genai_client: genai.Client,
+        requested_service_tier: types.ServiceTier | str | None = None,
     ) -> Generator[LLMResultChunk]:
         """
         Handle llm stream response
@@ -877,6 +925,9 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                     credentials=dict(credentials),
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
+                )
+                usage = self._apply_service_tier_pricing(
+                    usage, chunk, requested_service_tier
                 )
                 yield LLMResultChunk(
                     model=model,
@@ -1192,14 +1243,19 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
                 model=model, contents=contents, config=config
             )
             return self._handle_generate_stream_response(
-                model, credentials, response, prompt_messages, genai_client
+                model,
+                credentials,
+                response,
+                prompt_messages,
+                genai_client,
+                config.service_tier,
             )
 
         response = genai_client.models.generate_content(
             model=model, contents=contents, config=config
         )
         return self._handle_generate_response(
-            model, credentials, response, prompt_messages
+            model, credentials, response, prompt_messages, config.service_tier
         )
 
     def get_num_tokens(

--- a/models/gemini/models/tests/TEST_INSTRUCTIONS.md
+++ b/models/gemini/models/tests/TEST_INSTRUCTIONS.md
@@ -20,14 +20,15 @@ Copy the example environment file and provide a Google AI Studio API key.
 cp .env.example .env
 ```
 
-Set these values in `.env`.
+Set this value in `.env`.
 
 ```dotenv
 GEMINI_API_KEY=your-google-api-key
-RUN_GEMINI_LIVE=1
 ```
 
-Live tests always require `RUN_GEMINI_LIVE=1` to prevent accidental billable requests in local and CI environments.
+Pytest automatically loads `.env` and skips live tests when `GEMINI_API_KEY` is empty or missing.
+
+If a configured key is rejected by Google, the live test fails instead of hiding the authentication error as a skip.
 
 ## Run live tests
 
@@ -65,6 +66,6 @@ Responses are intentionally short to limit API cost.
 
 ## Troubleshooting
 
-Skipped live tests mean the API key or the local opt-in flag is missing.
+Live tests skip only when the API key is empty or missing.
 
-Authentication and model-access failures are test failures once live testing is explicitly enabled.
+Authentication and model-access failures are test failures when an API key is configured.

--- a/models/gemini/models/tests/TEST_INSTRUCTIONS.md
+++ b/models/gemini/models/tests/TEST_INSTRUCTIONS.md
@@ -1,131 +1,70 @@
-# Gemini Document Filtering Tests
+# Gemini tests
 
-This directory contains comprehensive tests for the Gemini API document filtering functionality.
+The Gemini plugin has offline unit tests and opt-in live tests that call the real Google API.
 
-## Test Structure
+## Offline tests
 
-### `test_document_filtering.py`
-- **Unit Tests** (`TestDocumentFilteringUnit`): No API key required
-- **Integration Tests** (`TestDocumentFilteringIntegration`): Requires valid API key
+Offline tests do not require credentials or make billable requests.
 
-## Test Configuration
-
-### Environment Setup
-
-1. Copy the example environment file:
-   ```bash
-   cp .env.example .env
-   ```
-
-2. Set your Gemini API key in `.env`:
-   ```bash
-   GEMINI_API_KEY=your_actual_api_key_here
-   ```
-
-3. Get your API key from [Google AI Studio](https://aistudio.google.com/apikey)
-
-### Test Configuration
-
-The tests use minimal cost configuration:
-- **Model**: `gemini-2.5-flash-lite`
-- **Max Output Tokens**: 5 (to minimize costs)
-- **Temperature**: 0.1
-
-You can modify these settings in the `GEMINI_TEST_CONFIG` dictionary in the test file.
-
-## Running Tests
-
-### All Tests
 ```bash
-# Run all tests
-uv run pytest
-
-# Run with detailed output
-uv run pytest models/tests/test_document_filtering.py -v -s
+uv run --frozen python -m pytest -m "not live"
 ```
 
-### Unit Tests Only (No API Key Required)
+They cover request construction, message conversion, model schemas, parameter validation, file handling, structured output, and tool-call ID preservation.
+
+## Live-test setup
+
+Copy the example environment file and provide a Google AI Studio API key.
+
 ```bash
-uv run pytest models/tests/test_document_filtering.py::TestDocumentFilteringUnit -v
+cp .env.example .env
 ```
 
-### Integration Tests Only (API Key Required)
-```bash
-uv run pytest models/tests/test_document_filtering.py::TestDocumentFilteringIntegration -v -m integration
+Set these values in `.env`.
+
+```dotenv
+GEMINI_API_KEY=your-google-api-key
+RUN_GEMINI_LIVE=1
 ```
 
-### Skip Integration Tests
+Live tests always require `RUN_GEMINI_LIVE=1` to prevent accidental billable requests in local and CI environments.
+
+## Run live tests
+
+Run the complete live suite.
+
 ```bash
-uv run pytest models/tests/test_document_filtering.py -v -m "not integration"
+uv run --frozen python -m pytest -m live -v -s
 ```
 
-## Test Features
+Run only the new Gemini LLM coverage.
 
-### Unit Tests Cover:
-- ✅ Supported document types (PDF, TXT, HTML, Markdown)
-- ✅ Unsupported document types (DOCX, XLSX, PPT, etc.)
-- ✅ MIME type filtering
-- ✅ File extension filtering
-- ✅ Case-insensitive extension filtering
-- ✅ Mixed supported/unsupported content
-- ✅ Empty content after filtering
-- ✅ File caching mechanism
-- ✅ Error handling
+```bash
+uv run --frozen python -m pytest models/tests/test_llm_live.py -v -s
+```
 
-### Integration Tests Cover:
-- ✅ Real PDF upload and processing
-- ✅ Real text document upload
-- ✅ Real Markdown document upload
-- ✅ Real filtering with mixed documents
-- ✅ Real unsupported document rejection
+Run embedding live tests.
 
-## Memory Management
+```bash
+uv run --frozen python -m pytest models/tests/test_embedding_live.py -v -s
+```
 
-- Tests use `MemoryFileCache` instead of persistent file cache
-- No files are written to disk during testing
-- Cache is cleared after each test
+Run document filtering integration tests.
 
-## Test Data
+```bash
+uv run --frozen python -m pytest models/tests/test_document_filtering.py -m live -v -s
+```
 
-The `DocumentGenerator` class creates minimal valid documents:
-- **PDF**: Minimal valid PDF structure
-- **Text**: Plain text content
-- **HTML**: Basic HTML structure
-- **Markdown**: Simple Markdown content
-- **DOCX**: Minimal ZIP structure (for negative testing)
+## New-model live coverage
 
-## Cost Optimization
+Both `gemini-3.6-flash` and `gemini-3.5-flash-lite` are tested through the plugin LLM interface.
 
-Integration tests are designed to minimize API costs:
-- Very short responses (5 tokens max)
-- Simple test documents
-- Efficient test cases
+The live suite covers streaming text generation, non-streaming structured output, inline image input, forced function calling, call ID preservation, function responses, and multi-turn replay.
 
-## Extensibility
-
-The test architecture supports easy extension for:
-- Additional document types
-- Image/video/audio testing (framework ready)
-- Different Gemini models
-- Custom test configurations
+Responses are intentionally short to limit API cost.
 
 ## Troubleshooting
 
-### Common Issues
+Skipped live tests mean the API key or the local opt-in flag is missing.
 
-1. **"GEMINI_API_KEY not found"**
-   - Set up your `.env` file with valid API key
-
-2. **"Invalid GEMINI_API_KEY"**
-   - Verify your API key at Google AI Studio
-   - Check API key permissions
-
-3. **Integration tests skipped**
-   - This is normal behavior when no API key is provided
-   - Only unit tests will run
-
-### Debug Mode
-```bash
-# Run with debug logging
-uv run pytest models/tests/test_document_filtering.py -v -s --log-cli-level=DEBUG
-```
+Authentication and model-access failures are test failures once live testing is explicitly enabled.

--- a/models/gemini/models/tests/conftest.py
+++ b/models/gemini/models/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def pytest_configure() -> None:
+    load_dotenv(ROOT / ".env")
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    enabled = (
+        bool(os.getenv("GEMINI_API_KEY", "").strip())
+        and os.getenv("RUN_GEMINI_LIVE") == "1"
+    )
+    if enabled:
+        return
+
+    skipped = pytest.mark.skip(
+        reason="live tests require GEMINI_API_KEY and RUN_GEMINI_LIVE=1"
+    )
+    for item in items:
+        if item.get_closest_marker("live") is not None:
+            item.add_marker(skipped)

--- a/models/gemini/models/tests/test_document_filtering.py
+++ b/models/gemini/models/tests/test_document_filtering.py
@@ -575,38 +575,25 @@ class TestDocumentFilteringUnit:
         assert self.mock_client.files.upload.call_count == 1
 
 
-@pytest.mark.skipif(
-    not os.getenv("GEMINI_API_KEY"), reason="GEMINI_API_KEY not found in environment"
-)
+@pytest.mark.live
+@pytest.mark.integration
 class TestDocumentFilteringIntegration:
     """Integration tests with real Gemini API (requires API key)."""
 
     @classmethod
     def setup_class(cls):
         """Setup class-level fixtures."""
-        cls.api_key = os.getenv("GEMINI_API_KEY")
-        if not cls.api_key:
-            pytest.skip("GEMINI_API_KEY not found")
+        cls.api_key = os.environ["GEMINI_API_KEY"]
+        cls.llm = GoogleLargeLanguageModel([])
+        cls.llm.validate_credentials(
+            model=GEMINI_TEST_CONFIG["model"],
+            credentials={"google_api_key": cls.api_key},
+        )
+        cls.client = genai.Client(api_key=cls.api_key)
+        cls.model = GEMINI_TEST_CONFIG["model"]
 
     def setup_method(self):
         """Setup test fixtures."""
-        self.llm = GoogleLargeLanguageModel([])
-
-        # Validate credentials first
-        try:
-            self.llm.validate_credentials(
-                model=GEMINI_TEST_CONFIG["model"],
-                credentials={"google_api_key": self.api_key},
-            )
-        except Exception as e:
-            pytest.skip(f"Invalid GEMINI_API_KEY: {e}")
-
-        # Create real client
-        self.client = genai.Client(api_key=self.api_key)
-
-        self.model = GEMINI_TEST_CONFIG["model"]
-
-        # Create minimal cost configuration
         self.config = types.GenerateContentConfig(
             max_output_tokens=GEMINI_TEST_CONFIG["max_output_tokens"],
             temperature=GEMINI_TEST_CONFIG["temperature"],
@@ -648,7 +635,6 @@ class TestDocumentFilteringIntegration:
 
         self.memory_cache.clear()
 
-    @pytest.mark.integration
     def test_real_pdf_upload_and_processing(self):
         """Test real PDF upload and processing with Gemini API."""
         pdf_bytes = DocumentGenerator.create_pdf_bytes()
@@ -688,7 +674,6 @@ class TestDocumentFilteringIntegration:
 
         assert response.text  # Should get some response
 
-    @pytest.mark.integration
     def test_real_text_document_upload(self):
         """Test real text document upload."""
         text_bytes = DocumentGenerator.create_text_bytes(
@@ -722,7 +707,6 @@ class TestDocumentFilteringIntegration:
 
         assert response.text
 
-    @pytest.mark.integration
     def test_real_markdown_document_upload(self):
         """Test real Markdown document upload."""
         md_bytes = DocumentGenerator.create_markdown_bytes(
@@ -753,7 +737,6 @@ class TestDocumentFilteringIntegration:
 
         assert response.text
 
-    @pytest.mark.integration
     def test_real_filtering_with_mixed_documents(self):
         """Test real API with mixed supported/unsupported documents."""
         message = UserPromptMessage(
@@ -804,7 +787,6 @@ class TestDocumentFilteringIntegration:
 
         assert response.text
 
-    @pytest.mark.integration
     def test_real_unsupported_document_rejection(self):
         """Test that unsupported documents are properly filtered in real calls."""
         message = UserPromptMessage(
@@ -836,17 +818,3 @@ class TestDocumentFilteringIntegration:
         )
 
         assert response.text
-
-
-# Configuration for pytest
-def pytest_configure(config):
-    """Configure pytest with custom markers."""
-    config.addinivalue_line(
-        "markers", "integration: mark test as integration test (requires API key)"
-    )
-
-
-# Run tests:
-# All tests: pytest test_document_filtering.py -v
-# Unit tests only: pytest test_document_filtering.py::TestDocumentFilteringUnit -v
-# Integration tests only: pytest test_document_filtering.py::TestDocumentFilteringIntegration -v -m integration

--- a/models/gemini/models/tests/test_embedding_live.py
+++ b/models/gemini/models/tests/test_embedding_live.py
@@ -5,11 +5,11 @@ These tests call the real Google Gemini API and require a valid API key.
 
 Usage:
     export GEMINI_API_KEY="your-google-api-key"
+    export RUN_GEMINI_LIVE=1
     cd models/gemini
     pytest models/tests/test_embedding_live.py -v -s
 
-All tests are marked with @pytest.mark.live so they can be skipped
-in CI or when no API key is available.
+All tests are marked with @pytest.mark.live and run only when explicitly enabled.
 """
 
 import os
@@ -23,20 +23,15 @@ from google.genai.types import EmbedContentConfig
 
 # ---- Configuration ----
 
-API_KEY = os.environ.get("GEMINI_API_KEY", "")
 MODEL_NAME = "gemini-embedding-2-preview"
 
-# Skip all tests in this module if no API key is set
-pytestmark = pytest.mark.skipif(
-    not API_KEY,
-    reason="GEMINI_API_KEY environment variable not set",
-)
+pytestmark = pytest.mark.live
 
 
 @pytest.fixture(scope="module")
 def client():
     """Create a Google Genai client."""
-    return genai.Client(api_key=API_KEY)
+    return genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 
 
 def _make_tiny_jpeg() -> bytes:

--- a/models/gemini/models/tests/test_embedding_live.py
+++ b/models/gemini/models/tests/test_embedding_live.py
@@ -5,11 +5,10 @@ These tests call the real Google Gemini API and require a valid API key.
 
 Usage:
     export GEMINI_API_KEY="your-google-api-key"
-    export RUN_GEMINI_LIVE=1
     cd models/gemini
     pytest models/tests/test_embedding_live.py -v -s
 
-All tests are marked with @pytest.mark.live and run only when explicitly enabled.
+All tests are marked with @pytest.mark.live and skip when no API key is available.
 """
 
 import os

--- a/models/gemini/models/tests/test_live_gate.py
+++ b/models/gemini/models/tests/test_live_gate.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+from conftest import ROOT, pytest_collection_modifyitems
+
+
+def test_live_gate_ignores_other_providers(monkeypatch) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", " ")
+    gemini = Mock(path=ROOT / "models/tests/test_live.py")
+    other = Mock(path=Path(ROOT).parent / "openai/tests/live/test_llm.py")
+    gemini.get_closest_marker.return_value = object()
+    other.get_closest_marker.return_value = object()
+
+    pytest_collection_modifyitems([gemini, other])
+
+    gemini.add_marker.assert_called_once()
+    other.add_marker.assert_not_called()

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -422,6 +422,22 @@ def test_file_url():
     assert file_url == "http://127.0.0.1/static/files/foo/bar.png"
 
 
+def test_json_schema_uses_json_schema_config_field():
+    config = types.GenerateContentConfig()
+    GoogleLargeLanguageModel._set_chat_parameters(
+        config=config,
+        model_parameters={
+            "json_schema": '{"type":"object","additionalProperties":false}'
+        },
+    )
+
+    assert config.response_json_schema == {
+        "type": "object",
+        "additionalProperties": False,
+    }
+    assert config.response_schema is None
+
+
 class TestBuildGeminiContents:
     """Test suite for the _build_gemini_contents method"""
 

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -1,9 +1,11 @@
 import base64
 import dataclasses
 import time
+from decimal import Decimal
 from unittest.mock import Mock, patch
 
 import pytest
+from dify_plugin.entities.model.llm import LLMUsage
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
     AudioPromptMessageContent,
@@ -1382,6 +1384,99 @@ class TestHandleGenerateResponse:
         """Setup test fixtures"""
         self.llm = GoogleLargeLanguageModel([])
         self.credentials = {"google_api_key": "test_key"}
+
+    @staticmethod
+    def _usage() -> LLMUsage:
+        return LLMUsage(
+            prompt_tokens=2,
+            prompt_unit_price=Decimal("1.5"),
+            prompt_price_unit=Decimal("0.000001"),
+            prompt_price=Decimal("3"),
+            completion_tokens=2,
+            completion_unit_price=Decimal("7.5"),
+            completion_price_unit=Decimal("0.000001"),
+            completion_price=Decimal("15"),
+            total_tokens=4,
+            total_price=Decimal("18"),
+            currency="USD",
+            latency=0,
+        )
+
+    @pytest.mark.parametrize(
+        ("actual_tier", "requested_tier", "multiplier"),
+        [
+            ("flex", types.ServiceTier.PRIORITY, Decimal("0.5")),
+            ("standard", types.ServiceTier.FLEX, Decimal("1")),
+            ("priority", None, Decimal("1.8")),
+            (None, types.ServiceTier.FLEX, Decimal("0.5")),
+        ],
+    )
+    def test_service_tier_pricing(
+        self,
+        actual_tier: str | None,
+        requested_tier: types.ServiceTier | None,
+        multiplier: Decimal,
+    ):
+        headers = (
+            {"X-Gemini-Service-Tier": actual_tier} if actual_tier is not None else {}
+        )
+        response = types.GenerateContentResponse(
+            sdk_http_response=types.HttpResponse(headers=headers)
+        )
+        usage = self._usage()
+
+        result = self.llm._apply_service_tier_pricing(usage, response, requested_tier)
+
+        assert result.prompt_unit_price == Decimal("1.5") * multiplier
+        assert result.prompt_price == Decimal("3") * multiplier
+        assert result.completion_unit_price == Decimal("7.5") * multiplier
+        assert result.completion_price == Decimal("15") * multiplier
+        assert result.total_price == Decimal("18") * multiplier
+
+    @pytest.mark.parametrize("stream", [False, True])
+    def test_generation_applies_requested_service_tier_pricing(
+        self, stream: bool
+    ) -> None:
+        response = types.GenerateContentResponse(
+            candidates=[
+                types.Candidate(
+                    content=types.Content(
+                        role="model", parts=[types.Part.from_text(text="OK")]
+                    ),
+                    finish_reason=types.FinishReason.STOP,
+                )
+            ],
+            usage_metadata=types.GenerateContentResponseUsageMetadata(
+                prompt_tokens_details=[
+                    types.ModalityTokenCount(
+                        modality=types.MediaModality.TEXT, token_count=2
+                    )
+                ],
+                candidates_token_count=2,
+            ),
+            sdk_http_response=types.HttpResponse(headers={}),
+        )
+        client = Mock()
+        client.models.generate_content.return_value = response
+        client.models.generate_content_stream.return_value = iter([response])
+
+        with (
+            patch("models.llm.llm.genai.Client", return_value=client),
+            patch.object(self.llm, "_calc_response_usage", return_value=self._usage()),
+        ):
+            result = self.llm._generate(
+                model="gemini-3.6-flash",
+                credentials=self.credentials,
+                prompt_messages=[UserPromptMessage(content="Reply with OK.")],
+                model_parameters={"service_tier": "flex"},
+                stream=stream,
+            )
+            usage = list(result)[-1].delta.usage if stream else result.usage
+
+        assert usage is not None
+        assert usage.prompt_price == Decimal("1.5")
+        assert usage.completion_price == Decimal("7.5")
+        assert usage.total_price == Decimal("9")
 
     def test_non_streaming_response_returns_structured_content(self):
         """Test that non-streaming response returns content as list of PromptMessageContent

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -575,6 +575,21 @@ class TestBuildGeminiContents:
         assert config.top_p is None
         assert config.top_k is None
 
+    def test_new_model_credentials_validation_omits_sampling_parameters(self):
+        mock_client = Mock()
+
+        with patch("models.llm.llm.genai.Client", return_value=mock_client):
+            self.llm.validate_credentials(
+                model="gemini-3.6-flash",
+                credentials={"google_api_key": "test-key"},
+            )
+
+        config = mock_client.models.generate_content.call_args.kwargs["config"]
+        assert config.max_output_tokens == 20
+        assert config.temperature is None
+        assert config.top_p is None
+        assert config.top_k is None
+
     @pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.5-flash-lite"])
     def test_new_models_reject_assistant_prefill(self, model):
         mock_client = Mock()

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -17,6 +17,7 @@ from dify_plugin.entities.model.message import (
     UserPromptMessage,
     VideoPromptMessageContent,
 )
+from dify_plugin.errors.model import InvokeBadRequestError
 from google.genai import types
 from models.llm.file_parts import (
     FILE_DOWNLOAD_TIMEOUT_SECONDS,
@@ -553,6 +554,50 @@ class TestBuildGeminiContents:
             "Draw a red fox.",
         ]
 
+    @pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.5-flash-lite"])
+    def test_new_models_drop_deprecated_sampling_parameters(self, model):
+        mock_client = Mock()
+
+        with (
+            patch("models.llm.llm.genai.Client", return_value=mock_client),
+            patch.object(self.llm, "_handle_generate_response"),
+        ):
+            self.llm._generate(
+                model=model,
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[UserPromptMessage(content="Hello")],
+                model_parameters={"temperature": 0, "top_p": 0.9, "top_k": 40},
+                stream=False,
+            )
+
+        config = mock_client.models.generate_content.call_args.kwargs["config"]
+        assert config.temperature is None
+        assert config.top_p is None
+        assert config.top_k is None
+
+    @pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.5-flash-lite"])
+    def test_new_models_reject_assistant_prefill(self, model):
+        mock_client = Mock()
+
+        with (
+            patch("models.llm.llm.genai.Client", return_value=mock_client),
+            pytest.raises(
+                InvokeBadRequestError, match="requires a non-empty final user turn"
+            ),
+        ):
+            self.llm._generate(
+                model=model,
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[
+                    AssistantPromptMessage(content="Prefill"),
+                    UserPromptMessage(content=""),
+                ],
+                model_parameters={},
+                stream=False,
+            )
+
+        mock_client.models.generate_content.assert_not_called()
+
     def test_multiple_text_system_messages_keep_last_scalar(self):
         messages = [
             SystemPromptMessage(content="First instruction."),
@@ -664,6 +709,26 @@ class TestBuildGeminiContents:
             ].system_instruction
             is None
         )
+
+    @pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.5-flash-lite"])
+    def test_new_models_accept_scalar_system_only_prompt(self, model):
+        mock_client = Mock()
+
+        with (
+            patch("models.llm.llm.genai.Client", return_value=mock_client),
+            patch.object(self.llm, "_handle_generate_response"),
+        ):
+            self.llm._generate(
+                model=model,
+                credentials={"google_api_key": "test-key"},
+                prompt_messages=[SystemPromptMessage(content="Instruction")],
+                model_parameters={},
+                stream=False,
+            )
+
+        request = mock_client.models.generate_content.call_args.kwargs
+        assert request["config"].system_instruction == "Instruction"
+        assert [part.text for part in request["contents"][0].parts] == ["Instruction"]
 
     @pytest.mark.parametrize(
         "empty_message",
@@ -876,9 +941,10 @@ class TestBuildGeminiContents:
         assert contents[0].parts[0].function_response.response == {
             "response": "The weather is sunny and 72°F"
         }
+        assert contents[0].parts[0].function_response.id == messages[0].tool_call_id
 
-    def test_assistant_message_with_tool_calls(self):
-        """Test conversion of assistant messages with tool calls"""
+    def test_parallel_tool_call_ids_round_trip(self):
+        """Test conversion of parallel tool calls and responses"""
         messages = [
             AssistantPromptMessage(
                 content="I'll check the weather for you",
@@ -889,9 +955,23 @@ class TestBuildGeminiContents:
                         function=AssistantPromptMessage.ToolCall.ToolCallFunction(
                             name="get_weather", arguments='{"location": "New York"}'
                         ),
-                    )
+                    ),
+                    AssistantPromptMessage.ToolCall(
+                        id="call_456",
+                        type="function",
+                        function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                            name="get_time",
+                            arguments='{"timezone": "America/New_York"}',
+                        ),
+                    ),
                 ],
-            )
+            ),
+            ToolPromptMessage(
+                name="get_weather", content="Sunny", tool_call_id="call_123"
+            ),
+            ToolPromptMessage(
+                name="get_time", content="12:00", tool_call_id="call_456"
+            ),
         ]
 
         contents = self.llm._build_gemini_contents(
@@ -900,12 +980,20 @@ class TestBuildGeminiContents:
             config=self.mock_config,
         )
 
-        assert len(contents) == 1
+        assert len(contents) == 2
         assert contents[0].role == "model"
-        assert len(contents[0].parts) == 2
+        assert len(contents[0].parts) == 3
         assert contents[0].parts[0].text == "I'll check the weather for you"
         assert contents[0].parts[1].function_call.name == "get_weather"
         assert contents[0].parts[1].function_call.args == {"location": "New York"}
+        assert contents[0].parts[1].function_call.id == "call_123"
+        assert contents[0].parts[2].function_call.name == "get_time"
+        assert contents[0].parts[2].function_call.id == "call_456"
+        assert contents[1].role == "user"
+        assert [part.function_response.id for part in contents[1].parts] == [
+            "call_123",
+            "call_456",
+        ]
 
     def test_role_alternation_merging(self):
         """Test that consecutive messages with the same role are merged"""
@@ -1002,9 +1090,11 @@ class TestBuildGeminiContents:
         assert not contents[3].parts[0].function_call
         assert contents[3].parts[1].function_call.name == "current_time"
         assert contents[3].parts[1].function_call.args == {}
+        assert contents[3].parts[1].function_call.id == tool_id
 
         assert contents[4].role == "user"
         assert contents[4].parts[0].function_response.name == "current_time"
+        assert contents[4].parts[0].function_response.id == tool_id
         _r = contents[4].parts[0].function_response.response.get("response")
         assert _r == "2025-08-12 02:08:12"
 
@@ -1313,6 +1403,7 @@ class TestHandleGenerateResponse:
     def test_non_streaming_response_with_function_call(self):
         """Test non-streaming response with function call returns structured content"""
         mock_function_call = Mock()
+        mock_function_call.id = "call_123"
         mock_function_call.name = "get_weather"
         mock_function_call.args = {"location": "Tokyo"}
 
@@ -1352,11 +1443,13 @@ class TestHandleGenerateResponse:
         assert isinstance(result.message.content, list)
         # Should have tool calls
         assert len(result.message.tool_calls) == 1
+        assert result.message.tool_calls[0].id == "call_123"
         assert result.message.tool_calls[0].function.name == "get_weather"
 
     def test_non_streaming_response_with_mixed_content(self):
         """Test non-streaming response with text and function call"""
         mock_function_call = Mock()
+        mock_function_call.id = "call_456"
         mock_function_call.name = "search"
         mock_function_call.args = {"query": "test"}
 

--- a/models/gemini/models/tests/test_llm_live.py
+++ b/models/gemini/models/tests/test_llm_live.py
@@ -34,7 +34,6 @@ schemas = [
     )
     for model in MODELS
 ]
-llm = GoogleLargeLanguageModel(schemas)
 
 
 def _invoke(
@@ -46,6 +45,8 @@ def _invoke(
     required_tool: str | None = None,
     stream: bool,
 ) -> list[LLMResultChunk]:
+    llm = GoogleLargeLanguageModel(schemas)
+
     def invoke() -> list[LLMResultChunk]:
         return list(
             llm.invoke(

--- a/models/gemini/models/tests/test_llm_live.py
+++ b/models/gemini/models/tests/test_llm_live.py
@@ -1,0 +1,227 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from dify_plugin.entities.model import AIModelEntity
+from dify_plugin.entities.model.llm import LLMResultChunk
+from dify_plugin.entities.model.message import (
+    ImagePromptMessageContent,
+    PromptMessage,
+    PromptMessageTool,
+    TextPromptMessageContent,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from google.genai import types
+from models.llm.llm import GoogleLargeLanguageModel
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODELS = ("gemini-3.6-flash", "gemini-3.5-flash-lite")
+RED_IMAGE = (
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR4nO3NsQ0A"
+    "AAzCMP5/un0CNkuZ41wybXsHAAAAAAAAAAAAxR4yw/wuPL6QkAAAAABJRU5ErkJggg=="
+)
+
+pytestmark = pytest.mark.live
+
+schemas = [
+    AIModelEntity(
+        **yaml.safe_load((ROOT / "models" / "llm" / f"{model}.yaml").read_text())
+    )
+    for model in MODELS
+]
+llm = GoogleLargeLanguageModel(schemas)
+
+
+def _invoke(
+    model: str,
+    messages: list[PromptMessage],
+    *,
+    parameters: dict | None = None,
+    tools: list[PromptMessageTool] | None = None,
+    required_tool: str | None = None,
+    stream: bool,
+) -> list[LLMResultChunk]:
+    def invoke() -> list[LLMResultChunk]:
+        return list(
+            llm.invoke(
+                model=model,
+                credentials={"google_api_key": os.environ["GEMINI_API_KEY"]},
+                prompt_messages=messages,
+                model_parameters=parameters
+                or {"max_output_tokens": 128, "thinking_level": "Minimal"},
+                tools=tools,
+                stream=stream,
+                user="gemini-live-test",
+            )
+        )
+
+    if not required_tool:
+        return invoke()
+
+    original = llm._set_tool_calling
+
+    def set_required_tool(*, config, model_parameters, tools) -> None:
+        original(config=config, model_parameters=model_parameters, tools=tools)
+        config.tool_config = types.ToolConfig(
+            function_calling_config=types.FunctionCallingConfig(
+                mode=types.FunctionCallingConfigMode.ANY,
+                allowed_function_names=[required_tool],
+            )
+        )
+
+    with patch.object(llm, "_set_tool_calling", side_effect=set_required_tool):
+        return invoke()
+
+
+def _text(chunks: list[LLMResultChunk]) -> str:
+    texts = []
+    for chunk in chunks:
+        content = chunk.delta.message.content
+        if isinstance(content, str):
+            texts.append(content)
+        elif content:
+            texts.extend(
+                part.data
+                for part in content
+                if isinstance(part, TextPromptMessageContent)
+            )
+    return "".join(texts)
+
+
+def _assert_usage(chunks: list[LLMResultChunk]) -> None:
+    usage = next(
+        (chunk.delta.usage for chunk in reversed(chunks) if chunk.delta.usage), None
+    )
+    assert usage is not None
+    assert usage.total_tokens > 0
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_streaming_text_generation(model: str) -> None:
+    chunks = _invoke(
+        model,
+        [UserPromptMessage(content="Reply with OK.")],
+        stream=True,
+    )
+
+    assert _text(chunks).strip()
+    _assert_usage(chunks)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_structured_output(model: str) -> None:
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string", "enum": ["OK"]}},
+        "required": ["answer"],
+        "additionalProperties": False,
+    }
+    chunks = _invoke(
+        model,
+        [UserPromptMessage(content="Return the required structured answer.")],
+        parameters={
+            "max_output_tokens": 128,
+            "thinking_level": "Minimal",
+            "json_schema": json.dumps(schema),
+        },
+        stream=False,
+    )
+
+    assert json.loads(_text(chunks)) == {"answer": "OK"}
+    _assert_usage(chunks)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_inline_image_input(model: str) -> None:
+    chunks = _invoke(
+        model,
+        [
+            UserPromptMessage(
+                content=[
+                    ImagePromptMessageContent(
+                        base64_data=RED_IMAGE,
+                        format="png",
+                        mime_type="image/png",
+                        filename="red.png",
+                    ),
+                    TextPromptMessageContent(
+                        data="Return only the primary color in this image."
+                    ),
+                ]
+            )
+        ],
+        parameters={
+            "max_output_tokens": 128,
+            "thinking_level": "Minimal",
+            "use_inline_file": True,
+        },
+        stream=False,
+    )
+
+    assert "RED" in _text(chunks).upper()
+    _assert_usage(chunks)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_tool_call_id_round_trip(model: str) -> None:
+    tools = [
+        PromptMessageTool(
+            name="lookup_weather",
+            description="Return the current weather for a city.",
+            parameters={
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        )
+    ]
+    prompt = UserPromptMessage(
+        content="Call lookup_weather exactly once for Paris before answering."
+    )
+    parameters = {"max_output_tokens": 512, "thinking_level": "Medium"}
+    first = _invoke(
+        model,
+        [prompt],
+        parameters=parameters,
+        tools=tools,
+        required_tool="lookup_weather",
+        stream=False,
+    )
+    assistant = first[-1].delta.message
+    calls = assistant.tool_calls
+
+    assert calls
+    assert all(call.function.name == "lookup_weather" for call in calls)
+    assert all(call.id for call in calls)
+    assert len({call.id for call in calls}) == len(calls)
+    assert all(
+        "paris" in json.loads(call.function.arguments)["city"].lower() for call in calls
+    )
+    _assert_usage(first)
+
+    second = _invoke(
+        model,
+        [
+            prompt,
+            assistant,
+            *[
+                ToolPromptMessage(
+                    name=call.function.name,
+                    content='{"temperature_celsius": 21, "condition": "sunny"}',
+                    tool_call_id=call.id,
+                )
+                for call in calls
+            ],
+        ],
+        parameters=parameters,
+        tools=tools,
+        stream=True,
+    )
+
+    assert _text(second).strip()
+    _assert_usage(second)

--- a/models/gemini/models/tests/test_model_schema.py
+++ b/models/gemini/models/tests/test_model_schema.py
@@ -1,7 +1,9 @@
+from decimal import Decimal
 from pathlib import Path
 
+import pytest
 import yaml
-from dify_plugin.entities.model import AIModelEntity
+from dify_plugin.entities.model import AIModelEntity, ModelFeature, ModelPropertyKey
 from models.llm.llm import GoogleLargeLanguageModel
 from models.llm.model_schema import (
     INLINE_FILE_PARAMETER_NAME,
@@ -10,6 +12,10 @@ from models.llm.model_schema import (
 
 
 LLM_SCHEMA_DIR = Path(__file__).parents[1] / "llm"
+LATEST_FLASH_MODELS = (
+    ("gemini-3.6-flash", "Medium", Decimal("1.50"), Decimal("7.50")),
+    ("gemini-3.5-flash-lite", "Minimal", Decimal("0.30"), Decimal("2.50")),
+)
 
 
 def _load_llm_model_schemas() -> list[AIModelEntity]:
@@ -51,3 +57,55 @@ def test_inline_file_parameter_covers_newer_gemini_models_without_yaml_edits():
     assert INLINE_FILE_PARAMETER_NAME not in {
         rule.name for rule in text_only.parameter_rules
     }
+
+
+@pytest.mark.parametrize(
+    ("model", "thinking_level", "input_price", "output_price"),
+    LATEST_FLASH_MODELS,
+)
+def test_latest_flash_model_contract(
+    model: str,
+    thinking_level: str,
+    input_price: Decimal,
+    output_price: Decimal,
+):
+    llm = GoogleLargeLanguageModel(_load_llm_model_schemas())
+    schema = llm.get_model_schema(model)
+    assert schema is not None
+
+    assert schema.model_properties[ModelPropertyKey.CONTEXT_SIZE] == 1_048_576
+    assert {
+        ModelFeature.TOOL_CALL,
+        ModelFeature.MULTI_TOOL_CALL,
+        ModelFeature.STREAM_TOOL_CALL,
+        ModelFeature.VISION,
+        ModelFeature.DOCUMENT,
+        ModelFeature.VIDEO,
+        ModelFeature.AUDIO,
+        ModelFeature.STRUCTURED_OUTPUT,
+    } <= set(schema.features or [])
+
+    rules = {rule.name: rule for rule in schema.parameter_rules}
+    assert not {"temperature", "top_p", "top_k"} & rules.keys()
+    assert rules["include_thoughts"].default is False
+    assert rules["media_resolution"].options == ["Default", "Low", "Medium", "High"]
+    assert rules["thinking_level"].default == thinking_level
+    assert rules["thinking_level"].options == ["Minimal", "Low", "Medium", "High"]
+    assert rules["max_output_tokens"].default == 65_536
+    assert rules["max_output_tokens"].max == 65_536
+    assert rules["service_tier"].default == "standard"
+    assert rules["service_tier"].options == ["flex", "standard", "priority"]
+    assert schema.pricing is not None
+    assert schema.pricing.input == input_price
+    assert schema.pricing.output == output_price
+    assert schema.pricing.unit == Decimal("0.000001")
+    assert schema.pricing.currency == "USD"
+
+
+def test_latest_flash_models_are_first_in_display_order():
+    position = yaml.safe_load((LLM_SCHEMA_DIR / "_position.yaml").read_text())
+    assert position[:3] == [
+        "gemini-3.6-flash",
+        "gemini-3.5-flash",
+        "gemini-3.5-flash-lite",
+    ]

--- a/models/gemini/pyproject.toml
+++ b/models/gemini/pyproject.toml
@@ -32,10 +32,12 @@ python_functions = ["test_*"]
 
 # Test discovery paths
 testpaths = ["models/tests/"]
+pythonpath = ["."]
 
 # Markers
 markers = [
-    "integration: marks tests as integration tests (requires API key)",
+    "integration: marks integration tests",
+    "live: sends billable requests to the real Gemini API",
     "unit: marks tests as unit tests (no API key required)"
 ]
 

--- a/models/gemini/pyproject.toml
+++ b/models/gemini/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
 
 [tool.pytest.ini_options]
 # Pytest configuration for Gemini plugin tests
+addopts = "--tb=short"
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
@@ -53,9 +54,6 @@ filterwarnings = [
     "ignore::PendingDeprecationWarning",
     "ignore:Monkey-patching ssl after ssl has already been imported:gevent.monkey.MonkeyPatchWarning"
 ]
-
-# Coverage options (if using pytest-cov)
-# addopts = ["--cov=models/llm", "--cov-report=term-missing", "--cov-report=html"]
 
 [tool.black]
 # Equivalent to: uv run black -C -l 100


### PR DESCRIPTION
## Summary

Closes #3479.

Adds the stable Gemini 3.6 Flash and Gemini 3.5 Flash-Lite models with official context limits, output limits, thinking defaults, capabilities, service tiers, and pricing.

Implements the latest API requirements by omitting deprecated sampling parameters, rejecting assistant prefills after content normalization, preserving function call IDs across parallel tool-call histories, and sending standard JSON Schema through `response_json_schema`.

Usage pricing follows the actual service tier returned by Google, including Priority downgrades, and Gemini live-test gating is isolated from other providers.

Adds real-API coverage for both new models across streaming text, structured output, inline images, forced function calls, call-ID round trips, function responses, and multi-turn replay.

Bumps the Gemini plugin version from 0.9.2 to 0.9.3.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin
- [x] LLM plugin

## Screenshots / Videos

Not applicable because this change updates backend model definitions, request handling, and automated tests.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change</summary>

- [x] Message flow
- [x] Tool interaction flow
- [x] Multimodal input
- [ ] Multimodal output
- [x] Structured output
- [x] Token consumption metrics
- [x] Other LLM functionality
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped the top-level version in manifest.yaml.
- [x] The current dify-plugin requirement is declared in pyproject.toml and locked in uv.lock.

## Testing

- [ ] Local deployment
- [ ] SaaS
- [x] Clean committed worktree: `pytest -q` completed with 174 passed and 28 live tests skipped when the API key was empty.
- [x] Real API: `pytest -m live -q` completed with all 28 tests passed.
- [x] The 8 new-model real-API cases passed for streaming text, JSON Schema, inline images, and function-call ID round trips.
- [x] Both test directories load the plugin-root `.env` automatically.
- [x] Missing or blank `GEMINI_API_KEY` values skip real-API tests, while configured credential errors fail normally.
- [x] Streaming and non-streaming usage pricing covers Flex, Standard, Priority, response-tier precedence, and requested-tier fallback.
- [x] A cross-provider regression confirms that Gemini's missing key does not skip OpenAI live tests.
- [x] `uv run --frozen ruff check` passed for every changed Python file.
- [x] `uv run --frozen ruff format --check` passed for every changed Python file.
- [x] `git diff --check` passed.

Pytest automatically loads `.env` and runs live tests whenever it contains a non-empty `GEMINI_API_KEY`.

Iterative subagent reviews continued after each fix, and the final review found no new issues.

All PR review threads have been addressed and resolved.

## References

- [Gemini 3.6 Flash](https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash)
- [Gemini 3.5 Flash-Lite](https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite)
- [Gemini latest models guide](https://ai.google.dev/gemini-api/docs/generate-content/latest-model)
- [Gemini structured outputs](https://ai.google.dev/gemini-api/docs/structured-output)
- [Gemini function calling](https://ai.google.dev/gemini-api/docs/generate-content/function-calling)
- [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing)
