### PR TITLE
fix(lemonade): pass model to credential validator so embedding and rerank models can be added

### DIFF
--- a/models/lemonade/manifest.yaml
+++ b/models/lemonade/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.15
+version: 0.0.16
 type: plugin
 author: "langgenius"
 name: "lemonade"

--- a/models/lemonade/models/rerank/rerank.py
+++ b/models/lemonade/models/rerank/rerank.py
@@ -18,7 +18,7 @@ class LemonadeRerankModel(OAICompatRerankModel):
         :return:
         """
         # Use shared validation function
-        validate_lemonade_credentials(credentials)
+        validate_lemonade_credentials(credentials, model)
 
     def get_customizable_model_schema(
         self, model: str, credentials: Mapping | dict

--- a/models/lemonade/models/text_embedding/text_embedding.py
+++ b/models/lemonade/models/text_embedding/text_embedding.py
@@ -26,4 +26,4 @@ class LemonadeTextEmbeddingModel(OAICompatEmbeddingModel):
         :return:
         """
         # Use shared validation function
-        validate_lemonade_credentials(credentials)
+        validate_lemonade_credentials(credentials, model)

--- a/models/lemonade/tests/test_validate_credentials.py
+++ b/models/lemonade/tests/test_validate_credentials.py
@@ -1,0 +1,82 @@
+"""Regression tests for issue #3470.
+
+Lemonade embedding and rerank models could not be added: their
+``validate_credentials`` methods called the shared
+``validate_lemonade_credentials(credentials)`` without the ``model`` argument,
+so the validator's ``if not model: raise CredentialsValidateFailedError(
+"Please specify a model name")`` guard fired unconditionally. The LLM, TTS and
+speech2text siblings already pass ``model``; these tests pin that the embedding
+and rerank call sites do too.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+from models.rerank.rerank import LemonadeRerankModel
+from models.text_embedding.text_embedding import LemonadeTextEmbeddingModel
+
+
+def _healthy_server_responses(model: str):
+    """Sequential ``requests.get`` return values: health check, then model list."""
+    health = MagicMock()
+    health.status_code = 200
+    health.json.return_value = {"status": "ok"}
+
+    models = MagicMock()
+    models.status_code = 200
+    models.json.return_value = {"data": [{"id": model}]}
+
+    return [health, models]
+
+
+class TestLemonadeCredentialModelArg(unittest.TestCase):
+    def setUp(self):
+        self.model_name = "Qwen3-Embedding-0.6B-GGUF"
+        self.credentials = {"endpoint_url": "http://localhost:8000"}
+
+    @patch("models.llm.llm.requests.get")
+    def test_text_embedding_passes_model_and_validates(self, mock_get):
+        """Embedding validation reaches the server checks instead of failing on
+        the missing-model guard (#3470)."""
+        mock_get.side_effect = _healthy_server_responses(self.model_name)
+
+        # Must not raise "Please specify a model name".
+        LemonadeTextEmbeddingModel(model_schemas=[]).validate_credentials(
+            self.model_name, self.credentials
+        )
+
+        # Health endpoint + models endpoint => the model name got past the guard.
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("models.llm.llm.requests.get")
+    def test_rerank_passes_model_and_validates(self, mock_get):
+        """Rerank validation reaches the server checks instead of failing on the
+        missing-model guard (#3470)."""
+        mock_get.side_effect = _healthy_server_responses(self.model_name)
+
+        LemonadeRerankModel(model_schemas=[]).validate_credentials(
+            self.model_name, self.credentials
+        )
+
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("models.llm.llm.requests.get")
+    def test_missing_model_name_error_no_longer_raised(self, mock_get):
+        """Pin the bug directly: even with an unreachable server, validation must
+        not fail with 'Please specify a model name' for embedding or rerank."""
+        mock_get.side_effect = requests.exceptions.ConnectionError("server down")
+
+        for model_cls in (LemonadeTextEmbeddingModel, LemonadeRerankModel):
+            with self.subTest(model=model_cls.__name__):
+                with self.assertRaises(CredentialsValidateFailedError) as ctx:
+                    model_cls(model_schemas=[]).validate_credentials(
+                        self.model_name, self.credentials
+                    )
+                self.assertNotIn("Please specify a model name", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #3470.

Adding a **Text Embedding** or **Rerank** model to the Lemonade provider always fails with `Please specify a model name`, even when a name is entered — so neither model type can be configured at all.

`validate_lemonade_credentials()` requires a `model` argument, but two call sites omit it:

- `models/text_embedding/text_embedding.py:29`
- `models/rerank/rerank.py:21`

With `model` missing, the validator raises `Please specify a model name` unconditionally, before any credential or network check runs. The provider's other model types already pass `model` at the same call — these two were missed.

This passes `model` at both call sites, matching the existing sibling pattern. Two one-argument changes, plus a regression test that fails on the current code with the exact `Please specify a model name` error and passes with the fix.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

Same inputs in both (`nomic-embed-text`, Text Embedding, `127.0.0.1:13305`, no Lemonade server running locally).

**Before (0.0.15):** validation fails with `Please specify a model name` although the name is filled in.
<img width="1280" height="1203" alt="2026-07-22_00-40-08" src="https://github.com/user-attachments/assets/0d712811-c605-4589-b3a6-02443722d361" />

**After (0.0.16, this fix):** the model-name error is gone; validation now proceeds to the server connection, which fails only because no Lemonade server is running locally.
<img width="1280" height="1203" alt="2026-07-22_00-50-12" src="https://github.com/user-attachments/assets/d5620635-91df-4dc0-a83a-02bd362cc556" />


## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — `0.0.15` → `0.0.16` (PATCH: bug fix)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`)
> Second box left unchecked: this plugin declares `dify-plugin>=0.9.0` in `pyproject.toml` (with `uv.lock` present), which falls outside the `>=0.3.0,<0.6.0` range in the template. Unchanged by this PR.
## Testing

- [x] Local deployment — Dify version: 1.16.0

Packaged the patched plugin (`lemonade-0.0.16.difypkg`) and installed it locally over the marketplace 0.0.15 build, then re-ran the Add-Model flow for a Text Embedding model — see the before/after above. Plugin tests pass (3 passed); the new regression test was verified to fail before the fix and pass after.

---

*AI assistance: this change was developed with Claude Code; I reviewed and verified the diff and the test behavior before submitting.*