### PR TITLE
refactor(dify_extractor): harden extraction pipeline

### DIFF
--- a/tools/dify_extractor/PRIVACY.md
+++ b/tools/dify_extractor/PRIVACY.md
@@ -1,3 +1,13 @@
-## Privacy
+# Privacy
 
-!!! Please fill in the privacy policy of the plugin.
+Dify Extractor processes the file supplied to the tool in the plugin runtime. It does not collect
+analytics, create user profiles, or retain extracted document content itself.
+
+When a Markdown or DOCX file references an external image, the plugin may request that HTTP(S) URL
+and upload the returned image to the Dify file service so it can be included in the tool output.
+This discloses the plugin runtime's network address and normal HTTP request metadata to the host of
+the referenced image. Embedded images are uploaded only to the configured Dify file service.
+
+Operational logs may contain source filenames, image URLs, and error descriptions. Retention and
+access to files and logs are controlled by the operator of the Dify deployment and the referenced
+image hosts.

--- a/tools/dify_extractor/README.md
+++ b/tools/dify_extractor/README.md
@@ -1,7 +1,50 @@
-## dify_extractor
+# Dify Extractor
 
-**Author:** langgenius
-**Version:** 0.0.2
-**Type:** tool
+Dify Extractor converts uploaded documents into Markdown plus structured document records for
+RAG pipelines and workflows.
 
-### Description
+## Supported formats
+
+- PDF (`.pdf`)
+- Microsoft Word (`.docx`)
+- Microsoft PowerPoint (`.pptx`)
+- Microsoft Excel (`.xls`, `.xlsx`)
+- Markdown (`.md`, `.markdown`, `.mdx`)
+- HTML (`.htm`, `.html`)
+- CSV (`.csv`)
+- JSON (`.json`)
+- YAML (`.yaml`, `.yml`)
+- Plain-text formats such as `.txt`, `.log`, `.rst`, `.ini`, `.cfg`, `.conf`, and `.xml`
+
+Text MIME types are also accepted when a file has no recognized extension. Unsupported binary
+formats return a clear error instead of being decoded as text.
+
+## Outputs
+
+- The text output contains the complete extracted Markdown.
+- `documents` contains format-appropriate records: rows for CSV/Excel, pages for PDF, sections for
+  Markdown, and a whole-file record for the other formats.
+- `images` is emitted when embedded or referenced images are successfully uploaded to Dify.
+
+Malformed, empty, undecodable, or resource-limit-breaking files return one error message and do
+not emit partial document variables.
+
+## Image and archive safeguards
+
+Remote Markdown and DOCX images are imported on a best-effort basis. Only HTTP(S) URLs are used,
+with a 30-second request timeout, a maximum of 20 images, a 15 MiB per-image limit, and a 100 MiB
+cumulative limit. A failed image download or upload does not discard otherwise extractable text.
+
+ZIP-based Office files are rejected before parsing if they contain more than 10,000 entries,
+expand beyond 200 MiB, or exceed a 1,000:1 compression ratio.
+
+## Development
+
+The plugin targets Python 3.12 and uses `uv` for dependency management.
+
+```bash
+uv sync --all-groups --frozen --python 3.12
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+```

--- a/tools/dify_extractor/manifest.yaml
+++ b/tools/dify_extractor/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.13
+version: 0.1.0
 type: plugin
 author: langgenius
 name: dify_extractor

--- a/tools/dify_extractor/provider/dify_extractor.py
+++ b/tools/dify_extractor/provider/dify_extractor.py
@@ -1,14 +1,7 @@
-from typing import Any
-
 from dify_plugin import ToolProvider
-from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 
 
 class DifyExtractorProvider(ToolProvider):
-    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
-        try:
-            """
-            IMPLEMENT YOUR VALIDATION HERE
-            """
-        except Exception as e:
-            raise ToolProviderCredentialValidationError(str(e))
+    def _validate_credentials(self, credentials: dict[str, object]) -> None:
+        """The extractor has no provider credentials to validate."""
+        return None

--- a/tools/dify_extractor/pyproject.toml
+++ b/tools/dify_extractor/pyproject.toml
@@ -1,19 +1,17 @@
 [project]
 name = "dify_extractor"
 version = "0.1.0"
-description = "Add your description here"
+description = "Extract structured Markdown and documents from common file formats for Dify"
 readme = "README.md"
 requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
     "dify_plugin>=0.9.0",
-    "pandas[excel,output-formatting,performance]>=3.0.3",
     "chardet>=7.4.3",
     "python-docx>=1.2.0",
     "python-pptx>=1.0.2",
     "openpyxl>=3.1.5",
-    "bs4>=0.0.2",
     "xlrd>=2.0.2",
     "pypdfium2>=5.8.0",
     "requests>=2.34.2",
@@ -22,8 +20,16 @@ dependencies = [
     "beautifulsoup4>=4.14.3",
 ]
 
-# uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
 dev = [
     "pytest>=9.1.1",
+    "ruff>=0.14.0",
+    "xlwt>=1.3.0",
 ]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/tools/dify_extractor/tests/conftest.py
+++ b/tools/dify_extractor/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tools/dify_extractor/tests/test_dify_extractor.py
+++ b/tools/dify_extractor/tests/test_dify_extractor.py
@@ -1,10 +1,11 @@
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import pytest
 
 from tools.dify_extractor import DifyExtractorTool
+from tools.document import Document, ExtractorResult
+from tools.errors import ExtractionError
+from tools.extractor_base import BaseExtractor
 
 
 class _MessageToolMixin:
@@ -17,42 +18,189 @@ class _MessageToolMixin:
 
 def _make_tool() -> DifyExtractorTool:
     tool = object.__new__(DifyExtractorTool)
-    tool.create_text_message = _MessageToolMixin.create_text_message.__get__(tool, DifyExtractorTool)
-    tool.create_variable_message = _MessageToolMixin.create_variable_message.__get__(tool, DifyExtractorTool)
+    tool.create_text_message = _MessageToolMixin.create_text_message.__get__(
+        tool, DifyExtractorTool
+    )
+    tool.create_variable_message = _MessageToolMixin.create_variable_message.__get__(
+        tool, DifyExtractorTool
+    )
     return tool
 
 
-def test_invoke_returns_error_for_corrupt_docx():
-    tool = _make_tool()
-    corrupt_file = SimpleNamespace(filename="report.docx", blob=b"not a zip file")
+def _file(
+    blob: bytes,
+    filename: str | None = "sample.txt",
+    extension: str | None = None,
+    mime_type: str | None = "text/plain",
+):
+    return SimpleNamespace(
+        filename=filename,
+        extension=extension,
+        mime_type=mime_type,
+        blob=blob,
+    )
 
-    messages = list(tool._invoke({"file": corrupt_file}))
+
+def test_success_preserves_message_order_and_outputs():
+    messages = list(_make_tool()._invoke({"file": _file(b"hello")}))
+
+    assert [message["type"] for message in messages] == ["text", "variable"]
+    assert messages[0]["value"] == "hello"
+    assert messages[1]["name"] == "documents"
+    assert messages[1]["value"][0].metadata == {"source": "sample.txt"}
+
+
+def test_missing_file_returns_one_error_message():
+    messages = list(_make_tool()._invoke({}))
+
+    assert messages == [{"type": "text", "value": "A file is required."}]
+
+
+def test_missing_filename_uses_supplied_extension():
+    messages = list(
+        _make_tool()._invoke(
+            {"file": _file(b"hello", filename=None, extension="txt", mime_type=None)}
+        )
+    )
+
+    assert messages[0]["value"] == "hello"
+    assert messages[1]["value"][0].metadata["source"] == "uploaded.txt"
+
+
+def test_supplied_extension_resolves_misnamed_file():
+    messages = list(
+        _make_tool()._invoke(
+            {
+                "file": _file(
+                    b'{"answer": 42}',
+                    filename="payload.bin",
+                    extension="json",
+                    mime_type="application/json",
+                )
+            }
+        )
+    )
+
+    assert messages[0]["value"].startswith("```json")
+
+
+def test_text_mime_type_enables_smart_fallback():
+    messages = list(
+        _make_tool()._invoke(
+            {"file": _file(b"plain", filename="sample.unknown", mime_type="text/plain")}
+        )
+    )
+
+    assert messages[0]["value"] == "plain"
+
+
+def test_unsupported_binary_returns_one_error_message():
+    messages = list(
+        _make_tool()._invoke(
+            {
+                "file": _file(
+                    b"binary",
+                    filename="archive.zip",
+                    mime_type="application/zip",
+                )
+            }
+        )
+    )
 
     assert len(messages) == 1
-    assert messages[0]["type"] == "text"
-    assert "not a valid .docx file" in messages[0]["value"]
-    assert "old binary .doc instead of .docx" in messages[0]["value"]
+    assert "Unsupported file format '.zip'" in messages[0]["value"]
 
 
-def test_invoke_returns_error_for_corrupt_pptx():
-    tool = _make_tool()
-    corrupt_file = SimpleNamespace(filename="slides.pptx", blob=b"not a zip file")
+def test_empty_file_returns_one_error_message():
+    messages = list(_make_tool()._invoke({"file": _file(b"")}))
 
-    messages = list(tool._invoke({"file": corrupt_file}))
-
-    assert len(messages) == 1
-    assert messages[0]["type"] == "text"
-    assert "not a valid .pptx file" in messages[0]["value"]
-    assert "old binary .ppt instead of .pptx" in messages[0]["value"]
+    assert messages == [{"type": "text", "value": "File 'sample.txt' is empty."}]
 
 
-def test_invoke_returns_error_for_corrupt_xlsx():
-    tool = _make_tool()
-    corrupt_file = SimpleNamespace(filename="sheet.xlsx", blob=b"not a zip file")
+def test_blob_read_failure_is_actionable():
+    class BrokenFile:
+        filename = "report.txt"
+        extension = ".txt"
+        mime_type = "text/plain"
 
-    messages = list(tool._invoke({"file": corrupt_file}))
+        @property
+        def blob(self):
+            raise ConnectionError("secret internal URL")
+
+    messages = list(_make_tool()._invoke({"file": BrokenFile()}))
 
     assert len(messages) == 1
-    assert messages[0]["type"] == "text"
-    assert "not a valid .xlsx file" in messages[0]["value"]
-    assert "old binary .xls instead of .xlsx" in messages[0]["value"]
+    assert "FILES_URL" in messages[0]["value"]
+    assert "secret internal URL" not in messages[0]["value"]
+
+
+def test_invalid_json_returns_error_without_document_variables():
+    messages = list(
+        _make_tool()._invoke(
+            {
+                "file": _file(
+                    b"{broken",
+                    filename="payload.json",
+                    mime_type="application/json",
+                )
+            }
+        )
+    )
+
+    assert len(messages) == 1
+    assert "invalid JSON" in messages[0]["value"]
+
+
+def test_header_only_csv_is_rejected_as_empty_content():
+    messages = list(
+        _make_tool()._invoke(
+            {"file": _file(b"name,age\n", filename="people.csv", mime_type="text/csv")}
+        )
+    )
+
+    assert len(messages) == 1
+    assert "contains no extractable content" in messages[0]["value"]
+
+
+@pytest.mark.parametrize(
+    ("extension", "format_hint"),
+    [
+        (".docx", "old binary .doc instead of .docx"),
+        (".pptx", "old binary .ppt instead of .pptx"),
+        (".xlsx", "old binary .xls instead of .xlsx"),
+    ],
+)
+def test_corrupt_office_file_returns_tailored_error(extension, format_hint):
+    filename = f"report{extension}"
+    messages = list(
+        _make_tool()._invoke({"file": _file(b"not a zip file", filename=filename, mime_type=None)})
+    )
+
+    assert len(messages) == 1
+    assert f"not a valid {extension} file" in messages[0]["value"]
+    assert format_hint in messages[0]["value"]
+
+
+def test_unexpected_extractor_error_is_sanitized(monkeypatch):
+    class BrokenExtractor(BaseExtractor):
+        def extract(self):
+            raise RuntimeError("database password")
+
+    monkeypatch.setitem(
+        __import__("tools.dify_extractor", fromlist=["_EXTRACTORS"])._EXTRACTORS,
+        ".txt",
+        BrokenExtractor,
+    )
+    messages = list(_make_tool()._invoke({"file": _file(b"hello")}))
+
+    assert len(messages) == 1
+    assert "database password" not in messages[0]["value"]
+    assert "plugin logs" in messages[0]["value"]
+
+
+def test_result_validation_accepts_only_meaningful_documents():
+    with pytest.raises(ExtractionError, match="no extractable content"):
+        DifyExtractorTool._validate_result(
+            ExtractorResult(md_content="heading", documents=[Document(page_content="")]),
+            "empty.txt",
+        )

--- a/tools/dify_extractor/tests/test_extractors.py
+++ b/tools/dify_extractor/tests/test_extractors.py
@@ -1,0 +1,285 @@
+from io import BytesIO
+
+import pytest
+import xlwt
+from docx import Document as WordDocument
+from dify_plugin.invocations.file import UploadFileResponse
+from openpyxl import Workbook
+from PIL import Image
+from pptx import Presentation
+from pptx.util import Inches
+
+from tools.context import ExtractionContext
+from tools.csv_extractor import CSVExtractor
+from tools.errors import ExtractionError
+from tools.excel_extractor import ExcelExtractor
+from tools.html_extractor import HtmlExtractor
+from tools.image_assets import ImageAsset
+from tools.json_extractor import JSONExtractor
+from tools.markdown_extractor import MarkdownExtractor
+from tools.pdf_extractor import PdfExtractor
+from tools.pptx_extractor import PPTXExtractor
+from tools.text_extractor import TextExtractor
+from tools.word_extractor import WordExtractor
+from tools.yaml_extractor import YAMLExtractor
+
+
+def _context(
+    blob: bytes,
+    filename: str,
+    extension: str,
+    *,
+    image_service=None,
+) -> ExtractionContext:
+    return ExtractionContext(
+        file_bytes=blob,
+        file_name=filename,
+        file_extension=extension,
+        image_service=image_service,
+    )
+
+
+def _save_workbook(workbook) -> bytes:
+    buffer = BytesIO()
+    workbook.save(buffer)
+    return buffer.getvalue()
+
+
+def _minimal_pdf(text: str) -> bytes:
+    stream = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET".encode()
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
+        ),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        f"<< /Length {len(stream)} >>\nstream\n".encode() + stream + b"\nendstream",
+    ]
+    pdf = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for object_number, body in enumerate(objects, start=1):
+        offsets.append(len(pdf))
+        pdf.extend(f"{object_number} 0 obj\n".encode())
+        pdf.extend(body)
+        pdf.extend(b"\nendobj\n")
+    xref_offset = len(pdf)
+    pdf.extend(f"xref\n0 {len(objects) + 1}\n".encode())
+    pdf.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        pdf.extend(f"{offset:010d} 00000 n \n".encode())
+    pdf.extend(
+        (
+            f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+            f"startxref\n{xref_offset}\n%%EOF\n"
+        ).encode()
+    )
+    return bytes(pdf)
+
+
+def test_text_extractor_decodes_non_utf8():
+    result = TextExtractor(_context("café".encode("cp1252"), "note.txt", ".txt")).extract()
+
+    assert result.md_content == "café"
+    assert result.documents[0].metadata == {"source": "note.txt"}
+
+
+def test_html_extractor_removes_non_content_elements():
+    html = b"<html><style>hidden</style><script>secret</script><body><h1>Hello</h1></body></html>"
+    result = HtmlExtractor(_context(html, "page.html", ".html")).extract()
+
+    assert result.md_content == "Hello"
+    assert "hidden" not in result.md_content
+    assert "secret" not in result.md_content
+
+
+def test_json_extractor_formats_valid_json_and_rejects_invalid_json():
+    valid = JSONExtractor(_context(b'{"city":"Shanghai"}', "data.json", ".json")).extract()
+
+    assert '"city": "Shanghai"' in valid.md_content
+    with pytest.raises(ExtractionError, match="line 1, column 2"):
+        JSONExtractor(_context(b"{broken", "bad.json", ".json")).extract()
+
+
+def test_yaml_extractor_formats_valid_yaml_and_rejects_invalid_yaml():
+    valid = YAMLExtractor(_context("城市: 上海\n".encode(), "data.yaml", ".yaml")).extract()
+
+    assert "城市: 上海" in valid.md_content
+    assert valid.md_content.endswith("```")
+    with pytest.raises(ExtractionError, match="invalid YAML"):
+        YAMLExtractor(_context(b"items: [", "bad.yaml", ".yaml")).extract()
+    with pytest.raises(ExtractionError, match="no YAML content"):
+        YAMLExtractor(_context(b"# only a comment\n", "empty.yaml", ".yaml")).extract()
+
+
+def test_csv_extractor_preserves_multiline_values_and_escapes_markdown():
+    blob = b'name,note\nAda,"first|second\nthird"\n'
+    result = CSVExtractor(_context(blob, "people.csv", ".csv")).extract()
+
+    assert "first\\|second<br>third" in result.md_content
+    assert result.documents[0].metadata == {"source": "people.csv", "row": 0}
+    assert "first|second\nthird" in result.documents[0].page_content
+
+
+def test_csv_extractor_rejects_inconsistent_column_count():
+    with pytest.raises(ExtractionError, match="expected 2"):
+        CSVExtractor(_context(b"a,b\n1\n", "bad.csv", ".csv")).extract()
+
+
+def test_markdown_extractor_splits_sections_and_ignores_headings_in_fences():
+    markdown = b"preamble\n# First\nbody\n```md\n# not a heading\n```\n## Second\nend"
+    result = MarkdownExtractor(_context(markdown, "readme.md", ".md")).extract()
+
+    assert [document.page_content for document in result.documents] == [
+        "preamble",
+        "First\nbody\n```md\n# not a heading\n```",
+        "Second\nend",
+    ]
+    assert all(document.metadata == {"source": "readme.md"} for document in result.documents)
+
+
+def test_markdown_remote_image_failure_preserves_original_link():
+    class FailedImageService:
+        def download_and_upload(self, _url):
+            return None
+
+    markdown = b"![diagram](https://example.com/diagram.png)"
+    result = MarkdownExtractor(
+        _context(markdown, "readme.md", ".md", image_service=FailedImageService())
+    ).extract()
+
+    assert result.md_content == markdown.decode()
+    assert result.img_list == []
+
+
+def test_markdown_remote_image_success_rewrites_link_and_returns_image():
+    uploaded_file = UploadFileResponse(
+        id="image-1",
+        name="diagram.png",
+        size=5,
+        extension="png",
+        mime_type="image/png",
+        preview_url="https://dify.example/diagram.png",
+    )
+
+    class SuccessfulImageService:
+        def download_and_upload(self, _url):
+            return ImageAsset(
+                file=uploaded_file,
+                markdown="![image](https://dify.example/diagram.png)",
+            )
+
+    result = MarkdownExtractor(
+        _context(
+            b"![diagram](https://example.com/diagram.png)",
+            "readme.md",
+            ".md",
+            image_service=SuccessfulImageService(),
+        )
+    ).extract()
+
+    assert result.md_content == "![diagram](https://dify.example/diagram.png)"
+    assert result.img_list == [uploaded_file]
+
+
+def test_xlsx_extractor_preserves_hyperlinks_and_metadata():
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "People"
+    sheet.append(["name", "profile"])
+    sheet.append(["Ada", "site|home"])
+    sheet["B2"].hyperlink = "https://example.com/ada"
+
+    result = ExcelExtractor(_context(_save_workbook(workbook), "people.xlsx", ".xlsx")).extract()
+
+    assert "[site\\|home](https://example.com/ada)" in result.md_content
+    assert "[site|home](https://example.com/ada)" in result.documents[0].page_content
+    assert result.documents[0].metadata == {
+        "source": "people.xlsx",
+        "sheet": "People",
+        "row": 0,
+    }
+
+
+def test_xls_extractor_uses_native_xlrd_path():
+    workbook = xlwt.Workbook()
+    sheet = workbook.add_sheet("People")
+    sheet.write(0, 0, "name")
+    sheet.write(1, 0, "Ada")
+    blob = _save_workbook(workbook)
+
+    result = ExcelExtractor(_context(blob, "people.xls", ".xls")).extract()
+
+    assert "## People" in result.md_content
+    assert result.documents[0].page_content == "name: Ada"
+
+
+def test_docx_extractor_handles_text_and_escaped_tables():
+    document = WordDocument()
+    paragraph = document.add_paragraph()
+    paragraph.add_run("Hello ")
+    paragraph.add_run("DOCX")
+    table = document.add_table(rows=2, cols=1)
+    table.cell(0, 0).text = "heading"
+    table.cell(1, 0).text = "a|b"
+
+    result = WordExtractor(_context(_save_workbook(document), "report.docx", ".docx")).extract()
+
+    assert "Hello DOCX" in result.md_content
+    assert "a\\|b" in result.md_content
+    assert result.documents[0].metadata == {"source": "report.docx"}
+
+
+def test_docx_embedded_image_failure_does_not_discard_text():
+    class FailedImageService:
+        def upload_embedded(self, *_args, **_kwargs):
+            return None
+
+    image = BytesIO()
+    Image.new("RGB", (1, 1), "white").save(image, format="PNG")
+    image.seek(0)
+    document = WordDocument()
+    document.add_paragraph("Text survives")
+    document.add_picture(image)
+
+    result = WordExtractor(
+        _context(
+            _save_workbook(document),
+            "report.docx",
+            ".docx",
+            image_service=FailedImageService(),
+        )
+    ).extract()
+
+    assert "Text survives" in result.md_content
+    assert result.img_list == []
+
+
+def test_pptx_extractor_supports_http_hyperlinks_and_escaped_tables():
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    textbox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
+    run = textbox.text_frame.paragraphs[0].add_run()
+    run.text = "Example"
+    run.hyperlink.address = "http://example.com"
+    table = slide.shapes.add_table(2, 1, Inches(1), Inches(2), Inches(4), Inches(1)).table
+    table.cell(0, 0).text = "heading"
+    table.cell(1, 0).text = "a|b"
+
+    result = PPTXExtractor(_context(_save_workbook(presentation), "slides.pptx", ".pptx")).extract()
+
+    assert "[Example](http://example.com)" in result.md_content
+    assert "a\\|b" in result.md_content
+
+
+def test_pdf_extractor_returns_page_documents_and_closes_resources():
+    result = PdfExtractor(_context(_minimal_pdf("Hello PDF"), "report.pdf", ".pdf")).extract()
+
+    assert "Hello PDF" in result.md_content
+    assert result.documents[0].metadata == {"source": "report.pdf", "page": 0}
+
+
+def test_pdf_extractor_rejects_invalid_pdf():
+    with pytest.raises(ExtractionError, match="not a valid PDF"):
+        PdfExtractor(_context(b"not a PDF", "bad.pdf", ".pdf")).extract()

--- a/tools/dify_extractor/tests/test_helpers.py
+++ b/tools/dify_extractor/tests/test_helpers.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+from zipfile import BadZipFile
+
+import pytest
+
+from tools import helpers
+from tools.errors import ExtractionError
+
+
+class _FakeArchive:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def infolist(self):
+        return self._entries
+
+
+def _entry(file_size=1, compress_size=1):
+    return SimpleNamespace(file_size=file_size, compress_size=compress_size)
+
+
+def test_decode_text_handles_utf16_bom():
+    assert helpers.decode_text("你好".encode("utf-16"), "hello.txt") == "你好"
+
+
+def test_decode_text_fails_when_no_candidate_decodes(monkeypatch):
+    monkeypatch.setattr(helpers.chardet, "detect_all", lambda _data: [{"encoding": "utf-8"}])
+
+    with pytest.raises(ExtractionError, match="could not be decoded"):
+        helpers.decode_text(b"\xff", "bad.txt", preferred_encoding="ascii")
+
+
+def test_markdown_table_escapes_pipes_backslashes_and_newlines():
+    rendered = helpers.render_markdown_table(["a|b"], [["x\\y\nnext"]])
+
+    assert "a\\|b" in rendered
+    assert "x\\\\y<br>next" in rendered
+
+
+def test_archive_validation_maps_bad_zip_to_format_error(monkeypatch):
+    def fail(_file):
+        raise BadZipFile
+
+    monkeypatch.setattr(helpers, "ZipFile", fail)
+
+    with pytest.raises(ExtractionError, match="old binary .doc"):
+        helpers.validate_office_archive(b"bad", "report.docx", ".docx")
+
+
+def test_archive_entry_limit(monkeypatch):
+    monkeypatch.setattr(helpers, "MAX_ARCHIVE_ENTRIES", 1)
+    monkeypatch.setattr(helpers, "ZipFile", lambda _file: _FakeArchive([_entry(), _entry()]))
+
+    with pytest.raises(ExtractionError, match="too many archive entries"):
+        helpers.validate_office_archive(b"zip", "report.docx", ".docx")
+
+
+def test_archive_expanded_size_limit(monkeypatch):
+    monkeypatch.setattr(helpers, "MAX_ARCHIVE_UNCOMPRESSED_BYTES", 10)
+    monkeypatch.setattr(helpers, "ZipFile", lambda _file: _FakeArchive([_entry(11, 5)]))
+
+    with pytest.raises(ExtractionError, match="200 MiB safety limit"):
+        helpers.validate_office_archive(b"zip", "report.xlsx", ".xlsx")
+
+
+def test_archive_compression_ratio_limit(monkeypatch):
+    monkeypatch.setattr(helpers, "MAX_ARCHIVE_COMPRESSION_RATIO", 2)
+    monkeypatch.setattr(helpers, "ZipFile", lambda _file: _FakeArchive([_entry(10, 1)]))
+
+    with pytest.raises(ExtractionError, match="compression-ratio"):
+        helpers.validate_office_archive(b"zip", "report.pptx", ".pptx")

--- a/tools/dify_extractor/tests/test_image_assets.py
+++ b/tools/dify_extractor/tests/test_image_assets.py
@@ -1,0 +1,161 @@
+from types import SimpleNamespace
+
+import pytest
+import requests
+from dify_plugin.invocations.file import UploadFileResponse
+
+from tools import image_assets
+from tools.image_assets import ImageAssetService
+
+
+class _Response:
+    def __init__(self, content=b"image", headers=None, url="https://example.com/image.png"):
+        self.content = content
+        self.headers = headers or {"Content-Type": "image/png"}
+        self.url = url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size):
+        del chunk_size
+        yield self.content
+
+
+class _Uploader:
+    def __init__(self, *, fail=False, preview_url="https://dify.example/preview.png"):
+        self.fail = fail
+        self.preview_url = preview_url
+        self.calls = []
+
+    def upload(self, filename, content, mime_type):
+        self.calls.append((filename, content, mime_type))
+        if self.fail:
+            raise RuntimeError("upload failed")
+        return UploadFileResponse(
+            id="file-1",
+            name=filename,
+            size=len(content),
+            extension=filename.rsplit(".", 1)[-1],
+            mime_type=mime_type,
+            preview_url=self.preview_url,
+        )
+
+
+def _service(uploader=None):
+    uploader = uploader or _Uploader()
+    tool = SimpleNamespace(session=SimpleNamespace(file=uploader))
+    return ImageAssetService(tool), uploader
+
+
+def test_remote_image_is_streamed_and_uploaded_with_one_dot(monkeypatch):
+    service, uploader = _service()
+    monkeypatch.setattr(image_assets.requests, "get", lambda *args, **kwargs: _Response())
+
+    asset = service.download_and_upload("https://example.com/image.png")
+
+    assert asset is not None
+    filename, content, mime_type = uploader.calls[0]
+    assert "..png" not in filename
+    assert filename.endswith(".png")
+    assert content == b"image"
+    assert mime_type == "image/png"
+
+
+def test_unsupported_url_scheme_is_skipped_without_request(monkeypatch):
+    service, uploader = _service()
+
+    def unexpected_request(*_args, **_kwargs):
+        raise AssertionError("request should not run")
+
+    monkeypatch.setattr(image_assets.requests, "get", unexpected_request)
+
+    assert service.download_and_upload("file:///etc/passwd") is None
+    assert uploader.calls == []
+
+
+def test_remote_timeout_is_non_fatal(monkeypatch):
+    service, uploader = _service()
+
+    def timeout(*_args, **_kwargs):
+        raise requests.Timeout("slow")
+
+    monkeypatch.setattr(image_assets.requests, "get", timeout)
+
+    assert service.download_and_upload("https://example.com/image.png") is None
+    assert uploader.calls == []
+
+
+def test_non_image_response_is_skipped(monkeypatch):
+    service, uploader = _service()
+    monkeypatch.setattr(
+        image_assets.requests,
+        "get",
+        lambda *args, **kwargs: _Response(
+            headers={"Content-Type": "text/html"},
+            url="https://example.com/page",
+        ),
+    )
+
+    assert service.download_and_upload("https://example.com/page") is None
+    assert uploader.calls == []
+
+
+@pytest.mark.parametrize("include_content_length", [True, False])
+def test_remote_size_limit_with_and_without_content_length(monkeypatch, include_content_length):
+    service, uploader = _service()
+    monkeypatch.setattr(image_assets, "MAX_IMAGE_BYTES", 4)
+    headers = {"Content-Type": "image/png"}
+    if include_content_length:
+        headers["Content-Length"] = "5"
+    monkeypatch.setattr(
+        image_assets.requests,
+        "get",
+        lambda *args, **kwargs: _Response(content=b"12345", headers=headers),
+    )
+
+    assert service.download_and_upload("https://example.com/image.png") is None
+    assert uploader.calls == []
+
+
+def test_image_count_limit_applies_to_embedded_images(monkeypatch):
+    service, uploader = _service()
+    monkeypatch.setattr(image_assets, "MAX_IMAGES", 1)
+
+    assert service.upload_embedded(b"one", extension="png") is not None
+    assert service.upload_embedded(b"two", extension="png") is None
+    assert len(uploader.calls) == 1
+
+
+def test_cumulative_budget_applies_to_embedded_images(monkeypatch):
+    service, uploader = _service()
+    monkeypatch.setattr(image_assets, "MAX_TOTAL_IMAGE_BYTES", 3)
+
+    assert service.upload_embedded(b"12", extension="png") is not None
+    assert service.upload_embedded(b"34", extension="png") is None
+    assert len(uploader.calls) == 1
+
+
+def test_failed_upload_still_consumes_cumulative_budget(monkeypatch):
+    service, uploader = _service(_Uploader(fail=True))
+    monkeypatch.setattr(image_assets, "MAX_TOTAL_IMAGE_BYTES", 5)
+
+    assert service.upload_embedded(b"1234", extension="png") is None
+    assert service.upload_embedded(b"56", extension="png") is None
+    assert len(uploader.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "uploader",
+    [_Uploader(fail=True), _Uploader(preview_url=None)],
+)
+def test_upload_failure_or_missing_preview_is_non_fatal(uploader):
+    service, _ = _service(uploader)
+
+    assert service.upload_embedded(b"image", extension="png") is None

--- a/tools/dify_extractor/tools/context.py
+++ b/tools/dify_extractor/tools/context.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tools.image_assets import ImageAssetService
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractionContext:
+    """Shared immutable inputs for a single extraction."""
+
+    file_bytes: bytes
+    file_name: str
+    file_extension: str
+    mime_type: str | None = None
+    image_service: "ImageAssetService | None" = None

--- a/tools/dify_extractor/tools/csv_extractor.py
+++ b/tools/dify_extractor/tools/csv_extractor.py
@@ -1,104 +1,61 @@
-"""Abstract interface for document loader implementations."""
+"""Strict CSV document extractor."""
 
 import csv
-from typing import Optional
+from io import StringIO
 
-import pandas as pd
-from tools.extractor_base import BaseExtractor
-from tools.helpers import detect_file_encodings
 from tools.document import Document, ExtractorResult
-from io import BytesIO, TextIOWrapper
+from tools.errors import ExtractionError
+from tools.extractor_base import BaseExtractor
+from tools.helpers import decode_text, render_markdown_table
 
 
 class CSVExtractor(BaseExtractor):
-    """Load CSV files.
-
-
-    Args:
-        file_bytes: file bytes.
-        file_name: file name.
-        encoding: encoding.
-        autodetect_encoding: autodetect encoding.
-        csv_args: csv args.
-    """
-
-    def __init__(
-        self,
-        file_bytes: bytes,
-        file_name: str,
-        encoding: Optional[str] = None,
-        autodetect_encoding: bool = False,
-        csv_args: Optional[dict] = None,
-    ):
-        """Initialize with file path."""
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-        self._encoding = encoding if encoding else "utf-8"
-        self._autodetect_encoding = autodetect_encoding
-        self.csv_args = csv_args or {}
-
     def extract(self) -> ExtractorResult:
-        """Load data into document objects."""
-        csv_result = ExtractorResult(md_content="", documents=[])
+        text = decode_text(self.context.file_bytes, self.context.file_name)
+        reader = csv.reader(StringIO(text, newline=""), strict=True)
         try:
-            csvfile = TextIOWrapper(
-                BytesIO(self._file_bytes), encoding=self._encoding, newline=""
-            )
-            markdown, docs = self._read_from_file(csvfile)
-            csv_result.md_content = markdown
-            csv_result.documents = docs
-        except UnicodeDecodeError as e:
-            if self._autodetect_encoding:
-                detected_encodings = detect_file_encodings(self._file_bytes)
-                for encoding in detected_encodings:
-                    try:
-                        csvfile = TextIOWrapper(
-                            BytesIO(self._file_bytes),
-                            encoding=encoding.encoding,
-                            newline="",
-                        )
-                        markdown, docs = self._read_from_file(csvfile)
-                        csv_result.md_content = markdown
-                        csv_result.documents = docs
-                        break
-                    except UnicodeDecodeError:
-                        continue
-            else:
-                raise RuntimeError(f"Error loading {self._file_name}") from e
+            raw_headers = next(reader)
+        except StopIteration as exc:
+            raise ExtractionError(f"File '{self.context.file_name}' contains no CSV rows.") from exc
+        except csv.Error as exc:
+            raise ExtractionError(
+                f"File '{self.context.file_name}' contains invalid CSV data."
+            ) from exc
 
-        return csv_result
+        if not raw_headers or not any(header.strip() for header in raw_headers):
+            raise ExtractionError(f"File '{self.context.file_name}' has no CSV header.")
+        headers = [
+            header.strip() or f"column_{index + 1}" for index, header in enumerate(raw_headers)
+        ]
 
-    def _read_from_file(self, csvfile) -> tuple[str, list[Document]]:
-        docs = []
-        markdown_content = ""
+        rows: list[list[str]] = []
+        documents: list[Document] = []
         try:
-            # load csv file into pandas dataframe
-            df = pd.read_csv(csvfile, on_bad_lines="skip", **self.csv_args)
-
-            # create markdown table header
-            headers = "| " + " | ".join(df.columns) + " |\n"
-            separators = "| " + " | ".join(["---"] * len(df.columns)) + " |\n"
-            markdown_content += headers + separators
-
-            # create document objects and markdown content
-            for i, row in df.iterrows():
-                # strip whitespace from column values
-                content = ";".join(
-                    f"{col.strip()}: {str(row[col]).strip()}" for col in df.columns
+            for row_index, row in enumerate(reader):
+                if not row or not any(cell.strip() for cell in row):
+                    continue
+                if len(row) != len(headers):
+                    raise ExtractionError(
+                        f"File '{self.context.file_name}' has {len(row)} columns on CSV row "
+                        f"{reader.line_num}; expected {len(headers)}."
+                    )
+                rows.append(row)
+                page_content = "; ".join(
+                    f"{header}: {value.strip()}" for header, value in zip(headers, row, strict=True)
                 )
-                metadata = {"source": self._file_name, "row": i}
-                doc = Document(page_content=content, metadata=metadata)
-                docs.append(doc)
-
-                # markdown row
-                markdown_row = (
-                    "| "
-                    + " | ".join(str(row[col]).strip() for col in df.columns)
-                    + " |\n"
+                documents.append(
+                    Document(
+                        page_content=page_content,
+                        metadata={"source": self.context.file_name, "row": row_index},
+                    )
                 )
-                markdown_content += markdown_row
+        except csv.Error as exc:
+            raise ExtractionError(
+                f"File '{self.context.file_name}' contains invalid CSV data near row "
+                f"{reader.line_num}."
+            ) from exc
 
-        except csv.Error as e:
-            raise e
-
-        return markdown_content, docs
+        return ExtractorResult(
+            md_content=render_markdown_table(headers, rows),
+            documents=documents,
+        )

--- a/tools/dify_extractor/tools/dify_extractor.py
+++ b/tools/dify_extractor/tools/dify_extractor.py
@@ -2,83 +2,186 @@ import logging
 import os
 from collections.abc import Generator
 from typing import Any
-from zipfile import BadZipFile
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
+from tools.context import ExtractionContext
 from tools.csv_extractor import CSVExtractor
+from tools.document import ExtractorResult
+from tools.errors import ExtractionError
 from tools.excel_extractor import ExcelExtractor
+from tools.extractor_base import BaseExtractor
+from tools.helpers import validate_office_archive
 from tools.html_extractor import HtmlExtractor
+from tools.image_assets import ImageAssetService
 from tools.json_extractor import JSONExtractor
 from tools.markdown_extractor import MarkdownExtractor
 from tools.pdf_extractor import PdfExtractor
+from tools.pptx_extractor import PPTXExtractor
 from tools.text_extractor import TextExtractor
 from tools.word_extractor import WordExtractor
-from tools.pptx_extractor import PPTXExtractor
 from tools.yaml_extractor import YAMLExtractor
 
 logger = logging.getLogger(__name__)
 
-_BAD_ZIP_FORMAT_EXAMPLES = {
-    ".docx": " (e.g., old binary .doc instead of .docx)",
-    ".xlsx": " (e.g., old binary .xls instead of .xlsx)",
-    ".pptx": " (e.g., old binary .ppt instead of .pptx)",
+_EXTRACTORS: dict[str, type[BaseExtractor]] = {
+    ".csv": CSVExtractor,
+    ".docx": WordExtractor,
+    ".htm": HtmlExtractor,
+    ".html": HtmlExtractor,
+    ".json": JSONExtractor,
+    ".md": MarkdownExtractor,
+    ".markdown": MarkdownExtractor,
+    ".mdx": MarkdownExtractor,
+    ".pdf": PdfExtractor,
+    ".pptx": PPTXExtractor,
+    ".xls": ExcelExtractor,
+    ".xlsx": ExcelExtractor,
+    ".yaml": YAMLExtractor,
+    ".yml": YAMLExtractor,
 }
+_PLAIN_TEXT_EXTENSIONS = {
+    ".cfg",
+    ".conf",
+    ".ini",
+    ".log",
+    ".rst",
+    ".text",
+    ".txt",
+    ".xml",
+}
+_TEXT_MIME_TYPES = {
+    "application/toml",
+    "application/xml",
+    "application/x-ndjson",
+    "application/x-yaml",
+}
+_MIME_EXTENSIONS = {
+    "application/json": ".json",
+    "application/pdf": ".pdf",
+    "application/vnd.ms-excel": ".xls",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+    "application/x-yaml": ".yaml",
+    "application/yaml": ".yaml",
+    "text/csv": ".csv",
+    "text/html": ".html",
+    "text/markdown": ".md",
+    "text/yaml": ".yaml",
+}
+_OOXML_EXTENSIONS = {".docx", ".pptx", ".xlsx"}
 
 
 class DifyExtractorTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         file = tool_parameters.get("file")
-        if not file:
-            raise ValueError("file is required")
-        file_name = file.filename
-        file_extension = os.path.splitext(file_name)[-1].lower()
+        if file is None:
+            yield self.create_text_message("A file is required.")
+            return
 
+        file_name, extension, mime_type = self._resolve_file_identity(file)
         try:
             file_bytes = file.blob
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to read file '%s'", file_name)
-            yield self.create_text_message(f"Failed to read file '{file_name}': {e}")
-            return
-
-        if file_extension in {".xlsx", ".xls"}:
-            extractor = ExcelExtractor(file_bytes, file_name)
-        elif file_extension == ".pdf":
-            extractor = PdfExtractor(self, file_bytes, file_name)
-        elif file_extension in {".md", ".markdown", ".mdx"}:
-            extractor = MarkdownExtractor(file_bytes, file_name, tool=self, autodetect_encoding=True)
-        elif file_extension in {".htm", ".html"}:
-            extractor = HtmlExtractor(file_bytes, file_name)
-        elif file_extension == ".docx":
-            extractor = WordExtractor(self, file_bytes, file_name)
-        elif file_extension == ".pptx":
-            extractor = PPTXExtractor(self, file_bytes, file_name)
-        elif file_extension == ".csv":
-            extractor = CSVExtractor(file_bytes, file_name, autodetect_encoding=True)
-        elif file_extension == ".json":
-            extractor = JSONExtractor(file_bytes, file_name, autodetect_encoding=True)
-        elif file_extension in {".yaml", ".yml"}:
-            extractor = YAMLExtractor(file_bytes, file_name, autodetect_encoding=True)
-        else:
-            # txt
-            extractor = TextExtractor(file_bytes, file_name, autodetect_encoding=True)
-
-        try:
-            extractor_result = extractor.extract()
-        except BadZipFile:
-            example = _BAD_ZIP_FORMAT_EXAMPLES.get(file_extension, "")
             yield self.create_text_message(
-                f"File '{file_name}' is not a valid {file_extension} file. "
-                f"It may be corrupted or in an incompatible format{example}."
+                f"Failed to read file '{file_name}'. Check that Dify's FILES_URL is "
+                "reachable from the plugin runtime."
             )
             return
-        except Exception as e:
-            logger.exception("Failed to extract '%s'", file_name)
-            yield self.create_text_message(f"Failed to extract '{file_name}': {e}")
+
+        if not isinstance(file_bytes, (bytes, bytearray)) or not file_bytes:
+            yield self.create_text_message(f"File '{file_name}' is empty.")
             return
 
-        if extractor_result.img_list:
-            yield self.create_variable_message("images", extractor_result.img_list)
-        yield self.create_text_message(extractor_result.md_content)
-        yield self.create_variable_message("documents", extractor_result.documents)
+        try:
+            extractor_class, resolved_extension = self._resolve_extractor(
+                extension,
+                mime_type,
+            )
+            content = bytes(file_bytes)
+            if resolved_extension in _OOXML_EXTENSIONS:
+                validate_office_archive(content, file_name, resolved_extension)
+
+            context = ExtractionContext(
+                file_bytes=content,
+                file_name=file_name,
+                file_extension=resolved_extension,
+                mime_type=mime_type,
+                image_service=ImageAssetService(self, logger),
+            )
+            result = extractor_class(context).extract()
+            self._validate_result(result, file_name)
+        except ExtractionError as exc:
+            logger.warning("Could not extract '%s': %s", file_name, exc)
+            yield self.create_text_message(str(exc))
+            return
+        except Exception:
+            logger.exception("Unexpected failure while extracting '%s'", file_name)
+            yield self.create_text_message(
+                f"Failed to extract '{file_name}'. See the plugin logs for details."
+            )
+            return
+
+        if result.img_list:
+            yield self.create_variable_message("images", result.img_list)
+        yield self.create_text_message(result.md_content)
+        yield self.create_variable_message("documents", result.documents)
+
+    @staticmethod
+    def _resolve_file_identity(file: Any) -> tuple[str, str, str | None]:
+        raw_name = getattr(file, "filename", None)
+        supplied_extension = DifyExtractorTool._normalize_extension(
+            getattr(file, "extension", None)
+        )
+        name_extension = DifyExtractorTool._normalize_extension(
+            os.path.splitext(raw_name)[1] if raw_name else None
+        )
+        mime_type = (getattr(file, "mime_type", None) or "").split(";", 1)[0].strip().casefold()
+        mime_extension = _MIME_EXTENSIONS.get(mime_type)
+
+        known_extensions = set(_EXTRACTORS) | _PLAIN_TEXT_EXTENSIONS
+        extension = next(
+            (
+                candidate
+                for candidate in (name_extension, supplied_extension, mime_extension)
+                if candidate in known_extensions
+            ),
+            name_extension or supplied_extension or mime_extension or "",
+        )
+        file_name = str(raw_name) if raw_name else f"uploaded{extension or '.txt'}"
+        return file_name, extension, mime_type or None
+
+    @staticmethod
+    def _resolve_extractor(
+        extension: str,
+        mime_type: str | None,
+    ) -> tuple[type[BaseExtractor], str]:
+        if extractor := _EXTRACTORS.get(extension):
+            return extractor, extension
+        if extension in _PLAIN_TEXT_EXTENSIONS:
+            return TextExtractor, extension
+        if mime_type and (mime_type.startswith("text/") or mime_type in _TEXT_MIME_TYPES):
+            return TextExtractor, extension or ".txt"
+
+        display_extension = extension or mime_type or "unknown"
+        raise ExtractionError(
+            f"Unsupported file format '{display_extension}'. Supported formats are PDF, DOCX, "
+            "PPTX, XLS/XLSX, Markdown, HTML, CSV, JSON, YAML, and plain text."
+        )
+
+    @staticmethod
+    def _normalize_extension(extension: str | None) -> str:
+        if not extension:
+            return ""
+        normalized = extension.strip().casefold()
+        return normalized if normalized.startswith(".") else f".{normalized}"
+
+    @staticmethod
+    def _validate_result(result: ExtractorResult, file_name: str) -> None:
+        if not result.md_content.strip() or not any(
+            document.page_content.strip() for document in result.documents
+        ):
+            raise ExtractionError(f"File '{file_name}' contains no extractable content.")

--- a/tools/dify_extractor/tools/dify_extractor.yaml
+++ b/tools/dify_extractor/tools/dify_extractor.yaml
@@ -20,10 +20,10 @@ parameters:
       zh_Hans: file
       pt_BR: file
     human_description:
-      en_US:  the file to be parsed (support pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv, json, yaml, yml)
-      zh_Hans: 用于解析的文件 (支持 pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv, json, yaml, yml)
-      pt_BR:  o arquivo a ser analisado (suporta pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv, json, yaml, yml)
-    llm_description: the file to be parsed (support pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv, json, yaml, yml)
+      en_US: the file to parse (supports pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv, json, yaml, yml, and plain text)
+      zh_Hans: 用于解析的文件 (支持 pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv, json, yaml, yml 和纯文本)
+      pt_BR: o arquivo a ser analisado (suporta pdf, xls, xlsx, md, markdown, mdx, htm, html, pptx, docx, csv, json, yaml, yml e texto simples)
+    llm_description: the file to parse (supports PDF, Office, Markdown, HTML, CSV, JSON, YAML, and plain text files)
     form: llm
 output_schema:
     type: object

--- a/tools/dify_extractor/tools/document.py
+++ b/tools/dify_extractor/tools/document.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any
 
 from dify_plugin.invocations.file import UploadFileResponse
 from pydantic import BaseModel, Field
@@ -9,12 +9,12 @@ class ChildDocument(BaseModel):
 
     page_content: str
 
-    vector: Optional[list[float]] = None
+    vector: list[float] | None = None
 
     """Arbitrary metadata about the page content (e.g., source, relationships to other
         documents, etc.).
     """
-    metadata: dict = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class Document(BaseModel):
@@ -22,16 +22,16 @@ class Document(BaseModel):
 
     page_content: str
 
-    vector: Optional[list[float]] = None
+    vector: list[float] | None = None
 
     """Arbitrary metadata about the page content (e.g., source, relationships to other
         documents, etc.).
     """
-    metadata: dict = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
-    provider: Optional[str] = "dify"
+    provider: str | None = "dify"
 
-    children: Optional[list[ChildDocument]] = None
+    children: list[ChildDocument] | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -39,9 +39,7 @@ class Document(BaseModel):
             "vector": self.vector if self.vector is not None else None,
             "metadata": self.metadata,
             "provider": self.provider,
-            "children": [child.model_dump() for child in self.children]
-            if self.children
-            else None,
+            "children": [child.model_dump() for child in self.children] if self.children else None,
         }
 
 
@@ -49,6 +47,6 @@ class ExtractorResult(BaseModel):
     """Class for storing the result of an extractor."""
 
     md_content: str
-    documents: Optional[list[Document]] = None
-    img_list: Optional[list[UploadFileResponse]] = None
-    origin_result: Optional[dict] = None
+    documents: list[Document] = Field(default_factory=list)
+    img_list: list[UploadFileResponse] = Field(default_factory=list)
+    origin_result: dict[str, Any] | None = None

--- a/tools/dify_extractor/tools/errors.py
+++ b/tools/dify_extractor/tools/errors.py
@@ -1,0 +1,2 @@
+class ExtractionError(Exception):
+    """An extraction failure that is safe to show to the user."""

--- a/tools/dify_extractor/tools/excel_extractor.py
+++ b/tools/dify_extractor/tools/excel_extractor.py
@@ -1,121 +1,134 @@
-"""Abstract interface for document loader implementations."""
+"""XLS and XLSX document extractor."""
 
-import os
-from typing import Optional, cast
+from __future__ import annotations
 
-import pandas as pd
-from openpyxl import load_workbook  # type: ignore
-
-from tools.extractor_base import BaseExtractor
-from tools.document import Document, ExtractorResult
+from datetime import date, datetime
 from io import BytesIO
+from typing import Any
+
+import xlrd
+from openpyxl import load_workbook
+
+from tools.document import Document, ExtractorResult
+from tools.errors import ExtractionError
+from tools.extractor_base import BaseExtractor
+from tools.helpers import render_markdown_table
 
 
 class ExcelExtractor(BaseExtractor):
-    """Load Excel files.
-
-
-    Args:
-        file_bytes: file bytes.
-        file_name: file name.
-        encoding: encoding.
-        autodetect_encoding: autodetect encoding.
-    """
-
-    def __init__(
-        self,
-        file_bytes: bytes,
-        file_name: str,
-        encoding: Optional[str] = None,
-        autodetect_encoding: bool = False,
-    ):
-        """Initialize with file path."""
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-        self._encoding = encoding
-        self._autodetect_encoding = autodetect_encoding
-
     def extract(self) -> ExtractorResult:
-        """Load from Excel file in xls or xlsx format using Pandas and openpyxl."""
-        documents = []
-        all_md_content = ""
-        file_extension = os.path.splitext(self._file_name)[-1].lower()
+        if self.context.file_extension == ".xlsx":
+            return self._extract_xlsx()
+        if self.context.file_extension == ".xls":
+            return self._extract_xls()
+        raise ExtractionError(f"Unsupported spreadsheet format '{self.context.file_extension}'.")
 
-        if file_extension == ".xlsx":
-            wb = load_workbook(filename=BytesIO(self._file_bytes), data_only=True)
-            for sheet_name in wb.sheetnames:
-                sheet = wb[sheet_name]
-                data = sheet.values
-                try:
-                    cols = next(data)
-                except StopIteration:
+    def _extract_xlsx(self) -> ExtractorResult:
+        workbook = load_workbook(BytesIO(self.context.file_bytes), data_only=True)
+        documents: list[Document] = []
+        sections: list[str] = []
+        try:
+            for sheet in workbook.worksheets:
+                rows = sheet.iter_rows()
+                header_cells = next(rows, None)
+                if header_cells is None:
                     continue
-                df = pd.DataFrame(data, columns=cols)
-
-                df.dropna(how="all", inplace=True)
-
-                md_content = f"## {sheet_name}\n\n"
-                md_content += "| " + " | ".join(str(col) for col in cols) + " |\n"
-                md_content += "| " + " | ".join(["---"] * len(cols)) + " |\n"
-
-                for index, row in df.iterrows():
-                    md_content += (
-                        "| "
-                        + " | ".join(
-                            [str(cell) if pd.notna(cell) else "" for cell in row]
-                        )
-                        + " |\n"
-                    )
-
-                    page_content = []
-                    for col_index, (k, v) in enumerate(row.items()):
-                        if pd.notna(v):
-                            cell = sheet.cell(
-                                row=cast(int, index) + 2, column=col_index + 1
-                            )  # +2 to account for header and 1-based index
-                            if cell.hyperlink:
-                                value = f"[{v}]({cell.hyperlink.target})"
-                                page_content.append(f'"{k}":"{value}"')
-                            else:
-                                page_content.append(f'"{k}":"{v}"')
+                headers = self._headers([cell.value for cell in header_cells])
+                table_rows: list[list[str]] = []
+                for row_number, cells in enumerate(rows, start=2):
+                    if not any(cell.value is not None for cell in cells):
+                        continue
+                    values: list[str] = []
+                    document_values: list[str] = []
+                    for header, cell in zip(headers, cells, strict=False):
+                        value = self._format_value(cell.value)
+                        if cell.hyperlink and value:
+                            value = f"[{value}]({cell.hyperlink.target})"
+                        values.append(value)
+                        if value:
+                            document_values.append(f"{header}: {value}")
+                    table_rows.append(values)
                     documents.append(
                         Document(
-                            page_content=";".join(page_content),
-                            metadata={"source": self._file_name},
+                            page_content="; ".join(document_values),
+                            metadata={
+                                "source": self.context.file_name,
+                                "sheet": sheet.title,
+                                "row": row_number - 2,
+                            },
                         )
                     )
-                all_md_content += md_content + "\n"
-
-        elif file_extension == ".xls":
-            excel_file = pd.ExcelFile(self._file_bytes, engine="xlrd")
-            for excel_sheet_name in excel_file.sheet_names:
-                df = excel_file.parse(sheet_name=excel_sheet_name)
-                df.dropna(how="all", inplace=True)
-
-                md_content = f"## {excel_sheet_name}\n\n"
-                md_content += "| " + " | ".join(df.columns) + " |\n"
-                md_content += "| " + " | ".join(["---"] * len(df.columns)) + " |\n"
-
-                for _, row in df.iterrows():
-                    md_content += (
-                        "| "
-                        + " | ".join(
-                            [str(cell) if pd.notna(cell) else "" for cell in row]
-                        )
-                        + " |\n"
+                if table_rows:
+                    sections.append(
+                        f"## {sheet.title}\n\n{render_markdown_table(headers, table_rows).rstrip()}"
                     )
-                    page_content = []
-                    for k, v in row.items():
-                        if pd.notna(v):
-                            page_content.append(f'"{k}":"{v}"')
+        finally:
+            workbook.close()
+        return ExtractorResult(md_content="\n\n".join(sections), documents=documents)
+
+    def _extract_xls(self) -> ExtractorResult:
+        try:
+            workbook = xlrd.open_workbook(file_contents=self.context.file_bytes, on_demand=True)
+        except xlrd.XLRDError as exc:
+            raise ExtractionError(
+                f"File '{self.context.file_name}' is not a valid .xls file."
+            ) from exc
+
+        documents: list[Document] = []
+        sections: list[str] = []
+        try:
+            for sheet in workbook.sheets():
+                if sheet.nrows == 0:
+                    continue
+                headers = self._headers(sheet.row_values(0))
+                table_rows: list[list[str]] = []
+                for row_number in range(1, sheet.nrows):
+                    cells = sheet.row(row_number)
+                    if not any(cell.value not in (None, "") for cell in cells):
+                        continue
+                    values = [self._format_xls_cell(cell, workbook.datemode) for cell in cells]
+                    table_rows.append(values)
                     documents.append(
                         Document(
-                            page_content=";".join(page_content),
-                            metadata={"source": self._file_name},
+                            page_content="; ".join(
+                                f"{header}: {value}"
+                                for header, value in zip(headers, values, strict=False)
+                                if value
+                            ),
+                            metadata={
+                                "source": self.context.file_name,
+                                "sheet": sheet.name,
+                                "row": row_number - 1,
+                            },
                         )
                     )
-                all_md_content += md_content + "\n"
-        else:
-            raise ValueError(f"Unsupported file extension: {file_extension}")
+                if table_rows:
+                    sections.append(
+                        f"## {sheet.name}\n\n{render_markdown_table(headers, table_rows).rstrip()}"
+                    )
+        finally:
+            workbook.release_resources()
+        return ExtractorResult(md_content="\n\n".join(sections), documents=documents)
 
-        return ExtractorResult(md_content=all_md_content, documents=documents)
+    @staticmethod
+    def _headers(values: list[Any]) -> list[str]:
+        return [
+            ExcelExtractor._format_value(value).strip() or f"column_{index + 1}"
+            for index, value in enumerate(values)
+        ]
+
+    @staticmethod
+    def _format_xls_cell(cell: xlrd.sheet.Cell, datemode: int) -> str:
+        if cell.ctype == xlrd.XL_CELL_DATE:
+            return xlrd.xldate_as_datetime(cell.value, datemode).isoformat()
+        return ExcelExtractor._format_value(cell.value)
+
+    @staticmethod
+    def _format_value(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        return str(value)

--- a/tools/dify_extractor/tools/extractor_base.py
+++ b/tools/dify_extractor/tools/extractor_base.py
@@ -2,10 +2,16 @@
 
 from abc import ABC, abstractmethod
 
+from tools.context import ExtractionContext
+from tools.document import ExtractorResult
+
 
 class BaseExtractor(ABC):
-    """Interface for extract files."""
+    """Uniform interface for extracting a file from an extraction context."""
+
+    def __init__(self, context: ExtractionContext) -> None:
+        self.context = context
 
     @abstractmethod
-    def extract(self):
+    def extract(self) -> ExtractorResult:
         raise NotImplementedError

--- a/tools/dify_extractor/tools/helpers.py
+++ b/tools/dify_extractor/tools/helpers.py
@@ -1,57 +1,106 @@
-"""Document loader helpers."""
+"""Shared decoding, Markdown, and archive-safety helpers."""
 
-import concurrent.futures
-from pathlib import Path
-from typing import NamedTuple, Optional, cast
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Sequence
+from io import BytesIO
+from zipfile import BadZipFile, ZipFile
+
+import chardet
+
+from tools.errors import ExtractionError
+
+MAX_ARCHIVE_ENTRIES = 10_000
+MAX_ARCHIVE_UNCOMPRESSED_BYTES = 200 * 1024 * 1024
+MAX_ARCHIVE_COMPRESSION_RATIO = 1_000
+
+_BAD_OFFICE_FORMAT_HINTS = {
+    ".docx": "old binary .doc instead of .docx",
+    ".xlsx": "old binary .xls instead of .xlsx",
+    ".pptx": "old binary .ppt instead of .pptx",
+}
 
 
-class FileEncoding(NamedTuple):
-    """A file encoding as the NamedTuple."""
+def decode_text(file_bytes: bytes, file_name: str, preferred_encoding: str | None = None) -> str:
+    """Decode text strictly, trying UTF-8/BOM handling before detected encodings."""
+    if not file_bytes:
+        raise ExtractionError(f"File '{file_name}' is empty.")
 
-    encoding: Optional[str]
-    """The encoding of the file."""
-    confidence: float
-    """The confidence of the encoding."""
-    language: Optional[str]
-    """The language of the file."""
+    candidates = [preferred_encoding, "utf-8-sig"]
+    detected = chardet.detect_all(file_bytes) or [chardet.detect(file_bytes)]
+    candidates.extend(result.get("encoding") for result in detected)
 
-
-def detect_file_encodings(file_bytes: bytes, timeout: int = 5) -> list[FileEncoding]:
-    """Try to detect the file encoding from bytes.
-
-    Args:
-        file_bytes: file bytes
-        timeout: timeout in seconds
-    """
-    import chardet
-    from io import BytesIO
-    import csv
-
-    def try_decode(data: bytes, encoding: str) -> bool:
+    attempted: set[str] = set()
+    for candidate in candidates:
+        if not candidate:
+            continue
+        normalized = candidate.casefold()
+        if normalized in attempted:
+            continue
+        attempted.add(normalized)
         try:
-            with BytesIO(data) as f:
-                csv.Sniffer().sniff(f.read(1024).decode(encoding))
-            return True
-        except:
-            return False
+            return file_bytes.decode(candidate)
+        except (LookupError, UnicodeDecodeError):
+            continue
 
-    def read_and_detect(data: bytes) -> list[dict]:
-        raw_results = chardet.detect_all(data) or [chardet.detect(data)]
+    raise ExtractionError(f"File '{file_name}' could not be decoded as text.")
 
-        valid_results = []
-        for result in raw_results:
-            if result["encoding"] and try_decode(data, result["encoding"]):
-                valid_results.append(result)
 
-        return valid_results or raw_results
+def escape_markdown_cell(value: object) -> str:
+    """Escape a value for use inside a GitHub-style Markdown table."""
+    if value is None:
+        return ""
+    text = str(value)
+    text = text.replace("\\", "\\\\").replace("|", "\\|")
+    return text.replace("\r\n", "<br>").replace("\r", "<br>").replace("\n", "<br>")
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        future = executor.submit(read_and_detect, file_bytes)
-        try:
-            encodings = future.result(timeout=timeout)
-        except concurrent.futures.TimeoutError:
-            raise TimeoutError("Timeout reached while detecting encoding")
 
-    if all(encoding["encoding"] is None for encoding in encodings):
-        raise RuntimeError("Could not detect encoding")
-    return [FileEncoding(**enc) for enc in encodings if enc["encoding"] is not None]
+def render_markdown_table(headers: Sequence[object], rows: Iterable[Sequence[object]]) -> str:
+    """Render a consistently escaped Markdown table."""
+    escaped_headers = [escape_markdown_cell(header) for header in headers]
+    lines = [
+        "| " + " | ".join(escaped_headers) + " |",
+        "| " + " | ".join("---" for _ in escaped_headers) + " |",
+    ]
+    lines.extend(
+        "| " + " | ".join(escape_markdown_cell(value) for value in row) + " |" for row in rows
+    )
+    return "\n".join(lines) + "\n"
+
+
+def validate_office_archive(file_bytes: bytes, file_name: str, extension: str) -> None:
+    """Reject corrupt or suspiciously expanded OOXML archives before parsing."""
+    try:
+        with ZipFile(BytesIO(file_bytes)) as archive:
+            entries = archive.infolist()
+    except BadZipFile as exc:
+        hint = _BAD_OFFICE_FORMAT_HINTS.get(extension)
+        suffix = f" (for example, {hint})" if hint else ""
+        raise ExtractionError(
+            f"File '{file_name}' is not a valid {extension} file. "
+            f"It may be corrupted or use an incompatible format{suffix}."
+        ) from exc
+
+    if len(entries) > MAX_ARCHIVE_ENTRIES:
+        raise ExtractionError(
+            f"File '{file_name}' contains too many archive entries "
+            f"(maximum {MAX_ARCHIVE_ENTRIES:,})."
+        )
+
+    total_uncompressed = sum(entry.file_size for entry in entries)
+    total_compressed = sum(entry.compress_size for entry in entries)
+    if total_uncompressed > MAX_ARCHIVE_UNCOMPRESSED_BYTES:
+        raise ExtractionError(f"File '{file_name}' expands beyond the 200 MiB safety limit.")
+
+    ratios = [entry.file_size / max(entry.compress_size, 1) for entry in entries if entry.file_size]
+    total_ratio = total_uncompressed / max(total_compressed, 1)
+    if total_ratio > MAX_ARCHIVE_COMPRESSION_RATIO or any(
+        ratio > MAX_ARCHIVE_COMPRESSION_RATIO for ratio in ratios
+    ):
+        raise ExtractionError(
+            f"File '{file_name}' exceeds the archive compression-ratio safety limit."
+        )
+
+    if not math.isfinite(total_ratio):
+        raise ExtractionError(f"File '{file_name}' has invalid archive metadata.")

--- a/tools/dify_extractor/tools/html_extractor.py
+++ b/tools/dify_extractor/tools/html_extractor.py
@@ -1,40 +1,25 @@
-"""Abstract interface for document loader implementations."""
+"""HTML document extractor."""
 
-from bs4 import BeautifulSoup  # type: ignore
+from bs4 import BeautifulSoup
 
-from tools.extractor_base import BaseExtractor
 from tools.document import Document, ExtractorResult
+from tools.extractor_base import BaseExtractor
+from tools.helpers import decode_text
 
 
 class HtmlExtractor(BaseExtractor):
-    """
-    Load html files.
-
-    Args:
-        file_bytes: HTML content in bytes format.
-        file_name: file name.
-    """
-
-    def __init__(self, file_bytes: bytes, file_name: str):
-        """Initialize with file bytes."""
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-
     def extract(self) -> ExtractorResult:
-        text = self._load_as_text()
+        html = decode_text(self.context.file_bytes, self.context.file_name)
+        soup = BeautifulSoup(html, "html.parser")
+        for element in soup(["script", "style", "noscript"]):
+            element.decompose()
+        text = "\n".join(line.strip() for line in soup.get_text("\n").splitlines() if line.strip())
         return ExtractorResult(
             md_content=text,
             documents=[
-                Document(page_content=text, metadata={"source": self._file_name})
+                Document(
+                    page_content=text,
+                    metadata={"source": self.context.file_name},
+                )
             ],
         )
-
-    def _load_as_text(self) -> str:
-        from io import BytesIO
-
-        text: str = ""
-        with BytesIO(self._file_bytes) as fp:
-            soup = BeautifulSoup(fp, "html.parser")
-            text = soup.get_text()
-            text = text.strip() if text else ""
-        return text

--- a/tools/dify_extractor/tools/image_assets.py
+++ b/tools/dify_extractor/tools/image_assets.py
@@ -1,0 +1,174 @@
+"""Bounded, best-effort image download and upload support."""
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+import uuid
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import requests
+from dify_plugin import Tool
+from dify_plugin.invocations.file import UploadFileResponse
+
+MAX_IMAGES = 20
+MAX_IMAGE_BYTES = 15 * 1024 * 1024
+MAX_TOTAL_IMAGE_BYTES = 100 * 1024 * 1024
+IMAGE_DOWNLOAD_TIMEOUT = 30
+IMAGE_DOWNLOAD_CHUNK_SIZE = 64 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class ImageAsset:
+    file: UploadFileResponse
+    markdown: str
+
+
+def is_http_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.scheme.casefold() in {"http", "https"} and bool(parsed.netloc)
+
+
+class ImageAssetService:
+    """Uploads images without allowing image failures to abort extraction."""
+
+    def __init__(self, tool: Tool, logger: logging.Logger | None = None) -> None:
+        self._tool = tool
+        self._logger = logger or logging.getLogger(__name__)
+        self._attempted = 0
+        self._consumed_bytes = 0
+
+    def upload_embedded(
+        self,
+        content: bytes,
+        *,
+        extension: str | None = None,
+        mime_type: str | None = None,
+        source: str = "embedded image",
+    ) -> ImageAsset | None:
+        if not self._reserve_attempt(source):
+            return None
+        resolved_mime = self._resolve_mime_type(mime_type, extension)
+        if not resolved_mime:
+            self._logger.warning("Skipping %s with an unknown image type", source)
+            return None
+        return self._upload_bytes(content, resolved_mime, extension, source)
+
+    def download_and_upload(self, url: str) -> ImageAsset | None:
+        if not is_http_url(url):
+            self._logger.warning("Skipping image with unsupported URL scheme: %s", url)
+            return None
+        if not self._reserve_attempt(url):
+            return None
+
+        remaining = MAX_TOTAL_IMAGE_BYTES - self._consumed_bytes
+        max_download = min(MAX_IMAGE_BYTES, remaining)
+        if max_download <= 0:
+            self._logger.warning("Skipping image because the cumulative image budget is exhausted")
+            return None
+
+        try:
+            with requests.get(
+                url,
+                stream=True,
+                timeout=IMAGE_DOWNLOAD_TIMEOUT,
+            ) as response:
+                response.raise_for_status()
+                final_url = getattr(response, "url", url)
+                if not is_http_url(final_url):
+                    raise ValueError("redirected to an unsupported URL scheme")
+
+                content_length = response.headers.get("Content-Length")
+                if content_length and int(content_length) > max_download:
+                    raise ValueError("image exceeds the download limit")
+
+                content = bytearray()
+                for chunk in response.iter_content(chunk_size=IMAGE_DOWNLOAD_CHUNK_SIZE):
+                    if not chunk:
+                        continue
+                    content.extend(chunk)
+                    if len(content) > max_download:
+                        raise ValueError("image exceeds the download limit")
+
+                mime_type = self._remote_mime_type(response, final_url)
+                if not mime_type:
+                    raise ValueError("response is not a supported image")
+                extension = mimetypes.guess_extension(mime_type)
+                return self._upload_bytes(bytes(content), mime_type, extension, url)
+        except (OSError, ValueError, requests.RequestException) as exc:
+            self._logger.warning("Failed to import remote image %s: %s", url, exc)
+            return None
+
+    def _reserve_attempt(self, source: str) -> bool:
+        if self._attempted >= MAX_IMAGES:
+            self._logger.warning(
+                "Skipping %s because the %d-image limit was reached", source, MAX_IMAGES
+            )
+            return False
+        self._attempted += 1
+        return True
+
+    def _upload_bytes(
+        self,
+        content: bytes,
+        mime_type: str,
+        extension: str | None,
+        source: str,
+    ) -> ImageAsset | None:
+        if not content:
+            self._logger.warning("Skipping empty image from %s", source)
+            return None
+        if len(content) > MAX_IMAGE_BYTES:
+            self._logger.warning("Skipping oversized image from %s", source)
+            return None
+        if self._consumed_bytes + len(content) > MAX_TOTAL_IMAGE_BYTES:
+            self._logger.warning(
+                "Skipping image from %s because the cumulative budget was reached", source
+            )
+            return None
+
+        self._consumed_bytes += len(content)
+
+        suffix = (
+            self._normalize_extension(extension) or mimetypes.guess_extension(mime_type) or ".img"
+        )
+        file_name = f"{uuid.uuid4()}{suffix}"
+        try:
+            file_response = self._tool.session.file.upload(file_name, content, mime_type)
+        except Exception as exc:
+            self._logger.warning("Failed to upload image from %s: %s", source, exc)
+            return None
+        if not file_response.preview_url:
+            self._logger.warning("Uploaded image from %s has no preview URL", source)
+            return None
+
+        return ImageAsset(
+            file=file_response,
+            markdown=f"![image]({file_response.preview_url})",
+        )
+
+    @staticmethod
+    def _normalize_extension(extension: str | None) -> str | None:
+        if not extension:
+            return None
+        normalized = extension.casefold().strip()
+        return normalized if normalized.startswith(".") else f".{normalized}"
+
+    @staticmethod
+    def _resolve_mime_type(mime_type: str | None, extension: str | None) -> str | None:
+        normalized = (mime_type or "").split(";", 1)[0].strip().casefold()
+        if normalized.startswith("image/"):
+            return normalized
+        guessed, _ = mimetypes.guess_type(
+            f"image{ImageAssetService._normalize_extension(extension) or ''}"
+        )
+        return guessed if guessed and guessed.startswith("image/") else None
+
+    @staticmethod
+    def _remote_mime_type(response: requests.Response, url: str) -> str | None:
+        content_type = response.headers.get("Content-Type", "").split(";", 1)[0].strip().casefold()
+        if content_type.startswith("image/"):
+            return content_type
+        guessed, _ = mimetypes.guess_type(urlparse(url).path)
+        return guessed if guessed and guessed.startswith("image/") else None

--- a/tools/dify_extractor/tools/json_extractor.py
+++ b/tools/dify_extractor/tools/json_extractor.py
@@ -1,73 +1,32 @@
-"""JSON document extractor implementation."""
+"""JSON document extractor."""
 
 import json
-from typing import Optional
 
-from tools.extractor_base import BaseExtractor
-from tools.helpers import detect_file_encodings
 from tools.document import Document, ExtractorResult
+from tools.errors import ExtractionError
+from tools.extractor_base import BaseExtractor
+from tools.helpers import decode_text
 
 
 class JSONExtractor(BaseExtractor):
-    """Load JSON files.
-
-    Args:
-        file_bytes: file bytes.
-        file_name: file name.
-        encoding: encoding.
-        autodetect_encoding: autodetect encoding.
-    """
-
-    def __init__(
-        self,
-        file_bytes: bytes,
-        file_name: str,
-        encoding: Optional[str] = None,
-        autodetect_encoding: bool = False,
-    ):
-        """Initialize with file bytes."""
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-        self._encoding = encoding
-        self._autodetect_encoding = autodetect_encoding
-
     def extract(self) -> ExtractorResult:
-        """Extract JSON content and format as markdown."""
-        text = ""
-        try:
-            # Decode bytes to text
-            text = self._file_bytes.decode(self._encoding if self._encoding else "utf-8")
-        except UnicodeDecodeError as e:
-            if self._autodetect_encoding:
-                detected_encodings = detect_file_encodings(self._file_bytes)
-                for encoding in detected_encodings:
-                    try:
-                        text = self._file_bytes.decode(encoding.encoding if encoding.encoding else "utf-8")
-                        break
-                    except UnicodeDecodeError:
-                        continue
-            else:
-                raise RuntimeError(f"Error decoding {self._file_name}") from e
-        except Exception as e:
-            raise RuntimeError(f"Error loading {self._file_name}") from e
-
-        # Parse JSON and format as markdown
+        text = decode_text(self.context.file_bytes, self.context.file_name)
         try:
             json_data = json.loads(text)
-            # Pretty print JSON with proper indentation
-            formatted_json = json.dumps(json_data, indent=2, ensure_ascii=False)
-            
-            # Format as markdown code block
-            md_content = f"```json\n{formatted_json}\n```"
-            
-        except json.JSONDecodeError as e:
-            # If JSON parsing fails, return the raw text with error info
-            md_content = f"# JSON Parse Error\n\nError: {str(e)}\n\n## Raw Content\n\n```\n{text}\n```"
-        except Exception as e:
-            raise RuntimeError(f"Error parsing JSON in {self._file_name}") from e
+        except json.JSONDecodeError as exc:
+            raise ExtractionError(
+                f"File '{self.context.file_name}' contains invalid JSON at "
+                f"line {exc.lineno}, column {exc.colno}."
+            ) from exc
 
-        metadata = {"source": self._file_name, "type": "json"}
+        formatted_json = json.dumps(json_data, indent=2, ensure_ascii=False)
+        md_content = f"```json\n{formatted_json}\n```"
         return ExtractorResult(
-            md_content=md_content, 
-            documents=[Document(page_content=md_content, metadata=metadata)]
+            md_content=md_content,
+            documents=[
+                Document(
+                    page_content=md_content,
+                    metadata={"source": self.context.file_name, "type": "json"},
+                )
+            ],
         )

--- a/tools/dify_extractor/tools/markdown_extractor.py
+++ b/tools/dify_extractor/tools/markdown_extractor.py
@@ -1,218 +1,82 @@
-"""Abstract interface for document loader implementations."""
+"""Markdown document extractor."""
 
-import mimetypes
 import re
-import uuid
-from pathlib import Path
-from typing import Optional, cast
-from urllib.parse import urlparse
 
-import requests
-from dify_plugin import Tool
-from dify_plugin.invocations.file import UploadFileResponse
-
-from tools.extractor_base import BaseExtractor
-from tools.helpers import detect_file_encodings
 from tools.document import Document, ExtractorResult
+from tools.extractor_base import BaseExtractor
+from tools.helpers import decode_text
+
+_REMOTE_IMAGE_PATTERN = re.compile(
+    r"!\[(?P<alt>[^\]]*)\]\((?P<url>https?://[^\s)]+)(?P<title>\s+(?:\"[^\"]*\"|'[^']*'))?\)",
+    re.IGNORECASE,
+)
+_FENCE_PATTERN = re.compile(r"^\s*(`{3,}|~{3,})")
+_HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 
 
 class MarkdownExtractor(BaseExtractor):
-    """Load Markdown files.
-
-    Args:
-        file_bytes: Markdown content in bytes format.
-        file_name: file name.
-        tool: tool.
-        remove_hyperlinks: remove hyperlinks.
-        remove_images: remove images.
-        encoding: encoding.
-        autodetect_encoding: autodetect encoding.
-    """
-
-    def __init__(
-        self,
-        file_bytes: bytes,
-        file_name: str,
-        tool: Tool,
-        remove_hyperlinks: bool = False,
-        remove_images: bool = False,
-        encoding: Optional[str] = None,
-        autodetect_encoding: bool = True,
-    ):
-        """Initialize with file bytes."""
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-        self._tool = tool
-        self._remove_hyperlinks = remove_hyperlinks
-        self._remove_images = remove_images
-        self._encoding = encoding
-        self._autodetect_encoding = autodetect_encoding
-
     def extract(self) -> ExtractorResult:
-        """Load from bytes."""
-        md_content, tups, img_list = self.parse_tups()
-        documents = []
-        for header, value in tups:
-            value = value.strip()
-            if header is None:
-                documents.append(Document(page_content=value))
-            else:
-                documents.append(Document(page_content=f"\n\n{header}\n{value}"))
+        content = decode_text(self.context.file_bytes, self.context.file_name)
+        image_files = []
+        image_service = self.context.image_service
 
+        if image_service:
+
+            def replace_remote_image(match: re.Match[str]) -> str:
+                asset = image_service.download_and_upload(match.group("url"))
+                if asset is None:
+                    return match.group(0)
+                image_files.append(asset.file)
+                title = match.group("title") or ""
+                return f"![{match.group('alt')}]({asset.file.preview_url}{title})"
+
+            content = _REMOTE_IMAGE_PATTERN.sub(replace_remote_image, content)
+
+        documents = [
+            Document(
+                page_content=section,
+                metadata={"source": self.context.file_name},
+            )
+            for section in self._split_sections(content)
+            if section.strip()
+        ]
         return ExtractorResult(
-            md_content=md_content, documents=documents, img_list=img_list, origin_result=None
+            md_content=content,
+            documents=documents,
+            img_list=image_files,
         )
 
     @staticmethod
-    def _is_valid_url(url: str) -> bool:
-        """Check if the url is valid."""
-        parsed = urlparse(url)
-        return bool(parsed.netloc) and bool(parsed.scheme)
+    def _split_sections(markdown_text: str) -> list[str]:
+        sections: list[str] = []
+        current_header: str | None = None
+        current_lines: list[str] = []
+        active_fence: str | None = None
 
-    def markdown_to_tups(self, markdown_text: str) -> list[tuple[Optional[str], str]]:
-        """Convert a markdown file to a dictionary.
+        def flush() -> None:
+            body = "\n".join(current_lines).strip()
+            if current_header is not None:
+                sections.append(f"{current_header}\n{body}".rstrip())
+            elif body:
+                sections.append(body)
 
-        The keys are the headers and the values are the text under each header.
-
-        """
-        markdown_tups: list[tuple[Optional[str], str]] = []
-        lines = markdown_text.split("\n")
-
-        current_header = None
-        current_text = ""
-        code_block_flag = False
-
-        for line in lines:
-            if line.startswith("```"):
-                code_block_flag = not code_block_flag
-                current_text += line + "\n"
+        for line in markdown_text.splitlines():
+            fence = _FENCE_PATTERN.match(line)
+            if fence:
+                marker = fence.group(1)[0]
+                if active_fence is None:
+                    active_fence = marker
+                elif active_fence == marker:
+                    active_fence = None
+                current_lines.append(line)
                 continue
-            if code_block_flag:
-                current_text += line + "\n"
-                continue
-            header_match = re.match(r"^#+\s", line)
-            if header_match:
-                if current_header is not None:
-                    markdown_tups.append((current_header, current_text))
 
-                current_header = line
-                current_text = ""
+            heading = _HEADING_PATTERN.match(line) if active_fence is None else None
+            if heading:
+                flush()
+                current_header = heading.group(2).strip()
+                current_lines = []
             else:
-                current_text += line + "\n"
-        markdown_tups.append((current_header, current_text))
-
-        if current_header is not None:
-            # pass linting, assert keys are defined
-            markdown_tups = [
-                (re.sub(r"#", "", cast(str, key)).strip(), re.sub(r"<.*?>", "", value))
-                for key, value in markdown_tups
-            ]
-        else:
-            markdown_tups = [
-                (key, re.sub("\n", "", value)) for key, value in markdown_tups
-            ]
-
-        return markdown_tups
-
-    def remove_images(self, content: str) -> str:
-        """Get a dictionary of a markdown file from its path."""
-        pattern = r"!{1}\[\[(.*)\]\]"
-        content = re.sub(pattern, "", content)
-        return content
-
-    def remove_hyperlinks(self, content: str) -> str:
-        """Get a dictionary of a markdown file from its path."""
-        pattern = r"\[(.*?)\]\((.*?)\)"
-        content = re.sub(pattern, r"\1", content)
-        return content
-
-    def parse_tups(self) -> tuple[str, list[tuple[Optional[str], str]], list[UploadFileResponse]]:
-        """Parse bytes into tuples."""
-        content = ""
-        try:
-            content = self._file_bytes.decode(
-                self._encoding if self._encoding else "utf-8"
-            )
-        except UnicodeDecodeError as e:
-            if self._autodetect_encoding:
-                detected_encodings = detect_file_encodings(self._file_bytes)
-                for encoding in detected_encodings:
-                    try:
-                        content = self._file_bytes.decode(encoding.encoding if encoding.encoding else "utf-8")
-                        break
-                    except UnicodeDecodeError:
-                        continue
-            else:
-                raise RuntimeError("Error decoding markdown content") from e
-
-        image_link_pattern = r"!\[.*?\]\((.*?)\)"
-        img_url_list = re.findall(image_link_pattern, content)
-        img_map = {}
-        img_list = []
-        for img_url in img_url_list:
-            if not self._is_valid_url(img_url):
-                continue
-            response = requests.get(img_url)
-            if response.status_code == 200:
-                image_ext = mimetypes.guess_extension(response.headers["Content-Type"])
-                if image_ext is None:
-                    continue
-                file_uuid = str(uuid.uuid4())
-                file_name = file_uuid + "." + image_ext
-                mime_type, _ = mimetypes.guess_type(file_name)
-
-                file_res = self._tool.session.file.upload(
-                    file_name, response.content, mime_type if mime_type else "image/png"
-                )
-                img_map[img_url] = file_res.preview_url
-                img_list.append(file_res)
-            else:
-                continue
-
-        for img_url, preview_url in img_map.items():
-            content = content.replace(img_url, preview_url)
-        if self._remove_hyperlinks:
-            content = self.remove_hyperlinks(content)
-
-        if self._remove_images:
-            content = self.remove_images(content)
-
-        return content, self._markdown_to_tups(content), img_list
-
-
-    def _markdown_to_tups(self, markdown_text: str) -> list[tuple[Optional[str], str]]:
-        """Convert a markdown file to a dictionary.
-
-        The keys are the headers and the values are the text under each header.
-
-        """
-        markdown_tups: list[tuple[Optional[str], str]] = []
-        lines = markdown_text.split("\n")
-
-        current_header = None
-        current_text = ""
-        code_block_flag = False
-
-        for line in lines:
-            if line.startswith("```"):
-                code_block_flag = not code_block_flag
-                current_text += line + "\n"
-                continue
-            if code_block_flag:
-                current_text += line + "\n"
-                continue
-            header_match = re.match(r"^#+\s", line)
-            if header_match:
-                markdown_tups.append((current_header, current_text))
-                current_header = line
-                current_text = ""
-            else:
-                current_text += line + "\n"
-        markdown_tups.append((current_header, current_text))
-
-        markdown_tups = [
-            (re.sub(r"#", "", cast(str, key)).strip() if key else None, re.sub(r"<.*?>", "", value))
-            for key, value in markdown_tups
-        ]
-
-        return markdown_tups
+                current_lines.append(line)
+        flush()
+        return sections

--- a/tools/dify_extractor/tools/pdf_extractor.py
+++ b/tools/dify_extractor/tools/pdf_extractor.py
@@ -1,35 +1,23 @@
-import io
+"""PDF document extractor."""
+
 import logging
-import mimetypes
-import uuid
-from collections.abc import Iterator
 from io import BytesIO
-
-from dify_plugin import Tool
-
-from tools.document import Document, ExtractorResult
-from tools.extractor_base import BaseExtractor
 
 import pypdfium2
 import pypdfium2.raw as pdfium_c
+
+from tools.document import Document, ExtractorResult
+from tools.errors import ExtractionError
+from tools.extractor_base import BaseExtractor
 
 logger = logging.getLogger(__name__)
 
 
 class PdfExtractor(BaseExtractor):
-    """Load pdf files.
-
-    Args:
-        tool: Tool instance
-        file_bytes: file bytes
-        file_name: file name.
-    """
-
-    # Magic bytes for image format detection: (magic_bytes, extension, mime_type)
     IMAGE_FORMATS = [
         (b"\xff\xd8\xff", "jpg", "image/jpeg"),
         (b"\x89PNG\r\n\x1a\n", "png", "image/png"),
-        (b"\x00\x00\x00\x0c\x6a\x50\x20\x20\x0d\x0a\x87\x0a", "jp2", "image/jp2"),
+        (b"\x00\x00\x00\x0cjP  \r\n\x87\n", "jp2", "image/jp2"),
         (b"GIF8", "gif", "image/gif"),
         (b"BM", "bmp", "image/bmp"),
         (b"II*\x00", "tiff", "image/tiff"),
@@ -37,98 +25,95 @@ class PdfExtractor(BaseExtractor):
         (b"II+\x00", "tiff", "image/tiff"),
         (b"MM\x00+", "tiff", "image/tiff"),
     ]
-    MAX_MAGIC_LEN = max(len(m) for m, _, _ in IMAGE_FORMATS)
-
-    def __init__(self, tool: Tool, file_bytes: bytes, file_name: str):
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-        self._tool = tool
+    MAX_MAGIC_LENGTH = max(len(magic) for magic, _, _ in IMAGE_FORMATS)
 
     def extract(self) -> ExtractorResult:
-        documents, img_list = self.parse()
-        text_list = []
-        for document in documents:
-            text_list.append(document.page_content)
-        text = "\n\n".join(text_list)
+        try:
+            documents, image_files = self._parse()
+        except pypdfium2.PdfiumError as exc:
+            raise ExtractionError(
+                f"File '{self.context.file_name}' is not a valid PDF file."
+            ) from exc
+        return ExtractorResult(
+            md_content="\n\n".join(document.page_content for document in documents),
+            documents=documents,
+            img_list=image_files,
+        )
 
-        return ExtractorResult(md_content=text, documents=documents, img_list=img_list)
-
-    def parse(self) -> tuple[list[Document], list]:
-        """Parse the bytes and return documents and images."""
-        documents = []
-        img_list = []
-        with BytesIO(self._file_bytes) as file:
-            pdf_reader = pypdfium2.PdfDocument(file, autoclose=True)
-            try:
-                for page_number, page in enumerate(pdf_reader):
+    def _parse(self) -> tuple[list[Document], list]:
+        documents: list[Document] = []
+        image_files = []
+        pdf_document = pypdfium2.PdfDocument(BytesIO(self.context.file_bytes), autoclose=True)
+        try:
+            for page_number in range(len(pdf_document)):
+                page = pdf_document[page_number]
+                try:
                     text_page = page.get_textpage()
-                    content = text_page.get_text_range()
-                    text_page.close()
+                    try:
+                        content = text_page.get_text_range()
+                    finally:
+                        text_page.close()
 
-                    image_content, page_img_list = self._extract_images(page)
+                    image_content, page_images = self._extract_images(page, page_number)
                     if image_content:
-                        content += "\n" + image_content
-                    img_list.extend(page_img_list)
-
+                        content = f"{content}\n{image_content}".strip()
+                    image_files.extend(page_images)
+                    documents.append(
+                        Document(
+                            page_content=content,
+                            metadata={
+                                "source": self.context.file_name,
+                                "page": page_number,
+                            },
+                        )
+                    )
+                finally:
                     page.close()
-                    metadata = {"source": self._file_name, "page": page_number}
-                    documents.append(Document(page_content=content, metadata=metadata))
-            finally:
-                pdf_reader.close()
-        return documents, img_list
+        finally:
+            pdf_document.close()
+        return documents, image_files
 
-    def _extract_images(self, page) -> tuple[str, list]:
-        """
-        Extract images from a PDF page, save them to storage,
-        and return markdown image links.
+    def _extract_images(self, page, page_number: int) -> tuple[str, list]:
+        image_service = self.context.image_service
+        if image_service is None:
+            return "", []
 
-        Args:
-            page: pypdfium2 page object.
-
-        Returns:
-            Markdown string containing links to the extracted images.
-        """
-        image_content = []
-        img_list = []
-
+        image_markdown: list[str] = []
+        image_files = []
         try:
             image_objects = page.get_objects(filter=(pdfium_c.FPDF_PAGEOBJ_IMAGE,))
-            for obj in image_objects:
-                try:
-                    # Extract image bytes
-                    img_byte_arr = io.BytesIO()
-                    # Extract DCTDecode (JPEG) and JPXDecode (JPEG 2000) images directly
-                    # Fallback to png for other formats
-                    obj.extract(img_byte_arr, fb_format="png")
-                    img_bytes = img_byte_arr.getvalue()
+        except Exception as exc:
+            logger.warning("Failed to enumerate images on PDF page %d: %s", page_number, exc)
+            return "", []
 
-                    if not img_bytes:
-                        continue
-
-                    header = img_bytes[: self.MAX_MAGIC_LEN]
-                    image_ext = None
-                    mime_type = None
-                    for magic, ext, mime in self.IMAGE_FORMATS:
-                        if header.startswith(magic):
-                            image_ext = ext
-                            mime_type = mime
-                            break
-
-                    if not image_ext or not mime_type:
-                        continue
-
-                    file_uuid = str(uuid.uuid4())
-                    file_name = file_uuid + "." + image_ext
-
-                    file_res = self._tool.session.file.upload(
-                        file_name, img_bytes, mime_type
-                    )
-                    image_content.append(f"![image]({file_res.preview_url})")
-                    img_list.append(file_res)
-                except Exception as e:
-                    logger.warning("Failed to extract image from PDF: %s", e)
+        for image_index, image_object in enumerate(image_objects):
+            try:
+                image_buffer = BytesIO()
+                image_object.extract(image_buffer, fb_format="png")
+                image_bytes = image_buffer.getvalue()
+                image_type = self._detect_image_type(image_bytes)
+                if image_type is None:
                     continue
-        except Exception as e:
-            logger.warning("Failed to get objects from PDF page: %s", e)
+                extension, mime_type = image_type
+                asset = image_service.upload_embedded(
+                    image_bytes,
+                    extension=extension,
+                    mime_type=mime_type,
+                    source=(
+                        f"{self.context.file_name}:page-{page_number + 1}-image-{image_index + 1}"
+                    ),
+                )
+                if asset:
+                    image_markdown.append(asset.markdown)
+                    image_files.append(asset.file)
+            except Exception as exc:
+                logger.warning("Failed to extract an image from PDF page %d: %s", page_number, exc)
+        return "\n".join(image_markdown), image_files
 
-        return "\n".join(image_content), img_list
+    @classmethod
+    def _detect_image_type(cls, image_bytes: bytes) -> tuple[str, str] | None:
+        header = image_bytes[: cls.MAX_MAGIC_LENGTH]
+        for magic, extension, mime_type in cls.IMAGE_FORMATS:
+            if header.startswith(magic):
+                return extension, mime_type
+        return None

--- a/tools/dify_extractor/tools/pptx_extractor.py
+++ b/tools/dify_extractor/tools/pptx_extractor.py
@@ -1,131 +1,97 @@
-"""Abstract interface for pptx document loader implementations."""
+"""PPTX document extractor."""
 
-import logging
-import mimetypes
-import re
-import uuid
 from io import BytesIO
 from urllib.parse import urlparse
 
-import requests
-from dify_plugin import Tool
 from pptx import Presentation
 
-from tools.extractor_base import BaseExtractor
 from tools.document import Document, ExtractorResult
-
-logger = logging.getLogger(__name__)
+from tools.extractor_base import BaseExtractor
+from tools.helpers import render_markdown_table
 
 
 class PPTXExtractor(BaseExtractor):
-    """Load pptx files.
-
-    Args:
-        tool: Tool instance
-        file_bytes: file bytes
-        file_name: file name
-    """
-
-    def __init__(self, tool: Tool, file_bytes: bytes, file_name: str):
-        """Initialize with file path."""
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-        self._tool = tool
-
     def extract(self) -> ExtractorResult:
-        """Load given path as single page."""
-        content, img_list = self.parse_pptx(self._file_bytes)
+        content, image_files = self._parse_pptx()
         return ExtractorResult(
             md_content=content,
             documents=[
-                Document(page_content=content, metadata={"source": self._file_name})
+                Document(
+                    page_content=content,
+                    metadata={"source": self.context.file_name},
+                )
             ],
-            img_list=img_list,
-            origin_result=None
+            img_list=image_files,
         )
 
-    @staticmethod
-    def _is_valid_url(url: str) -> bool:
-        """Check if the url is valid."""
-        parsed = urlparse(url)
-        return bool(parsed.netloc) and bool(parsed.scheme)
-
-    def _extract_images_from_pptx(self, prs):
+    def _extract_images(self, presentation):
         image_map = {}
-        img_list = []
-        for slide_idx, slide in enumerate(prs.slides):
+        image_files = []
+        image_service = self.context.image_service
+        if image_service is None:
+            return image_map, image_files
+
+        for slide_index, slide in enumerate(presentation.slides):
             for shape in slide.shapes:
-                if hasattr(shape, "image"):
-                    image_ext = shape.image.ext
-                    if image_ext is None:
-                        continue
-                    file_uuid = str(uuid.uuid4())
-                    file_name = file_uuid + "." + image_ext
-                    mime_type, _ = mimetypes.guess_type(file_name)
+                image = getattr(shape, "image", None)
+                if image is None:
+                    continue
+                asset = image_service.upload_embedded(
+                    image.blob,
+                    extension=image.ext,
+                    source=f"{self.context.file_name}:slide-{slide_index + 1}",
+                )
+                if asset:
+                    image_map[(slide_index, shape.shape_id)] = asset.markdown
+                    image_files.append(asset.file)
+        return image_map, image_files
 
-                    file_res = self._tool.session.file.upload(
-                        file_name, shape.image.blob, mime_type
-                    )
+    @staticmethod
+    def _table_to_markdown(table) -> str:
+        if not table.rows:
+            return ""
+        headers = [cell.text.strip() for cell in table.rows[0].cells]
+        rows = [[cell.text.strip() for cell in row.cells] for row in list(table.rows)[1:]]
+        return render_markdown_table(headers, rows)
 
-                    image_map[(slide_idx, shape.shape_id)] = f"![image]({file_res.preview_url})"
-                    img_list.append(file_res)
+    def _parse_pptx(self) -> tuple[str, list]:
+        presentation = Presentation(BytesIO(self.context.file_bytes))
+        image_map, image_files = self._extract_images(presentation)
+        content: list[str] = []
 
-        return image_map, img_list
-
-    def _table_to_markdown(self, table):
-        markdown = ""
-        rows = table.rows
-        cols = table.columns
-        total_cols = len(cols)
-
-        # Header
-        header_cells = [cell.text.strip() for cell in rows[0].cells]
-        markdown += "| " + " | ".join(header_cells) + " |\n"
-        markdown += "| " + " | ".join(["---"] * total_cols) + " |\n"
-
-        # Rows
-        for row in list(rows)[1:]:
-            row_cells = [cell.text.strip() for cell in row.cells]
-            markdown += "| " + " | ".join(row_cells) + " |\n"
-
-        return markdown
-
-    def parse_pptx(self, file_bytes):
-        prs = Presentation(BytesIO(file_bytes))
-
-        content = []
-
-        image_map, img_list = self._extract_images_from_pptx(prs)
-
-        url_pattern = re.compile(r"http://[^\s+]+//|https://[^\s+]+")
-        for slide_idx, slide in enumerate(prs.slides):
-            slide_content = []
+        for slide_index, slide in enumerate(presentation.slides):
+            slide_content: list[str] = []
             for shape in slide.shapes:
-                # Extract text (including hyperlinks)
                 if shape.has_text_frame:
                     for paragraph in shape.text_frame.paragraphs:
-                        para_text = ""
+                        paragraph_parts: list[str] = []
                         for run in paragraph.runs:
                             run_text = run.text or ""
-                            # Check for hyperlink
-                            if run.hyperlink and run.hyperlink.address:
-                                if url_pattern.match(run.hyperlink.address):
-                                    para_text += f"[{run_text}]({run.hyperlink.address})"
-                                else:
-                                    para_text += run_text
+                            address = run.hyperlink.address if run.hyperlink else None
+                            if address and self._is_safe_hyperlink(address):
+                                paragraph_parts.append(f"[{run_text}]({address})")
                             else:
-                                para_text += run_text
-                        if para_text.strip():
-                            slide_content.append(para_text.strip())
-                # Extract images
-                if hasattr(shape, "image"):
-                    image_md = image_map.get((slide_idx, shape.shape_id))
-                    if image_md:
-                        slide_content.append(image_md)
-                # Extract tables
+                                paragraph_parts.append(run_text)
+                        paragraph_text = "".join(paragraph_parts).strip()
+                        if paragraph_text:
+                            slide_content.append(paragraph_text)
+
+                image_markdown = image_map.get((slide_index, shape.shape_id))
+                if image_markdown:
+                    slide_content.append(image_markdown)
+
                 if shape.has_table:
-                    table_md = self._table_to_markdown(shape.table)
-                    slide_content.append(table_md)
+                    table_markdown = self._table_to_markdown(shape.table)
+                    if table_markdown:
+                        slide_content.append(table_markdown.rstrip())
+
             if slide_content:
-                content.append(f"# Slide {slide_idx + 1}\n" + "\n".join(slide_content))
-        return "\n\n".join(content), img_list
+                content.append(f"# Slide {slide_index + 1}\n" + "\n".join(slide_content))
+        return "\n\n".join(content), image_files
+
+    @staticmethod
+    def _is_safe_hyperlink(url: str) -> bool:
+        parsed = urlparse(url)
+        if parsed.scheme.casefold() == "mailto":
+            return bool(parsed.path)
+        return parsed.scheme.casefold() in {"http", "https"} and bool(parsed.netloc)

--- a/tools/dify_extractor/tools/text_extractor.py
+++ b/tools/dify_extractor/tools/text_extractor.py
@@ -1,57 +1,15 @@
-"""Abstract interface for document loader implementations."""
+"""Plain-text document extractor."""
 
-from pathlib import Path
-from typing import Optional
-
-from tools.extractor_base import BaseExtractor
-from tools.helpers import detect_file_encodings
 from tools.document import Document, ExtractorResult
+from tools.extractor_base import BaseExtractor
+from tools.helpers import decode_text
 
 
 class TextExtractor(BaseExtractor):
-    """Load text files.
-
-
-    Args:
-        file_bytes: file bytes.
-        file_name: file name.
-        encoding: encoding.
-        autodetect_encoding: autodetect encoding.
-    """
-
-    def __init__(
-        self,
-        file_bytes: bytes,
-        file_name: str,
-        encoding: Optional[str] = None,
-        autodetect_encoding: bool = False,
-    ):
-        """Initialize with file path."""
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-        self._encoding = encoding
-        self._autodetect_encoding = autodetect_encoding
-
     def extract(self) -> ExtractorResult:
-        """Load from file path."""
-        text = ""
-        try:
-            text = self._file_bytes.decode(self._encoding if self._encoding else "utf-8")
-        except UnicodeDecodeError as e:
-            if self._autodetect_encoding:
-                detected_encodings = detect_file_encodings(self._file_bytes)
-                for encoding in detected_encodings:
-                    try:
-                        text = self._file_bytes.decode(encoding.encoding if encoding.encoding else "utf-8")
-                        break
-                    except UnicodeDecodeError:
-                        continue
-            else:
-                raise RuntimeError(f"Error loading {self._file_name}") from e
-        except Exception as e:
-            raise RuntimeError(f"Error loading {self._file_name}") from e
-
-        metadata = {"source": self._file_name}
+        text = decode_text(self.context.file_bytes, self.context.file_name)
+        metadata = {"source": self.context.file_name}
         return ExtractorResult(
-            md_content=text, documents=[Document(page_content=text, metadata=metadata)]
+            md_content=text,
+            documents=[Document(page_content=text, metadata=metadata)],
         )

--- a/tools/dify_extractor/tools/word_extractor.py
+++ b/tools/dify_extractor/tools/word_extractor.py
@@ -1,122 +1,67 @@
-"""Abstract interface for document loader implementations."""
+"""DOCX document extractor."""
 
 import logging
-import mimetypes
 import re
-import uuid
 from io import BytesIO
-from urllib.parse import urlparse
-import requests
-from dify_plugin import Tool
+
 from docx import Document as DocxDocument
 from docx.oxml.ns import qn
 from docx.text.run import Run
 
 from tools.document import Document, ExtractorResult
 from tools.extractor_base import BaseExtractor
+from tools.helpers import render_markdown_table
+from tools.image_assets import is_http_url
 
 logger = logging.getLogger(__name__)
 
 
 class WordExtractor(BaseExtractor):
-    """Load docx files.
-
-    Args:
-        tool: Tool instance
-        file_bytes: file bytes
-        file_name: file name
-        encoding: encoding
-        autodetect_encoding: autodetect encoding
-    """
-
-    def __init__(self, tool: Tool, file_bytes: bytes, file_name: str):
-        """Initialize with file path."""
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-        self._tool = tool
-
     def extract(self) -> ExtractorResult:
-        """Load given path as single page."""
-        content, img_list = self.parse_docx(self._file_bytes)
+        content, img_list = self.parse_docx(self.context.file_bytes)
         return ExtractorResult(
             md_content=content,
-            documents=[
-                Document(page_content=content, metadata={"source": self._file_name})
-            ],
+            documents=[Document(page_content=content, metadata={"source": self.context.file_name})],
             img_list=img_list,
-            origin_result=None
         )
 
-    @staticmethod
-    def _is_valid_url(url: str) -> bool:
-        """Check if the url is valid."""
-        parsed = urlparse(url)
-        return bool(parsed.netloc) and bool(parsed.scheme)
-
     def _extract_images_from_docx(self, doc):
-        image_count = 0
         image_map = {}
         img_list = []
-        for rId, rel in doc.part.rels.items():
-            if "image" in rel.target_ref:
-                image_count += 1
-                if rel.is_external:
-                    url = rel.target_ref
-                    if not self._is_valid_url(url):
-                        continue
-                    try:
-                        response = requests.get(url)
-                    except requests.exceptions.RequestException as e:
-                        logger.exception("Failed to download image from URL: %s, error: %s", url, e)
-                        continue
-                    if response.status_code == 200:
-                        image_ext = mimetypes.guess_extension(
-                            response.headers["Content-Type"]
-                        )
-                        if image_ext is None:
-                            continue
-                        file_uuid = str(uuid.uuid4())
-                        file_name = file_uuid + "." + image_ext
-                        mime_type, _ = mimetypes.guess_type(file_name)
+        image_service = self.context.image_service
+        if image_service is None:
+            return image_map, img_list
 
-                        file_res = self._tool.session.file.upload(
-                            file_name, response.content, mime_type or "application/octet-stream"
-                        )
-                        image_map[rId] = f"![image]({file_res.preview_url})"
-                        img_list.append(file_res)
-                else:
-                    image_ext = rel.target_ref.split(".")[-1]
-                    if image_ext is None:
-                        continue
-                    # user uuid as file name
-                    file_uuid = str(uuid.uuid4())
-                    file_name = file_uuid + "." + image_ext
-                    mime_type, _ = mimetypes.guess_type(file_name)
-
-                    file_res = self._tool.session.file.upload(
-                        file_name, rel.target_part.blob, mime_type or "application/octet-stream"
-                    )
-
-                    image_map[rel.target_part] = f"![image]({file_res.preview_url})"
-                    img_list.append(file_res)
+        for relationship_id, relationship in doc.part.rels.items():
+            if "image" not in relationship.target_ref:
+                continue
+            if relationship.is_external:
+                asset = image_service.download_and_upload(relationship.target_ref)
+                map_key = relationship_id
+            else:
+                extension = relationship.target_ref.rsplit(".", 1)[-1]
+                asset = image_service.upload_embedded(
+                    relationship.target_part.blob,
+                    extension=extension,
+                    source=f"{self.context.file_name}:{relationship.target_ref}",
+                )
+                map_key = relationship.target_part
+            if asset:
+                image_map[map_key] = asset.markdown
+                img_list.append(asset.file)
+            elif relationship.is_external and is_http_url(relationship.target_ref):
+                image_map[map_key] = f"![image]({relationship.target_ref})"
 
         return image_map, img_list
 
     def _table_to_markdown(self, table, image_map):
-        markdown = ""
-        # calculate the total number of columns
+        if not table.rows:
+            return ""
         total_cols = max(len(row.cells) for row in table.rows)
-
         header_row = table.rows[0]
         headers = self._parse_row(header_row, image_map, total_cols)
-        markdown += "| " + " | ".join(headers) + " |\n"
-        markdown += "| " + " | ".join(["---"] * total_cols) + " |\n"
-
-        for row in table.rows[1:]:
-            row_cells = self._parse_row(row, image_map, total_cols)
-            markdown += "| " + " | ".join(row_cells) + " |\n"
-
-        return markdown
+        rows = [self._parse_row(row, image_map, total_cols) for row in table.rows[1:]]
+        return render_markdown_table(headers, rows)
 
     def _parse_row(self, row, image_map, total_cols):
         # Initialize a row, all of which are empty by default
@@ -171,22 +116,6 @@ class WordExtractor(BaseExtractor):
                 paragraph_content.append(run.text)
         return "".join(paragraph_content).strip()
 
-    def _parse_paragraph(self, paragraph, image_map):
-        paragraph_content = []
-        for run in paragraph.runs:
-            if run.element.xpath(".//a:blip"):
-                for blip in run.element.xpath(".//a:blip"):
-                    embed_id = blip.get(
-                        "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}embed"
-                    )
-                    if embed_id:
-                        rel_target = run.part.rels[embed_id].target_ref
-                        if rel_target in image_map:
-                            paragraph_content.append(image_map[rel_target])
-            if run.text.strip():
-                paragraph_content.append(run.text.strip())
-        return " ".join(paragraph_content) if paragraph_content else ""
-
     def parse_docx(self, file_bytes):
         doc = DocxDocument(BytesIO(file_bytes))
 
@@ -208,7 +137,11 @@ class WordExtractor(BaseExtractor):
 
             def process_run(run, target_buffer):
                 # Helper to extract text and embedded images from a run element and append them to target_buffer
-                if hasattr(run.element, "tag") and isinstance(run.element.tag, str) and run.element.tag.endswith("r"):
+                if (
+                    hasattr(run.element, "tag")
+                    and isinstance(run.element.tag, str)
+                    and run.element.tag.endswith("r")
+                ):
                     # Process drawing type images
                     drawing_elements = run.element.findall(
                         ".//{http://schemas.openxmlformats.org/wordprocessingml/2006/main}drawing"
@@ -258,8 +191,8 @@ class WordExtractor(BaseExtractor):
                             )
                             if image_id and image_id in doc.part.rels:
                                 append_image_link(image_id, has_drawing, target_buffer)
-                if run.text.strip():
-                    target_buffer.append(run.text.strip())
+                if run.text:
+                    target_buffer.append(run.text)
 
             def process_hyperlink(hyperlink_elem, target_buffer):
                 # Helper to extract text from a hyperlink element and append it to target_buffer
@@ -310,7 +243,9 @@ class WordExtractor(BaseExtractor):
                         for instr in instr_texts:
                             if instr.text and "HYPERLINK" in instr.text:
                                 # Quick regex to extract URL
-                                match = re.search(r'HYPERLINK\s+"([^"]+)"', instr.text, re.IGNORECASE)
+                                match = re.search(
+                                    r'HYPERLINK\s+"([^"]+)"', instr.text, re.IGNORECASE
+                                )
                                 if match:
                                     hyperlink_field_url = match.group(1)
 
@@ -340,28 +275,28 @@ class WordExtractor(BaseExtractor):
                                 is_collecting_field_text = False
 
                     # Decide where to append content
-                    target_buffer = hyperlink_field_text_parts if is_collecting_field_text else paragraph_content
+                    target_buffer = (
+                        hyperlink_field_text_parts
+                        if is_collecting_field_text
+                        else paragraph_content
+                    )
                     process_run(run, target_buffer)
                 elif tag == qn("w:hyperlink"):
                     process_hyperlink(child, paragraph_content)
-            return "".join(paragraph_content) if paragraph_content else ""
+            return "".join(paragraph_content).strip() if paragraph_content else ""
 
         paragraphs = doc.paragraphs.copy()
         tables = doc.tables.copy()
         for element in doc.element.body:
             if hasattr(element, "tag"):
-                if isinstance(element.tag, str) and element.tag.endswith(
-                    "p"
-                ):  # paragraph
+                if isinstance(element.tag, str) and element.tag.endswith("p"):  # paragraph
                     para = paragraphs.pop(0)
                     parsed_paragraph = parse_paragraph(para)
                     if parsed_paragraph.strip():
                         content.append(parsed_paragraph)
                     else:
                         content.append("\n")
-                elif isinstance(element.tag, str) and element.tag.endswith(
-                    "tbl"
-                ):  # table
+                elif isinstance(element.tag, str) and element.tag.endswith("tbl"):  # table
                     table = tables.pop(0)
                     content.append(self._table_to_markdown(table, image_map))
-        return "\n".join(content), img_list
+        return "\n".join(content).strip(), img_list

--- a/tools/dify_extractor/tools/yaml_extractor.py
+++ b/tools/dify_extractor/tools/yaml_extractor.py
@@ -1,73 +1,43 @@
-"""YAML document extractor implementation."""
+"""YAML document extractor."""
 
 import yaml
-from typing import Optional
 
-from tools.extractor_base import BaseExtractor
-from tools.helpers import detect_file_encodings
 from tools.document import Document, ExtractorResult
+from tools.errors import ExtractionError
+from tools.extractor_base import BaseExtractor
+from tools.helpers import decode_text
 
 
 class YAMLExtractor(BaseExtractor):
-    """Load YAML files.
-
-    Args:
-        file_bytes: file bytes.
-        file_name: file name.
-        encoding: encoding.
-        autodetect_encoding: autodetect encoding.
-    """
-
-    def __init__(
-        self,
-        file_bytes: bytes,
-        file_name: str,
-        encoding: Optional[str] = None,
-        autodetect_encoding: bool = False,
-    ):
-        """Initialize with file bytes."""
-        self._file_bytes = file_bytes
-        self._file_name = file_name
-        self._encoding = encoding
-        self._autodetect_encoding = autodetect_encoding
-
     def extract(self) -> ExtractorResult:
-        """Extract YAML content and format as markdown."""
-        text = ""
-        try:
-            # Decode bytes to text
-            text = self._file_bytes.decode(self._encoding if self._encoding else "utf-8")
-        except UnicodeDecodeError as e:
-            if self._autodetect_encoding:
-                detected_encodings = detect_file_encodings(self._file_bytes)
-                for encoding in detected_encodings:
-                    try:
-                        text = self._file_bytes.decode(encoding.encoding if encoding.encoding else "utf-8")
-                        break
-                    except UnicodeDecodeError:
-                        continue
-            else:
-                raise RuntimeError(f"Error decoding {self._file_name}") from e
-        except Exception as e:
-            raise RuntimeError(f"Error loading {self._file_name}") from e
-
-        # Parse YAML and format as markdown
+        text = decode_text(self.context.file_bytes, self.context.file_name)
+        if not text.strip() or all(
+            not line.strip() or line.lstrip().startswith("#") for line in text.splitlines()
+        ):
+            raise ExtractionError(f"File '{self.context.file_name}' contains no YAML content.")
         try:
             yaml_data = yaml.safe_load(text)
-            # Convert back to YAML with proper formatting
-            formatted_yaml = yaml.dump(yaml_data, default_flow_style=False, allow_unicode=True, indent=2)
-            
-            # Format as markdown code block
-            md_content = f"```yaml\n{formatted_yaml}```"
-            
-        except yaml.YAMLError as e:
-            # If YAML parsing fails, return the raw text with error info
-            md_content = f"# YAML Parse Error\n\nError: {str(e)}\n\n## Raw Content\n\n```\n{text}\n```"
-        except Exception as e:
-            raise RuntimeError(f"Error parsing YAML in {self._file_name}") from e
+        except yaml.YAMLError as exc:
+            mark = getattr(exc, "problem_mark", None)
+            location = f" at line {mark.line + 1}, column {mark.column + 1}" if mark else ""
+            raise ExtractionError(
+                f"File '{self.context.file_name}' contains invalid YAML{location}."
+            ) from exc
 
-        metadata = {"source": self._file_name, "type": "yaml"}
+        formatted_yaml = yaml.safe_dump(
+            yaml_data,
+            allow_unicode=True,
+            default_flow_style=False,
+            indent=2,
+            sort_keys=False,
+        )
+        md_content = f"```yaml\n{formatted_yaml}```"
         return ExtractorResult(
-            md_content=md_content, 
-            documents=[Document(page_content=md_content, metadata=metadata)]
+            md_content=md_content,
+            documents=[
+                Document(
+                    page_content=md_content,
+                    metadata={"source": self.context.file_name, "type": "yaml"},
+                )
+            ],
         )

--- a/tools/dify_extractor/uv.lock
+++ b/tools/dify_extractor/uv.lock
@@ -55,64 +55,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bottleneck"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/14/d8/6d641573e210768816023a64966d66463f2ce9fc9945fa03290c8a18f87c/bottleneck-1.6.0.tar.gz", hash = "sha256:028d46ee4b025ad9ab4d79924113816f825f62b17b87c9e1d0d8ce144a4a0e31", size = 104311, upload-time = "2025-09-08T16:30:38.617Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/72/7e3593a2a3dd69ec831a9981a7b1443647acb66a5aec34c1620a5f7f8498/bottleneck-1.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3bb16a16a86a655fdbb34df672109a8a227bb5f9c9cf5bb8ae400a639bc52fa3", size = 100515, upload-time = "2025-09-08T16:29:55.141Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/d4/e7bbea08f4c0f0bab819d38c1a613da5f194fba7b19aae3e2b3a27e78886/bottleneck-1.6.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0fbf5d0787af9aee6cef4db9cdd14975ce24bd02e0cc30155a51411ebe2ff35f", size = 377451, upload-time = "2025-09-08T16:29:56.718Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/80/a6da430e3b1a12fd85f9fe90d3ad8fe9a527ecb046644c37b4b3f4baacfc/bottleneck-1.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d08966f4a22384862258940346a72087a6f7cebb19038fbf3a3f6690ee7fd39f", size = 368303, upload-time = "2025-09-08T16:29:57.834Z" },
-    { url = "https://files.pythonhosted.org/packages/30/11/abd30a49f3251f4538430e5f876df96f2b39dabf49e05c5836820d2c31fe/bottleneck-1.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:604f0b898b43b7bc631c564630e936a8759d2d952641c8b02f71e31dbcd9deaa", size = 361232, upload-time = "2025-09-08T16:29:59.104Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/ac/1c0e09d8d92b9951f675bd42463ce76c3c3657b31c5bf53ca1f6dd9eccff/bottleneck-1.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d33720bad761e642abc18eda5f188ff2841191c9f63f9d0c052245decc0faeb9", size = 373234, upload-time = "2025-09-08T16:30:00.488Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/ea/382c572ae3057ba885d484726bb63629d1f63abedf91c6cd23974eb35a9b/bottleneck-1.6.0-cp312-cp312-win32.whl", hash = "sha256:a1e5907ec2714efbe7075d9207b58c22ab6984a59102e4ecd78dced80dab8374", size = 108020, upload-time = "2025-09-08T16:30:01.773Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ad/d71da675eef85ac153eef5111ca0caa924548c9591da00939bcabba8de8e/bottleneck-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:81e3822499f057a917b7d3972ebc631ac63c6bbcc79ad3542a66c4c40634e3a6", size = 113493, upload-time = "2025-09-08T16:30:02.872Z" },
-    { url = "https://files.pythonhosted.org/packages/97/1a/e117cd5ff7056126d3291deb29ac8066476e60b852555b95beb3fc9d62a0/bottleneck-1.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d015de414ca016ebe56440bdf5d3d1204085080527a3c51f5b7b7a3e704fe6fd", size = 100521, upload-time = "2025-09-08T16:30:03.89Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/22/05555a9752357e24caa1cd92324d1a7fdde6386aab162fcc451f8f8eedc2/bottleneck-1.6.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:456757c9525b0b12356f472e38020ed4b76b18375fd76e055f8d33fb62956f5e", size = 377719, upload-time = "2025-09-08T16:30:05.135Z" },
-    { url = "https://files.pythonhosted.org/packages/11/ee/76593af47097d9633109bed04dbcf2170707dd84313ca29f436f9234bc51/bottleneck-1.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c65254d51b6063c55f6272f175e867e2078342ae75f74be29d6612e9627b2c0", size = 368577, upload-time = "2025-09-08T16:30:06.387Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/f7/4dcacaf637d2b8d89ea746c74159adda43858d47358978880614c3fa4391/bottleneck-1.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a172322895fbb79c6127474f1b0db0866895f0b804a18d5c6b841fea093927fe", size = 361441, upload-time = "2025-09-08T16:30:07.613Z" },
-    { url = "https://files.pythonhosted.org/packages/05/34/21eb1eb1c42cb7be2872d0647c292fc75768d14e1f0db66bf907b24b2464/bottleneck-1.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d5e81b642eb0d5a5bf00312598d7ed142d389728b694322a118c26813f3d1fa9", size = 373416, upload-time = "2025-09-08T16:30:08.899Z" },
-    { url = "https://files.pythonhosted.org/packages/48/cb/7957ff40367a151139b5f1854616bf92e578f10804d226fbcdecfd73aead/bottleneck-1.6.0-cp313-cp313-win32.whl", hash = "sha256:543d3a89d22880cd322e44caff859af6c0489657bf9897977d1f5d3d3f77299c", size = 108029, upload-time = "2025-09-08T16:30:09.909Z" },
-    { url = "https://files.pythonhosted.org/packages/90/a8/735df4156fa5595501d5d96a6ee102f49c13d2ce9e2a287ad51806bc3ba0/bottleneck-1.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:48a44307d604ceb81e256903e5d57d3adb96a461b1d3c6a69baa2c67e823bd36", size = 113497, upload-time = "2025-09-08T16:30:10.82Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5c/8c1260df8ade7cebc2a8af513a27082b5e36aa4a5fb762d56ea6d969d893/bottleneck-1.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:547e6715115867c4657c9ae8cc5ddac1fec8fdad66690be3a322a7488721b06b", size = 101606, upload-time = "2025-09-08T16:30:11.935Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ea/f03e2944e91ee962922c834ed21e5be6d067c8395681f5dc6c67a0a26853/bottleneck-1.6.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e4a4a6e05b6f014c307969129e10d1a0afd18f3a2c127b085532a4a76677aef", size = 391804, upload-time = "2025-09-08T16:30:13.13Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/58/2b356b8a81eb97637dccee6cf58237198dd828890e38be9afb4e5e58e38e/bottleneck-1.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2baae0d1589b4a520b2f9cf03528c0c8b20717b3f05675e212ec2200cf628f12", size = 383443, upload-time = "2025-09-08T16:30:14.318Z" },
-    { url = "https://files.pythonhosted.org/packages/55/52/cf7d09ed3736ad0d50c624787f9b580ae3206494d95cc0f4814b93eef728/bottleneck-1.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2e407139b322f01d8d5b6b2e8091b810f48a25c7fa5c678cfcdc420dfe8aea0a", size = 375458, upload-time = "2025-09-08T16:30:15.379Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/e9/7c87a34a24e339860064f20fac49f6738e94f1717bc8726b9c47705601d8/bottleneck-1.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1adefb89b92aba6de9c6ea871d99bcd29d519f4fb012cc5197917813b4fc2c7f", size = 386384, upload-time = "2025-09-08T16:30:17.012Z" },
-    { url = "https://files.pythonhosted.org/packages/59/57/db51855e18a47671801180be748939b4c9422a0544849af1919116346b5f/bottleneck-1.6.0-cp313-cp313t-win32.whl", hash = "sha256:64b8690393494074923780f6abdf5f5577d844b9d9689725d1575a936e74e5f0", size = 109448, upload-time = "2025-09-08T16:30:18.076Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/1e/683c090b624f13a5bf88a0be2241dc301e98b2fb72a45812a7ae6e456cc4/bottleneck-1.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:cb67247f65dcdf62af947c76c6c8b77d9f0ead442cac0edbaa17850d6da4e48d", size = 115190, upload-time = "2025-09-08T16:30:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/77/e2/eb7c08964a3f3c4719f98795ccd21807ee9dd3071a0f9ad652a5f19196ff/bottleneck-1.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98f1d789042511a0f042b3bdcd2903e8567e956d3aa3be189cce3746daeb8550", size = 100544, upload-time = "2025-09-08T16:30:20.22Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ec/c6f3be848f37689f481797ce7d9807d5f69a199d7fc0e46044f9b708c468/bottleneck-1.6.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1fad24c99e39ad7623fc2a76d37feb26bd32e4dd170885edf4dbf4bfce2199a3", size = 378315, upload-time = "2025-09-08T16:30:21.409Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/8f/2d6600836e2ea8f14fcefac592dc83497e5b88d381470c958cb9cdf88706/bottleneck-1.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643e61e50a6f993debc399b495a1609a55b3bd76b057e433e4089505d9f605c7", size = 368978, upload-time = "2025-09-08T16:30:23.458Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/b5/bf72b49f5040212873b985feef5050015645e0a02204b591e1d265fc522a/bottleneck-1.6.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa668efbe4c6b200524ea0ebd537212da9b9801287138016fdf64119d6fcf201", size = 362074, upload-time = "2025-09-08T16:30:24.71Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/c8/c4891a0604eb680031390182c6e264247e3a9a8d067d654362245396fadf/bottleneck-1.6.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9f7dd35262e89e28fedd79d45022394b1fa1aceb61d2e747c6d6842e50546daa", size = 374019, upload-time = "2025-09-08T16:30:26.438Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/2d/ed096f8d1b9147e84914045dd89bc64e3c32eee49b862d1e20d573a9ab0d/bottleneck-1.6.0-cp314-cp314-win32.whl", hash = "sha256:bd90bec3c470b7fdfafc2fbdcd7a1c55a4e57b5cdad88d40eea5bc9bab759bf1", size = 110173, upload-time = "2025-09-08T16:30:27.521Z" },
-    { url = "https://files.pythonhosted.org/packages/33/70/1414acb6ae378a15063cfb19a0a39d69d1b6baae1120a64d2b069902549b/bottleneck-1.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:b43b6d36a62ffdedc6368cf9a708e4d0a30d98656c2b5f33d88894e1bcfd6857", size = 115899, upload-time = "2025-09-08T16:30:28.524Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ed/4570b5d8c1c85ce3c54963ebc37472231ed54f0b0d8dbb5dde14303f775f/bottleneck-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:53296707a8e195b5dcaa804b714bd222b5e446bd93cd496008122277eb43fa87", size = 101615, upload-time = "2025-09-08T16:30:29.556Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/93/c148faa07ae91f266be1f3fad1fde95aa2449e12937f3f3df2dd720b86e0/bottleneck-1.6.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d6df19cc48a83efd70f6d6874332aa31c3f5ca06a98b782449064abbd564cf0e", size = 392411, upload-time = "2025-09-08T16:30:31.186Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/1c/e6ad221d345a059e7efb2ad1d46a22d9fdae0486faef70555766e1123966/bottleneck-1.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96bb3a52cb3c0aadfedce3106f93ab940a49c9d35cd4ed612e031f6deb27e80f", size = 384022, upload-time = "2025-09-08T16:30:32.364Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/40/5b15c01eb8c59d59bc84c94d01d3d30797c961f10ec190f53c27e05d62ab/bottleneck-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d1db9e831b69d5595b12e79aeb04cb02873db35576467c8dd26cdc1ee6b74581", size = 376004, upload-time = "2025-09-08T16:30:33.731Z" },
-    { url = "https://files.pythonhosted.org/packages/74/f6/cb228f5949553a5c01d1d5a3c933f0216d78540d9e0bf8dd4343bb449681/bottleneck-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4dd7ac619570865fcb7a0e8925df418005f076286ad2c702dd0f447231d7a055", size = 386909, upload-time = "2025-09-08T16:30:34.973Z" },
-    { url = "https://files.pythonhosted.org/packages/09/9a/425065c37a67a9120bf53290371579b83d05bf46f3212cce65d8c01d470a/bottleneck-1.6.0-cp314-cp314t-win32.whl", hash = "sha256:7fb694165df95d428fe00b98b9ea7d126ef786c4a4b7d43ae2530248396cadcb", size = 111636, upload-time = "2025-09-08T16:30:36.044Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/23/c41006e42909ec5114a8961818412310aa54646d1eae0495dbff3598a095/bottleneck-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:174b80930ce82bd8456c67f1abb28a5975c68db49d254783ce2cb6983b4fea40", size = 117611, upload-time = "2025-09-08T16:30:37.055Z" },
-]
-
-[[package]]
-name = "bs4"
-version = "0.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/aa/4acaf814ff901145da37332e05bb510452ebed97bc9602695059dd46ef39/bs4-0.0.2.tar.gz", hash = "sha256:a48685c58f50fe127722417bae83fe6badf500d54b55f7e39ffe43b798653925", size = 698, upload-time = "2024-01-17T18:15:47.371Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/bb/bf7aab772a159614954d84aa832c129624ba6c32faa559dfb200a534e50b/bs4-0.0.2-py2.py3-none-any.whl", hash = "sha256:abf8742c0805ef7f662dce4b51cca104cffe52b835238afc169142ab9b3fbccc", size = 1189, upload-time = "2024-01-17T18:15:48.613Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -126,7 +68,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and sys_platform == 'win32'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -270,25 +212,14 @@ wheels = [
 ]
 
 [[package]]
-name = "defusedxml"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
 name = "dify-extractor"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },
-    { name = "bs4" },
     { name = "chardet" },
     { name = "dify-plugin" },
     { name = "openpyxl" },
-    { name = "pandas", extra = ["excel", "output-formatting", "performance"] },
     { name = "pydantic" },
     { name = "pypdfium2" },
     { name = "python-docx" },
@@ -301,16 +232,16 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
+    { name = "xlwt" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
-    { name = "bs4", specifier = ">=0.0.2" },
     { name = "chardet", specifier = ">=7.4.3" },
     { name = "dify-plugin", specifier = ">=0.9.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
-    { name = "pandas", extras = ["excel", "output-formatting", "performance"], specifier = ">=3.0.3" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pypdfium2", specifier = ">=5.8.0" },
     { name = "python-docx", specifier = ">=1.2.0" },
@@ -321,7 +252,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.1.1" }]
+dev = [
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.14.0" },
+    { name = "xlwt", specifier = ">=1.3.0" },
+]
 
 [[package]]
 name = "dify-plugin"
@@ -576,30 +511,6 @@ wheels = [
 ]
 
 [[package]]
-name = "llvmlite"
-version = "0.47.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
-    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
-    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
-    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
-    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
-    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
-    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
-    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
-    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
-]
-
-[[package]]
 name = "lxml"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -842,155 +753,6 @@ wheels = [
 ]
 
 [[package]]
-name = "numba"
-version = "0.65.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "llvmlite" },
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
-    { url = "https://files.pythonhosted.org/packages/69/47/a415af0283e4db0398104c6d1c11c9861a98dc67a7aa442a7769ed5d6196/numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84", size = 3802467, upload-time = "2026-04-24T02:02:27.712Z" },
-    { url = "https://files.pythonhosted.org/packages/46/36/246f73ec99cfeab2f2cb2ce7d4218766cc36a2da418901223f4f4da9c813/numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977", size = 3502628, upload-time = "2026-04-24T02:02:29.763Z" },
-    { url = "https://files.pythonhosted.org/packages/db/9e/3c679b2ee078425b9e99a91e44f8d132a6830d8ccce5227bc5e9181aeed8/numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a", size = 2750611, upload-time = "2026-04-24T02:02:31.477Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b", size = 3810619, upload-time = "2026-04-24T02:02:36.041Z" },
-    { url = "https://files.pythonhosted.org/packages/62/08/e16a8b5d9a018962ebb5c66be662317cde32b9f5dab08441f90bed5522fb/numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464", size = 3509783, upload-time = "2026-04-24T02:02:38.245Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/a5/03c970d57f4c1741354837353ce39fb5206952ae1dba8922d29c86f64805/numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62", size = 2750534, upload-time = "2026-04-24T02:02:39.903Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
-    { url = "https://files.pythonhosted.org/packages/87/96/f3eb235fafa82a34e2ab5dd7dc9ffff998ebf5f0bbc23fa56a96aeb44da6/numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7", size = 3779602, upload-time = "2026-04-24T02:02:43.726Z" },
-    { url = "https://files.pythonhosted.org/packages/09/90/b0f09b48752d23640b8284f22aa597737e8adaddc7fbfacc4708b7f73a4c/numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35", size = 3479532, upload-time = "2026-04-24T02:02:45.427Z" },
-    { url = "https://files.pythonhosted.org/packages/56/46/3f7fc04fb853559e74b210e0b62c19974ec844cefec611f9e535f4da3761/numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63", size = 2752637, upload-time = "2026-04-24T02:02:47.664Z" },
-    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
-    { url = "https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d", size = 3817198, upload-time = "2026-04-24T02:02:51.266Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/83/0dad21057ece5a835599f5d24099b091703995e23dbbf894f259e91c010b/numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20", size = 3533862, upload-time = "2026-04-24T02:02:52.987Z" },
-    { url = "https://files.pythonhosted.org/packages/32/36/8be7118ffd4c8440881046eac3d0982cc5ab42909508cf5d67024d62a2e4/numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38", size = 2758237, upload-time = "2026-04-24T02:02:54.612Z" },
-]
-
-[[package]]
-name = "numexpr"
-version = "2.14.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/2f/fdba158c9dbe5caca9c3eca3eaffffb251f2fb8674bf8e2d0aed5f38d319/numexpr-2.14.1.tar.gz", hash = "sha256:4be00b1086c7b7a5c32e31558122b7b80243fe098579b170967da83f3152b48b", size = 119400, upload-time = "2025-10-13T16:17:27.351Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/20/c473fc04a371f5e2f8c5749e04505c13e7a8ede27c09e9f099b2ad6f43d6/numexpr-2.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:91ebae0ab18c799b0e6b8c5a8d11e1fa3848eb4011271d99848b297468a39430", size = 162790, upload-time = "2025-10-13T16:16:34.903Z" },
-    { url = "https://files.pythonhosted.org/packages/45/93/b6760dd1904c2a498e5f43d1bb436f59383c3ddea3815f1461dfaa259373/numexpr-2.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47041f2f7b9e69498fb311af672ba914a60e6e6d804011caacb17d66f639e659", size = 152196, upload-time = "2025-10-13T16:16:36.593Z" },
-    { url = "https://files.pythonhosted.org/packages/72/94/cc921e35593b820521e464cbbeaf8212bbdb07f16dc79fe283168df38195/numexpr-2.14.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d686dfb2c1382d9e6e0ee0b7647f943c1886dba3adbf606c625479f35f1956c1", size = 452468, upload-time = "2025-10-13T16:13:29.531Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/43/560e9ba23c02c904b5934496486d061bcb14cd3ebba2e3cf0e2dccb6c22b/numexpr-2.14.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee6d4fbbbc368e6cdd0772734d6249128d957b3b8ad47a100789009f4de7083", size = 443631, upload-time = "2025-10-13T16:15:02.473Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/6c/78f83b6219f61c2c22d71ab6e6c2d4e5d7381334c6c29b77204e59edb039/numexpr-2.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3a2839efa25f3c8d4133252ea7342d8f81226c7c4dda81f97a57e090b9d87a48", size = 1417670, upload-time = "2025-10-13T16:13:33.464Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/bb/1ccc9dcaf46281568ce769888bf16294c40e98a5158e4b16c241de31d0d3/numexpr-2.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9f9137f1351b310436662b5dc6f4082a245efa8950c3b0d9008028df92fefb9b", size = 1466212, upload-time = "2025-10-13T16:15:12.828Z" },
-    { url = "https://files.pythonhosted.org/packages/31/9f/203d82b9e39dadd91d64bca55b3c8ca432e981b822468dcef41a4418626b/numexpr-2.14.1-cp312-cp312-win32.whl", hash = "sha256:36f8d5c1bd1355df93b43d766790f9046cccfc1e32b7c6163f75bcde682cda07", size = 166996, upload-time = "2025-10-13T16:17:10.369Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/67/ffe750b5452eb66de788c34e7d21ec6d886abb4d7c43ad1dc88ceb3d998f/numexpr-2.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:fdd886f4b7dbaf167633ee396478f0d0aa58ea2f9e7ccc3c6431019623e8d68f", size = 160187, upload-time = "2025-10-13T16:17:11.974Z" },
-    { url = "https://files.pythonhosted.org/packages/73/b4/9f6d637fd79df42be1be29ee7ba1f050fab63b7182cb922a0e08adc12320/numexpr-2.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:09078ba73cffe94745abfbcc2d81ab8b4b4e9d7bfbbde6cac2ee5dbf38eee222", size = 162794, upload-time = "2025-10-13T16:16:38.291Z" },
-    { url = "https://files.pythonhosted.org/packages/35/ae/d58558d8043de0c49f385ea2fa789e3cfe4d436c96be80200c5292f45f15/numexpr-2.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dce0b5a0447baa7b44bc218ec2d7dcd175b8eee6083605293349c0c1d9b82fb6", size = 152203, upload-time = "2025-10-13T16:16:39.907Z" },
-    { url = "https://files.pythonhosted.org/packages/13/65/72b065f9c75baf8f474fd5d2b768350935989d4917db1c6c75b866d4067c/numexpr-2.14.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06855053de7a3a8425429bd996e8ae3c50b57637ad3e757e0fa0602a7874be30", size = 455860, upload-time = "2025-10-13T16:13:35.811Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/f9/c9457652dfe28e2eb898372da2fe786c6db81af9540c0f853ee04a0699cc/numexpr-2.14.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f9366d23a2e991fd5a8b5e61a17558f028ba86158a4552f8f239b005cdf83c", size = 446574, upload-time = "2025-10-13T16:15:17.367Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/99/8d3879c4d67d3db5560cf2de65ce1778b80b75f6fa415eb5c3e7bd37ba27/numexpr-2.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c5f1b1605695778896534dfc6e130d54a65cd52be7ed2cd0cfee3981fd676bf5", size = 1417306, upload-time = "2025-10-13T16:13:42.813Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/05/6bddac9f18598ba94281e27a6943093f7d0976544b0cb5d92272c64719bd/numexpr-2.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a4ba71db47ea99c659d88ee6233fa77b6dc83392f1d324e0c90ddf617ae3f421", size = 1466145, upload-time = "2025-10-13T16:15:27.464Z" },
-    { url = "https://files.pythonhosted.org/packages/24/5d/cbeb67aca0c5a76ead13df7e8bd8dd5e0d49145f90da697ba1d9f07005b0/numexpr-2.14.1-cp313-cp313-win32.whl", hash = "sha256:638dce8320f4a1483d5ca4fda69f60a70ed7e66be6e68bc23fb9f1a6b78a9e3b", size = 166996, upload-time = "2025-10-13T16:17:13.803Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/23/9281bceaeb282cead95f0aa5f7f222ffc895670ea689cc1398355f6e3001/numexpr-2.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:9fdcd4735121658a313f878fd31136d1bfc6a5b913219e7274e9fca9f8dac3bb", size = 160189, upload-time = "2025-10-13T16:17:15.417Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/76/7aac965fd93a56803cbe502aee2adcad667253ae34b0badf6c5af7908b6c/numexpr-2.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:557887ad7f5d3c2a40fd7310e50597045a68e66b20a77b3f44d7bc7608523b4b", size = 163524, upload-time = "2025-10-13T16:16:42.213Z" },
-    { url = "https://files.pythonhosted.org/packages/58/65/79d592d5e63fbfab3b59a60c386853d9186a44a3fa3c87ba26bdc25b6195/numexpr-2.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:af111c8fe6fc55d15e4c7cab11920fc50740d913636d486545b080192cd0ad73", size = 152919, upload-time = "2025-10-13T16:16:44.229Z" },
-    { url = "https://files.pythonhosted.org/packages/84/78/3c8335f713d4aeb99fa758d7c62f0be1482d4947ce5b508e2052bb7aeee9/numexpr-2.14.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33265294376e7e2ae4d264d75b798a915d2acf37b9dd2b9405e8b04f84d05cfc", size = 465972, upload-time = "2025-10-13T16:13:45.061Z" },
-    { url = "https://files.pythonhosted.org/packages/35/81/9ee5f69b811e8f18746c12d6f71848617684edd3161927f95eee7a305631/numexpr-2.14.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83647d846d3eeeb9a9255311236135286728b398d0d41d35dedb532dca807fe9", size = 456953, upload-time = "2025-10-13T16:15:31.186Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/39/9b8bc6e294d85cbb54a634e47b833e9f3276a8bdf7ce92aa808718a0212d/numexpr-2.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6e575fd3ad41ddf3355d0c7ef6bd0168619dc1779a98fe46693cad5e95d25e6e", size = 1426199, upload-time = "2025-10-13T16:13:48.231Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/ce/0d4fcd31ab49319740d934fba1734d7dad13aa485532ca754e555ca16c8b/numexpr-2.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:67ea4771029ce818573b1998f5ca416bd255156feea017841b86176a938f7d19", size = 1474214, upload-time = "2025-10-13T16:15:38.893Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/47/b2a93cbdb3ba4e009728ad1b9ef1550e2655ea2c86958ebaf03b9615f275/numexpr-2.14.1-cp313-cp313t-win32.whl", hash = "sha256:15015d47d3d1487072d58c0e7682ef2eb608321e14099c39d52e2dd689483611", size = 167676, upload-time = "2025-10-13T16:17:17.351Z" },
-    { url = "https://files.pythonhosted.org/packages/86/99/ee3accc589ed032eea68e12172515ed96a5568534c213ad109e1f4411df1/numexpr-2.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:94c711f6d8f17dfb4606842b403699603aa591ab9f6bf23038b488ea9cfb0f09", size = 161096, upload-time = "2025-10-13T16:17:19.174Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/36/9db78dfbfdfa1f8bf0872993f1a334cdd8fca5a5b6567e47dcb128bcb7c2/numexpr-2.14.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ede79f7ff06629f599081de644546ce7324f1581c09b0ac174da88a470d39c21", size = 162848, upload-time = "2025-10-13T16:16:46.216Z" },
-    { url = "https://files.pythonhosted.org/packages/13/c1/a5c78ae637402c5550e2e0ba175275d2515d432ec28af0cdc23c9b476e65/numexpr-2.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2eac7a5a2f70b3768c67056445d1ceb4ecd9b853c8eda9563823b551aeaa5082", size = 152270, upload-time = "2025-10-13T16:16:47.92Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/ed/aabd8678077848dd9a751c5558c2057839f5a09e2a176d8dfcd0850ee00e/numexpr-2.14.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5aedf38d4c0c19d3cecfe0334c3f4099fb496f54c146223d30fa930084bc8574", size = 455918, upload-time = "2025-10-13T16:13:50.338Z" },
-    { url = "https://files.pythonhosted.org/packages/88/e1/3db65117f02cdefb0e5e4c440daf1c30beb45051b7f47aded25b7f4f2f34/numexpr-2.14.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439ec4d57b853792ebe5456e3160312281c3a7071ecac5532ded3278ede614de", size = 446512, upload-time = "2025-10-13T16:15:42.313Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/fb/7ceb9ee55b5f67e4a3e4d73d5af4c7e37e3c9f37f54bee90361b64b17e3f/numexpr-2.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e23b87f744e04e302d82ac5e2189ae20a533566aec76a46885376e20b0645bf8", size = 1417845, upload-time = "2025-10-13T16:13:53.836Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2d/9b5764d0eafbbb2889288f80de773791358acf6fad1a55767538d8b79599/numexpr-2.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:44f84e0e5af219dbb62a081606156420815890e041b87252fbcea5df55214c4c", size = 1466211, upload-time = "2025-10-13T16:15:48.985Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/21/204db708eccd71aa8bc55bcad55bc0fc6c5a4e01ad78e14ee5714a749386/numexpr-2.14.1-cp314-cp314-win32.whl", hash = "sha256:1f1a5e817c534539351aa75d26088e9e1e0ef1b3a6ab484047618a652ccc4fc3", size = 168835, upload-time = "2025-10-13T16:17:20.82Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/3e/d83e9401a1c3449a124f7d4b3fb44084798e0d30f7c11e60712d9b94cf11/numexpr-2.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:587c41509bc373dfb1fe6086ba55a73147297247bedb6d588cda69169fc412f2", size = 162608, upload-time = "2025-10-13T16:17:22.228Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/d6/ec947806bb57836d6379a8c8a253c2aeaa602b12fef2336bfd2462bb4ed5/numexpr-2.14.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ec368819502b64f190c3f71be14a304780b5935c42aae5bf22c27cc2cbba70b5", size = 163525, upload-time = "2025-10-13T16:16:50.133Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/77/048f30dcf661a3d52963a88c29b52b6d5ce996d38e9313a56a922451c1e0/numexpr-2.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e87f6d203ac57239de32261c941e9748f9309cbc0da6295eabd0c438b920d3a", size = 152917, upload-time = "2025-10-13T16:16:52.055Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/d3/956a13e628d722d649fbf2fded615134a308c082e122a48bad0e90a99ce9/numexpr-2.14.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd72d8c2a165fe45ea7650b16eb8cc1792a94a722022006bb97c86fe51fd2091", size = 466242, upload-time = "2025-10-13T16:13:55.795Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/dd/abe848678d82486940892f2cacf39e82eec790e8930d4d713d3f9191063b/numexpr-2.14.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70d80fcb418a54ca208e9a38e58ddc425c07f66485176b261d9a67c7f2864f73", size = 457149, upload-time = "2025-10-13T16:15:52.036Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/bb/797b583b5fb9da5700a5708ca6eb4f889c94d81abb28de4d642c0f4b3258/numexpr-2.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:edea2f20c2040df8b54ee8ca8ebda63de9545b2112872466118e9df4d0ae99f3", size = 1426493, upload-time = "2025-10-13T16:13:59.244Z" },
-    { url = "https://files.pythonhosted.org/packages/77/c4/0519ab028fdc35e3e7ee700def7f2b4631b175cd9e1202bd7966c1695c33/numexpr-2.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:790447be6879a6c51b9545f79612d24c9ea0a41d537a84e15e6a8ddef0b6268e", size = 1474413, upload-time = "2025-10-13T16:15:59.211Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/4a/33044878c8f4a75213cfe9c11d4c02058bb710a7a063fe14f362e8de1077/numexpr-2.14.1-cp314-cp314t-win32.whl", hash = "sha256:538961096c2300ea44240209181e31fae82759d26b51713b589332b9f2a4117e", size = 169502, upload-time = "2025-10-13T16:17:23.829Z" },
-    { url = "https://files.pythonhosted.org/packages/41/a2/5a1a2c72528b429337f49911b18c302ecd36eeab00f409147e1aa4ae4519/numexpr-2.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a40b350cd45b4446076fa11843fa32bbe07024747aeddf6d467290bf9011b392", size = 163589, upload-time = "2025-10-13T16:17:25.696Z" },
-]
-
-[[package]]
-name = "numpy"
-version = "2.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
-    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
-    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
-    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
-    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
-    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
-    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
-    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
-    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
-    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
-    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
-    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
-    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
-    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
-    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
-]
-
-[[package]]
-name = "odfpy"
-version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "defusedxml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/97/73/8ade73f6749177003f7ce3304f524774adda96e6aaab30ea79fd8fda7934/odfpy-1.4.1.tar.gz", hash = "sha256:db766a6e59c5103212f3cc92ec8dd50a0f3a02790233ed0b52148b70d3c438ec", size = 717045, upload-time = "2020-01-18T16:55:48.852Z" }
-
-[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1009,77 +771,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
-]
-
-[[package]]
-name = "pandas"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
-    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
-    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
-    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
-    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
-    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
-    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
-    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
-    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
-    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
-    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
-    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
-    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
-    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
-]
-
-[package.optional-dependencies]
-excel = [
-    { name = "odfpy" },
-    { name = "openpyxl" },
-    { name = "python-calamine" },
-    { name = "pyxlsb" },
-    { name = "xlrd" },
-    { name = "xlsxwriter" },
-]
-output-formatting = [
-    { name = "jinja2" },
-    { name = "tabulate" },
-]
-performance = [
-    { name = "bottleneck" },
-    { name = "numba" },
-    { name = "numexpr" },
 ]
 
 [[package]]
@@ -1422,94 +1113,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-calamine"
-version = "0.6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/18/e1e53ade001b30a3c6642d876e5defe8431da8c31fb7798909e6c8ab8c34/python_calamine-0.6.2.tar.gz", hash = "sha256:2c90e5224c5e92db9fcd8f22b6085ce63b935cfe7a893ac9a1c3c56793bafd9d", size = 138000, upload-time = "2026-02-18T13:38:17.389Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/ec/e111c1a3a4c138ebc41e416e33730ee6d7c54e714af21c2a4e59b41715a5/python_calamine-0.6.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:857e4cddadba9b55c76dc583c58c5dc101a6cd5320190c10f8b2ab98d66c9040", size = 879539, upload-time = "2026-02-18T13:36:21.674Z" },
-    { url = "https://files.pythonhosted.org/packages/53/26/fe4c2138ff21542e2f1130a4d83c330d7f9486b62775196e998b88a03de6/python_calamine-0.6.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cd89d6a53e4b22328cd685fc054c31d359cb3ae67bd24bc57e1c1db62a4cfc97", size = 858642, upload-time = "2026-02-18T13:36:23.847Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b0/bfeaf45ac5e2f6553723dd2fbe127d1d17c6f26496db5781de42a933776a/python_calamine-0.6.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d6c9af39db39e0c70710ae79cd1b5d980f9c0aea55fc16d194460c1561a0c6a", size = 925242, upload-time = "2026-02-18T13:36:25.236Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/6e/81106aa80609075015d400584030605b05f5e12931717160dcc58fdc4980/python_calamine-0.6.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a2382dbc410dd48c99d89ee460662cc70892fe1b2901ab982604b923e8eb8f6", size = 905295, upload-time = "2026-02-18T13:36:27.152Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/ba/6311b24f9889246be63b664630c5601039ef771f7ed04c8f51aace39b7a9/python_calamine-0.6.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3ebb93255709874ede5b5e62828cb5758e60097e5390b6c9a3eb7751b617b12e", size = 1063473, upload-time = "2026-02-18T13:36:29.226Z" },
-    { url = "https://files.pythonhosted.org/packages/23/e4/027a1b046d30768872307ebe808dc4cdc5357295cdcda98b30b3ea924904/python_calamine-0.6.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:837bca19bd945cb83aded433f4cf76e80d70a5400404d876400ca7e88e5ea311", size = 965355, upload-time = "2026-02-18T13:36:31.376Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/4d/da8716a1b3a66938aaabe36873f6fa210fa063bab1b20c2ec236013de6b3/python_calamine-0.6.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:723990a47668cb819f307ccc634741370d3cd3804a0ee8cda392a522ae6d5016", size = 935091, upload-time = "2026-02-18T13:36:32.777Z" },
-    { url = "https://files.pythonhosted.org/packages/36/40/9521e8da5496cbc4b18027626a40018301f546b3e9802ca2f3a6cb5b4739/python_calamine-0.6.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b067630d693e1d7de41e3d44a99c7dd3feebb52db8dda8636ac3f70d8b6a4ad6", size = 974070, upload-time = "2026-02-18T13:36:34.055Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/b0/7a63963512c5ba7e9539b7452e2b1561625e63e4e29c044e487e2e93dcbe/python_calamine-0.6.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:6ab09c9da53a2b33633e9f940aed11c08e083810a0fd6885826cdc52ba4f86a5", size = 1100321, upload-time = "2026-02-18T13:36:35.475Z" },
-    { url = "https://files.pythonhosted.org/packages/22/81/e2bc38a5cf9629f656adcdabe8e134028f60c236e4bb96375dda90db3fdd/python_calamine-0.6.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:ae08e1308a0d0c6b8b4cc0a039ed8a85fc9ee2f8a3ca9ea57b1af9f97ed68fe4", size = 1181039, upload-time = "2026-02-18T13:36:37.195Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ea/513117015fd5903ca6dde9c8fb8502af60af6965642f4e3311623943e673/python_calamine-0.6.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c441a20c7aff0e904ca01b5cdc1e5be2c6d4a41a24a0ea4d5ea6d211343bb95f", size = 1144843, upload-time = "2026-02-18T13:36:38.393Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/14/8846478dacf31535f5f15448ade3bc688b51f3183f1b52844451aa27b0e6/python_calamine-0.6.2-cp312-cp312-win32.whl", hash = "sha256:39cae8e66f8bce499f5f965f4575ddf61e30184cc97f02e1c7031a57abe0903b", size = 692411, upload-time = "2026-02-18T13:36:39.741Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/e2/2d2dcf4ec7e5ec08e33bf966ab010a7be178a4b623bd5f7601d47f2c734c/python_calamine-0.6.2-cp312-cp312-win_amd64.whl", hash = "sha256:1617efa24532f2420934a8cf77e6d33ff1740cae1d39355cab4f4cf141fdab49", size = 748960, upload-time = "2026-02-18T13:36:40.922Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/eb/2f50f3395c0435e6186cab56c36d04c06581ba827264bca1f1acae523aa3/python_calamine-0.6.2-cp312-cp312-win_arm64.whl", hash = "sha256:c2b378db494740e540e8157a7e5fe61dadae69ad2d988a7c80f9583f434acf07", size = 718992, upload-time = "2026-02-18T13:36:42.671Z" },
-    { url = "https://files.pythonhosted.org/packages/15/db/f409c3ffa5d452b8184978c94440b48c933c79232c5e40fe9ce3608ff06d/python_calamine-0.6.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:4c6e68c233841604fa3f63899d13bd2e47cddf0787c4b4b8188f74c3be452045", size = 878907, upload-time = "2026-02-18T13:36:44.039Z" },
-    { url = "https://files.pythonhosted.org/packages/66/fe/8cf4309a00ad5628c45e69f13352d6a1e0e0a3148a2fc28d7a43a8cefec9/python_calamine-0.6.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0fd5bcbd904d05f8b9f127a93706fdbb0a5934efdc9677b402a82d91e6e3f920", size = 858314, upload-time = "2026-02-18T13:36:45.28Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/cc/c5edfb89a99d19c66b029e2e6dc0db052709888753fc0a771bf28343c5e5/python_calamine-0.6.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cef6454aa1b3b2137d7a202c9f84b87dffdd187ff218f2cee459480c102c20a3", size = 924748, upload-time = "2026-02-18T13:36:46.462Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/bd/d0504a0e85b1588ad4ddb97f2ba003d22d9ae7cd719b82a5be2e71d97519/python_calamine-0.6.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:19c55c35edaf89b4d18d5d3cfaac619362f2e8339e4c876f9f0c80640d990db3", size = 903646, upload-time = "2026-02-18T13:36:47.737Z" },
-    { url = "https://files.pythonhosted.org/packages/94/1d/7cf92a77e83f62b8a106af36aa6b314f4b42abc7959787e5a746de4b0525/python_calamine-0.6.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d29984496a22286f511668ea6483293c0e58ac0f25916e1d88125e5e1d83313b", size = 1063499, upload-time = "2026-02-18T13:36:48.998Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/2b/1d90207328fa7f8e74ce13337ae2965669e762877846dab3db8a6f90dec3/python_calamine-0.6.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b0c4deabc2646c6c07abb3620088c5d6d2af26f8954726938ebcdbc6c56a8bd", size = 964671, upload-time = "2026-02-18T13:36:50.289Z" },
-    { url = "https://files.pythonhosted.org/packages/30/2a/7a58828ef14801b4efb323ad9b1ae3d2d2e82e1c5ce35502189e7a201a14/python_calamine-0.6.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc536feb86c948b330c4db8a9f1d9f9094f8d70a981d04de87ece9d9b9300458", size = 935016, upload-time = "2026-02-18T13:36:51.628Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/63/08c63af2d5074d96b808ad7ae4cb04a3ab59d8d6260223b4d03d99b9cf49/python_calamine-0.6.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7c0f9e769c735cfb0564aefb4273c6dfeee9fbab1db69b9099cb19cfb8208ddf", size = 973549, upload-time = "2026-02-18T13:36:52.913Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/91/ea25bd171222b9bab1f79e5cb923b891903afbcb19c5241528f9d87b80a9/python_calamine-0.6.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:e3824c211eb9505461a9820ed893cf6e39a3af8024fd1892d2cc174ce8329955", size = 1100508, upload-time = "2026-02-18T13:36:54.497Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/21/79f4095e53b4935e36e9e2ed5c7d9683fb448dd9c1bba69144277df9b3a6/python_calamine-0.6.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:8323edededa282cace538805cfa7cab30ad9dd19bca4a23215ea975c73ce9f26", size = 1177921, upload-time = "2026-02-18T13:36:56.339Z" },
-    { url = "https://files.pythonhosted.org/packages/67/02/d0328a96f2cac5cd7d13e50691207b6c06f33b22010d70d3dafde13e50fd/python_calamine-0.6.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f64b93e41dd878a317f958fbf9bfa64342ef9aea58956a93a52d4b9d646a6ef4", size = 1144850, upload-time = "2026-02-18T13:36:57.812Z" },
-    { url = "https://files.pythonhosted.org/packages/28/8c/97012240a29ad22a8a2fb69097d4de52e48a05b7e6cddda9916eec439c83/python_calamine-0.6.2-cp313-cp313-win32.whl", hash = "sha256:91fbfa837aaa6f7fc72e9277678aa0c95b0c3c7df76c7c7bac4ab4a128834a70", size = 691860, upload-time = "2026-02-18T13:36:59.156Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/35/f505780ba2228510412837a56bd9fb1721b021c2203afa10e25aebe67751/python_calamine-0.6.2-cp313-cp313-win_amd64.whl", hash = "sha256:0b2464e036819ecce50181220e120d674b1caac806a31e48eed2e2183acf9a69", size = 748488, upload-time = "2026-02-18T13:37:01.432Z" },
-    { url = "https://files.pythonhosted.org/packages/12/67/309ec85184f189709d238c9f2ec1b056354a8310a4eacefbfdd17b47061c/python_calamine-0.6.2-cp313-cp313-win_arm64.whl", hash = "sha256:64b1ce2bd452a9d2ae00a97e2629e3444b9669ce348e1f534f3a91f55694de15", size = 718567, upload-time = "2026-02-18T13:37:02.773Z" },
-    { url = "https://files.pythonhosted.org/packages/66/a4/0be8520de23b10d3e9179fe620e22ea7ef5f864152cd7ce322df1c9f707a/python_calamine-0.6.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:050f0b830fcdf209826e98849432fb6ee1328895949bf7c63632fd34130cef8d", size = 877980, upload-time = "2026-02-18T13:37:03.932Z" },
-    { url = "https://files.pythonhosted.org/packages/72/92/c6f3e47f84bd9b0298f63dca7a47136121c8a180b09660728ba381eb10a4/python_calamine-0.6.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f3636e14736cd2ab2377418aeb2ef8c17d1ce7e19bbbe52e445027cf43a2a745", size = 857296, upload-time = "2026-02-18T13:37:05.14Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/60/bb3cc5a7bfd5618307262c1234c38a137532ac17c4c385364a6594c59d91/python_calamine-0.6.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f86a51485f93264679eb449dc93dc498553f449322c81936eac47ace45365e89", size = 923713, upload-time = "2026-02-18T13:37:06.333Z" },
-    { url = "https://files.pythonhosted.org/packages/20/b9/156223f20a685071223bff0f9d220511ed9012e6ba96cede417dde13abcb/python_calamine-0.6.2-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b44fbdd11ac44dc5eecf49c1597e7234633cbc9f38c73521ce00278cf0bd8976", size = 902503, upload-time = "2026-02-18T13:37:07.696Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/5b/64f62bbdaaaf7b8fec3c509038edc3cecf7f6dd8539828baf03ba45854ee/python_calamine-0.6.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a0d5fd48c92ae04bf8ef1f326d7ec23295545d171f4b810dc8fa08f28932900f", size = 1061675, upload-time = "2026-02-18T13:37:09.006Z" },
-    { url = "https://files.pythonhosted.org/packages/be/7e/0c440a6aac2b35328e6de7055ea20424456118e67f934ee778a79060f9f3/python_calamine-0.6.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:19363504d08c5c2c7aca188a5c4ded89a47cbba1cbc9a083cd230839f977c5a8", size = 962969, upload-time = "2026-02-18T13:37:10.248Z" },
-    { url = "https://files.pythonhosted.org/packages/66/25/fcbe045e5595a6bc734e6e091909b64099a69725f8335596a6493c21aa05/python_calamine-0.6.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72078b550a871249c07b71fe5b94fbd30857604ff99380304d273d84a8bcd7c8", size = 934205, upload-time = "2026-02-18T13:37:11.649Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/44/361972390dea31d700b8a8974510cf7d5cac0a0bc563fa1726879b801e2f/python_calamine-0.6.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e18e524ef1532f8269739b63ca9c6ab7dbd75e9dff20ca7e2e2d8d13c59964b2", size = 971168, upload-time = "2026-02-18T13:37:12.95Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f8/635566a955138d14fd1ecbc49be48f9add3e2107861507ce1fefd92192a9/python_calamine-0.6.2-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:b665c55d5d03b5cc205e4b68c711712cff8aac273f2aa930ab8ab5960b9dc90f", size = 1099592, upload-time = "2026-02-18T13:37:14.312Z" },
-    { url = "https://files.pythonhosted.org/packages/57/12/6b02a3adba57ed2ef7f2ed5ffa557f6a29a06a77f1fd40770ab3d530d2c9/python_calamine-0.6.2-cp313-cp313t-musllinux_1_1_armv7l.whl", hash = "sha256:dc21843a6fca8ae5a722e66bde14324da4f43be98b772b0689ac75dd89d888fd", size = 1176734, upload-time = "2026-02-18T13:37:15.581Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/fb/b6ffd03dc468b0e3bb5747b747bcb4cdd6a98fea7b0f444d8600f2ebaa4e/python_calamine-0.6.2-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:e16192fbbb3a3009c89aa62530d807bca272e68a67b362da5c9d156a8950cd51", size = 1143744, upload-time = "2026-02-18T13:37:18.425Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/95/ca5d3f09c98d0420fb03643aea3897c2d68e77df7d3108ad660e9024c277/python_calamine-0.6.2-cp313-cp313t-win_amd64.whl", hash = "sha256:a94a560c0b7ec791f6edfb3fede6ade35b048a61be80e584de8411bf930a8902", size = 749291, upload-time = "2026-02-18T13:37:19.842Z" },
-    { url = "https://files.pythonhosted.org/packages/73/b3/a9ee154d185e64edfeb5bb0c5621a650bc946c071a7be5a2ccfe81da413e/python_calamine-0.6.2-cp313-cp313t-win_arm64.whl", hash = "sha256:2574072b9e26aeae26ebd051a1661bb72fd202ce2904f920f9c605de9555c057", size = 716122, upload-time = "2026-02-18T13:37:21.172Z" },
-    { url = "https://files.pythonhosted.org/packages/86/c3/30e8ebbc5813d332edc6733c63f861bb87b61ad8a71fc97f39d687fb0195/python_calamine-0.6.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:630d32f10b16bafbca86fb9373e7a4eccbd0268bc9e80dac923b731a8e472704", size = 878817, upload-time = "2026-02-18T13:37:22.358Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b7/2c0c82c1d3938bee3972fe97103da158ef9cf2b3bd2ba88ef1fa7e766564/python_calamine-0.6.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39de4d8c1f9db34d02a2d9b7eaad55cdd013b5881cf0a5ab281e2167d090b22e", size = 857826, upload-time = "2026-02-18T13:37:23.856Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/b0/260135d30b0c5e1b723bb5d450426614a20409b27b9e5cdd17076abe1516/python_calamine-0.6.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36148e9c5022494fd6a2c111fb51d24e6e39cbf3027a3ddedad44545598609ca", size = 925839, upload-time = "2026-02-18T13:37:25.276Z" },
-    { url = "https://files.pythonhosted.org/packages/04/d1/6cc11c5287020a04326da01e46a7a4169d4496d462f94c69ac993e4b6c1d/python_calamine-0.6.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2526bddc75829b4376a515cad83afeab4019bbe5b770a892852de66b0017527b", size = 902844, upload-time = "2026-02-18T13:37:27.015Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/56/c2197448e66cf8369ecc3ed6450fc26085404b8ddf3f3409958d82a44908/python_calamine-0.6.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:711a664b8cf1e4f6c55fbd5e15e70fc5792e382e3866416044c23b0d3ffdd055", size = 1063688, upload-time = "2026-02-18T13:37:28.824Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/68/c26b811cf88b39afc107af73fab1a42af56d7ea19e33b80eddc3e869a6e7/python_calamine-0.6.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d449b6130f1469810ebe9f423f9efecaabc60e110db7a5a56d0f098ea78b22f", size = 963750, upload-time = "2026-02-18T13:37:30.655Z" },
-    { url = "https://files.pythonhosted.org/packages/35/d8/4f4bee70187f148661f6112b6cff572c199518b943b4821d9303c3d5084d/python_calamine-0.6.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f3841986cf512893e8871555ef586387e5e36484cebd0d9398046c3bde1e13c", size = 933485, upload-time = "2026-02-18T13:37:32.082Z" },
-    { url = "https://files.pythonhosted.org/packages/08/67/5f9826d9ee2cb167fa86a496f3dd6551aa727c8dcef8041eb7362c0eeb80/python_calamine-0.6.2-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7a8f437273c8dee9d9ae89cc766b6c313a1a99155b74a1a6560a01b82db89b51", size = 973008, upload-time = "2026-02-18T13:37:33.36Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/20/8384433127d4bef3b663e71285d9c5f21d2e312e6b9ae37170290ec28566/python_calamine-0.6.2-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6a2dfcfbf1907f37e6a13e2dffff409f79cff911e44e1ce7deb65510b8bbb0de", size = 1101447, upload-time = "2026-02-18T13:37:34.678Z" },
-    { url = "https://files.pythonhosted.org/packages/57/ab/f86f30f3f72a930e6787c7a28b1042458045572c785b6362a77e42920fb1/python_calamine-0.6.2-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:0c4a6131835f28897cdf36942067220e2c8c6c23f4b7747a094dca6748190c12", size = 1176774, upload-time = "2026-02-18T13:37:37.256Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/2a/3a4d0332b5a30604c6e2645f3a3a54d443ee78ba45d4ad2be015e32bab4a/python_calamine-0.6.2-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e8f50885c5042fb3bdd9ad820e4b871e6a1758e15957964acf0515b5d0fb3984", size = 1143674, upload-time = "2026-02-18T13:37:39.007Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/e1/28254dc423f63a62d1c0da649e673ca492ac84250adcc63f90547b83bfbf/python_calamine-0.6.2-cp314-cp314-win32.whl", hash = "sha256:d4b6fe3564596b1a85fdb7dea60ae7dda2bd56898e88128e0306ebfca29d3659", size = 691485, upload-time = "2026-02-18T13:37:40.64Z" },
-    { url = "https://files.pythonhosted.org/packages/17/24/3954b1279ea1b4e25368bccd139098d1abeb3188f4100f2604555be67bae/python_calamine-0.6.2-cp314-cp314-win_amd64.whl", hash = "sha256:39a6703c80e71c9df2eefa4b9aedd994c27d6ae1fda07a48ee3306414d76d39b", size = 749519, upload-time = "2026-02-18T13:37:41.871Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/be/e103f840b48677a85085eaca4667fb2f7c0828c7c49b3ea9e1300d5074bc/python_calamine-0.6.2-cp314-cp314-win_arm64.whl", hash = "sha256:cedae91678a016690775a815c7dc66288b3f0968451bf2161689846b5b330b84", size = 718799, upload-time = "2026-02-18T13:37:43.692Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/36/08e98171718cec3a22e0c4082714894d9ae71c8aaba2ca47dabc5dbf4cf0/python_calamine-0.6.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5c3ca40133330cccdafb7326c39f7dd60247ad1995d9b92fdcd5052853fc31e5", size = 876825, upload-time = "2026-02-18T13:37:44.933Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/06/327a49b20cd2565457a1eb361b8e078aeb2eb8c2473358924563fc737701/python_calamine-0.6.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5599d12fa06ad42694255fecb1de48f6eb2d074fa55b2f532a93158ae1cc3958", size = 857368, upload-time = "2026-02-18T13:37:46.798Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/fc/b0d380ea649833acc79ecc829470cb632565b865713865c6ba995e505e55/python_calamine-0.6.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb50c1f6303650d5712a707c8c13842eeebcd433bd660dcdaebc8aedd9085d37", size = 922634, upload-time = "2026-02-18T13:37:50.205Z" },
-    { url = "https://files.pythonhosted.org/packages/50/b7/89128cca52c80c8b9649176bac374356f1923997af0b262a7b5547479fb1/python_calamine-0.6.2-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42f1b3172fc2c916990a9749c30f5c2aad5351a807c6597febf7b5b9444eaf4d", size = 901578, upload-time = "2026-02-18T13:37:52.108Z" },
-    { url = "https://files.pythonhosted.org/packages/78/40/bf06d465c761d59beab8d42cb4f5b648862a8ef0a1d900790b7efce1fa5f/python_calamine-0.6.2-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3bb6370d855c9035e8727e6d8685775d411e5f5a3b114e0048bacd2efc2dc5", size = 1062802, upload-time = "2026-02-18T13:37:53.383Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/fd/87792c5f5c5822036ee4bdb01853bd7cb854f982f88cb7fdf6405a36072d/python_calamine-0.6.2-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d790fa2065c3c5d07de27ead53486b6afa64b935036444e5593c670baaf7394", size = 964571, upload-time = "2026-02-18T13:37:54.754Z" },
-    { url = "https://files.pythonhosted.org/packages/31/6c/9981f4ca131d104e7e2d275c97a22026984c766009ec98269fb3b23a8a9f/python_calamine-0.6.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba4ac4bc59fb16e76d57bbbb2b5567e9d78f99e0b7d6cf27b1fc968dddad9e52", size = 934577, upload-time = "2026-02-18T13:37:56.03Z" },
-    { url = "https://files.pythonhosted.org/packages/19/02/7c1fe7038f9921d520b4bf52299c260db4e21cbba7d3df29ed960ebb31c6/python_calamine-0.6.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16750f933fd68d6796c24390d5379abe02cc592b8cb5c2c715d09885a4e4db78", size = 971699, upload-time = "2026-02-18T13:37:57.303Z" },
-    { url = "https://files.pythonhosted.org/packages/06/10/9da5009d84154e6d86dd73c7f35fe6402803eb054c198a22605d74ab07a0/python_calamine-0.6.2-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:0c3a65ee5e1bbed8d32225882b6fae147c187a5019b895bd1a9631fb1e8ebd1b", size = 1098043, upload-time = "2026-02-18T13:37:59.168Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d0/53238c2185ad59659245d8bc7a86e4902860bd3c73303744b039a35ae517/python_calamine-0.6.2-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:80f54662715b25078e90794d792df6ef45154f1affea472c9e802c5d3dda5a9e", size = 1175384, upload-time = "2026-02-18T13:38:00.542Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/40/c421fe66af1e94267a66735940dfc01f7e423eb8c0217a9bc97b03927de6/python_calamine-0.6.2-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:7568800d967b7b7b56d1a139d8d6c343b70d88695c8f3c3906aaa1b8bff76900", size = 1144251, upload-time = "2026-02-18T13:38:01.881Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ed/def5e5fa257658894ca2ca3f9c532064056cd1b686f3bc2861f6313ccac7/python_calamine-0.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:aab8ef96f19feb5df3704dc04805b1e0d6e82827546bea92d660344c674ed9e1", size = 748446, upload-time = "2026-02-18T13:38:03.35Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/24/3587fb169ddd82e78fcd4cd7b2e3eb3ecaa9b28dbee1da18dd0db13b27e6/python_calamine-0.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:514b3b0ccba57cf807bd4869a76020eb53e2d797f35c95fceb274a5208da1651", size = 714386, upload-time = "2026-02-18T13:38:04.643Z" },
-]
-
-[[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
 name = "python-docx"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1544,15 +1147,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
-]
-
-[[package]]
-name = "pyxlsb"
-version = "1.0.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/13/eebaeb7a40b062d1c6f7f91d09e73d30a69e33e4baa7cbe4b7658548b1cd/pyxlsb-1.0.10.tar.gz", hash = "sha256:8062d1ea8626d3f1980e8b1cfe91a4483747449242ecb61013bc2df85435f685", size = 22424, upload-time = "2022-10-14T19:17:47.308Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/92/345823838ae367c59b63e03aef9c331f485370f9df6d049256a61a28f06d/pyxlsb-1.0.10-py2.py3-none-any.whl", hash = "sha256:87c122a9a622e35ca5e741d2e541201d28af00fb46bec492cfa9586890b120b4", size = 23849, upload-time = "2022-10-14T19:17:46.079Z" },
 ]
 
 [[package]]
@@ -1705,12 +1299,28 @@ wheels = [
 ]
 
 [[package]]
-name = "six"
-version = "1.17.0"
+name = "ruff"
+version = "0.15.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
 ]
 
 [[package]]
@@ -1729,15 +1339,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
-]
-
-[[package]]
-name = "tabulate"
-version = "0.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]
@@ -1809,15 +1410,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tzdata"
-version = "2026.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
-]
-
-[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1854,6 +1446,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
+]
+
+[[package]]
+name = "xlwt"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/97/56a6f56ce44578a69343449aa5a0d98eefe04085d69da539f3034e2cd5c1/xlwt-1.3.0.tar.gz", hash = "sha256:c59912717a9b28f1a3c2a98fd60741014b06b043936dcecbc113eaaada156c88", size = 153929, upload-time = "2017-08-22T06:47:16.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/48/def306413b25c3d01753603b1a222a011b8621aed27cd7f89cbc27e6b0f4/xlwt-1.3.0-py2.py3-none-any.whl", hash = "sha256:a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e", size = 99981, upload-time = "2017-08-22T06:47:15.281Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Refactor and harden `tools/dify_extractor` so valid files keep the existing output contract while malformed inputs fail once with actionable errors.

- centralize format dispatch, extraction context, typed errors, result validation, text decoding, table rendering, and image handling
- replace pandas-backed CSV/Excel parsing with strict stdlib CSV plus native `openpyxl`/`xlrd`
- add OOXML archive-bomb guards and bounded best-effort remote/embedded image processing
- normalize JSON, YAML, Markdown, HTML, PDF, DOCX, PPTX, CSV, and Excel behavior
- expand coverage from 3 regression tests to 49 tests across all supported formats and failure paths
- document supported behavior and privacy implications; bump the plugin to `0.1.0`

The previous implementation handled errors independently in each extractor, silently accepted some malformed/empty inputs, made unbounded remote image requests, and carried a large pandas dependency for row-oriented parsing. This change makes those paths deterministic and reduces runtime/dependency weight without changing the public tool schema.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

Not applicable; this is a backend extraction and reliability refactor with no UI changes.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`

The plugin already targets the repository's current `dify_plugin>=0.9.0` SDK line, so the older SDK-range checkbox is not applicable.

## Testing

- [ ] Local deployment — Dify version: N/A
- [ ] SaaS (cloud.dify.ai)

Validated locally with the production Python 3.12 runtime:

- `uv sync --all-groups --frozen --python 3.12`
- `uv run --frozen pytest -q` — 49 passed
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen python -m compileall -q tools tests`
- `uv lock --check`
- `dify plugin package` plus archive integrity verification
- repository serverless plugin install validator and HTTP probe — success
