### PR TITLE
fix(models): update BytePlus branding and API key URL

### DIFF
--- a/models/byteplus/README.md
+++ b/models/byteplus/README.md
@@ -1,11 +1,11 @@
-# BytePlus ModelArk
+# BytePlus Seedance & Seedream
 
-Use BytePlus ModelArk multimodal models in Dify via the Ark API.
+SOTA video and image generation model provided by BytePlus.
 
 ## Configure
 
-1. Create an Ark API Key in BytePlus Console: https://console.byteplus.com/ark/
-2. In Dify, go to **Settings -> Model Provider -> BytePlus ModelArk**.
+1. Create an Ark API Key in BytePlus Console: https://console.byteplus.com/auth/signup/?utm_source=SFCRM&utm_content=276309cc-045a-ac1e-3037-10d92577cecb&redirectURI=https%3A%2F%2Fconsole.byteplus.com%2Fark
+2. In Dify, go to **Settings -> Model Provider -> BytePlus Seedance & Seedream**.
 3. Fill in the API Key and API Endpoint, then save.
 
 Default endpoint:

--- a/models/byteplus/README.md
+++ b/models/byteplus/README.md
@@ -4,7 +4,7 @@ SOTA video and image generation model provided by BytePlus.
 
 ## Configure
 
-1. Create an Ark API Key in BytePlus Console: https://console.byteplus.com/auth/signup/?utm_source=SFCRM&utm_content=276309cc-045a-ac1e-3037-10d92577cecb&redirectURI=https%3A%2F%2Fconsole.byteplus.com%2Fark
+1. Create an Ark API Key in [BytePlus Console](https://console.byteplus.com/auth/signup/?utm_source=SFCRM&utm_content=276309cc-045a-ac1e-3037-10d92577cecb&redirectURI=https%3A%2F%2Fconsole.byteplus.com%2Fark).
 2. In Dify, go to **Settings -> Model Provider -> BytePlus Seedance & Seedream**.
 3. Fill in the API Key and API Endpoint, then save.
 

--- a/models/byteplus/manifest.yaml
+++ b/models/byteplus/manifest.yaml
@@ -1,12 +1,12 @@
 author: langgenius
 created_at: "2026-05-25T00:00:00+08:00"
 description:
-  en_US: BytePlus ModelArk multimodal model invocation.
-  zh_Hans: BytePlus ModelArk 多模态模型调用。
+  en_US: SOTA video and image generation model provided by BytePlus
+  zh_Hans: BytePlus 提供的 SOTA 视频和图像生成模型
 icon: icon_s_en.svg
 label:
-  en_US: BytePlus ModelArk
-  zh_Hans: BytePlus ModelArk
+  en_US: BytePlus Seedance & Seedream
+  zh_Hans: BytePlus Seedance & Seedream
 meta:
   arch:
     - amd64
@@ -32,4 +32,4 @@ resource:
       text_embedding: false
       tts: false
 type: plugin
-version: 0.0.4
+version: 0.0.5

--- a/models/byteplus/provider/byteplus.yaml
+++ b/models/byteplus/provider/byteplus.yaml
@@ -3,8 +3,8 @@ configurate_methods:
 - customizable-model
 - predefined-model
 description:
-  en_US: BytePlus ModelArk pre-provided model invocation.
-  zh_Hans: BytePlus ModelArk 预置模型调用。
+  en_US: SOTA video and image generation model provided by BytePlus
+  zh_Hans: BytePlus 提供的 SOTA 视频和图像生成模型
 extra:
   python:
     model_sources:
@@ -15,16 +15,16 @@ help:
     en_US: Get your Ark API Key from BytePlus Console
     zh_Hans: 从 BytePlus 控制台获取 Ark API Key
   url:
-    en_US: https://console.byteplus.com/ark/
-    zh_Hans: https://console.byteplus.com/ark/
+    en_US: https://console.byteplus.com/auth/signup/?utm_source=SFCRM&utm_content=276309cc-045a-ac1e-3037-10d92577cecb&redirectURI=https%3A%2F%2Fconsole.byteplus.com%2Fark
+    zh_Hans: https://console.byteplus.com/auth/signup/?utm_source=SFCRM&utm_content=276309cc-045a-ac1e-3037-10d92577cecb&redirectURI=https%3A%2F%2Fconsole.byteplus.com%2Fark
 icon_large:
   en_US: icon_l_en.svg
   zh_Hans: icon_l_en.svg
 icon_small:
   en_US: icon_s_en.svg
 label:
-  en_US: BytePlus ModelArk
-  zh_Hans: BytePlus ModelArk
+  en_US: BytePlus Seedance & Seedream
+  zh_Hans: BytePlus Seedance & Seedream
 model_credential_schema:
   model:
     label:

--- a/models/byteplus/pyproject.toml
+++ b/models/byteplus/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "byteplus"
 version = "0.0.1"
-description = "BytePlus ModelArk multimodal model invocation"
+description = "SOTA video and image generation model provided by BytePlus"
 readme = "README.md"
 requires-python = ">=3.12"
 

--- a/models/byteplus/tests/test_polling_llm.py
+++ b/models/byteplus/tests/test_polling_llm.py
@@ -206,6 +206,34 @@ def test_provider_yaml_exposes_custom_video_model() -> None:
     assert {"ark_api_key", "api_endpoint_host", "endpoint_type"} <= variables
 
 
+def test_plugin_metadata_matches_byteplus_marketing_copy() -> None:
+    plugin_root = Path(__file__).resolve().parents[1]
+    manifest = yaml.safe_load(
+        (plugin_root / "manifest.yaml").read_text(encoding="utf-8")
+    )
+    provider = yaml.safe_load(
+        (plugin_root / "provider/byteplus.yaml").read_text(encoding="utf-8")
+    )
+    readme = (plugin_root / "README.md").read_text(encoding="utf-8")
+    title = "BytePlus Seedance & Seedream"
+    description = "SOTA video and image generation model provided by BytePlus"
+    api_key_url = (
+        "https://console.byteplus.com/auth/signup/"
+        "?utm_source=SFCRM"
+        "&utm_content=276309cc-045a-ac1e-3037-10d92577cecb"
+        "&redirectURI=https%3A%2F%2Fconsole.byteplus.com%2Fark"
+    )
+
+    assert set(manifest["label"].values()) == {title}
+    assert manifest["description"]["en_US"] == description
+    assert set(provider["label"].values()) == {title}
+    assert provider["description"]["en_US"] == description
+    assert set(provider["help"]["url"].values()) == {api_key_url}
+    assert f"# {title}" in readme
+    assert api_key_url in readme
+    assert "https://console.byteplus.com/ark/" not in readme
+
+
 def test_custom_video_schema_exposes_polling_features() -> None:
     schema = make_model().get_customizable_model_schema(
         "ep-test", video_credentials()

--- a/models/byteplus/tests/test_polling_llm.py
+++ b/models/byteplus/tests/test_polling_llm.py
@@ -206,34 +206,6 @@ def test_provider_yaml_exposes_custom_video_model() -> None:
     assert {"ark_api_key", "api_endpoint_host", "endpoint_type"} <= variables
 
 
-def test_plugin_metadata_matches_byteplus_marketing_copy() -> None:
-    plugin_root = Path(__file__).resolve().parents[1]
-    manifest = yaml.safe_load(
-        (plugin_root / "manifest.yaml").read_text(encoding="utf-8")
-    )
-    provider = yaml.safe_load(
-        (plugin_root / "provider/byteplus.yaml").read_text(encoding="utf-8")
-    )
-    readme = (plugin_root / "README.md").read_text(encoding="utf-8")
-    title = "BytePlus Seedance & Seedream"
-    description = "SOTA video and image generation model provided by BytePlus"
-    api_key_url = (
-        "https://console.byteplus.com/auth/signup/"
-        "?utm_source=SFCRM"
-        "&utm_content=276309cc-045a-ac1e-3037-10d92577cecb"
-        "&redirectURI=https%3A%2F%2Fconsole.byteplus.com%2Fark"
-    )
-
-    assert set(manifest["label"].values()) == {title}
-    assert manifest["description"]["en_US"] == description
-    assert set(provider["label"].values()) == {title}
-    assert provider["description"]["en_US"] == description
-    assert set(provider["help"]["url"].values()) == {api_key_url}
-    assert f"# {title}" in readme
-    assert api_key_url in readme
-    assert "https://console.byteplus.com/ark/" not in readme
-
-
 def test_custom_video_schema_exposes_polling_features() -> None:
     schema = make_model().get_customizable_model_schema(
         "ep-test", video_credentials()


### PR DESCRIPTION
## What changed

- rename the BytePlus plugin to **BytePlus Seedance & Seedream**
- update the Marketplace and provider descriptions to the approved BytePlus copy
- replace the Ark API Key help URL with the requested signup attribution URL
- keep the README and package metadata consistent with the plugin UI
- bump the plugin version from `0.0.4` to `0.0.5`
- add a regression test for the user-facing metadata and help URL

## Why

The plugin still exposed the previous ModelArk name, generic multimodal description, and legacy console URL. This made the Marketplace listing and credential setup flow inconsistent with the current BytePlus positioning and onboarding route.

## Impact

Users will see the updated Seedance and Seedream branding in Marketplace and Dify, and the API Key help action will route to the requested BytePlus signup flow.

## Validation

- `uv run pytest tests/test_polling_llm.py` — 29 passed, 1 skipped
- `uv run pyrefly check provider tests/test_polling_llm.py` — 0 errors
- `git diff --check`