### PR TITLE
fix(lemonade): use the /api/v1 embeddings endpoint so document indexing works

### DIFF
--- a/models/lemonade/manifest.yaml
+++ b/models/lemonade/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.16
+version: 0.0.17
 type: plugin
 author: "langgenius"
 name: "lemonade"

--- a/models/lemonade/models/text_embedding/text_embedding.py
+++ b/models/lemonade/models/text_embedding/text_embedding.py
@@ -1,6 +1,7 @@
-from typing import Mapping
+from typing import Mapping, Optional
 
-from dify_plugin.entities.model import AIModelEntity, I18nObject
+from dify_plugin.entities.model import AIModelEntity, EmbeddingInputType, I18nObject
+from dify_plugin.entities.model.text_embedding import TextEmbeddingResult
 from dify_plugin.errors.model import CredentialsValidateFailedError
 from dify_plugin.interfaces.model.openai_compatible.text_embedding import OAICompatEmbeddingModel
 
@@ -8,6 +9,23 @@ from ..llm.llm import validate_lemonade_credentials
 
 
 class LemonadeTextEmbeddingModel(OAICompatEmbeddingModel):
+
+    def _invoke(
+        self,
+        model: str,
+        credentials: dict,
+        texts: list[str],
+        user: Optional[str] = None,
+        input_type: EmbeddingInputType = EmbeddingInputType.DOCUMENT,
+    ) -> TextEmbeddingResult:
+        # Lemonade serves its OpenAI-compatible API under /api/v1. The base class
+        # posts to {endpoint_url}/embeddings, so without /api/v1 the request hits
+        # {host}/embeddings and 404s (issue #3491). The LLM path already applies
+        # this normalization in _add_custom_parameters; mirror it here, guarding
+        # against an endpoint that already contains /api/v1.
+        if "endpoint_url" in credentials and "/api/v1" not in credentials["endpoint_url"]:
+            credentials["endpoint_url"] = credentials["endpoint_url"].rstrip("/") + "/api/v1"
+        return super()._invoke(model, credentials, texts, user, input_type)
 
     def get_customizable_model_schema(
         self, model: str, credentials: Mapping | dict

--- a/models/lemonade/tests/test_embedding_endpoint.py
+++ b/models/lemonade/tests/test_embedding_endpoint.py
@@ -1,0 +1,65 @@
+"""Regression test for issue #3491.
+
+Lemonade embedding models 404 on `/embeddings` when indexing a document. The
+base ``OAICompatEmbeddingModel._invoke`` posts to ``{endpoint_url}/embeddings``,
+and the embedding path (unlike the LLM path's ``_add_custom_parameters``) never
+appended Lemonade's ``/api/v1`` prefix — so with the placeholder endpoint
+``http://127.0.0.1:13305`` the request went to ``.../embeddings`` and 404'd. The
+fix normalizes ``endpoint_url`` to include ``/api/v1`` before delegating, so the
+request goes to ``.../api/v1/embeddings``.
+"""
+
+import contextlib
+import unittest
+from unittest.mock import MagicMock, patch
+
+from models.text_embedding.text_embedding import LemonadeTextEmbeddingModel
+
+# The base class builds the URL inside this module's `requests`, so patch there.
+_REQUESTS_POST = "dify_plugin.interfaces.model.openai_compatible.text_embedding.requests.post"
+
+
+class TestLemonadeEmbeddingEndpoint(unittest.TestCase):
+    def _run_invoke_and_capture_url(self, endpoint_url: str) -> str:
+        """Invoke embedding with a mocked HTTP layer; return the POSTed URL."""
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3]}],
+            "usage": {"total_tokens": 3},
+        }
+
+        # Pin the model-property helpers so _invoke reaches the HTTP call without
+        # needing a predefined model schema; the endpoint URL is what's under test.
+        with (
+            patch(_REQUESTS_POST, return_value=resp) as mock_post,
+            patch.object(LemonadeTextEmbeddingModel, "_get_context_size", return_value=8192),
+            patch.object(LemonadeTextEmbeddingModel, "_get_max_chunks", return_value=1),
+        ):
+            # Downstream response/usage handling is the SDK's concern, not under
+            # test — the URL is captured at the POST regardless of what follows.
+            with contextlib.suppress(Exception):
+                LemonadeTextEmbeddingModel(model_schemas=[])._invoke(
+                    "nomic-embed-text-v1-GGUF",
+                    {"endpoint_url": endpoint_url},
+                    ["hello world"],
+                )
+            self.assertTrue(mock_post.called, "embedding must issue an HTTP request")
+            call = mock_post.call_args
+            return call.args[0] if call.args else call.kwargs["url"]
+
+    def test_embedding_posts_to_api_v1_embeddings(self):
+        """With the bare placeholder endpoint, the request must target
+        /api/v1/embeddings (not /embeddings) — the #3491 fix."""
+        url = self._run_invoke_and_capture_url("http://127.0.0.1:13305")
+        self.assertEqual(url, "http://127.0.0.1:13305/api/v1/embeddings")
+
+    def test_embedding_does_not_double_api_v1(self):
+        """If the endpoint already includes /api/v1, it must not be duplicated
+        (matches the LLM path's guard)."""
+        url = self._run_invoke_and_capture_url("http://127.0.0.1:13305/api/v1")
+        self.assertEqual(url, "http://127.0.0.1:13305/api/v1/embeddings")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #3491.

Embedding a document with a Lemonade model fails: the Lemonade server returns a repeating **404** and the document lands in **Error** state. The reporter saw this across four embedding models, and the same models embed correctly via Ollama and OpenWebUI — so it isn't the models or the server.

The cause is plugin-side URL construction. `OAICompatEmbeddingModel._invoke` posts to `{endpoint}/embeddings`, and the embedding path never applies the `/api/v1` normalization that the LLM path already does. Lemonade serves embeddings under `/api/v1`, so the request 404s. Dify surfaces it as:

```
[models] Bad Request Error, 404 Client Error: Not Found for url:
http://host.docker.internal:13305/embeddings
```

**Verified against a live Lemonade 11.0.0 server** (macOS, llama.cpp/Metal backend, `nomic-embed-text-v1-GGUF`):

| POST path | Result |
| --- | --- |
| `/api/v1/embeddings` | **200** |
| `/v1/embeddings` | **200** |
| `/embeddings` | **404** ← what the plugin was requesting |

This adds a minimal `_invoke` override mirroring the LLM sibling, so the request targets `/api/v1/embeddings`. Added a regression test verified to **fail** on the current code (POST goes to `…/embeddings`) and **pass** with the fix (POST goes to `…/api/v1/embeddings`). 5/5 tests pass.

Two notes for reviewers:

- **`common_openai.py:33` is not the cause.** The bot comment on #3491 points there, but that method (`_CommonOpenAI._to_credential_kwargs`) is dead code — nothing calls it. The failure is the missing `/api/v1` on the invoke path.
- **Rerank appears to have the same latent gap** (same delegate-to-SDK pattern, no `/api/v1` normalization), but I left it out of scope: Lemonade 11.0.0 serves no rerank endpoint — `/api/v1/rerank` and `/rerank` both return 404 — so I can't verify a fix. Happy to follow up if you'd like it addressed.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

Same Knowledge Base flow both times (`Create a ready-to-use knowledge base` → small `.txt` → Index Method **High Quality** → Lemonade `nomic-embed-text-v1-GGUF`), against the same live Lemonade server. Only the plugin version differs.

**Before (0.0.16)**
<img width="681" height="463" alt="2026-07-22_08-49-41" src="https://github.com/user-attachments/assets/df656dea-2886-44d0-a5e2-7e978766834a" />

**After (0.0.17, this fix)** 
<img width="619" height="471" alt="2026-07-22_09-04-41" src="https://github.com/user-attachments/assets/e861b3c3-ab0b-48a3-83e1-a6dbc98be0a8" />

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — `0.0.16` → `0.0.17` (PATCH: bug fix)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`)

> Second box left unchecked: this plugin declares `dify-plugin>=0.9.0` in `pyproject.toml` (with `uv.lock` present), which falls outside the `>=0.3.0,<0.6.0` range in the template. Unchanged by this PR.

## Testing

- [x] Local deployment — Dify version: 1.16.0
- [ ] SaaS (cloud.dify.ai)

Packaged the patched plugin (`lemonade-0.0.17.difypkg`), installed it locally over 0.0.16, and re-ran the same Knowledge Base indexing flow against a live Lemonade 11.0.0 server — see before/after above.

---

*AI assistance: this change was developed with Claude Code; I reviewed and verified the diff, the endpoint behaviour, and the test before submitting.*