### PR TITLE
feat(aihubmix): add reasoning_effort for mimo v2.5 and add gemini-3.5-flash-lite

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.39
+version: 0.0.40
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/_position.yaml
+++ b/models/aihubmix/models/llm/_position.yaml
@@ -17,6 +17,7 @@
 - qwen3.7-plus
 - gemini-3.6-flash
 - gemini-3.5-flash
+- gemini-3.5-flash-lite
 - grok-4.3
 - gpt-5.5
 - claude-opus-4-7

--- a/models/aihubmix/models/llm/gemini-3.5-flash-lite.yaml
+++ b/models/aihubmix/models/llm/gemini-3.5-flash-lite.yaml
@@ -1,0 +1,128 @@
+model: gemini-3.5-flash-lite
+label:
+  en_US: Gemini 3.5 Flash Lite
+model_type: llm
+features:
+  - tool-call
+  - multi-tool-call
+  - agent-thought
+  - vision
+  - stream-tool-call
+  - document
+  - video
+  - audio
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: include_thoughts
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Include thoughts
+      zh_Hans: 返回思考过程
+    help:
+      en_US: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available. Default is false.
+      zh_Hans: 是否返回思考过程。若为 true 则只有模型支持思考且启动思考模式时才返回思考过程。默认为 false。
+  - name: media_resolution
+    type: string
+    required: true
+    default: "Default"
+    options:
+      - Default
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Media resolution
+      zh_Hans: 媒体分辨率
+    help:
+      en_US: |
+        Gemini 3 introduces fine-grained control over multimodal visual processing via the `media_resolution` parameter. Higher resolution improves the model's ability to read small text or recognize fine details, but increases token usage and latency.
+
+        Recommended Settings:
+        - Images: `media_resolution_high` (1120 tokens) - Recommended for most image analysis tasks to ensure best quality.
+        - PDF: `media_resolution_medium` (560 tokens) - Great for document understanding; quality usually saturates at medium.
+        - Video (Regular): `media_resolution_low` or `medium` (70 tokens/frame) - Sufficient for most action recognition and description tasks.
+        - Video (Text-heavy): `media_resolution_high` (280 tokens/frame) - Needed only when use cases involve reading dense text (OCR) or tiny details in video frames.
+
+        Note: If not specified, the model uses the best default value based on the media type.
+      zh_Hans: |
+        Gemini 3 通过 `media_resolution` 参数引入了对多模态视觉处理的精细控制。分辨率越高，模型读取细小文本或识别细微细节的能力就越强，但会增加令牌用量和延迟时间。
+
+        推荐设置：
+        - 图片：`media_resolution_high` (1120 tokens) - 建议用于大多数图片分析任务，以确保获得最佳质量。
+        - PDF：`media_resolution_medium` (560 tokens) - 非常适合文档理解；质量通常在 medium 时达到饱和。
+        - 视频（常规）：`media_resolution_low` 或 `medium` (70 tokens/帧) - 对于大多数动作识别和描述任务来说已经足够。
+        - 视频（文字较多）：`media_resolution_high` (280 tokens/帧) - 仅当用例涉及读取密集文本 (OCR) 或视频帧中的微小细节时才需要。
+
+        注意：如果不指定，模型会根据媒体类型使用最佳默认值。
+  - name: thinking_level
+    type: string
+    required: true
+    default: "Medium"
+    options:
+      - Minimal
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Thinking level
+      zh_Hans: 思考层级
+    help:
+      en_US: Indicates the thinking level. Default is Medium.
+      zh_Hans: 思考层级。默认为 Medium。
+  - name: grounding
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Grounding
+      zh_Hans: 事实核查
+    help:
+      en_US: Grounding with Google Search
+      zh_Hans: Google 事实核查
+  - name: url_context
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: URL context
+      zh_Hans: 链接详情
+    help:
+      en_US: Browse the url context
+      zh_Hans: 获取并分析该链接的详细信息，为回答提供参考依据。
+  - name: code_execution
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Code execution
+      zh_Hans: 代码执行
+    help:
+      en_US: Lets Gemini use code to solve complex tasks
+      zh_Hans: 让 Gemini 使用代码来解决复杂任务。
+  - name: use_inline_file
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Use inline file mode
+      zh_Hans: 使用内嵌文件模式
+    help:
+      en_US: |
+        When enabled, files will be embedded directly in the request (inline mode) for better performance.
+        When disabled, files will be uploaded using the Files API. Default is disabled (Files API).
+      zh_Hans: |
+        启用后，文件将直接内嵌在请求中（内联模式）以提高性能。
+        禁用后，文件将使用 Files API 上传。默认为禁用（使用 Files API）。
+  - name: json_schema
+    use_template: json_schema
+# https://aihubmix.com/model/gemini-3.5-flash-lite
+pricing:
+  input: "0.3"
+  output: "2.5"
+  unit: "0.000001"
+  currency: USD

--- a/models/aihubmix/models/llm/gemini-3.5-flash-lite.yaml
+++ b/models/aihubmix/models/llm/gemini-3.5-flash-lite.yaml
@@ -62,7 +62,7 @@ parameter_rules:
   - name: thinking_level
     type: string
     required: true
-    default: "Medium"
+    default: "Minimal"
     options:
       - Minimal
       - Low
@@ -72,8 +72,8 @@ parameter_rules:
       en_US: Thinking level
       zh_Hans: 思考层级
     help:
-      en_US: Indicates the thinking level. Default is Medium.
-      zh_Hans: 思考层级。默认为 Medium。
+      en_US: Indicates the thinking level. Default is Minimal.
+      zh_Hans: 思考层级。默认为 Minimal。
   - name: grounding
     type: boolean
     required: true

--- a/models/aihubmix/models/llm/xiaomi-mimo-v2.5-pro.yaml
+++ b/models/aihubmix/models/llm/xiaomi-mimo-v2.5-pro.yaml
@@ -27,6 +27,19 @@ parameter_rules:
       - json_schema
   - name: json_schema
     use_template: json_schema
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - none
+      - high
+    help:
+      zh_Hans: 控制模型的思考能力。none 关闭思考，其他档位开启思考。
+      en_US: Controls the model's thinking capability. none disables thinking, other levels enable thinking.
 pricing:
   input: '1.1'
   output: '3.3'

--- a/models/aihubmix/models/llm/xiaomi-mimo-v2.5-pro.yaml
+++ b/models/aihubmix/models/llm/xiaomi-mimo-v2.5-pro.yaml
@@ -41,7 +41,7 @@ parameter_rules:
       zh_Hans: 控制模型的思考能力。none 关闭思考，其他档位开启思考。
       en_US: Controls the model's thinking capability. none disables thinking, other levels enable thinking.
 pricing:
-  input: '1.1'
-  output: '3.3'
+  input: '0.48'
+  output: '0.96'
   unit: '0.000001'
   currency: USD

--- a/models/aihubmix/models/llm/xiaomi-mimo-v2.5.yaml
+++ b/models/aihubmix/models/llm/xiaomi-mimo-v2.5.yaml
@@ -45,7 +45,7 @@ parameter_rules:
       zh_Hans: 控制模型的思考能力。none 关闭思考，其他档位开启思考。
       en_US: Controls the model's thinking capability. none disables thinking, other levels enable thinking.
 pricing:
-  input: '0.44'
-  output: '2.2'
+  input: '0.155'
+  output: '0.31'
   unit: '0.000001'
   currency: USD

--- a/models/aihubmix/models/llm/xiaomi-mimo-v2.5.yaml
+++ b/models/aihubmix/models/llm/xiaomi-mimo-v2.5.yaml
@@ -31,6 +31,19 @@ parameter_rules:
       - json_schema
   - name: json_schema
     use_template: json_schema
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - none
+      - high
+    help:
+      zh_Hans: 控制模型的思考能力。none 关闭思考，其他档位开启思考。
+      en_US: Controls the model's thinking capability. none disables thinking, other levels enable thinking.
 pricing:
   input: '0.44'
   output: '2.2'


### PR DESCRIPTION
## Summary

- **mimo v2.5 series thinking mode**: Added `reasoning_effort` parameter to `xiaomi-mimo-v2.5-pro.yaml` and `xiaomi-mimo-v2.5.yaml`, following the aihubmix unified reasoning parameter spec. Two options: `none` (disable thinking) and `high` (enable thinking).
- **gemini-3.5-flash-lite**: Added new model `gemini-3.5-flash-lite` with pricing $0.3/$2.5 per 1M tokens, context_size 1048576, and updated `_position.yaml`.

## Related Issues or Context

The `reasoning_effort` parameter follows the aihubmix unified reasoning spec documented at `https://docs.aihubmix.com/cn/api/unified-inference`. For models that only support on/off thinking (deepseek, qwen, glm, kimi, mimo), `reasoning_effort: none` disables thinking, any other value enables it.

## This PR contains Changes to *LLM Models Plugin*

- [ ] My Changes Affect Message Flow Handling (System Messages and User→Assistant Turn-Taking)
- [ ] My Changes Affect Tool Interaction Flow (Multi-Round Usage and Output Handling, for both Agent App and Agent Node)
- [ ] My Changes Affect Multimodal Input Handling (Images, PDFs, Audio, Video, etc.)
- [ ] My Changes Affect Multimodal Output Generation (Images, Audio, Video, etc.)
- [ ] My Changes Affect Structured Output Format (JSON, XML, etc.)
- [ ] My Changes Affect Token Consumption Metrics
- [x] My Changes Affect Other LLM Functionalities (Reasoning Process, Grounding, Prompt Caching, etc.)
- [x] Other Changes (Add New Models, Fix Model Parameters etc.)

## Version Control

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.16.0
- [ ] SaaS (cloud.dify.ai)
