### PR TITLE
fix(funasr): align marketplace copy and upload limits

### DIFF
--- a/models/funasr/README.md
+++ b/models/funasr/README.md
@@ -1,20 +1,45 @@
 # FunASR Speech Recognition Plugin
 
-Open-source speech recognition from Alibaba DAMO Academy. 170x faster than Whisper.
+Self-hosted speech recognition through FunASR's OpenAI-compatible API. The
+plugin supports multilingual ASR models for private Dify deployments without
+sending audio to a hosted transcription service.
+
+In FunASR's
+[192-minute benchmark](https://modelscope.github.io/FunASR/benchmark.html),
+SenseVoiceSmall reached 170x real-time on GPU and 17x real-time on CPU.
+Whisper-large-v3 reached 13x real-time on GPU in the same benchmark. Results
+depend on the hardware, audio, model, and concurrency settings.
 
 ## Setup
 
-1. Deploy FunASR server:
+1. Deploy a SenseVoice server:
+
 ```bash
-pip install funasr vllm fastapi uvicorn
-funasr-server --device cuda --host 0.0.0.0 --port 8000
+pip install "funasr>=1.3.26" fastapi uvicorn python-multipart
+funasr-server --device cuda --model sensevoice --host 0.0.0.0 --port 8000
 ```
 
-2. In Dify, configure this plugin with your FunASR server URL (e.g. `http://your-server:8000`).
+Use `--device cpu` when CUDA is unavailable. Fun-ASR-Nano deployments use
+vLLM and can be installed separately:
+
+```bash
+pip install "funasr>=1.3.26" vllm fastapi uvicorn python-multipart
+funasr-server --device cuda --model fun-asr-nano --host 0.0.0.0 --port 8000
+```
+
+2. In Dify, configure this plugin with the server URL, for example
+   `http://your-server:8000` or `http://your-server:8000/v1`. The plugin
+   normalizes both forms to a base URL ending in `/v1`, such as
+   `http://localhost:8000/v1`. Leave the API key empty when the server does
+   not require one.
+
+Predefined models accept audio files up to 25 MB.
 
 ## Supported Models
 
-- **sensevoice** — 50+ languages, emotion detection (default)
-- **paraformer** — Chinese, with punctuation
-- **paraformer-en** — English
-- **fun-asr-nano** — Encoder+LLM architecture
+- **sensevoice** - Mandarin, Cantonese, English, Japanese, and Korean ASR with
+  emotion and audio-event tags (default)
+- **paraformer** - Chinese ASR with punctuation
+- **paraformer-en** - English ASR
+- **fun-asr-nano** - Chinese, English, Japanese, and Chinese dialect/accent ASR
+  with an encoder + LLM architecture

--- a/models/funasr/manifest.yaml
+++ b/models/funasr/manifest.yaml
@@ -1,8 +1,8 @@
 author: langgenius
 created_at: '2026-06-12T00:00:00.00000000-00:00'
 description:
-  en_US: Fast open-source speech recognition from Alibaba DAMO Academy. 170x faster than Whisper.
-  zh_Hans: 阿里巴巴达摩院开源语音识别，比 Whisper 快 170 倍。
+  en_US: Open-source speech recognition with OpenAI-compatible serving and multilingual models.
+  zh_Hans: 支持 OpenAI 兼容服务与多语种模型的开源语音识别。
 icon: icon_s_en.svg
 label:
   en_US: FunASR
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.0
+version: 0.1.1

--- a/models/funasr/models/speech2text/fun-asr-nano.yaml
+++ b/models/funasr/models/speech2text/fun-asr-nano.yaml
@@ -1,5 +1,5 @@
 model: fun-asr-nano
 model_type: speech2text
 model_properties:
-  file_upload_limit: 1
+  file_upload_limit: 25
   supported_file_extensions: flac,mp3,mp4,mpeg,mpga,m4a,ogg,wav,webm

--- a/models/funasr/models/speech2text/paraformer-en.yaml
+++ b/models/funasr/models/speech2text/paraformer-en.yaml
@@ -1,5 +1,5 @@
 model: paraformer-en
 model_type: speech2text
 model_properties:
-  file_upload_limit: 1
+  file_upload_limit: 25
   supported_file_extensions: flac,mp3,mp4,mpeg,mpga,m4a,ogg,wav,webm

--- a/models/funasr/models/speech2text/paraformer.yaml
+++ b/models/funasr/models/speech2text/paraformer.yaml
@@ -1,5 +1,5 @@
 model: paraformer
 model_type: speech2text
 model_properties:
-  file_upload_limit: 1
+  file_upload_limit: 25
   supported_file_extensions: flac,mp3,mp4,mpeg,mpga,m4a,ogg,wav,webm

--- a/models/funasr/models/speech2text/sensevoice.yaml
+++ b/models/funasr/models/speech2text/sensevoice.yaml
@@ -1,5 +1,5 @@
 model: sensevoice
 model_type: speech2text
 model_properties:
-  file_upload_limit: 1
+  file_upload_limit: 25
   supported_file_extensions: flac,mp3,mp4,mpeg,mpga,m4a,ogg,wav,webm

--- a/models/funasr/provider/funasr.yaml
+++ b/models/funasr/provider/funasr.yaml
@@ -2,8 +2,8 @@ configurate_methods:
   - customizable-model
   - predefined-model
 description:
-  en_US: Fast open-source speech recognition. 170x faster than Whisper.
-  zh_Hans: 开源语音识别，比 Whisper 快 170 倍。
+  en_US: OpenAI-compatible self-hosted speech recognition with multilingual models.
+  zh_Hans: 支持 OpenAI 兼容接口与多语种模型的自托管语音识别。
 extra:
   python:
     model_sources:

--- a/models/funasr/pyproject.toml
+++ b/models/funasr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "funasr"
-version = "0.1.0"
+version = "0.1.1"
 description = "FunASR speech recognition plugin for Dify"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/models/funasr/tests/test_marketplace_metadata.py
+++ b/models/funasr/tests/test_marketplace_metadata.py
@@ -1,0 +1,73 @@
+import re
+import tomllib
+from pathlib import Path
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+MODEL_DIR = PLUGIN_DIR / "models" / "speech2text"
+PREDEFINED_MODELS = (
+    "sensevoice.yaml",
+    "paraformer.yaml",
+    "paraformer-en.yaml",
+    "fun-asr-nano.yaml",
+)
+
+
+def _read(relative_path: str) -> str:
+    return (PLUGIN_DIR / relative_path).read_text(encoding="utf-8")
+
+
+def test_marketplace_version_is_bumped_consistently():
+    manifest = _read("manifest.yaml")
+    pyproject = tomllib.loads(_read("pyproject.toml"))
+    lock = tomllib.loads(_read("uv.lock"))
+
+    manifest_version = re.search(r"^version:\s*(\S+)\s*$", manifest, re.MULTILINE)
+    locked_project = next(
+        package
+        for package in lock["package"]
+        if package["name"] == "funasr" and package.get("source") == {"virtual": "."}
+    )
+
+    assert manifest_version is not None
+    versions = {
+        manifest_version.group(1),
+        pyproject["project"]["version"],
+        locked_project["version"],
+    }
+    assert len(versions) == 1
+    version = next(iter(versions))
+    assert tuple(int(part) for part in version.split(".")) >= (0, 1, 1)
+
+
+def test_public_copy_scopes_benchmark_and_released_checkpoint():
+    readme = _read("README.md")
+    public_copy = "\n".join(
+        (readme, _read("manifest.yaml"), _read("provider/funasr.yaml"))
+    )
+
+    assert "170x faster than Whisper" not in public_copy
+    assert "比 Whisper 快 170 倍" not in public_copy
+    assert "50+ languages" not in public_copy
+
+    assert "170x real-time" in readme
+    assert "192-minute benchmark" in readme
+    assert "https://modelscope.github.io/FunASR/benchmark.html" in readme
+    assert "Mandarin, Cantonese, English, Japanese, and Korean" in readme
+
+
+def test_predefined_upload_limits_match_customizable_models():
+    for filename in PREDEFINED_MODELS:
+        text = (MODEL_DIR / filename).read_text(encoding="utf-8")
+        assert re.search(r"^\s*file_upload_limit:\s*25\s*$", text, re.MULTILINE)
+
+    model_source = _read("models/speech2text/speech2text.py")
+    assert "ModelPropertyKey.FILE_UPLOAD_LIMIT: 25" in model_source
+
+
+def test_readme_installs_default_server_dependencies_and_model():
+    readme = _read("README.md")
+
+    assert 'pip install "funasr>=1.3.26" fastapi uvicorn python-multipart' in readme
+    assert "funasr-server --device cuda --model sensevoice" in readme
+    assert "http://localhost:8000/v1" in readme

--- a/models/funasr/uv.lock
+++ b/models/funasr/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "funasr"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "dify-plugin" },


### PR DESCRIPTION
## Summary

The published FunASR plugin currently has 322 installs, but its Marketplace copy says "170x faster than Whisper", describes the released SenseVoiceSmall route as "50+ languages", and limits all four predefined models to 1 MB while customizable models allow 25 MB.

This patch:

- scopes the speed statement to the documented 192-minute benchmark (SenseVoiceSmall: 170x real-time GPU / 17x CPU; Whisper-large-v3: 13x GPU)
- describes the released SenseVoiceSmall checkpoint as Mandarin, Cantonese, English, Japanese, and Korean
- aligns every predefined model's upload limit with the existing 25 MB customizable-model limit
- documents the lightweight SenseVoice server dependencies separately from the optional Fun-ASR-Nano/vLLM path
- bumps the plugin, project, and lock versions to 0.1.1 and adds metadata regression coverage

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Metadata, README, and upload-limit correction; no visual component changed.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change</summary>

- [x] Multimodal input (audio)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` to 0.1.1
- [x] Regenerated `uv.lock` from the existing `dify_plugin>=0.9.0` dependency; frozen sync installs 42 packages

## Testing

- [ ] Local deployment — Dify version:
- [ ] SaaS (cloud.dify.ai)

Validated the production boundaries without claiming a full Dify UI run:

- `uv sync --all-groups --frozen --python 3.12`: passed
- Dify CLI v0.6.5 `plugin package`: passed; package SHA-256 `1462ae7736d11ad45b251c00e4cdfbe2097aeb11de67c53a1b61a8630819950d`
- current Marketplace toolkit `validator/test-plugin-install.py`: passed in serverless mode
- unpacked package test run: 4 passed
- YAML parse and `git diff --check`: passed
- real FunASR endpoint smoke: started SenseVoice on CPU, verified `/health`, `/v1/models`, direct multipart transcription, and the Dify plugin `_invoke` path with an empty API key and a base URL without `/v1`; both returned:
  `the tribal chieftain called for the boy and presented him with fifty pieces of gold`

The Marketplace API confirms 0.1.1 is currently unused (HTTP 404), so the version is publishable.
