### PR TITLE
feat(aihubmix): add Gemini 3.5 Flash Lite and MiMo reasoning

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.39
+version: 0.0.40
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/_position.yaml
+++ b/models/aihubmix/models/llm/_position.yaml
@@ -17,6 +17,7 @@
 - qwen3.7-plus
 - gemini-3.6-flash
 - gemini-3.5-flash
+- gemini-3.5-flash-lite
 - grok-4.3
 - gpt-5.5
 - claude-opus-4-7

--- a/models/aihubmix/models/llm/gemini-3.5-flash-lite.yaml
+++ b/models/aihubmix/models/llm/gemini-3.5-flash-lite.yaml
@@ -1,0 +1,95 @@
+# https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite
+model: gemini-3.5-flash-lite
+label:
+  en_US: Gemini 3.5 Flash-Lite
+model_type: llm
+features:
+  - tool-call
+  - multi-tool-call
+  - agent-thought
+  - vision
+  - stream-tool-call
+  - document
+  - video
+  - audio
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: include_thoughts
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Include thoughts
+    help:
+      en_US: Return thought content when available.
+  - name: media_resolution
+    type: string
+    required: true
+    default: Default
+    options:
+      - Default
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Media resolution
+    help:
+      en_US: Controls visual input resolution and the corresponding token usage.
+  - name: thinking_level
+    type: string
+    required: true
+    default: Minimal
+    options:
+      - Minimal
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Thinking level
+    help:
+      en_US: Controls Gemini thinking depth. The model default is Minimal.
+  - name: grounding
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Grounding
+    help:
+      en_US: Ground responses with Google Search.
+  - name: url_context
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: URL context
+    help:
+      en_US: Allow Gemini to retrieve URL context.
+  - name: code_execution
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Code execution
+    help:
+      en_US: Allow Gemini to use code execution.
+  - name: max_output_tokens
+    use_template: max_tokens
+    type: int
+    required: true
+    default: 65536
+    min: 1
+    max: 65536
+    label:
+      en_US: Output length
+    help:
+      en_US: The maximum number of tokens to generate in the response.
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.30'
+  output: '2.50'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/xiaomi-mimo-v2.5-pro.yaml
+++ b/models/aihubmix/models/llm/xiaomi-mimo-v2.5-pro.yaml
@@ -17,7 +17,6 @@ parameter_rules:
     max: 4096
   - name: response_format
     label:
-      zh_Hans: 回复格式
       en_US: Response Format
     type: string
     required: false
@@ -27,8 +26,19 @@ parameter_rules:
       - json_schema
   - name: json_schema
     use_template: json_schema
+  - name: reasoning_effort
+    label:
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - none
+      - high
+    help:
+      en_US: Controls the model thinking capability. none disables thinking; high enables it.
 pricing:
-  input: '1.1'
-  output: '3.3'
+  input: '0.48'
+  output: '0.96'
   unit: '0.000001'
   currency: USD

--- a/models/aihubmix/models/llm/xiaomi-mimo-v2.5.yaml
+++ b/models/aihubmix/models/llm/xiaomi-mimo-v2.5.yaml
@@ -21,7 +21,6 @@ parameter_rules:
     max: 4096
   - name: response_format
     label:
-      zh_Hans: 回复格式
       en_US: Response Format
     type: string
     required: false
@@ -31,8 +30,19 @@ parameter_rules:
       - json_schema
   - name: json_schema
     use_template: json_schema
+  - name: reasoning_effort
+    label:
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - none
+      - high
+    help:
+      en_US: Controls the model thinking capability. none disables thinking; high enables it.
 pricing:
-  input: '0.44'
-  output: '2.2'
+  input: '0.155'
+  output: '0.31'
   unit: '0.000001'
   currency: USD


### PR DESCRIPTION
## What changed

- Added Gemini 3.5 Flash-Lite to the AIHubMix LLM provider with Gemini-native multimodal, tool, structured-output, and thinking controls.
- Added output-length control for Gemini 3.5 Flash-Lite and aligned its default thinking level with the official model configuration.
- Added MiMo V2.5 and MiMo V2.5 Pro reasoning controls and synchronized their AIHubMix pricing.
- Updated the provider manifest version and model ordering.

## Validation

- Reused successful targeted live validation for Gemini 3.5 Flash-Lite: thinking levels, structured output, function calling, grounding, URL context, code execution, and inline PDF input.
- Reused successful live validation for MiMo V2.5 and MiMo V2.5 Pro reasoning requests.
- Parsed all changed YAML files, simulated the Gemini Dify parameter mapping, compiled the related handlers, and packaged the complete plugin successfully.