### PR TITLE
feat(tongyi): add qwen-long document input support with file upload polling

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -20,10 +20,10 @@ plugins:
   models:
     - provider/tongyi.yaml
 resource:
-  memory: 268435456
+  memory: 536870912
   permission:
     model:
       enabled: false
 type: plugin
-version: 0.2.6
+version: 0.2.7
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -9,7 +9,6 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Optional, Union, cast
 
-import requests
 from dashscope import Generation, MultiModalConversation, get_tokenizer
 from dashscope.api_entities.dashscope_response import GenerationResponse
 from dashscope.common.error import (
@@ -64,6 +63,7 @@ from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
 from openai import OpenAI
 from models._common import get_http_base_address
 from ..constant import BURY_POINT_HEADER
+from .qwen_long import QwenLongFileUploader
 
 logger = logging.getLogger(__name__)
 
@@ -317,9 +317,14 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 base_address=base_address,
             )
         else:
-            params["messages"] = self._convert_prompt_messages_to_tongyi_messages(
-                credentials, prompt_messages
-            )
+            if model.startswith("qwen-long"):
+                params["messages"] = self._convert_qwen_long_prompt_messages(
+                    credentials, prompt_messages
+                )
+            else:
+                params["messages"] = self._convert_prompt_messages_to_tongyi_messages(
+                    credentials, prompt_messages
+                )
             response = Generation.call(
                 **params,
                 headers=self._get_market_bury_point_header(params["messages"], extra_headers_str),
@@ -589,6 +594,83 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         )
         return text.rstrip()
 
+    def _convert_qwen_long_prompt_messages(
+        self,
+        credentials: dict,
+        prompt_messages: list[PromptMessage],
+    ) -> list[dict]:
+        document_count = sum(
+            1
+            for prompt_message in prompt_messages
+            if isinstance(prompt_message.content, list)
+            for content in prompt_message.content
+            if isinstance(content, DocumentPromptMessageContent)
+        )
+        if document_count > 100:
+            raise InvokeBadRequestError(
+                "Qwen-Long supports at most 100 documents per request."
+            )
+
+        messages = []
+        has_role_definition = bool(
+            prompt_messages
+            and isinstance(prompt_messages[0], SystemPromptMessage)
+            and prompt_messages[0].get_text_content().strip()
+        )
+        if document_count and not has_role_definition:
+            messages.append(
+                {"role": "system", "content": "You are a helpful assistant."}
+            )
+
+        for prompt_message in prompt_messages:
+            if isinstance(prompt_message, SystemPromptMessage):
+                content = prompt_message.get_text_content()
+                if content:
+                    messages.append({"role": "system", "content": content})
+                continue
+
+            if isinstance(prompt_message, UserPromptMessage):
+                text_content = prompt_message.get_text_content().strip()
+                if not text_content:
+                    raise InvokeBadRequestError(
+                        "Qwen-Long requires a non-empty text question."
+                    )
+
+                file_ids = []
+                if isinstance(prompt_message.content, list):
+                    for content in prompt_message.content:
+                        if isinstance(content, DocumentPromptMessageContent):
+                            file_id = self._upload_file_to_tongyi(
+                                credentials, content
+                            )
+                            file_ids.append(f"fileid://{file_id}")
+                        elif not isinstance(content, TextPromptMessageContent):
+                            raise InvokeBadRequestError(
+                                f"Qwen-Long does not support {content.type.value} input."
+                            )
+
+                if file_ids:
+                    messages.append(
+                        {"role": "system", "content": ",".join(file_ids)}
+                    )
+
+                messages.append({"role": "user", "content": text_content})
+                continue
+
+            if isinstance(prompt_message, AssistantPromptMessage):
+                content = prompt_message.get_text_content() or " "
+                messages.append({"role": "assistant", "content": content})
+                continue
+
+            if isinstance(prompt_message, ToolPromptMessage):
+                raise InvokeBadRequestError(
+                    "Qwen-Long does not support tool messages."
+                )
+
+            raise ValueError(f"Got unknown type {prompt_message}")
+
+        return messages
+
     def _convert_prompt_messages_to_tongyi_messages(
         self,
         credentials: dict,
@@ -757,36 +839,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 api_key=credentials["dashscope_api_key"],
                 base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
             )
-        temp_file_path = None
-        try:
-            with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-                temp_file_path = temp_file.name
-                if message_content.base64_data:
-                    file_content = base64.b64decode(message_content.base64_data)
-                    temp_file.write(file_content)
-                else:
-                    try:
-                        response = requests.get(message_content.url, timeout=60)
-                        response.raise_for_status()
-                        temp_file.write(response.content)
-                    except Exception as ex:
-                        raise ValueError(
-                            f"Failed to fetch data from url {message_content.url}, {ex}"
-                        ) from ex
-                temp_file.flush()
-            # Close temp file first, then reopen with open() for OpenAI SDK compatibility
-            with open(temp_file_path, "rb") as f:
-                response = client.files.create(file=f, purpose="file-extract")
-            return response.id
-        finally:
-            # Clean up temporary file after upload
-            if temp_file_path and os.path.exists(temp_file_path):
-                try:
-                    os.remove(temp_file_path)
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to remove temporary file {temp_file_path}: {e}"
-                    )
+        return QwenLongFileUploader(client).upload(message_content)
 
     def _convert_tools(self, tools: list[PromptMessageTool]) -> list[dict]:
         """

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -1,6 +1,6 @@
 import base64
-import logging
 import json
+import logging
 import os
 import tempfile
 import uuid
@@ -9,6 +9,10 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Optional, Union, cast
 
+# isort: off
+import dify_plugin  # noqa: F401 - patches gevent before HTTP SDK imports
+# isort: on
+import openai
 from dashscope import Generation, MultiModalConversation, get_tokenizer
 from dashscope.api_entities.dashscope_response import GenerationResponse
 from dashscope.common.error import (
@@ -37,6 +41,7 @@ from dify_plugin.entities.model.llm import (
 )
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
+    AudioPromptMessageContent,
     DocumentPromptMessageContent,
     ImagePromptMessageContent,
     PromptMessage,
@@ -48,7 +53,6 @@ from dify_plugin.entities.model.message import (
     ToolPromptMessage,
     UserPromptMessage,
     VideoPromptMessageContent,
-    AudioPromptMessageContent,
 )
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,
@@ -60,10 +64,11 @@ from dify_plugin.errors.model import (
     InvokeServerUnavailableError,
 )
 from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
-from openai import OpenAI
+
 from models._common import get_http_base_address
+
 from ..constant import BURY_POINT_HEADER
-from .qwen_long import QwenLongFileUploader
+from .qwen_long import MAX_DOCUMENT_INPUT_BASE64_BYTES, QwenLongFiles
 
 logger = logging.getLogger(__name__)
 
@@ -305,45 +310,89 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
 
         base_address = get_http_base_address(credentials)
 
-        if ModelFeature.VISION in (model_schema.features or []):
-            params["messages"] = self._convert_prompt_messages_to_tongyi_messages(
-                credentials, prompt_messages, rich_content=True
-            )
-            response = MultiModalConversation.call(
-                **params,
-                stream=stream,
-                headers=self._get_market_bury_point_header(params["messages"], extra_headers_str),
-                incremental_output=incremental_output,
-                base_address=base_address,
-            )
-        else:
-            if model.startswith("qwen-long"):
-                params["messages"] = self._convert_qwen_long_prompt_messages(
-                    credentials, prompt_messages
+        qwen_long_files = None
+        try:
+            if ModelFeature.VISION in (model_schema.features or []):
+                params["messages"] = self._convert_prompt_messages_to_tongyi_messages(
+                    prompt_messages, rich_content=True
+                )
+                response = MultiModalConversation.call(
+                    **params,
+                    stream=stream,
+                    headers=self._get_market_bury_point_header(
+                        params["messages"], extra_headers_str
+                    ),
+                    incremental_output=incremental_output,
+                    base_address=base_address,
                 )
             else:
-                params["messages"] = self._convert_prompt_messages_to_tongyi_messages(
-                    credentials, prompt_messages
+                if model.startswith("qwen-long"):
+                    if credentials.get("use_international_endpoint", "false") == "true":
+                        raise InvokeBadRequestError(
+                            "Qwen-Long is only available in the Beijing region."
+                        )
+                    if tools:
+                        raise InvokeBadRequestError("Qwen-Long does not support tools.")
+                    qwen_long_files = QwenLongFiles(
+                        openai.OpenAI(
+                            api_key=credentials["dashscope_api_key"],
+                            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+                            max_retries=0,
+                            timeout=120,
+                        )
+                    )
+                    params["messages"] = self._convert_qwen_long_prompt_messages(
+                        qwen_long_files, prompt_messages
+                    )
+                else:
+                    params["messages"] = (
+                        self._convert_prompt_messages_to_tongyi_messages(
+                            prompt_messages
+                        )
+                    )
+                response = Generation.call(
+                    **params,
+                    headers=self._get_market_bury_point_header(
+                        params["messages"], extra_headers_str
+                    ),
+                    result_format="message",
+                    stream=stream,
+                    incremental_output=incremental_output,
+                    base_address=base_address,
                 )
-            response = Generation.call(
-                **params,
-                headers=self._get_market_bury_point_header(params["messages"], extra_headers_str),
-                result_format="message",
-                stream=stream,
-                incremental_output=incremental_output,
-                base_address=base_address,
-            )
+        except BaseException:
+            if qwen_long_files:
+                qwen_long_files.cleanup()
+            raise
+
         if stream:
-            return self._handle_generate_stream_response(
+            result = self._handle_generate_stream_response(
                 model,
                 credentials,
                 response,
                 prompt_messages,
                 incremental_output,
             )
-        return self._handle_generate_response(
-            model, credentials, response, prompt_messages
-        )
+            if qwen_long_files:
+                result = self._cleanup_qwen_long_stream(result, qwen_long_files)
+            return result
+        try:
+            return self._handle_generate_response(
+                model, credentials, response, prompt_messages
+            )
+        finally:
+            if qwen_long_files:
+                qwen_long_files.cleanup()
+
+    @staticmethod
+    def _cleanup_qwen_long_stream(
+        result: Generator,
+        files: QwenLongFiles,
+    ) -> Generator:
+        try:
+            yield from result
+        finally:
+            files.cleanup()
 
     def _handle_generate_response(
         self,
@@ -596,84 +645,120 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
 
     def _convert_qwen_long_prompt_messages(
         self,
-        credentials: dict,
+        files: QwenLongFiles,
         prompt_messages: list[PromptMessage],
     ) -> list[dict]:
-        document_count = sum(
-            1
-            for prompt_message in prompt_messages
-            if isinstance(prompt_message.content, list)
-            for content in prompt_message.content
-            if isinstance(content, DocumentPromptMessageContent)
-        )
+        normalized_messages: list[
+            tuple[str, str, list[DocumentPromptMessageContent]]
+        ] = []
+        document_count = 0
+        document_base64_bytes = 0
+        index = 0
+
+        while index < len(prompt_messages):
+            prompt_message = prompt_messages[index]
+            if isinstance(prompt_message, SystemPromptMessage):
+                if isinstance(prompt_message.content, list) and any(
+                    not isinstance(content, TextPromptMessageContent)
+                    for content in prompt_message.content
+                ):
+                    raise InvokeBadRequestError(
+                        "Qwen-Long only supports text system messages."
+                    )
+                text = prompt_message.get_text_content().strip()
+                if text:
+                    normalized_messages.append(("system", text, []))
+                index += 1
+                continue
+
+            if isinstance(prompt_message, UserPromptMessage):
+                user_run = []
+                while index < len(prompt_messages) and isinstance(
+                    prompt_messages[index], UserPromptMessage
+                ):
+                    user_run.append(prompt_messages[index])
+                    index += 1
+
+                texts = []
+                documents = []
+                for user_message in user_run:
+                    if isinstance(user_message.content, list):
+                        for content in user_message.content:
+                            if isinstance(content, DocumentPromptMessageContent):
+                                documents.append(content)
+                            elif not isinstance(content, TextPromptMessageContent):
+                                raise InvokeBadRequestError(
+                                    f"Qwen-Long does not support {content.type.value} input."
+                                )
+                    texts.append(user_message.get_text_content().strip())
+
+                question = "\n".join(text for text in texts if text)
+                if not question:
+                    raise InvokeBadRequestError(
+                        "Qwen-Long requires a non-empty text question."
+                    )
+                normalized_messages.append(("user", question, documents))
+                document_count += len(documents)
+                document_base64_bytes += sum(
+                    len(document.base64_data) for document in documents
+                )
+                continue
+
+            if isinstance(prompt_message, AssistantPromptMessage):
+                if isinstance(prompt_message.content, list) and any(
+                    not isinstance(content, TextPromptMessageContent)
+                    for content in prompt_message.content
+                ):
+                    raise InvokeBadRequestError(
+                        "Qwen-Long only supports text assistant messages."
+                    )
+                normalized_messages.append(
+                    ("assistant", prompt_message.get_text_content() or " ", [])
+                )
+                index += 1
+                continue
+
+            if isinstance(prompt_message, ToolPromptMessage):
+                raise InvokeBadRequestError("Qwen-Long does not support tool messages.")
+
+            raise ValueError(f"Got unknown type {prompt_message}")
+
         if document_count > 100:
             raise InvokeBadRequestError(
                 "Qwen-Long supports at most 100 documents per request."
             )
-
-        messages = []
-        has_role_definition = bool(
-            prompt_messages
-            and isinstance(prompt_messages[0], SystemPromptMessage)
-            and prompt_messages[0].get_text_content().strip()
-        )
-        if document_count and not has_role_definition:
-            messages.append(
-                {"role": "system", "content": "You are a helpful assistant."}
+        if document_base64_bytes > MAX_DOCUMENT_INPUT_BASE64_BYTES:
+            raise InvokeBadRequestError(
+                "Qwen-Long document input exceeds this plugin's aggregate size limit."
             )
 
-        for prompt_message in prompt_messages:
-            if isinstance(prompt_message, SystemPromptMessage):
-                content = prompt_message.get_text_content()
-                if content:
-                    messages.append({"role": "system", "content": content})
-                continue
+        has_role_definition = bool(
+            normalized_messages
+            and normalized_messages[0][0] == "system"
+            and normalized_messages[0][1]
+        )
+        if document_count and not has_role_definition:
+            normalized_messages.insert(
+                0, ("system", "You are a helpful assistant.", [])
+            )
 
-            if isinstance(prompt_message, UserPromptMessage):
-                text_content = prompt_message.get_text_content().strip()
-                if not text_content:
-                    raise InvokeBadRequestError(
-                        "Qwen-Long requires a non-empty text question."
-                    )
+        messages = []
+        for role, text, documents in normalized_messages:
+            if role == "system" and text:
+                messages.append({"role": "system", "content": text})
+            if documents:
+                file_ids = [
+                    f"fileid://{files.upload(document)}" for document in documents
+                ]
+                messages.append({"role": "system", "content": ",".join(file_ids)})
+            if role != "system":
+                messages.append({"role": role, "content": text})
 
-                file_ids = []
-                if isinstance(prompt_message.content, list):
-                    for content in prompt_message.content:
-                        if isinstance(content, DocumentPromptMessageContent):
-                            file_id = self._upload_file_to_tongyi(
-                                credentials, content
-                            )
-                            file_ids.append(f"fileid://{file_id}")
-                        elif not isinstance(content, TextPromptMessageContent):
-                            raise InvokeBadRequestError(
-                                f"Qwen-Long does not support {content.type.value} input."
-                            )
-
-                if file_ids:
-                    messages.append(
-                        {"role": "system", "content": ",".join(file_ids)}
-                    )
-
-                messages.append({"role": "user", "content": text_content})
-                continue
-
-            if isinstance(prompt_message, AssistantPromptMessage):
-                content = prompt_message.get_text_content() or " "
-                messages.append({"role": "assistant", "content": content})
-                continue
-
-            if isinstance(prompt_message, ToolPromptMessage):
-                raise InvokeBadRequestError(
-                    "Qwen-Long does not support tool messages."
-                )
-
-            raise ValueError(f"Got unknown type {prompt_message}")
-
+        files.wait_until_processed()
         return messages
 
     def _convert_prompt_messages_to_tongyi_messages(
         self,
-        credentials: dict,
         prompt_messages: list[PromptMessage],
         rich_content: bool = False,
     ) -> list[dict]:
@@ -710,7 +795,6 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                     )
                 else:
                     user_messages = []
-                    file_id_list = []
                     for message_content in prompt_message.content:
                         if message_content.type == PromptMessageContentType.TEXT:
                             message_content = cast(
@@ -751,19 +835,6 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                                 audio_data = self._save_base64_to_file(audio_data)
                             sub_message_dict = {"audio": audio_data}
                             user_messages.append(sub_message_dict)
-                        elif message_content.type == PromptMessageContentType.DOCUMENT:
-                            message_content = cast(
-                                DocumentPromptMessageContent, message_content
-                            )
-                            file_id = self._upload_file_to_tongyi(
-                                credentials, message_content
-                            )
-                            file_id_url = f"fileid://{file_id}"
-                            file_id_list.append(file_id_url)
-                    if len(file_id_list) > 0:
-                        tongyi_messages.append(
-                            {"role": "system", "content": ",".join(file_id_list)}
-                        )
                     user_messages = sorted(user_messages, key=lambda x: "text" in x)
                     tongyi_messages.append({"role": "user", "content": user_messages})
             elif isinstance(prompt_message, AssistantPromptMessage):
@@ -819,27 +890,6 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             except Exception as e:
                 logger.warning(f"Failed to remove temporary file {file_path}: {e}")
         self._temp_files.clear()
-
-    def _upload_file_to_tongyi(
-        self, credentials: dict, message_content: DocumentPromptMessageContent
-    ) -> str:
-        """
-        Upload file to Tongyi
-
-        :param credentials: credentials for Tongyi
-        :param message_content: message content to upload
-        :return: file ID in Tongyi
-        """
-        client = OpenAI(
-            api_key=credentials["dashscope_api_key"],
-            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-        )
-        if credentials.get("use_international_endpoint", "false") == "true":
-            client = OpenAI(
-                api_key=credentials["dashscope_api_key"],
-                base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-            )
-        return QwenLongFileUploader(client).upload(message_content)
 
     def _convert_tools(self, tools: list[PromptMessageTool]) -> list[dict]:
         """
@@ -961,6 +1011,11 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             else:
                 raise InvokeServerUnavailableError(error_msg)
 
+    def _transform_invoke_error(self, error: Exception) -> InvokeError:
+        if isinstance(error, InvokeError):
+            return error
+        return super()._transform_invoke_error(error)
+
     @property
     def _invoke_error_mapping(self) -> dict[type[InvokeError], list[type[Exception]]]:
         """
@@ -972,14 +1027,29 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         :return: Invoke error mapping
         """
         return {
-            InvokeConnectionError: [RequestFailure],
-            InvokeServerUnavailableError: [ServiceUnavailableError],
-            InvokeRateLimitError: [],
-            InvokeAuthorizationError: [AuthenticationError],
+            InvokeServerUnavailableError: [
+                ServiceUnavailableError,
+                openai.InternalServerError,
+            ],
+            InvokeConnectionError: [
+                RequestFailure,
+                openai.APIConnectionError,
+                openai.APITimeoutError,
+            ],
+            InvokeRateLimitError: [openai.RateLimitError],
+            InvokeAuthorizationError: [
+                AuthenticationError,
+                openai.AuthenticationError,
+                openai.PermissionDeniedError,
+            ],
             InvokeBadRequestError: [
                 InvalidParameter,
                 UnsupportedModel,
                 UnsupportedHTTPMethod,
+                openai.BadRequestError,
+                openai.NotFoundError,
+                openai.UnprocessableEntityError,
+                openai.APIError,
             ],
         }
 

--- a/models/tongyi/models/llm/qwen-long.yaml
+++ b/models/tongyi/models/llm/qwen-long.yaml
@@ -1,12 +1,9 @@
-# for more details, please refer to https://help.aliyun.com/zh/model-studio/getting-started/models
+# https://help.aliyun.com/zh/model-studio/long-context-qwen-long
 model: qwen-long
 label:
   en_US: qwen-long
 model_type: llm
 features:
-  - multi-tool-call
-  - agent-thought
-  - stream-tool-call
   - document
 model_properties:
   mode: chat
@@ -26,7 +23,7 @@ parameter_rules:
     type: int
     default: 2000
     min: 1
-    max: 8192
+    max: 32768
     help:
       zh_Hans: 用于指定模型在生成内容时 token 的最大数量，它定义了生成的上限，但不保证每次都会生成到这个数量。
       en_US: It is used to specify the maximum number of tokens when the model generates content. It defines the upper limit of generation, but does not guarantee that this number will be generated every time.

--- a/models/tongyi/models/llm/qwen_long.py
+++ b/models/tongyi/models/llm/qwen_long.py
@@ -1,0 +1,106 @@
+import base64
+import os
+import tempfile
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+import requests
+from dify_plugin.entities.model.message import DocumentPromptMessageContent
+from openai import OpenAI
+
+FILE_DOWNLOAD_TIMEOUT_SECONDS = 60
+FILE_PROCESSING_POLL_INTERVAL_SECONDS = 5
+FILE_PROCESSING_TIMEOUT_SECONDS = 300
+PENDING_FILE_STATUSES = {"processing", "uploaded"}
+
+
+class QwenLongFileUploader:
+    def __init__(self, client: OpenAI) -> None:
+        self.client = client
+
+    def upload(self, content: DocumentPromptMessageContent) -> str:
+        payload = self._read_payload(content)
+        filename = self._filename(content)
+        suffix = Path(filename).suffix
+        temp_file_path = None
+
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+                temp_file.write(payload)
+                temp_file.flush()
+                temp_file_path = temp_file.name
+
+            with open(temp_file_path, "rb") as file:
+                uploaded_file = self.client.files.create(
+                    file=(filename, file, content.mime_type or None),
+                    purpose="file-extract",
+                )
+
+            processed_file = self._wait_until_processed(uploaded_file)
+            return processed_file.id
+        finally:
+            if temp_file_path:
+                with suppress(FileNotFoundError, PermissionError):
+                    os.unlink(temp_file_path)
+
+    @staticmethod
+    def _read_payload(content: DocumentPromptMessageContent) -> bytes:
+        if content.base64_data:
+            return base64.b64decode(content.base64_data)
+
+        if not content.url:
+            raise ValueError(
+                "Qwen-Long document content requires base64 data or a URL."
+            )
+
+        try:
+            response = requests.get(
+                content.url,
+                timeout=FILE_DOWNLOAD_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            raise ValueError(
+                f"Failed to fetch Qwen-Long document from {content.url}"
+            ) from exc
+        return response.content
+
+    @staticmethod
+    def _filename(content: DocumentPromptMessageContent) -> str:
+        if content.filename:
+            return Path(content.filename).name
+        if content.format:
+            return f"document.{content.format.lstrip('.')}"
+        return "document"
+
+    def _wait_until_processed(self, uploaded_file: Any) -> Any:
+        deadline = time.monotonic() + FILE_PROCESSING_TIMEOUT_SECONDS
+        current_file = uploaded_file
+
+        while self._status(current_file) in PENDING_FILE_STATUSES:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Timed out waiting for Qwen-Long file {current_file.id} to be processed."
+                )
+            time.sleep(FILE_PROCESSING_POLL_INTERVAL_SECONDS)
+            current_file = self.client.files.retrieve(current_file.id)
+
+        if self._status(current_file) == "error":
+            details = getattr(current_file, "status_details", None) or getattr(
+                current_file, "error", None
+            )
+            message = f"Failed to process Qwen-Long file {current_file.id}."
+            if details:
+                message = f"{message} {details}"
+            raise ValueError(message)
+
+        return current_file
+
+    @staticmethod
+    def _status(file: Any) -> str:
+        status = getattr(file, "status", "")
+        if hasattr(status, "value"):
+            status = status.value
+        return str(status or "").lower()

--- a/models/tongyi/models/llm/qwen_long.py
+++ b/models/tongyi/models/llm/qwen_long.py
@@ -1,106 +1,161 @@
 import base64
-import os
-import tempfile
+import logging
 import time
-from contextlib import suppress
 from pathlib import Path
-from typing import Any
+from tempfile import SpooledTemporaryFile
 
-import requests
 from dify_plugin.entities.model.message import DocumentPromptMessageContent
+from dify_plugin.errors.model import (
+    InvokeBadRequestError,
+    InvokeServerUnavailableError,
+)
 from openai import OpenAI
 
-FILE_DOWNLOAD_TIMEOUT_SECONDS = 60
 FILE_PROCESSING_POLL_INTERVAL_SECONDS = 5
-FILE_PROCESSING_TIMEOUT_SECONDS = 300
-PENDING_FILE_STATUSES = {"processing", "uploaded"}
+FILE_PROCESSING_TIMEOUT_SECONDS = 240
+# ponytail: pace each invocation only; add a shared limiter if this becomes high traffic.
+FILE_UPLOAD_INTERVAL_SECONDS = 0.35
+FILE_REQUEST_INTERVAL_SECONDS = 0.1
+FILE_CLEANUP_TIMEOUT_SECONDS = 10
+FILE_READ_CHUNK_BYTES = 1024 * 1024
+IMAGE_MAX_BYTES = 20 * 1024 * 1024
+DOCUMENT_MAX_BYTES = 150 * 1024 * 1024
+MAX_DOCUMENT_INPUT_BASE64_BYTES = 4 * ((DOCUMENT_MAX_BYTES + 2) // 3)
+IMAGE_FORMATS = {"bmp", "gif", "jpeg", "jpg", "png"}
+
+logger = logging.getLogger(__name__)
 
 
-class QwenLongFileUploader:
+class QwenLongFiles:
     def __init__(self, client: OpenAI) -> None:
         self.client = client
+        self.uploaded_ids: list[str] = []
 
     def upload(self, content: DocumentPromptMessageContent) -> str:
-        payload = self._read_payload(content)
-        filename = self._filename(content)
-        suffix = Path(filename).suffix
-        temp_file_path = None
+        if self.uploaded_ids:
+            time.sleep(FILE_UPLOAD_INTERVAL_SECONDS)
 
-        try:
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
-                temp_file.write(payload)
-                temp_file.flush()
-                temp_file_path = temp_file.name
+        filename = Path(content.filename).name or (
+            f"document.{content.format.lstrip('.')}"
+        )
+        max_bytes = (
+            IMAGE_MAX_BYTES
+            if content.mime_type.lower().startswith("image/")
+            or content.format.lower().lstrip(".") in IMAGE_FORMATS
+            else DOCUMENT_MAX_BYTES
+        )
 
-            with open(temp_file_path, "rb") as file:
-                uploaded_file = self.client.files.create(
-                    file=(filename, file, content.mime_type or None),
-                    purpose="file-extract",
-                )
-
-            processed_file = self._wait_until_processed(uploaded_file)
-            return processed_file.id
-        finally:
-            if temp_file_path:
-                with suppress(FileNotFoundError, PermissionError):
-                    os.unlink(temp_file_path)
-
-    @staticmethod
-    def _read_payload(content: DocumentPromptMessageContent) -> bytes:
-        if content.base64_data:
-            return base64.b64decode(content.base64_data)
-
-        if not content.url:
-            raise ValueError(
-                "Qwen-Long document content requires base64 data or a URL."
+        with SpooledTemporaryFile(max_size=FILE_READ_CHUNK_BYTES) as file:
+            self._write_content(file, content, max_bytes)
+            file.seek(0)
+            uploaded = self.client.files.create(
+                file=(filename, file, content.mime_type or None),
+                purpose="file-extract",
             )
+            self.uploaded_ids.append(uploaded.id)
 
-        try:
-            response = requests.get(
-                content.url,
-                timeout=FILE_DOWNLOAD_TIMEOUT_SECONDS,
-            )
-            response.raise_for_status()
-        except requests.exceptions.RequestException as exc:
-            raise ValueError(
-                f"Failed to fetch Qwen-Long document from {content.url}"
-            ) from exc
-        return response.content
+        return uploaded.id
 
-    @staticmethod
-    def _filename(content: DocumentPromptMessageContent) -> str:
-        if content.filename:
-            return Path(content.filename).name
-        if content.format:
-            return f"document.{content.format.lstrip('.')}"
-        return "document"
-
-    def _wait_until_processed(self, uploaded_file: Any) -> Any:
+    def wait_until_processed(self) -> None:
         deadline = time.monotonic() + FILE_PROCESSING_TIMEOUT_SECONDS
-        current_file = uploaded_file
-
-        while self._status(current_file) in PENDING_FILE_STATUSES:
-            if time.monotonic() >= deadline:
-                raise TimeoutError(
-                    f"Timed out waiting for Qwen-Long file {current_file.id} to be processed."
+        for index, file_id in enumerate(self.uploaded_ids):
+            if index:
+                time.sleep(FILE_REQUEST_INTERVAL_SECONDS)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise InvokeServerUnavailableError(
+                    "Timed out waiting for Qwen-Long documents to be processed."
                 )
-            time.sleep(FILE_PROCESSING_POLL_INTERVAL_SECONDS)
-            current_file = self.client.files.retrieve(current_file.id)
+            try:
+                processed = self.client.files.wait_for_processing(
+                    file_id,
+                    poll_interval=FILE_PROCESSING_POLL_INTERVAL_SECONDS,
+                    max_wait_seconds=remaining,
+                )
+            except RuntimeError as exc:
+                raise InvokeServerUnavailableError(
+                    "Timed out waiting for Qwen-Long documents to be processed."
+                ) from exc
 
-        if self._status(current_file) == "error":
-            details = getattr(current_file, "status_details", None) or getattr(
-                current_file, "error", None
-            )
-            message = f"Failed to process Qwen-Long file {current_file.id}."
-            if details:
-                message = f"{message} {details}"
-            raise ValueError(message)
+            status = getattr(processed.status, "value", processed.status)
+            if status != "processed":
+                details = getattr(processed, "status_details", None) or getattr(
+                    processed, "error", None
+                )
+                message = f"Qwen-Long document processing ended with status {status}."
+                if details:
+                    message = f"{message} {details}"
+                raise InvokeBadRequestError(message)
 
-        return current_file
+    def cleanup(self) -> None:
+        remaining = list(self.uploaded_ids)
+        for attempt in range(2):
+            failed = []
+            for index, file_id in enumerate(remaining):
+                if index or attempt:
+                    time.sleep(FILE_REQUEST_INTERVAL_SECONDS)
+                try:
+                    deleted = self.client.files.delete(
+                        file_id,
+                        timeout=FILE_CLEANUP_TIMEOUT_SECONDS,
+                    )
+                    if deleted.deleted is not True:
+                        failed.append(file_id)
+                except Exception:  # noqa: BLE001 - cleanup must remain best effort
+                    failed.append(file_id)
+            remaining = failed
+            if not remaining:
+                break
+        for file_id in remaining:
+            logger.warning("Failed to delete temporary Qwen-Long file %s.", file_id)
+        self.uploaded_ids.clear()
+        try:
+            self.client.close()
+        except Exception:
+            logger.warning("Failed to close Qwen-Long file client.", exc_info=True)
 
     @staticmethod
-    def _status(file: Any) -> str:
-        status = getattr(file, "status", "")
-        if hasattr(status, "value"):
-            status = status.value
-        return str(status or "").lower()
+    def _write_content(
+        file,
+        content: DocumentPromptMessageContent,
+        max_bytes: int,
+    ) -> None:
+        if not content.base64_data:
+            raise InvokeBadRequestError(
+                "Qwen-Long document content requires base64 data; set "
+                "MULTIMODAL_SEND_FORMAT=base64."
+            )
+
+        max_encoded_bytes = 4 * ((max_bytes + 2) // 3)
+        if len(content.base64_data) > max_encoded_bytes:
+            raise InvokeBadRequestError(
+                "Qwen-Long document exceeds the supported file size."
+            )
+
+        size = 0
+        try:
+            for offset in range(0, len(content.base64_data), FILE_READ_CHUNK_BYTES):
+                encoded_chunk = content.base64_data[
+                    offset : offset + FILE_READ_CHUNK_BYTES
+                ]
+                if (
+                    offset + FILE_READ_CHUNK_BYTES < len(content.base64_data)
+                    and "=" in encoded_chunk
+                ):
+                    raise InvokeBadRequestError(
+                        "Qwen-Long document contains invalid base64 data."
+                    )
+                chunk = base64.b64decode(
+                    encoded_chunk,
+                    validate=True,
+                )
+                size += len(chunk)
+                if size > max_bytes:
+                    raise InvokeBadRequestError(
+                        "Qwen-Long document exceeds the supported file size."
+                    )
+                file.write(chunk)
+        except ValueError as exc:
+            raise InvokeBadRequestError(
+                "Qwen-Long document contains invalid base64 data."
+            ) from exc

--- a/models/tongyi/tests/test_llm_qwen_long.py
+++ b/models/tongyi/tests/test_llm_qwen_long.py
@@ -1,0 +1,234 @@
+import base64
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dify_plugin.entities.model import ModelFeature
+from dify_plugin.entities.model.message import (
+    DocumentPromptMessageContent,
+    SystemPromptMessage,
+    TextPromptMessageContent,
+    UserPromptMessage,
+)
+from dify_plugin.errors.model import InvokeBadRequestError
+
+from models.llm.llm import TongyiLargeLanguageModel
+from models.llm.qwen_long import QwenLongFileUploader
+
+
+def _document(filename: str = "report.pdf") -> DocumentPromptMessageContent:
+    return DocumentPromptMessageContent(
+        format="pdf",
+        base64_data=base64.b64encode(b"document content").decode(),
+        mime_type="application/pdf",
+        filename=filename,
+    )
+
+
+def _model() -> TongyiLargeLanguageModel:
+    return TongyiLargeLanguageModel(model_schemas=MagicMock())
+
+
+def test_qwen_long_converts_document_to_system_file_id() -> None:
+    model = _model()
+    model._upload_file_to_tongyi = MagicMock(return_value="file-fe-123")
+
+    messages = model._convert_qwen_long_prompt_messages(
+        credentials={"dashscope_api_key": "test-key"},
+        prompt_messages=[
+            SystemPromptMessage(content="You are a document analyst."),
+            UserPromptMessage(
+                content=[
+                    TextPromptMessageContent(data="Summarize this document."),
+                    _document(),
+                ]
+            ),
+        ],
+    )
+
+    assert messages == [
+        {"role": "system", "content": "You are a document analyst."},
+        {"role": "system", "content": "fileid://file-fe-123"},
+        {"role": "user", "content": "Summarize this document."},
+    ]
+    assert isinstance(messages[2]["content"], str)
+
+
+def test_qwen_long_generate_sends_string_user_content() -> None:
+    model = _model()
+    model.get_model_mode = MagicMock(return_value="chat")
+    model.get_model_schema = MagicMock(
+        return_value=SimpleNamespace(features=[ModelFeature.DOCUMENT])
+    )
+    model._upload_file_to_tongyi = MagicMock(return_value="file-fe-123")
+    model._handle_generate_response = MagicMock(return_value="result")
+
+    with patch(
+        "models.llm.llm.Generation.call",
+        return_value=MagicMock(),
+    ) as call:
+        result = model._generate(
+            model="qwen-long",
+            credentials={"dashscope_api_key": "test-key"},
+            prompt_messages=[
+                SystemPromptMessage(content="You are a document analyst."),
+                UserPromptMessage(
+                    content=[
+                        TextPromptMessageContent(data="Summarize this document."),
+                        _document(),
+                    ]
+                ),
+            ],
+            model_parameters={},
+            stream=False,
+        )
+
+    assert result == "result"
+    messages = call.call_args.kwargs["messages"]
+    assert messages == [
+        {"role": "system", "content": "You are a document analyst."},
+        {"role": "system", "content": "fileid://file-fe-123"},
+        {"role": "user", "content": "Summarize this document."},
+    ]
+    assert isinstance(messages[2]["content"], str)
+
+
+def test_qwen_long_injects_role_definition_for_document_input() -> None:
+    model = _model()
+    model._upload_file_to_tongyi = MagicMock(return_value="file-fe-123")
+
+    messages = model._convert_qwen_long_prompt_messages(
+        credentials={"dashscope_api_key": "test-key"},
+        prompt_messages=[
+            UserPromptMessage(
+                content=[
+                    TextPromptMessageContent(data="Summarize this document."),
+                    _document(),
+                ]
+            )
+        ],
+    )
+
+    assert messages[0] == {
+        "role": "system",
+        "content": "You are a helpful assistant.",
+    }
+    assert messages[1] == {
+        "role": "system",
+        "content": "fileid://file-fe-123",
+    }
+    assert messages[2] == {
+        "role": "user",
+        "content": "Summarize this document.",
+    }
+
+
+def test_qwen_long_combines_multiple_file_ids() -> None:
+    model = _model()
+    model._upload_file_to_tongyi = MagicMock(side_effect=["file-fe-123", "file-fe-456"])
+
+    messages = model._convert_qwen_long_prompt_messages(
+        credentials={"dashscope_api_key": "test-key"},
+        prompt_messages=[
+            SystemPromptMessage(content="You are a document analyst."),
+            UserPromptMessage(
+                content=[
+                    TextPromptMessageContent(data="Compare these documents."),
+                    _document("first.pdf"),
+                    _document("second.pdf"),
+                ]
+            ),
+        ],
+    )
+
+    assert messages[1] == {
+        "role": "system",
+        "content": "fileid://file-fe-123,fileid://file-fe-456",
+    }
+    assert messages[2] == {
+        "role": "user",
+        "content": "Compare these documents.",
+    }
+
+
+def test_qwen_long_rejects_document_without_question() -> None:
+    model = _model()
+    model._upload_file_to_tongyi = MagicMock(return_value="file-fe-123")
+
+    with pytest.raises(InvokeBadRequestError, match="non-empty text question"):
+        model._convert_qwen_long_prompt_messages(
+            credentials={"dashscope_api_key": "test-key"},
+            prompt_messages=[UserPromptMessage(content=[_document()])],
+        )
+
+
+def test_qwen_long_file_uploader_waits_until_processed() -> None:
+    client = MagicMock()
+    client.files.create.return_value = SimpleNamespace(
+        id="file-fe-123",
+        status="processing",
+    )
+    client.files.retrieve.return_value = SimpleNamespace(
+        id="file-fe-123",
+        status="processed",
+    )
+
+    with patch("models.llm.qwen_long.time.sleep") as sleep:
+        file_id = QwenLongFileUploader(client).upload(_document())
+
+    assert file_id == "file-fe-123"
+    client.files.retrieve.assert_called_once_with("file-fe-123")
+    sleep.assert_called_once_with(5)
+    upload = client.files.create.call_args.kwargs
+    assert upload["purpose"] == "file-extract"
+    assert upload["file"][0] == "report.pdf"
+    assert upload["file"][2] == "application/pdf"
+
+
+def test_qwen_long_file_uploader_reports_processing_error() -> None:
+    client = MagicMock()
+    client.files.create.return_value = SimpleNamespace(
+        id="file-fe-123",
+        status="error",
+        status_details="invalid document",
+    )
+
+    with pytest.raises(ValueError, match="invalid document"):
+        QwenLongFileUploader(client).upload(_document())
+
+
+def test_qwen_long_file_uploader_times_out() -> None:
+    client = MagicMock()
+    client.files.create.return_value = SimpleNamespace(
+        id="file-fe-123",
+        status="processing",
+    )
+
+    with (
+        patch(
+            "models.llm.qwen_long.time.monotonic",
+            side_effect=[0, 301],
+        ),
+        pytest.raises(TimeoutError, match="Timed out"),
+    ):
+        QwenLongFileUploader(client).upload(_document())
+
+    client.files.retrieve.assert_not_called()
+
+
+def test_qwen_long_model_metadata_matches_supported_features() -> None:
+    model_file = Path(__file__).parent.parent / "models" / "llm" / "qwen-long.yaml"
+    schema = yaml.safe_load(model_file.read_text())
+
+    assert schema["features"] == ["document"]
+    max_tokens = next(
+        rule for rule in schema["parameter_rules"] if rule["name"] == "max_tokens"
+    )
+    assert max_tokens["max"] == 32768

--- a/models/tongyi/tests/test_llm_qwen_long.py
+++ b/models/tongyi/tests/test_llm_qwen_long.py
@@ -1,234 +1,502 @@
 import base64
 import os
+import subprocess
 import sys
-from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
-import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from dify_plugin.entities.model import ModelFeature
 from dify_plugin.entities.model.message import (
+    AssistantPromptMessage,
     DocumentPromptMessageContent,
     SystemPromptMessage,
     TextPromptMessageContent,
     UserPromptMessage,
 )
-from dify_plugin.errors.model import InvokeBadRequestError
+from dify_plugin.errors.model import (
+    InvokeBadRequestError,
+    InvokeServerUnavailableError,
+)
 
 from models.llm.llm import TongyiLargeLanguageModel
-from models.llm.qwen_long import QwenLongFileUploader
+from models.llm.qwen_long import QwenLongFiles
 
 
-def _document(filename: str = "report.pdf") -> DocumentPromptMessageContent:
+def _document(
+    filename: str = "report.pdf",
+    data: bytes = b"document content",
+) -> DocumentPromptMessageContent:
     return DocumentPromptMessageContent(
         format="pdf",
-        base64_data=base64.b64encode(b"document content").decode(),
+        base64_data=base64.b64encode(data).decode(),
         mime_type="application/pdf",
         filename=filename,
     )
 
 
 def _model() -> TongyiLargeLanguageModel:
-    return TongyiLargeLanguageModel(model_schemas=MagicMock())
-
-
-def test_qwen_long_converts_document_to_system_file_id() -> None:
-    model = _model()
-    model._upload_file_to_tongyi = MagicMock(return_value="file-fe-123")
-
-    messages = model._convert_qwen_long_prompt_messages(
-        credentials={"dashscope_api_key": "test-key"},
-        prompt_messages=[
-            SystemPromptMessage(content="You are a document analyst."),
-            UserPromptMessage(
-                content=[
-                    TextPromptMessageContent(data="Summarize this document."),
-                    _document(),
-                ]
-            ),
-        ],
-    )
-
-    assert messages == [
-        {"role": "system", "content": "You are a document analyst."},
-        {"role": "system", "content": "fileid://file-fe-123"},
-        {"role": "user", "content": "Summarize this document."},
-    ]
-    assert isinstance(messages[2]["content"], str)
-
-
-def test_qwen_long_generate_sends_string_user_content() -> None:
-    model = _model()
+    model = TongyiLargeLanguageModel(model_schemas=MagicMock())
     model.get_model_mode = MagicMock(return_value="chat")
     model.get_model_schema = MagicMock(
         return_value=SimpleNamespace(features=[ModelFeature.DOCUMENT])
     )
-    model._upload_file_to_tongyi = MagicMock(return_value="file-fe-123")
-    model._handle_generate_response = MagicMock(return_value="result")
+    return model
 
-    with patch(
-        "models.llm.llm.Generation.call",
-        return_value=MagicMock(),
-    ) as call:
+
+def _client() -> MagicMock:
+    client = MagicMock()
+    client.files.create.return_value = SimpleNamespace(id="file-fe-123")
+    client.files.wait_for_processing.return_value = SimpleNamespace(
+        id="file-fe-123",
+        status="processed",
+    )
+    client.files.delete.return_value = SimpleNamespace(deleted=True)
+    return client
+
+
+def test_qwen_long_generate_normalizes_graphon_split_input_and_cleans_up() -> None:
+    model = _model()
+    model._handle_generate_response = MagicMock(return_value="result")
+    client = _client()
+
+    with (
+        patch("models.llm.llm.openai.OpenAI", return_value=client) as openai_client,
+        patch("models.llm.llm.Generation.call", return_value=MagicMock()) as call,
+    ):
         result = model._generate(
             model="qwen-long",
             credentials={"dashscope_api_key": "test-key"},
             prompt_messages=[
                 SystemPromptMessage(content="You are a document analyst."),
-                UserPromptMessage(
-                    content=[
-                        TextPromptMessageContent(data="Summarize this document."),
-                        _document(),
-                    ]
-                ),
+                UserPromptMessage(content="Summarize this document."),
+                UserPromptMessage(content=[_document()]),
             ],
             model_parameters={},
             stream=False,
         )
 
     assert result == "result"
-    messages = call.call_args.kwargs["messages"]
-    assert messages == [
+    openai_client.assert_called_once_with(
+        api_key="test-key",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        max_retries=0,
+        timeout=120,
+    )
+    assert call.call_args.kwargs["messages"] == [
         {"role": "system", "content": "You are a document analyst."},
         {"role": "system", "content": "fileid://file-fe-123"},
         {"role": "user", "content": "Summarize this document."},
     ]
-    assert isinstance(messages[2]["content"], str)
+    client.files.delete.assert_called_once_with("file-fe-123", timeout=10)
+    client.close.assert_called_once()
 
 
-def test_qwen_long_injects_role_definition_for_document_input() -> None:
+def test_qwen_long_keeps_documents_in_their_conversation_turn() -> None:
     model = _model()
-    model._upload_file_to_tongyi = MagicMock(return_value="file-fe-123")
+    files = MagicMock(spec=QwenLongFiles)
+    files.upload.side_effect = ["file-fe-1", "file-fe-2"]
 
     messages = model._convert_qwen_long_prompt_messages(
-        credentials={"dashscope_api_key": "test-key"},
-        prompt_messages=[
+        files,
+        [
+            UserPromptMessage(content=[_document("first.pdf")]),
+            UserPromptMessage(content="Summarize the first document."),
+            AssistantPromptMessage(content="First summary."),
             UserPromptMessage(
                 content=[
-                    TextPromptMessageContent(data="Summarize this document."),
-                    _document(),
-                ]
-            )
-        ],
-    )
-
-    assert messages[0] == {
-        "role": "system",
-        "content": "You are a helpful assistant.",
-    }
-    assert messages[1] == {
-        "role": "system",
-        "content": "fileid://file-fe-123",
-    }
-    assert messages[2] == {
-        "role": "user",
-        "content": "Summarize this document.",
-    }
-
-
-def test_qwen_long_combines_multiple_file_ids() -> None:
-    model = _model()
-    model._upload_file_to_tongyi = MagicMock(side_effect=["file-fe-123", "file-fe-456"])
-
-    messages = model._convert_qwen_long_prompt_messages(
-        credentials={"dashscope_api_key": "test-key"},
-        prompt_messages=[
-            SystemPromptMessage(content="You are a document analyst."),
-            UserPromptMessage(
-                content=[
-                    TextPromptMessageContent(data="Compare these documents."),
-                    _document("first.pdf"),
                     _document("second.pdf"),
+                    TextPromptMessageContent(data="Compare both documents."),
                 ]
             ),
         ],
     )
 
-    assert messages[1] == {
-        "role": "system",
-        "content": "fileid://file-fe-123,fileid://file-fe-456",
-    }
-    assert messages[2] == {
-        "role": "user",
-        "content": "Compare these documents.",
-    }
+    assert messages == [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "system", "content": "fileid://file-fe-1"},
+        {"role": "user", "content": "Summarize the first document."},
+        {"role": "assistant", "content": "First summary."},
+        {"role": "system", "content": "fileid://file-fe-2"},
+        {"role": "user", "content": "Compare both documents."},
+    ]
+    files.wait_until_processed.assert_called_once()
 
 
-def test_qwen_long_rejects_document_without_question() -> None:
+def test_qwen_long_rejects_document_without_question_before_upload() -> None:
     model = _model()
-    model._upload_file_to_tongyi = MagicMock(return_value="file-fe-123")
+    files = MagicMock(spec=QwenLongFiles)
 
     with pytest.raises(InvokeBadRequestError, match="non-empty text question"):
         model._convert_qwen_long_prompt_messages(
-            credentials={"dashscope_api_key": "test-key"},
-            prompt_messages=[UserPromptMessage(content=[_document()])],
+            files,
+            [UserPromptMessage(content=[_document()])],
         )
 
+    files.upload.assert_not_called()
 
-def test_qwen_long_file_uploader_waits_until_processed() -> None:
-    client = MagicMock()
-    client.files.create.return_value = SimpleNamespace(
-        id="file-fe-123",
-        status="processing",
+
+def test_qwen_long_rejects_system_document_before_upload() -> None:
+    model = _model()
+    files = MagicMock(spec=QwenLongFiles)
+
+    with pytest.raises(InvokeBadRequestError, match="text system messages"):
+        model._convert_qwen_long_prompt_messages(
+            files,
+            [
+                SystemPromptMessage(content=[_document()]),
+                UserPromptMessage(content="Summarize."),
+            ],
+        )
+
+    files.upload.assert_not_called()
+
+
+def test_qwen_long_rejects_more_than_100_documents_before_upload() -> None:
+    model = _model()
+    files = MagicMock(spec=QwenLongFiles)
+
+    with pytest.raises(InvokeBadRequestError, match="at most 100"):
+        model._convert_qwen_long_prompt_messages(
+            files,
+            [
+                UserPromptMessage(
+                    content=[
+                        TextPromptMessageContent(data="Compare the documents."),
+                        *[_document(f"{index}.pdf") for index in range(101)],
+                    ]
+                )
+            ],
+        )
+
+    files.upload.assert_not_called()
+
+
+def test_qwen_long_rejects_aggregate_document_size_before_upload() -> None:
+    model = _model()
+    files = MagicMock(spec=QwenLongFiles)
+
+    with (
+        patch("models.llm.llm.MAX_DOCUMENT_INPUT_BASE64_BYTES", 7),
+        pytest.raises(InvokeBadRequestError, match="aggregate size"),
+    ):
+        model._convert_qwen_long_prompt_messages(
+            files,
+            [
+                UserPromptMessage(
+                    content=[
+                        TextPromptMessageContent(data="Compare."),
+                        _document("first.pdf", b"a"),
+                        _document("second.pdf", b"b"),
+                    ]
+                )
+            ],
+        )
+
+    files.upload.assert_not_called()
+
+
+def test_qwen_long_files_uploads_with_metadata_and_shared_wait() -> None:
+    client = _client()
+    captured = {}
+
+    def create(*, file, purpose):
+        captured["filename"] = file[0]
+        captured["payload"] = file[1].read()
+        captured["mime_type"] = file[2]
+        captured["purpose"] = purpose
+        return SimpleNamespace(id="file-fe-123")
+
+    client.files.create.side_effect = create
+    files = QwenLongFiles(client)
+
+    with patch(
+        "models.llm.qwen_long.time.monotonic",
+        side_effect=[100, 101],
+    ):
+        assert files.upload(_document()) == "file-fe-123"
+        files.wait_until_processed()
+
+    assert captured == {
+        "filename": "report.pdf",
+        "payload": b"document content",
+        "mime_type": "application/pdf",
+        "purpose": "file-extract",
+    }
+    client.files.wait_for_processing.assert_called_once_with(
+        "file-fe-123",
+        poll_interval=5,
+        max_wait_seconds=239,
     )
-    client.files.retrieve.return_value = SimpleNamespace(
-        id="file-fe-123",
-        status="processed",
-    )
+
+
+def test_qwen_long_files_roughly_spaces_shared_api_requests() -> None:
+    client = _client()
+    client.files.create.side_effect = [
+        SimpleNamespace(id="file-fe-1"),
+        SimpleNamespace(id="file-fe-2"),
+    ]
+    files = QwenLongFiles(client)
 
     with patch("models.llm.qwen_long.time.sleep") as sleep:
-        file_id = QwenLongFileUploader(client).upload(_document())
+        files.upload(_document("first.pdf"))
+        files.upload(_document("second.pdf"))
+        files.wait_until_processed()
+        files.cleanup()
 
-    assert file_id == "file-fe-123"
-    client.files.retrieve.assert_called_once_with("file-fe-123")
-    sleep.assert_called_once_with(5)
-    upload = client.files.create.call_args.kwargs
-    assert upload["purpose"] == "file-extract"
-    assert upload["file"][0] == "report.pdf"
-    assert upload["file"][2] == "application/pdf"
+    assert sleep.call_args_list == [call(0.35), call(0.1), call(0.1)]
+    assert client.files.delete.call_args_list == [
+        call("file-fe-1", timeout=10),
+        call("file-fe-2", timeout=10),
+    ]
 
 
-def test_qwen_long_file_uploader_reports_processing_error() -> None:
-    client = MagicMock()
-    client.files.create.return_value = SimpleNamespace(
+def test_qwen_long_files_retries_failed_cleanup_once() -> None:
+    client = _client()
+    client.files.delete.side_effect = [
+        SimpleNamespace(deleted=False),
+        SimpleNamespace(deleted=True),
+    ]
+    files = QwenLongFiles(client)
+    files.upload(_document())
+
+    with patch("models.llm.qwen_long.time.sleep") as sleep:
+        files.cleanup()
+
+    assert client.files.delete.call_count == 2
+    sleep.assert_called_once_with(0.1)
+    client.close.assert_called_once()
+
+
+@pytest.mark.parametrize("status", ["error", "deleted"])
+def test_qwen_long_files_rejects_failed_processing_status(status: str) -> None:
+    client = _client()
+    client.files.wait_for_processing.return_value = SimpleNamespace(
         id="file-fe-123",
-        status="error",
+        status=status,
         status_details="invalid document",
     )
+    files = QwenLongFiles(client)
+    files.upload(_document())
 
-    with pytest.raises(ValueError, match="invalid document"):
-        QwenLongFileUploader(client).upload(_document())
+    with pytest.raises(InvokeBadRequestError, match=status):
+        files.wait_until_processed()
 
 
-def test_qwen_long_file_uploader_times_out() -> None:
-    client = MagicMock()
-    client.files.create.return_value = SimpleNamespace(
-        id="file-fe-123",
-        status="processing",
+def test_qwen_long_files_maps_processing_timeout() -> None:
+    client = _client()
+    client.files.wait_for_processing.side_effect = RuntimeError("timeout")
+    files = QwenLongFiles(client)
+    files.upload(_document())
+
+    with pytest.raises(InvokeServerUnavailableError, match="Timed out"):
+        files.wait_until_processed()
+
+
+def test_qwen_long_files_rejects_invalid_base64_before_upload() -> None:
+    client = _client()
+    files = QwenLongFiles(client)
+    document = DocumentPromptMessageContent(
+        format="pdf",
+        base64_data="not-base64",
+        mime_type="application/pdf",
+        filename="report.pdf",
+    )
+
+    with pytest.raises(InvokeBadRequestError, match="invalid base64"):
+        files.upload(document)
+
+    client.files.create.assert_not_called()
+
+
+def test_qwen_long_files_rejects_padding_before_the_final_base64_chunk() -> None:
+    client = _client()
+    files = QwenLongFiles(client)
+    document = DocumentPromptMessageContent(
+        format="pdf",
+        base64_data="YQ==Yg==",
+        mime_type="application/pdf",
+        filename="report.pdf",
     )
 
     with (
-        patch(
-            "models.llm.qwen_long.time.monotonic",
-            side_effect=[0, 301],
-        ),
-        pytest.raises(TimeoutError, match="Timed out"),
+        patch("models.llm.qwen_long.FILE_READ_CHUNK_BYTES", 4),
+        pytest.raises(InvokeBadRequestError, match="invalid base64"),
     ):
-        QwenLongFileUploader(client).upload(_document())
+        files.upload(document)
 
-    client.files.retrieve.assert_not_called()
+    client.files.create.assert_not_called()
 
 
-def test_qwen_long_model_metadata_matches_supported_features() -> None:
-    model_file = Path(__file__).parent.parent / "models" / "llm" / "qwen-long.yaml"
-    schema = yaml.safe_load(model_file.read_text())
+def test_qwen_long_files_rejects_oversized_base64_before_upload() -> None:
+    client = _client()
+    files = QwenLongFiles(client)
 
-    assert schema["features"] == ["document"]
-    max_tokens = next(
-        rule for rule in schema["parameter_rules"] if rule["name"] == "max_tokens"
+    with (
+        patch("models.llm.qwen_long.DOCUMENT_MAX_BYTES", 3),
+        pytest.raises(InvokeBadRequestError, match="file size"),
+    ):
+        files.upload(_document(data=b"four"))
+
+    client.files.create.assert_not_called()
+
+
+def test_qwen_long_files_rejects_url_input_before_upload() -> None:
+    client = _client()
+    files = QwenLongFiles(client)
+    document = DocumentPromptMessageContent(
+        format="pdf",
+        url="https://example.com/report.pdf",
+        mime_type="application/pdf",
+        filename="report.pdf",
     )
-    assert max_tokens["max"] == 32768
+
+    with pytest.raises(InvokeBadRequestError, match="requires base64"):
+        files.upload(document)
+
+    client.files.create.assert_not_called()
+
+
+def test_qwen_long_cleans_up_when_processing_fails() -> None:
+    model = _model()
+    client = _client()
+    client.files.wait_for_processing.return_value = SimpleNamespace(
+        id="file-fe-123",
+        status="error",
+    )
+
+    with (
+        patch("models.llm.llm.openai.OpenAI", return_value=client),
+        patch("models.llm.llm.Generation.call") as call,
+        pytest.raises(InvokeBadRequestError, match="status error"),
+    ):
+        model._generate(
+            model="qwen-long",
+            credentials={"dashscope_api_key": "test-key"},
+            prompt_messages=[
+                UserPromptMessage(
+                    content=[
+                        TextPromptMessageContent(data="Summarize."),
+                        _document(),
+                    ]
+                )
+            ],
+            model_parameters={},
+            stream=False,
+        )
+
+    call.assert_not_called()
+    client.files.delete.assert_called_once_with("file-fe-123", timeout=10)
+    client.close.assert_called_once()
+
+
+def test_qwen_long_cleans_up_when_invocation_is_cancelled() -> None:
+    class Cancellation(BaseException):
+        pass
+
+    model = _model()
+    client = _client()
+
+    with (
+        patch("models.llm.llm.openai.OpenAI", return_value=client),
+        patch("models.llm.llm.Generation.call", side_effect=Cancellation),
+        pytest.raises(Cancellation),
+    ):
+        model._generate(
+            model="qwen-long",
+            credentials={"dashscope_api_key": "test-key"},
+            prompt_messages=[
+                UserPromptMessage(
+                    content=[
+                        TextPromptMessageContent(data="Summarize."),
+                        _document(),
+                    ]
+                )
+            ],
+            model_parameters={},
+            stream=False,
+        )
+
+    client.files.delete.assert_called_once_with("file-fe-123", timeout=10)
+    client.close.assert_called_once()
+
+
+def test_qwen_long_stream_cleanup_waits_for_stream_completion() -> None:
+    model = _model()
+    model._handle_generate_stream_response = MagicMock(
+        return_value=iter(["first", "second"])
+    )
+    client = _client()
+
+    with (
+        patch("models.llm.llm.openai.OpenAI", return_value=client),
+        patch("models.llm.llm.Generation.call", return_value=MagicMock()),
+    ):
+        result = model._generate(
+            model="qwen-long",
+            credentials={"dashscope_api_key": "test-key"},
+            prompt_messages=[
+                UserPromptMessage(
+                    content=[
+                        TextPromptMessageContent(data="Summarize."),
+                        _document(),
+                    ]
+                )
+            ],
+            model_parameters={},
+            stream=True,
+        )
+
+        client.files.delete.assert_not_called()
+        assert list(result) == ["first", "second"]
+
+    client.files.delete.assert_called_once_with("file-fe-123", timeout=10)
+    client.close.assert_called_once()
+
+
+def test_qwen_long_rejects_international_endpoint_before_upload() -> None:
+    model = _model()
+
+    with (
+        patch("models.llm.llm.openai.OpenAI") as openai,
+        patch("models.llm.llm.Generation.call") as call,
+        pytest.raises(InvokeBadRequestError, match="Beijing"),
+    ):
+        model._generate(
+            model="qwen-long",
+            credentials={
+                "dashscope_api_key": "test-key",
+                "use_international_endpoint": "true",
+            },
+            prompt_messages=[UserPromptMessage(content="Hello.")],
+            model_parameters={},
+            stream=False,
+        )
+
+    openai.assert_not_called()
+    call.assert_not_called()
+
+
+def test_qwen_long_preserves_standard_invoke_errors() -> None:
+    error = InvokeBadRequestError("invalid input")
+
+    assert _model()._transform_invoke_error(error) is error
+
+
+def test_tongyi_import_patches_gevent_before_http_sdks() -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import warnings; "
+                "from gevent.monkey import MonkeyPatchWarning; "
+                "warnings.simplefilter('error', MonkeyPatchWarning); "
+                "import models.llm.llm"
+            ),
+        ],
+        check=True,
+    )


### PR DESCRIPTION


## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->



## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |  <img width="835" height="339" alt="image" src="https://github.com/user-attachments/assets/7eec04c9-9b3f-498e-b55e-541c74e16e42" />     |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [ ] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: <!-- e.g. 1.2.0 -->
- [ ] SaaS (cloud.dify.ai)
