### PR TITLE
[gemini] Performance: client cache, FileCache, token fallback, splitter local counting (Fixes #3333)

### DIFF
--- a/models/gemini/conftest.py
+++ b/models/gemini/conftest.py
@@ -21,3 +21,28 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         in_gemini = Path(str(item.path)).resolve().is_relative_to(ROOT)
         if in_gemini and item.get_closest_marker("live") is not None:
             item.add_marker(skipped)
+
+
+@pytest.fixture(autouse=True)
+def _reset_genai_client_caches():
+    """Reset the module-level ``genai.Client`` caches (added for issue #3333)
+    before and after every test.
+
+    ``models.llm.llm._genai_client_cache`` and
+    ``models.text_embedding.text_embedding._genai_emb_client_cache`` are
+    process-wide module-level dicts keyed by API key. Many tests in this
+    suite reuse the same placeholder credentials (e.g. ``"fake-key"``,
+    ``"test-key"``). Without resetting the caches, a test could silently
+    receive a cached client (and its mock) left behind by an earlier,
+    unrelated test instead of the one it just patched -- a correctness
+    hazard specific to the test suite, not to production use (real
+    deployments use real, distinct API keys).
+    """
+    from models.llm import llm as _llm_module
+    from models.text_embedding import text_embedding as _embedding_module
+
+    _llm_module._genai_client_cache.clear()
+    _embedding_module._genai_emb_client_cache.clear()
+    yield
+    _llm_module._genai_client_cache.clear()
+    _embedding_module._genai_emb_client_cache.clear()

--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.3
+version: 0.9.4

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import re
+import threading
 import time
 from collections.abc import Generator, Iterator, Sequence
 from contextlib import suppress
@@ -46,6 +47,16 @@ from .utils import FileCache
 
 file_cache = FileCache()
 
+# Cache of genai.Client instances keyed by (api_key, base_url). Reusing the
+# client (and its underlying httpx connection pool) avoids a fresh TCP+TLS
+# handshake to generativelanguage.googleapis.com on every LLM node call.
+# Bounded with a simple oldest-first eviction so long-running multi-tenant
+# deployments (many distinct API keys) cannot grow this dict unboundedly and
+# leak open HTTP connection pools.
+_GENAI_CLIENT_CACHE_MAX_SIZE = 100
+_genai_client_cache: dict[tuple[str, Optional[str]], genai.Client] = {}
+_genai_client_cache_lock = threading.Lock()
+
 IMAGE_GENERATION_MODELS = {"gemini-2.5-flash-image", "gemini-3-pro-image-preview"}
 NO_SAMPLING_OR_PREFILL_MODELS = {"gemini-3.6-flash", "gemini-3.5-flash-lite"}
 
@@ -56,6 +67,35 @@ _SERVICE_TIER_PRICE_MULTIPLIERS = {
     "flex": Decimal("0.5"),
     "priority": Decimal("1.8"),
 }
+
+
+def _get_genai_client(api_key: str, base_url: Optional[str] = None) -> genai.Client:
+    """Return a cached genai.Client for the given credentials, creating one if needed.
+
+    :param api_key: Google API key
+    :param base_url: optional custom API base URL (falsy values normalized to
+        None so "" and None share the same cache entry)
+    :return: cached or newly created genai.Client
+    """
+    cache_key = (api_key.strip(), base_url or None)
+    with _genai_client_cache_lock:
+        client = _genai_client_cache.get(cache_key)
+        if client is not None:
+            # Move to end (most-recently-used) so eviction picks the
+            # least-recently-used entry, not the oldest-inserted.
+            _genai_client_cache[cache_key] = _genai_client_cache.pop(cache_key)
+            return client
+        if len(_genai_client_cache) >= _GENAI_CLIENT_CACHE_MAX_SIZE:
+            # Evict the least-recently-used entry (first in insertion order
+            # after the LRU reordering above) to bound memory/connection-pool
+            # growth in multi-tenant deployments with many distinct API keys.
+            _genai_client_cache.pop(next(iter(_genai_client_cache)))
+        client = genai.Client(
+            api_key=api_key.strip(),
+            http_options=types.HttpOptions(base_url=base_url or None),
+        )
+        _genai_client_cache[cache_key] = client
+        return client
 
 
 class GoogleLargeLanguageModel(LargeLanguageModel):
@@ -216,7 +256,13 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         # The reasoning content and final answer of the Gemini model are priced using the same standard.
         completion_tokens = thoughts_token_count + candidates_token_count
         # The `prompt_tokens` includes the historical conversation QA plus the current input.
-        prompt_tokens = prompt_tokens_standard
+        # Fall back to the API's aggregate `prompt_token_count` when the
+        # per-modality breakdown is absent (some models/configs omit it).
+        # Without this fallback, `prompt_tokens` silently becomes 0, which
+        # forces the caller into the expensive local GPT-2 tokenizer fallback
+        # (see `get_num_tokens` / `_get_num_tokens_by_gpt2`) even though the
+        # API already returned an accurate total.
+        prompt_tokens = prompt_tokens_standard or usage_metadata.prompt_token_count or 0
 
         return prompt_tokens, completion_tokens
 
@@ -1142,11 +1188,8 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         # == InitConfig == #
 
         config = types.GenerateContentConfig()
-        genai_client = genai.Client(
-            api_key=credentials["google_api_key"],
-            http_options=types.HttpOptions(
-                base_url=credentials.get("google_base_url", None)
-            ),
+        genai_client = _get_genai_client(
+            credentials["google_api_key"], credentials.get("google_base_url", None)
         )
 
         # == ChatConfig == #

--- a/models/gemini/models/llm/utils.py
+++ b/models/gemini/models/llm/utils.py
@@ -1,56 +1,78 @@
-import os
-import json
-import pathlib
+import threading
 import time
-import tempfile
 
 
 class FileCache:
+    """In-memory, thread-safe cache with lazy expiry-based eviction.
+
+    Replaces the original disk-backed JSON implementation, which re-read and
+    re-wrote the entire file on every exists()/get()/setex() call with no
+    locking -- concurrent plugin-daemon workers could corrupt the file or
+    lose updates, and every operation paid a full-file read/parse (or
+    read/parse/serialize/write for setex()) cost.
+
+    Note on persistence trade-off: this cache backs Gemini Files API
+    uploads (see file_parts.GeminiFilePartFactory), which are free to
+    re-upload and expire on Google's side after ~48h anyway. Losing the
+    cache across a plugin-daemon restart only costs a re-upload of
+    recently-used files, not correctness or data. The performance and
+    concurrency-safety win of an in-memory cache outweighs keeping the
+    disk-backed persistence.
+    """
+
+    _EVICT_AFTER_ENTRIES = 500
+    _EVICT_MIN_INTERVAL_SECONDS = 600
+
     def __init__(self, cache_file="file_cache.json"):
-        dir = os.path.dirname(cache_file)
-        try:
-            # try to check if the cache file is writable
-            with tempfile.TemporaryDirectory(dir=dir):
-                self.cache_file = cache_file
-        except Exception:
-            self.cache_file = str(pathlib.Path(tempfile.gettempdir()) / cache_file)
+        # Kept for backward-compatible signature; no longer used for storage.
+        self.cache_file = cache_file
+        self._cache: dict[str, dict] = {}
+        self._lock = threading.Lock()
+        self._last_evict_at = time.time()
 
-        self._ensure_cache_file()
+    def _maybe_evict_locked(self):
+        """Purge expired entries — or the oldest entries if none are expired —
+        once the cache has grown large enough and enough time has passed since
+        the last purge. Must be called while holding self._lock.
 
-    def _ensure_cache_file(self):
-        if not os.path.exists(self.cache_file):
-            with open(self.cache_file, "w") as f:
-                json.dump({}, f)
-
-    def _load_cache(self):
-        try:
-            with open(self.cache_file, "r") as f:
-                cache = json.load(f)
-            return cache
-        except Exception:
-            return {}
-
-    def _save_cache(self, cache):
-        cleaned_cache = {
-            k: v for k, v in cache.items() if v.get("expires_at", 0) > time.time()
-        }
-        with open(self.cache_file, "w") as f:
-            json.dump(cleaned_cache, f)
+        Without the ``while`` loop, a cache with >``_EVICT_AFTER_ENTRIES``
+        entries that are all long-lived (none expired) would update
+        ``_last_evict_at`` and continue growing unboundedly across ``setex``
+        calls.
+        """
+        now = time.time()
+        if (
+            len(self._cache) > self._EVICT_AFTER_ENTRIES
+            and now - self._last_evict_at > self._EVICT_MIN_INTERVAL_SECONDS
+        ):
+            expired = [
+                k for k, v in self._cache.items() if v.get("expires_at", 0) <= now
+            ]
+            for k in expired:
+                del self._cache[k]
+            while len(self._cache) > self._EVICT_AFTER_ENTRIES:
+                self._cache.pop(next(iter(self._cache)))
+            self._last_evict_at = now
 
     def exists(self, key):
-        cache = self._load_cache()
-        return key in cache and cache[key].get("expires_at", 0) > time.time()
+        with self._lock:
+            entry = self._cache.get(key)
+            return entry is not None and entry.get("expires_at", 0) > time.time()
 
     def get(self, key):
-        cache = self._load_cache()
-        if key in cache and cache[key].get("expires_at", 0) > time.time():
-            return cache[key]["value"]
-        return None
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is not None and entry.get("expires_at", 0) > time.time():
+                return entry["value"]
+            return None
 
     def setex(self, key, expires_in_seconds, value):
-        cache = self._load_cache()
-        cache[key] = {"value": value, "expires_at": time.time() + expires_in_seconds}
-        self._save_cache(cache)
+        with self._lock:
+            self._cache[key] = {
+                "value": value,
+                "expires_at": time.time() + expires_in_seconds,
+            }
+            self._maybe_evict_locked()
 
 
 # Gemini API File Type Support Constants

--- a/models/gemini/models/tests/test_embedding.py
+++ b/models/gemini/models/tests/test_embedding.py
@@ -1145,19 +1145,31 @@ class TestSplitTextsTermination:
     a text counted as ``>= context_size`` tokens while being <= ``context_size``
     characters (token-dense content like CJK / code / base64), the head slice was
     the unchanged text and the recursion never terminated.
+
+    Updated for issue #3333: the splitter no longer calls the live
+    ``_count_tokens`` API (an HTTP round-trip) to decide whether a chunk needs
+    splitting -- it now uses the local, instant ``_get_num_tokens_by_gpt2``
+    estimate instead (see ``_split_texts_to_fit_model_specs``). The
+    recursion-safety behavior covered by these tests is unaffected by that
+    change, so they are updated to mock the new dependency in the same way.
+    ``client``/``model`` are still accepted by ``_split_texts_to_fit_model_specs``
+    for call-site compatibility, even though they are no longer used to
+    estimate tokens.
     """
 
     def setup_method(self):
         self.model = GeminiTextEmbeddingModel([])
 
-    def _patch_count_tokens(self, chars_per_token: float):
-        """Patch _count_tokens with a deterministic char-based token estimate."""
+    def _patch_token_estimate(self, chars_per_token: float):
+        """Patch _get_num_tokens_by_gpt2 with a deterministic char-based token estimate."""
 
-        def fake_count_tokens(_client, _model, text):
+        def fake_estimate(text):
             # at least 1 token for any non-empty text
             return max(1, int(len(text) / chars_per_token) + (1 if text else 0))
 
-        return patch.object(self.model, "_count_tokens", side_effect=fake_count_tokens)
+        return patch.object(
+            self.model, "_get_num_tokens_by_gpt2", side_effect=fake_estimate
+        )
 
     def test_token_dense_text_terminates(self):
         """Token-dense text (more tokens than chars) must not recurse forever."""
@@ -1166,7 +1178,7 @@ class TestSplitTextsTermination:
         # as ~200 tokens (>> context_size). The original code sliced at the token
         # count as a char index, leaving the head unchanged -> infinite recursion.
         text = "字" * 50  # 50 chars
-        with self._patch_count_tokens(
+        with self._patch_token_estimate(
             chars_per_token=0.25
         ):  # ~4 tokens/char => ~200 tokens
             result = self.model._split_texts_to_fit_model_specs(
@@ -1182,7 +1194,7 @@ class TestSplitTextsTermination:
         """A long text splits into multiple chunks that each fit the context size."""
         context_size = 32
         text = ("The quick brown fox jumps over the lazy dog. " * 40).strip()
-        with self._patch_count_tokens(chars_per_token=4.0):  # ~1 token / 4 chars
+        with self._patch_token_estimate(chars_per_token=4.0):  # ~1 token / 4 chars
             result = self.model._split_texts_to_fit_model_specs(
                 Mock(), "gemini-embedding-2-preview", [text], context_size
             )
@@ -1195,7 +1207,7 @@ class TestSplitTextsTermination:
         """Text already within the context size is returned unchanged."""
         context_size = 1000
         text = "hello world"
-        with self._patch_count_tokens(chars_per_token=4.0):
+        with self._patch_token_estimate(chars_per_token=4.0):
             result = self.model._split_texts_to_fit_model_specs(
                 Mock(), "gemini-embedding-2-preview", [text], context_size
             )
@@ -1212,12 +1224,34 @@ class TestSplitTextsTermination:
         """
         context_size = 0
         text = "字字字字字"  # 5 chars, > 1 -> enters the split branch
-        with patch.object(self.model, "_count_tokens", return_value=0):
+        with patch.object(self.model, "_get_num_tokens_by_gpt2", return_value=0):
             result = self.model._split_texts_to_fit_model_specs(
                 Mock(), "gemini-embedding-2-preview", [text], context_size
             )
         # No crash, the recursion terminated, and the text is preserved.
         assert "".join(chunk for chunk, _ in result) == text
+
+    def test_splitter_never_calls_live_count_tokens_api(self):
+        """Issue #3333: the splitter must not perform any network round-trip.
+
+        ``_count_tokens`` calls ``client.models.get()`` and
+        ``client.models.count_tokens()`` -- both are blocking HTTP requests.
+        The splitter should rely exclusively on the local GPT-2 estimate.
+        """
+        context_size = 8192
+        text = "The quick brown fox jumps over the lazy dog."
+        mock_client = Mock()
+        with patch.object(
+            self.model,
+            "_count_tokens",
+            side_effect=AssertionError("must not be called"),
+        ):
+            result = self.model._split_texts_to_fit_model_specs(
+                mock_client, "gemini-embedding-2-preview", [text], context_size
+            )
+        assert result[0][0] == text
+        mock_client.models.get.assert_not_called()
+        mock_client.models.count_tokens.assert_not_called()
 
 
 # ================================================================

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -1502,6 +1502,12 @@ class TestHandleGenerateResponse:
 
         mock_usage = Mock()
         mock_usage.prompt_tokens_details = []
+        # Explicitly 0 (not left as an auto-vivified Mock attribute): with the
+        # #3333 fallback `prompt_tokens_standard or usage_metadata.prompt_token_count
+        # or 0`, an unset Mock attribute is truthy and would poison `prompt_tokens`
+        # with a non-numeric value instead of falling through to the manual
+        # `get_num_tokens` calculation this test exercises.
+        mock_usage.prompt_token_count = 0
         mock_usage.thoughts_token_count = 0
         mock_usage.candidates_token_count = 10
 
@@ -1549,6 +1555,7 @@ class TestHandleGenerateResponse:
 
         mock_usage = Mock()
         mock_usage.prompt_tokens_details = []
+        mock_usage.prompt_token_count = 0
         mock_usage.thoughts_token_count = 0
         mock_usage.candidates_token_count = 5
 
@@ -1603,6 +1610,7 @@ class TestHandleGenerateResponse:
 
         mock_usage = Mock()
         mock_usage.prompt_tokens_details = []
+        mock_usage.prompt_token_count = 0
         mock_usage.thoughts_token_count = 0
         mock_usage.candidates_token_count = 15
 

--- a/models/gemini/models/text_embedding/text_embedding.py
+++ b/models/gemini/models/text_embedding/text_embedding.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import logging
 import re
+import threading
 import time
 import numpy as np
 from typing import Optional, Union
@@ -33,6 +34,31 @@ TASK_TYPE_BY_INPUT_TYPE = {
     EmbeddingInputType.DOCUMENT: "RETRIEVAL_DOCUMENT",
     EmbeddingInputType.QUERY: "RETRIEVAL_QUERY",
 }
+
+# Cache of genai.Client instances keyed by api_key, distinct from the LLM
+# module's client cache (models/llm/llm.py) to avoid collisions if both
+# modules are loaded in the same process. Reusing the client avoids a fresh
+# TCP+TLS handshake to generativelanguage.googleapis.com on every embedding
+# call. Bounded with oldest-first eviction to avoid unbounded growth in
+# multi-tenant deployments with many distinct API keys.
+_GENAI_EMB_CLIENT_CACHE_MAX_SIZE = 100
+_genai_emb_client_cache: dict[str, genai.Client] = {}
+_genai_emb_client_cache_lock = threading.Lock()
+
+
+def _get_genai_client(api_key: str) -> genai.Client:
+    """Return a cached genai.Client for the given API key, creating one if needed."""
+    _key = api_key.strip()
+    with _genai_emb_client_cache_lock:
+        client = _genai_emb_client_cache.get(_key)
+        if client is not None:
+            _genai_emb_client_cache[_key] = _genai_emb_client_cache.pop(_key)
+            return client
+        if len(_genai_emb_client_cache) >= _GENAI_EMB_CLIENT_CACHE_MAX_SIZE:
+            _genai_emb_client_cache.pop(next(iter(_genai_emb_client_cache)))
+        client = genai.Client(api_key=_key)
+        _genai_emb_client_cache[_key] = client
+        return client
 
 
 class GeminiTextEmbeddingModel(_CommonGemini, TextEmbeddingModel):
@@ -74,7 +100,7 @@ class GeminiTextEmbeddingModel(_CommonGemini, TextEmbeddingModel):
         :param user: unique user id
         :return: embeddings result
         """
-        client = genai.Client(api_key=credentials["google_api_key"])
+        client = _get_genai_client(credentials["google_api_key"])
 
         # get model properties
         context_size = self._get_context_size(model, credentials)
@@ -157,7 +183,14 @@ class GeminiTextEmbeddingModel(_CommonGemini, TextEmbeddingModel):
         """
         splitted_text = []
         for text in texts:
-            num_tokens = self._count_tokens(client, model, text)
+            # Estimate locally via GPT-2 BPE instead of calling `_count_tokens`
+            # (an API round-trip, and in fact two: `client.models.get()` to
+            # check supported actions, then `client.models.count_tokens()`).
+            # GPT-2 overestimates vs Gemini's SentencePiece tokenizer, so the
+            # resulting chunks end up conservatively smaller -- this never
+            # exceeds the context limit, it just avoids ~150-400ms of network
+            # latency per recursion level for every embedded document.
+            num_tokens = self._get_num_tokens_by_gpt2(text)
             if num_tokens >= context_size and len(text) > 1:
                 # `context_size` is a token budget, not a character index. Estimate a
                 # character cutoff from the token-to-character ratio so the head is
@@ -403,7 +436,7 @@ class GeminiTextEmbeddingModel(_CommonGemini, TextEmbeddingModel):
         :return: embeddings result
         """
         self.started_at = time.perf_counter()
-        client = genai.Client(api_key=credentials["google_api_key"])
+        client = _get_genai_client(credentials["google_api_key"])
 
         # Convert MultiModalContent to Google Genai format, tracking content types
         contents = []  # converted content for API call


### PR DESCRIPTION
## Summary

Fixes #3333 — four independent performance bottlenecks in the `gemini` plugin, each compounding latency in multi-node workflows.

### Changes

**1. Client caching (LLM + embeddings)**
- Module-level `_get_genai_client()` helper with `threading.Lock` and LRU eviction (max 100 entries), keyed by `(api_key, base_url)`. Reuses the `httpx` connection pool across calls instead of establishing a fresh TCP+TLS handshake (~150–400 ms per call) on every `_generate()` / `_invoke()` / `_invoke_multimodal()` invocation.
- `validate_credentials()` unchanged (intentionally fresh client per credential check).

**2. Token counting fallback (`_calculate_tokens_from_usage_metadata`)**
- When `prompt_tokens_details` is absent for a model/config, the old code returned `prompt_tokens = 0`, which forced the expensive GPT-2 BPE local tokenizer (`_get_num_tokens_by_gpt2`, 500 ms–2.5 s) on every streaming chunk. Now falls back to `usage_metadata.prompt_token_count` — the APIs aggregate total — before falling through to the expensive fallback.

**3. `FileCache` in memory (was: disk-backed JSON + no locking)**
- The original implementation read/parsed (and for `setex`, serialized/wrote) the entire JSON file on every operation with no threading lock — concurrently workers could corrupt the file or lose updates.
- Replaced with an in-memory `dict` + `threading.Lock` + lazy eviction (expired-entry purge at 500 entries / 600s; oldest-entry force-eviction when the purge is insufficient).
- Cache keys in `file_parts.py` already use stable `hashlib.sha256`, so disk persistence would now be functional — but in a containerized plugin-daemon the re-upload cost (Gemini Files API, no financial cost) is negligible vs. the performance and correctness cost of the old I/O-per-call approach. See **Design Decisions** below.

**4. Embedding splitter uses local token estimation**
- `_split_texts_to_fit_model_specs` called `_count_tokens(client, model, text)` — which in the current 0.9.3 code does **two** blocking HTTP requests per recursion level (`client.models.get()` to check supported actions, then `client.models.count_tokens()`).
- Changed to `_get_num_tokens_by_gpt2(text)` — the same local GPT-2 BPE estimator already used by `get_num_tokens()`. GPT-2 overestimates vs Geminis SentencePiece, so resulting chunks are conservatively smaller and never exceed the context limit.

### Design Decisions & Trade-offs

**FileCache persistence:** The disk-backed JSON cache in `utils.py` has been replaced with a pure in-memory cache. The Gemini Files API uploads that this cache backs (via `GeminiFilePartFactory`) are free (no financial cost) and auto-expire on Googles side after ~48h anyway. In a containerized plugin-daemon deployment, disk persistence adds complexity (file permissions, concurrent-write corruption, `/tmp` limits) for negligible benefit — a restart triggers a small number of re-uploads of recently-used files, not correctness loss. The commit message and class docstring document this trade-off explicitly.

**LRU client eviction:** Both client caches (LLM and embedding) use insertion-order reordering on hit to approximate LRU, with a max size of 100 entries and oldest-first eviction when at capacity. This bounds memory/connection-pool growth in multi-tenant deployments where many distinct API keys are active over time.

### Testing

- python3 -m py_compile — pass (3 modified files + conftest + test files)
- `ruff check` — All checks passed
- `ruff format` — all formatted
- `pytest models/tests/` — **203/203 passed** (unit tests + live tests with real GEMINI_API_KEY against Gemini API: streaming, structured output, inline images, tool call ID round-trips, embedding, multimodal embedding)
- Existing `TestSplitTextsTermination` tests updated to mock the new dependency (`_get_num_tokens_by_gpt2` instead of `_count_tokens`); new test `test_splitter_never_calls_live_count_tokens_api` verifies the splitter never performs network calls.
- Autouse conftest fixture `_reset_genai_client_caches` prevents test-suite contamination from module-level caches across tests that reuse the same placeholder API keys.

### Version

manifest.yaml: 0.9.3 → 0.9.4 (PATCH bump — performance and concurrency fixes, no public API changes)