### PR TITLE
feat(bedrock): add Claude Opus 5 model

### DIFF
--- a/models/bedrock/README.md
+++ b/models/bedrock/README.md
@@ -18,15 +18,15 @@ The models of Amazon Bedrock.
 ## Usage
 Select **Amazon Bedrock** as the model provider in Dify, choose an available model, and use it in applications, agents, or workflows.
 
-## Claude 5 Models (Sonnet 5 / Fable 5)
+## Claude 5 Models (Opus 5 / Sonnet 5 / Fable 5)
 
-The "Anthropic Claude 5" entry provides Claude Sonnet 5 (`anthropic.claude-sonnet-5`) and Claude Fable 5 (`anthropic.claude-fable-5`). These models differ from earlier Claude generations:
+The "Anthropic Claude 5" entry provides Claude Opus 5 (`anthropic.claude-opus-5`), Claude Sonnet 5 (`anthropic.claude-sonnet-5`), and Claude Fable 5 (`anthropic.claude-fable-5`). These models differ from earlier Claude generations:
 
-- **Inference profiles only.** Invocable exclusively via `us.` (US/Canada regions) or `global.` cross-region inference profiles — there is no on-demand bare-ID invocation and no `eu.`/`apac.` geo profiles. The plugin resolves this from your *Cross-Region Inference* selection; from non-US regions choose `global`.
-- **Adaptive thinking is always on** and cannot be disabled. Thinking depth is controlled by the *Effort* parameter (`low`/`medium`/`high`/`xhigh`/`max`) instead of a thinking budget. Sampling parameters (temperature / top_p / top_k) are not configurable on these models and are not exposed.
+- **Inference profiles only.** Invocable exclusively via cross-region inference profiles — there is no on-demand bare-ID invocation. Geographic profile coverage varies per model: Opus 5 and Sonnet 5 offer `us.` (also serves Canada regions), `eu.`, and `au.` profiles; Fable 5 offers `us.` only. `global.` works from virtually all commercial regions. The plugin resolves this from your *Cross-Region Inference* selection; when your region has no geo profile, choose `global`.
+- **Adaptive thinking is on by default.** Thinking depth is controlled by the *Effort* parameter (`low`/`medium`/`high`/`xhigh`/`max`) instead of a thinking budget. Sampling parameters (temperature / top_p / top_k) are not configurable on these models and are not exposed.
 - **Refusals & fallback.** Requests can be declined by safety classifiers (`stop_reason: refusal`; materially more frequent on Fable 5). With *Refusal Fallback* enabled (default), the plugin automatically retries the identical request with Claude 4.8 Opus. Mid-stream refusals that occur after output has been produced cannot fall back and raise an error instead.
 - **Fable 5 prerequisite: data retention opt-in.** Your AWS account must set data retention mode to `provider_data_share` via the Bedrock Data Retention API before invoking Fable 5 (no console UI at launch). See the [Fable 5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html). The plugin never changes account settings.
-- **Pricing note.** Displayed prices are the Global cross-region rates (Sonnet 5 $3/$15, Fable 5 $10/$50 per 1M tokens). Geo/in-region invocation is ~10% higher. Prompt-cache read/write rates are not representable in Dify's cost tracking — refer to your AWS bill.
+- **Pricing note.** Displayed prices are the Global cross-region rates (Opus 5 $5/$25, Sonnet 5 $3/$15, Fable 5 $10/$50 per 1M tokens). Geo/in-region invocation is ~10% higher. Prompt-cache read/write rates are not representable in Dify's cost tracking — refer to your AWS bill.
 
 ## Privacy
 This plugin sends the inputs required by the selected operation to the upstream service. See [PRIVACY.md](PRIVACY.md) for details.

--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.75
+version: 0.0.76
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/anthropic-claude-5.yaml
+++ b/models/bedrock/models/llm/anthropic-claude-5.yaml
@@ -12,13 +12,15 @@ features:
 model_properties:
   mode: chat
   context_size: 1000000
-# Claude 5 generation models (Sonnet 5 / Fable 5).
-# - Invocable ONLY via inference profiles (us. / global.); no on-demand bare-ID calls.
-# - Adaptive thinking is always on and cannot be disabled; depth is controlled
-#   by the effort parameter (replaces reasoning budget).
+# Claude 5 generation models (Opus 5 / Sonnet 5 / Fable 5).
+# - Invocable ONLY via inference profiles (us. / eu. / au. / global., varies
+#   per model); no on-demand bare-ID calls.
+# - Adaptive thinking is on by default; depth is controlled by the effort
+#   parameter (replaces reasoning budget).
 # - Sampling parameters (temperature / top_p / top_k) are NOT configurable:
 #   non-default values are rejected by the API, so they are not exposed here.
 # docs:
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
 parameter_rules:
@@ -33,6 +35,7 @@ parameter_rules:
     required: true
     default: Sonnet 5
     options:
+      - Opus 5
       - Sonnet 5
       - Fable 5
   - name: cross-region
@@ -46,8 +49,8 @@ parameter_rules:
       - global
       - geographic
     help:
-      zh_Hans: Claude 5 模型仅支持通过推理配置文件调用。Global 可从几乎所有区域调用（推荐）；Geographic 仅限美国/加拿大区域（us. 配置文件），其他区域请选择 Global。
-      en_US: Claude 5 models can only be invoked through inference profiles. Global works from virtually all regions (recommended); Geographic is limited to US/Canada regions (us. profile) — use Global elsewhere.
+      zh_Hans: Claude 5 模型仅支持通过推理配置文件调用。Global 可从几乎所有区域调用（推荐）；Geographic 使用地理配置文件（Opus 5 / Sonnet 5 支持 us./eu./au.，Fable 5 仅支持 us.），不支持的区域请选择 Global。
+      en_US: Claude 5 models can only be invoked through inference profiles. Global works from virtually all regions (recommended); Geographic uses geo profiles (us./eu./au. for Opus 5 and Sonnet 5, us. only for Fable 5) — use Global elsewhere.
   - name: max_tokens
     use_template: max_tokens
     required: true

--- a/models/bedrock/models/llm/anthropic-claude-5.yaml
+++ b/models/bedrock/models/llm/anthropic-claude-5.yaml
@@ -117,17 +117,11 @@ parameter_rules:
     help:
       zh_Hans: anthropic beta 参数是一串测试版标题的列表，用于表示选择加入一组特定的测试版功能。使用英文逗号连接。
       en_US: The anthropic beta parameter is a list of strings of beta headers used to indicate opt-in to a particular set of beta features. Use commas to join.
-  - name: json_schema
-    label:
-      zh_Hans: JSON Schema
-      en_US: JSON Schema
-    type: string
-    required: false
-    help:
-      zh_Hans: JSON Schema for structured output
-      en_US: JSON Schema for structured output
-  - name: response_format
-    use_template: response_format
+  # NOTE: json_schema / response_format are intentionally NOT exposed.
+  # Live-verified on Opus 5 and Sonnet 5: Converse outputConfig.textFormat
+  # (json_schema) is rejected with "output_config.format: Extra inputs are
+  # not permitted", and the legacy response_format fallback relies on
+  # assistant prefill, which Claude 5 models reject.
 pricing:
   input: "0.003"
   output: "0.015"

--- a/models/bedrock/models/llm/cache_config.py
+++ b/models/bedrock/models/llm/cache_config.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 
 # Models that support prompt caching
 CACHE_SUPPORTED_MODELS = [
+    "anthropic.claude-opus-5",
     "anthropic.claude-sonnet-5",
     "anthropic.claude-fable-5",
     "anthropic.claude-opus-4-8",
@@ -26,6 +27,11 @@ CACHE_SUPPORTED_MODELS = [
 
 # Cache configuration for each model
 CACHE_CONFIG = {
+    "anthropic.claude-opus-5": {
+        "min_tokens": 512,
+        "max_checkpoints": 4,
+        "supported_fields": ["system", "messages", "tools"]
+    },
     "anthropic.claude-sonnet-5": {
         "min_tokens": 4096,
         "max_checkpoints": 4,

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -1866,6 +1866,7 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
             'GPT-5.4': 'gpt-5-4',
             # Claude models
             # Claude 5 generation models
+            'Opus 5': 'claude-5-opus',
             'Sonnet 5': 'claude-5-sonnet',
             'Fable 5': 'claude-5-fable',
             'Claude 4.8 Opus': 'claude-4-8-opus',

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -85,6 +85,8 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         {"prefix": "us.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
         {"prefix": "eu.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
         {"prefix": "apac.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "jp.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
+        {"prefix": "au.anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
         {"prefix": "anthropic.claude", "support_system_prompts": True, "support_tool_use": True},
         {"prefix": "amazon.nova", "support_system_prompts": True, "support_tool_use": True},
         {"prefix": "us.amazon.nova", "support_system_prompts": True, "support_tool_use": True},

--- a/models/bedrock/models/llm/model_configurations/claude-5-opus.yaml
+++ b/models/bedrock/models/llm/model_configurations/claude-5-opus.yaml
@@ -1,0 +1,19 @@
+model: claude-5-opus
+label:
+  en_US: Claude Opus 5
+icon: icon_s_en.svg
+model_type: llm
+features:
+  - agent-thought
+  - vision
+  - tool-call
+  - stream-tool-call
+  - document
+model_properties:
+  mode: chat
+  context_size: 1000000
+pricing:
+  input: '0.005'
+  output: '0.025'
+  unit: '0.001'
+  currency: USD

--- a/models/bedrock/models/llm/model_ids.py
+++ b/models/bedrock/models/llm/model_ids.py
@@ -8,6 +8,7 @@ Based on AWS documentation:
 
 BEDROCK_MODEL_IDS = {
     'anthropic claude 5': {
+        'Opus 5': 'anthropic.claude-opus-5',
         'Sonnet 5': 'anthropic.claude-sonnet-5',
         'Fable 5': 'anthropic.claude-fable-5',
     },
@@ -143,15 +144,21 @@ def get_region_area(region_name, prefer_global=False):
 
 # Claude 5 generation models are invocable ONLY through inference profiles
 # (inferenceTypesSupported == [INFERENCE_PROFILE]; live-verified — bare-ID
-# converse returns ValidationException) and, unlike earlier Claude models,
-# only 'us' and 'global' profiles exist — there are no eu./apac. geo
-# profiles. See the model cards:
+# converse returns ValidationException). Geo profile coverage varies per
+# model (live-verified via list-inference-profiles): Opus 5 and Sonnet 5
+# have us./eu./au. geo profiles, Fable 5 only us. — there is no apac. geo
+# profile for any of them. See the model cards:
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html
 CLAUDE5_PROFILE_PREFIXES = {
-    'anthropic.claude-sonnet-5': ('us', 'global'),
+    'anthropic.claude-opus-5': ('us', 'eu', 'au', 'global'),
+    'anthropic.claude-sonnet-5': ('us', 'eu', 'au', 'global'),
     'anthropic.claude-fable-5': ('us', 'global'),
 }
+
+# AWS regions served by the 'au' geographic inference profile
+_AU_REGIONS = {'ap-southeast-2', 'ap-southeast-4'}
 
 CLAUDE5_REFUSAL_FALLBACK_BASE_ID = 'anthropic.claude-opus-4-8'
 
@@ -206,6 +213,10 @@ def resolve_claude5_profile_id(model_id, cross_region, region_name):
         # The US geo profile serves Canadian source regions (per model card)
         if area is None and region_name.startswith('ca-'):
             area = 'us'
+        # Australian regions are served by the 'au' geo profile (there is no
+        # apac. profile for Claude 5 models)
+        if area == 'apac' and region_name in _AU_REGIONS and 'au' in allowed:
+            area = 'au'
         if area in allowed:
             return f"{area}.{model_id}"
         raise ValueError(

--- a/models/bedrock/readme/README_zh_Hans.md
+++ b/models/bedrock/readme/README_zh_Hans.md
@@ -33,15 +33,15 @@ After installing the plugin, configure the Amazon Bedrock credentials within the
 
 
 
-## Claude 5 系列模型（Sonnet 5 / Fable 5）
+## Claude 5 系列模型（Opus 5 / Sonnet 5 / Fable 5）
 
-“Anthropic Claude 5” 条目提供 Claude Sonnet 5（`anthropic.claude-sonnet-5`）与 Claude Fable 5（`anthropic.claude-fable-5`）。与之前的 Claude 世代相比：
+“Anthropic Claude 5” 条目提供 Claude Opus 5（`anthropic.claude-opus-5`）、Claude Sonnet 5（`anthropic.claude-sonnet-5`）与 Claude Fable 5（`anthropic.claude-fable-5`）。与之前的 Claude 世代相比：
 
-- **仅支持推理配置文件调用。** 只能通过 `us.`（美国/加拿大区域）或 `global.` 跨区域推理配置文件调用——不支持裸模型 ID 的按需调用，也没有 `eu.`/`apac.` 地理配置文件。插件根据“跨区域推理”选项自动解析；非美国区域请选择 `global`。
-- **自适应思考始终开启**，无法关闭。思考深度由 Effort 参数（`low`/`medium`/`high`/`xhigh`/`max`）控制，取代思考预算。这两个模型不支持调节采样参数（temperature / top_p / top_k），因此不再暴露。
+- **仅支持推理配置文件调用。** 不支持裸模型 ID 的按需调用。各模型的地理配置文件覆盖不同：Opus 5 / Sonnet 5 提供 `us.`（同时服务加拿大区域）、`eu.`、`au.` 配置文件；Fable 5 仅提供 `us.`。`global.` 可从几乎所有商业区域调用。插件根据“跨区域推理”选项自动解析；所在区域没有地理配置文件时请选择 `global`。
+- **自适应思考默认开启。** 思考深度由 Effort 参数（`low`/`medium`/`high`/`xhigh`/`max`）控制，取代思考预算。这些模型不支持调节采样参数（temperature / top_p / top_k），因此不再暴露。
 - **拒答与回落。** 请求可能被安全分类器拒绝（`stop_reason: refusal`，Fable 5 概率明显更高）。默认开启“拒答回落”时，插件会自动用 Claude 4.8 Opus 重试同一请求；流式输出已产生内容后发生的拒绝无法回落，将直接报错。
 - **Fable 5 前置条件：数据保留 opt-in。** 调用 Fable 5 前，AWS 账户必须通过 Bedrock Data Retention API 将数据保留模式设置为 `provider_data_share`（上线初期无控制台入口）。详见 [Fable 5 模型卡](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html)。插件不会修改账户设置。
-- **价格说明。** 展示价格为 Global 跨区域费率（Sonnet 5 每百万 token $3/$15，Fable 5 $10/$50）。Geo/区域内调用约贵 10%。Prompt 缓存读写费率无法体现在 Dify 费用统计中，请以 AWS 账单为准。
+- **价格说明。** 展示价格为 Global 跨区域费率（Opus 5 每百万 token $5/$25，Sonnet 5 $3/$15，Fable 5 $10/$50）。Geo/区域内调用约贵 10%。Prompt 缓存读写费率无法体现在 Dify 费用统计中，请以 AWS 账单为准。
 
 ## Issue Feedback | 问题反馈
 

--- a/models/bedrock/tests/test_claude5_cache_config.py
+++ b/models/bedrock/tests/test_claude5_cache_config.py
@@ -11,6 +11,13 @@ _spec.loader.exec_module(cache_config)
 
 
 class TestClaude5CacheRegistration:
+    def test_opus5_supported_with_min_512(self):
+        # Opus 5 model card: min 512 tokens per cache checkpoint
+        assert cache_config.is_cache_supported("anthropic.claude-opus-5")
+        cfg = cache_config.get_cache_config("anthropic.claude-opus-5")
+        assert cfg["min_tokens"] == 512
+        assert cfg["supported_fields"] == ["system", "messages", "tools"]
+
     def test_sonnet5_supported_with_min_4096(self):
         assert cache_config.is_cache_supported("anthropic.claude-sonnet-5")
         cfg = cache_config.get_cache_config("anthropic.claude-sonnet-5")

--- a/models/bedrock/tests/test_claude5_llm_params.py
+++ b/models/bedrock/tests/test_claude5_llm_params.py
@@ -62,6 +62,26 @@ class TestEffortConversion:
         assert additional["thinking"] == {"type": "adaptive"}
 
 
+class TestClaude5FamilyYamlSurface:
+    def test_structured_output_params_not_exposed(self):
+        # Live-verified: Opus 5 / Sonnet 5 reject Converse
+        # outputConfig.textFormat ("output_config.format: Extra inputs are not
+        # permitted") and reject the prefill-based response_format fallback.
+        # Neither parameter may appear on the Claude 5 family yaml.
+        import yaml
+        from pathlib import Path
+        yaml_path = (
+            Path(__file__).resolve().parent.parent
+            / "models" / "llm" / "anthropic-claude-5.yaml"
+        )
+        schema = yaml.safe_load(yaml_path.read_text())
+        param_names = {r["name"] for r in schema["parameter_rules"]}
+        assert "json_schema" not in param_names
+        assert "response_format" not in param_names
+        # sampling params stay unexposed too
+        assert not {"temperature", "top_p", "top_k"} & param_names
+
+
 class TestClaude5RegionResolutionInGetModelInfo:
     def _get_model_info(self, model_name, cross_region, region):
         params = {"model_name": model_name, "cross-region": cross_region}
@@ -85,6 +105,20 @@ class TestClaude5RegionResolutionInGetModelInfo:
         # Opus 5 / Sonnet 5 have eu. geo profiles (live-verified)
         info, _ = self._get_model_info("Opus 5", "geographic", "eu-central-1")
         assert info["model"] == "eu.anthropic.claude-opus-5"
+
+    @pytest.mark.parametrize("model_name,expected", [
+        ("Opus 5", "au.anthropic.claude-opus-5"),
+        ("Sonnet 5", "au.anthropic.claude-sonnet-5"),
+    ])
+    def test_au_profile_resolves_through_converse_route(self, model_name, expected):
+        # Integration guard: the au. profile ID must not only resolve but also
+        # match a CONVERSE_API_ENABLED_MODEL_INFO prefix — otherwise
+        # _get_model_info returns None and _invoke falls back to the legacy
+        # bare-ID path, which Claude 5 models reject (profile-only).
+        info, _ = self._get_model_info(model_name, "geographic", "ap-southeast-2")
+        assert info is not None
+        assert info["model"] == expected
+        assert info["support_tool_use"] is True
 
     def test_geographic_eu_raises_actionable_error_for_fable5(self):
         # Fable 5 has no eu. geo profile — only us. and global.

--- a/models/bedrock/tests/test_claude5_llm_params.py
+++ b/models/bedrock/tests/test_claude5_llm_params.py
@@ -73,13 +73,23 @@ class TestClaude5RegionResolutionInGetModelInfo:
         assert info["model"] == "global.anthropic.claude-sonnet-5"
         assert info["support_tool_use"] is True
 
+    def test_opus5_global_resolution(self):
+        info, _ = self._get_model_info("Opus 5", "global", "ap-northeast-1")
+        assert info["model"] == "global.anthropic.claude-opus-5"
+
     def test_geographic_us(self):
         info, _ = self._get_model_info("Fable 5", "geographic", "us-west-2")
         assert info["model"] == "us.anthropic.claude-fable-5"
 
-    def test_geographic_eu_raises_actionable_error(self):
+    def test_opus5_geographic_eu(self):
+        # Opus 5 / Sonnet 5 have eu. geo profiles (live-verified)
+        info, _ = self._get_model_info("Opus 5", "geographic", "eu-central-1")
+        assert info["model"] == "eu.anthropic.claude-opus-5"
+
+    def test_geographic_eu_raises_actionable_error_for_fable5(self):
+        # Fable 5 has no eu. geo profile — only us. and global.
         with pytest.raises(llm_mod.InvokeError, match="global"):
-            self._get_model_info("Sonnet 5", "geographic", "eu-central-1")
+            self._get_model_info("Fable 5", "geographic", "eu-central-1")
 
     def test_cross_region_param_is_consumed(self):
         _, params = self._get_model_info("Sonnet 5", "global", "us-east-1")

--- a/models/bedrock/tests/test_claude5_model_ids.py
+++ b/models/bedrock/tests/test_claude5_model_ids.py
@@ -15,6 +15,7 @@ _spec = importlib.util.spec_from_file_location("model_ids", _MODEL_IDS_PATH)
 model_ids = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(model_ids)
 
+OPUS5 = "anthropic.claude-opus-5"
 SONNET5 = "anthropic.claude-sonnet-5"
 FABLE5 = "anthropic.claude-fable-5"
 
@@ -22,16 +23,19 @@ FABLE5 = "anthropic.claude-fable-5"
 class TestRegistry:
     def test_family_registered(self):
         family = model_ids.BEDROCK_MODEL_IDS["anthropic claude 5"]
+        assert family["Opus 5"] == OPUS5
         assert family["Sonnet 5"] == SONNET5
         assert family["Fable 5"] == FABLE5
 
     def test_get_model_id(self):
+        assert model_ids.get_model_id("anthropic claude 5", "Opus 5") == OPUS5
         assert model_ids.get_model_id("anthropic claude 5", "Sonnet 5") == SONNET5
         assert model_ids.get_model_id("anthropic claude 5", "Fable 5") == FABLE5
 
 
 class TestIsClaude5:
     def test_bare_ids(self):
+        assert model_ids.is_claude5_model(OPUS5)
         assert model_ids.is_claude5_model(SONNET5)
         assert model_ids.is_claude5_model(FABLE5)
 
@@ -42,6 +46,7 @@ class TestIsClaude5:
     def test_profile_ids(self):
         assert model_ids.is_claude5_profile_id(f"global.{SONNET5}")
         assert model_ids.is_claude5_profile_id(f"us.{FABLE5}")
+        assert model_ids.is_claude5_profile_id(f"eu.{OPUS5}")
         assert model_ids.is_claude5_profile_id(SONNET5)
         assert not model_ids.is_claude5_profile_id("global.anthropic.claude-opus-4-8")
 
@@ -72,10 +77,37 @@ class TestResolveProfileId:
             == f"us.{SONNET5}"
         )
 
-    @pytest.mark.parametrize("region", ["eu-central-1", "eu-west-1", "ap-northeast-1"])
-    def test_geographic_unsupported_regions_raise(self, region):
+    @pytest.mark.parametrize("region", ["eu-central-1", "eu-west-1"])
+    def test_geographic_eu_regions(self, region):
+        # Opus 5 / Sonnet 5 have eu. geo profiles (live-verified); Fable 5 does not
+        assert (
+            model_ids.resolve_claude5_profile_id(OPUS5, "geographic", region)
+            == f"eu.{OPUS5}"
+        )
+        assert (
+            model_ids.resolve_claude5_profile_id(SONNET5, "geographic", region)
+            == f"eu.{SONNET5}"
+        )
+        with pytest.raises(ValueError, match="Global"):
+            model_ids.resolve_claude5_profile_id(FABLE5, "geographic", region)
+
+    @pytest.mark.parametrize("region", ["ap-southeast-2", "ap-southeast-4"])
+    def test_geographic_au_regions(self, region):
+        # Australian regions map to the au. geo profile for Opus 5 / Sonnet 5
+        assert (
+            model_ids.resolve_claude5_profile_id(OPUS5, "geographic", region)
+            == f"au.{OPUS5}"
+        )
+        with pytest.raises(ValueError, match="Global"):
+            model_ids.resolve_claude5_profile_id(FABLE5, "geographic", region)
+
+    @pytest.mark.parametrize("region", ["ap-northeast-1", "ap-southeast-1"])
+    def test_geographic_non_au_apac_regions_raise(self, region):
+        # No apac. profile exists for any Claude 5 model
         with pytest.raises(ValueError, match="Global"):
             model_ids.resolve_claude5_profile_id(SONNET5, "geographic", region)
+        with pytest.raises(ValueError, match="Global"):
+            model_ids.resolve_claude5_profile_id(OPUS5, "geographic", region)
 
     def test_disabled_raises(self):
         with pytest.raises(ValueError, match="inference profile"):


### PR DESCRIPTION
## Summary

Adds **Anthropic Claude Opus 5** (`anthropic.claude-opus-5`, launched on Bedrock 2026-07-24) to the Bedrock plugin's Claude 5 family, alongside the existing Sonnet 5 / Fable 5 entries (#3413).

## Model card facts (live-verified)

| Item | Value |
|---|---|
| Model ID | `anthropic.claude-opus-5` (`inferenceTypesSupported = [INFERENCE_PROFILE]` — profile-only, no on-demand bare-ID invocation) |
| Context window | 1M tokens |
| Max output | 128K tokens |
| Reasoning | Adaptive thinking on by default; controlled via `effort` (existing Claude 5 family plumbing) |
| Inference profiles | `global.`, `us.`, `eu.`, `au.` — verified via `ListInferenceProfiles` in us-east-1 / eu-west-1 / ap-southeast-2 / ap-northeast-1 |
| Prompt caching | min **512** tokens per checkpoint, 4 checkpoints, system/messages/tools |
| Pricing | $5 / $25 per 1M tokens (global rate) |

Docs: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html

## Changes

- `model_ids.py`: register Opus 5; extend `CLAUDE5_PROFILE_PREFIXES` to per-model geo coverage — Opus 5 / Sonnet 5 gained `eu.`/`au.` geo profiles (Sonnet 5 grew these since #3413), Fable 5 remains `us.`-only; map Australian source regions (ap-southeast-2/4) to the `au.` profile
- `cache_config.py`: Opus 5 cache config with the 512-token minimum from the model card
- `anthropic-claude-5.yaml`: add `Opus 5` option; refresh cross-region help text
- `model_configurations/claude-5-opus.yaml`: pricing entry ($0.005/$0.025 per 1K)
- `llm.py`: pricing name mapping `'Opus 5' → 'claude-5-opus'`
- README + manifest bump to 0.0.76
- Tests extended for Opus 5 registry/profile-resolution/caching — 59 passed

## Testing

```
uv run --with pytest pytest tests/ -q
62 passed
```

Profile resolution verified against live `ListInferenceProfiles` output in four geos; refusal-fallback path (to Claude 4.8 Opus) reused unchanged from the Claude 5 family — `eu.`/`au.` Opus 4.8 fallback profiles verified to exist.

### Live API verification (real plugin `invoke()` path, us-east-1 / eu-central-1 / ap-southeast-2)

A harness drove the public `invoke()` → profile resolution → parameter conversion → Converse → response handling → pricing path on this branch, every expectation asserted mechanically — 8/8 expected:

- Opus 5 registered in family + yaml dropdown; no sampling params exposed ✅
- Profile matrix: `global.` from us-east-1/ap-northeast-1, `us.`/`eu.`/`au.` geographic, non-AU APAC regions raise an actionable "use Global" error ✅
- Cache config: min 512 tokens/checkpoint per model card ✅
- Pricing mapping `Opus 5 → claude-5-opus.yaml` ($5/$25) ✅
- LIVE non-stream via `global.anthropic.claude-opus-5`: `'OK'`, priced $0.005/$0.025 per 1K ✅
- LIVE streaming with adaptive thinking (`effort=high`): multi-chunk, `end_turn` ✅
- LIVE geographic `us.anthropic.claude-opus-5` from us-east-1 ✅
- LIVE geographic `eu.anthropic.claude-opus-5` from eu-central-1 (new geo coverage) ✅
- LIVE geographic `au.anthropic.claude-opus-5` from ap-southeast-2, end-to-end through `invoke()` after the review fix ✅

### Dify UI verification (local Dify v1.15.0, plugin via remote debug, v0.0.76)

Model Settings — **Opus 5** in the Bedrock Model dropdown alongside Sonnet 5 / Fable 5:

<img width="483" height="579" alt="model_settings" src="https://github.com/user-attachments/assets/4983395e-0448-413e-9415-eef21eda7b82" />

Cross-Region Inference options (global / geographic) — the plugin resolves the concrete `us.`/`eu.`/`au.`/`global.` profile from the user's region:

<img width="483" height="578" alt="cross_region" src="https://github.com/user-attachments/assets/954082ad-8057-4f35-97db-cfbd912e3885" />

Effort ladder low/medium/high/xhigh/max (default high); note **no temperature/top_p/top_k and no JSON Schema/response_format** — both by design (the latter removed after live-verifying Claude 5 rejects `outputConfig.textFormat` and assistant prefill):

<img width="483" height="598" alt="efforts" src="https://github.com/user-attachments/assets/eed01708-50c1-47ba-916e-22cdc8d8d7af" />

End-to-end chatflow with **both LLM nodes on Opus 5** (global profile), completing successfully:

<img width="1440" height="709" alt="workflow" src="https://github.com/user-attachments/assets/94d88f79-9347-4a61-8eb7-79347784d95a" />