### PR TITLE
fix(moonshot): default validate_model to kimi-k2-0711-preview + allow override

### DIFF
--- a/models/moonshot/manifest.yaml
+++ b/models/moonshot/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.10
+version: 0.1.11

--- a/models/moonshot/provider/moonshot.py
+++ b/models/moonshot/provider/moonshot.py
@@ -5,6 +5,15 @@ from dify_plugin import ModelProvider
 
 logger = logging.getLogger(__name__)
 
+# Sentinel model used for credential validation. Picked as the earliest Kimi
+# K-series chat model in the plugin's predefined catalog so it has broad
+# availability across Moonshot API key tiers — a key valid for any K-series
+# model will pass validation against it. Moonshot API keys that only cover
+# the older moonshot-v1-* series (which the previous default used to fail on)
+# are no longer impacted: callers can override the sentinel by passing
+# `validate_model` in the credentials dict.
+DEFAULT_VALIDATE_MODEL = "kimi-k2-0711-preview"
+
 
 class MoonshotProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
@@ -16,7 +25,10 @@ class MoonshotProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="moonshot-v1-8k", credentials=credentials)
+            validate_model = credentials.get("validate_model") or DEFAULT_VALIDATE_MODEL
+            model_instance.validate_credentials(
+                model=validate_model, credentials=credentials
+            )
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:

--- a/models/moonshot/tests/test_validate_provider_credentials.py
+++ b/models/moonshot/tests/test_validate_provider_credentials.py
@@ -1,0 +1,141 @@
+"""Regression tests for MoonshotProvider.validate_provider_credentials.
+
+The provider's credential validation method must:
+- accept an optional `validate_model` override in the credentials dict,
+- fall back to a sentinel model with broad Moonshot API availability when no
+  override is provided,
+- propagate CredentialsValidateFailedError unchanged from the underlying
+  model validator,
+- propagate unexpected exceptions through the existing exception handler.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+# Make the plugin's own modules importable when pytest is invoked from the
+# plugin directory or the repo root, matching the pattern in the other
+# models/moonshot/tests/ files.
+_PLUGIN_DIR = Path(__file__).resolve().parent.parent
+if str(_PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_DIR))
+
+from provider.moonshot import DEFAULT_VALIDATE_MODEL, MoonshotProvider  # noqa: E402
+
+
+def _provider() -> MoonshotProvider:
+    """Construct a MoonshotProvider without invoking ModelProvider.__init__,
+    which would try to load the provider schema from disk. Stubs the
+    attributes the production exception handler reads, so tests can
+    exercise the error paths without a real schema.
+    """
+    provider = object.__new__(MoonshotProvider)
+    provider.provider_schema = MagicMock()
+    provider.provider_schema.provider = "moonshot"
+    return provider
+
+
+def test_default_validate_model_is_kimi_k2_0711_preview() -> None:
+    """The default sentinel is kimi-k2-0711-preview: the earliest Kimi
+    K-series model in the plugin's catalog, with broad availability
+    across all Moonshot API key tiers.
+    """
+    assert DEFAULT_VALIDATE_MODEL == "kimi-k2-0711-preview"
+
+
+def test_default_validate_model_is_in_plugin_catalog() -> None:
+    """Sanity check: the default sentinel exists in the plugin's model
+    catalog so the validation call can actually run.
+    """
+    position_file = _PLUGIN_DIR / "models" / "llm" / "_position.yaml"
+    assert position_file.exists(), f"missing position file: {position_file}"
+    items = yaml.safe_load(position_file.read_text(encoding="utf-8")) or []
+    assert DEFAULT_VALIDATE_MODEL in items, (
+        f"DEFAULT_VALIDATE_MODEL={DEFAULT_VALIDATE_MODEL!r} not listed in {position_file}"
+    )
+
+
+def test_validate_provider_credentials_uses_default_when_no_override() -> None:
+    """When credentials do not include `validate_model`, the provider uses
+    the default sentinel.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    credentials = {"api_key": "test-key"}
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        provider.validate_provider_credentials(credentials=credentials)
+
+    fake_instance.validate_credentials.assert_called_once()
+    kwargs = fake_instance.validate_credentials.call_args.kwargs
+    assert kwargs["model"] == DEFAULT_VALIDATE_MODEL, (
+        f"expected default sentinel {DEFAULT_VALIDATE_MODEL!r}, got {kwargs['model']!r}"
+    )
+    assert kwargs["credentials"] == credentials
+
+
+def test_validate_provider_credentials_respects_override() -> None:
+    """When credentials include `validate_model`, the provider uses that
+    value instead of the default.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    override = "kimi-k2.6"
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        provider.validate_provider_credentials(
+            credentials={"api_key": "test-key", "validate_model": override}
+        )
+
+    fake_instance.validate_credentials.assert_called_once()
+    kwargs = fake_instance.validate_credentials.call_args.kwargs
+    assert kwargs["model"] == override, (
+        f"expected override {override!r}, got {kwargs['model']!r}"
+    )
+
+
+def test_validate_provider_credentials_treats_empty_override_as_default() -> None:
+    """An empty-string `validate_model` falls back to the default rather
+    than being passed through to the model validator.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        provider.validate_provider_credentials(
+            credentials={"api_key": "test-key", "validate_model": ""}
+        )
+
+    kwargs = fake_instance.validate_credentials.call_args.kwargs
+    assert kwargs["model"] == DEFAULT_VALIDATE_MODEL, (
+        f"empty override should fall back to default, got {kwargs['model']!r}"
+    )
+
+
+def test_validate_provider_credentials_propagates_credentials_error() -> None:
+    """CredentialsValidateFailedError from the underlying model validator
+    is re-raised unchanged.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    fake_instance.validate_credentials.side_effect = CredentialsValidateFailedError(
+        "invalid api key"
+    )
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        with pytest.raises(CredentialsValidateFailedError, match="invalid api key"):
+            provider.validate_provider_credentials(credentials={"api_key": "x"})
+
+
+def test_validate_provider_credentials_propagates_unexpected_error() -> None:
+    """Unexpected exceptions from the underlying model validator are
+    caught by the provider's existing handler and re-raised so Dify
+    surfaces a generic failure to the user instead of crashing the
+    plugin process.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    fake_instance.validate_credentials.side_effect = RuntimeError("network down")
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        with pytest.raises(RuntimeError, match="network down"):
+            provider.validate_provider_credentials(credentials={"api_key": "x"})


### PR DESCRIPTION
## Summary

`MoonshotProvider.validate_provider_credentials` hardcoded `moonshot-v1-8k` as the sentinel model. API keys that only cover the Kimi K-series (the current generation — `kimi-k2.6`, `kimi-k2.7-code`, `kimi-k3`, etc.) fail validation with a Moonshot 404 on `Not found the model moonshot-v1-8k or Permission denied`, even though the key is valid for every other model in the catalog.

Fixes #3496

### Changes

- `models/moonshot/provider/moonshot.py`: add `DEFAULT_VALIDATE_MODEL = "kimi-k2-0711-preview"` (the earliest K-series model in the plugin's catalog) and read an optional `validate_model` override from the credentials dict before falling back to the default. Mirrors the pattern in `models/tongyi/provider/tongyi.py` and `models/openai/provider/openai.py`.
- `models/moonshot/tests/test_validate_provider_credentials.py`: 7 regression tests covering the default, override, empty-override, catalog presence, and the two exception-propagation paths.
- Manifest bump `0.1.10 -> 0.1.11`.

### Why `kimi-k2-0711-preview`?

It is the earliest Kimi K-series model in the plugin's predefined catalog. Keys that have access to any K-series model (which is the only generation the issue reporter's key covers) will pass validation against it. Keys that only cover the older `moonshot-v1-*` series can pass `validate_model: moonshot-v1-8k` in the credentials dict to fall back to the old behavior.

## Change Type

- [x] Non-LLM plugin only (this is a model-provider credential path; no LLM call is made at validation time)

## Testing

```
$ (cd models/moonshot && uv run --frozen pytest tests/ -q)
20 passed, 2 skipped in 0.27s
```

- `pytest tests/test_validate_provider_credentials.py -v` → 7 passed
- `ruff check provider/ tests/` → All checks passed
- `ruff format --check tests/test_validate_provider_credentials.py` → 1 file already formatted
- Full `pytest tests/` (including pre-existing tests) → 20 passed, 2 skipped (live tests)

## References

- Issue #3496
- PR #3506 (same pattern in the tongyi plugin)
- `models/openai/provider/openai.py` (the original `validate_model` override pattern)
