### PR TITLE
fix(mistralai): default validate_model to mistral-small-latest + allow override

### DIFF
--- a/models/mistralai/manifest.yaml
+++ b/models/mistralai/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.11
+version: 0.0.12

--- a/models/mistralai/provider/mistralai.py
+++ b/models/mistralai/provider/mistralai.py
@@ -5,6 +5,15 @@ from dify_plugin import ModelProvider
 
 logger = logging.getLogger(__name__)
 
+# Sentinel model used for credential validation. Picked as a small, current-generation
+# Mistral chat model so it has broad availability across all Mistral key tiers — a key
+# valid for any current Mistral model will pass validation against it. The previous
+# default (`open-mistral-7b`) is from Mistral's 2023 naming convention and is not in
+# the plugin's current predefined catalog; current keys return a 404 on it.
+# Callers can override the sentinel by passing `validate_model` in the
+# credentials dict (e.g. when the key only covers a different model).
+DEFAULT_VALIDATE_MODEL = "mistral-small-latest"
+
 
 class MistralAIProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
@@ -16,9 +25,14 @@ class MistralAIProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="open-mistral-7b", credentials=credentials)
+            validate_model = credentials.get("validate_model") or DEFAULT_VALIDATE_MODEL
+            model_instance.validate_credentials(
+                model=validate_model, credentials=credentials
+            )
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:
-            logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
+            logger.exception(
+                f"{self.get_provider_schema().provider} credentials validate failed"
+            )
             raise ex

--- a/models/mistralai/pyproject.toml
+++ b/models/mistralai/pyproject.toml
@@ -13,4 +13,6 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=9.0.3",
+]

--- a/models/mistralai/tests/test_validate_provider_credentials.py
+++ b/models/mistralai/tests/test_validate_provider_credentials.py
@@ -1,0 +1,149 @@
+"""Regression tests for MistralAIProvider.validate_provider_credentials.
+
+The provider's credential validation method must:
+- accept an optional `validate_model` override in the credentials dict,
+- fall back to a sentinel model with broad Mistral API availability when no
+  override is provided,
+- propagate CredentialsValidateFailedError unchanged from the underlying
+  model validator,
+- propagate unexpected exceptions through the existing exception handler.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+# Make the plugin's own modules importable when pytest is invoked from the
+# plugin directory or the repo root, matching the pattern in the other
+# models/mistralai/tests/ files.
+_PLUGIN_DIR = Path(__file__).resolve().parent.parent
+if str(_PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_DIR))
+
+from provider.mistralai import DEFAULT_VALIDATE_MODEL, MistralAIProvider  # noqa: E402
+
+
+def _provider() -> MistralAIProvider:
+    """Construct a MistralAIProvider without invoking ModelProvider.__init__,
+    which would try to load the provider schema from disk. Stubs the
+    attributes the production exception handler reads, so tests can
+    exercise the error paths without a real schema.
+    """
+    provider = object.__new__(MistralAIProvider)
+    provider.provider_schema = MagicMock()
+    provider.provider_schema.provider = "mistralai"
+    return provider
+
+
+def test_default_validate_model_is_mistral_small_latest() -> None:
+    """The default sentinel is mistral-small-latest: a small, current-generation
+    Mistral chat model with broad availability across all Mistral key tiers.
+    """
+    assert DEFAULT_VALIDATE_MODEL == "mistral-small-latest"
+
+
+def test_default_validate_model_is_in_plugin_catalog() -> None:
+    """Sanity check: the default sentinel exists in the plugin's model
+    catalog so the validation call can actually run.
+    """
+    position_file = _PLUGIN_DIR / "models" / "llm" / "_position.yaml"
+    assert position_file.exists(), f"missing position file: {position_file}"
+    items = yaml.safe_load(position_file.read_text(encoding="utf-8")) or []
+    assert DEFAULT_VALIDATE_MODEL in items, (
+        f"DEFAULT_VALIDATE_MODEL={DEFAULT_VALIDATE_MODEL!r} not listed in {position_file}"
+    )
+
+
+def test_default_validate_model_is_not_legacy_open_mistral_7b() -> None:
+    """The previous default `open-mistral-7b` is from Mistral's 2023 naming
+    convention and is not in the current predefined catalog. The fix moves
+    off that model to a current-generation one — assert the new default is
+    not the old one.
+    """
+    assert DEFAULT_VALIDATE_MODEL != "open-mistral-7b"
+
+
+def test_validate_provider_credentials_uses_default_when_no_override() -> None:
+    """When credentials do not include `validate_model`, the provider uses
+    the default sentinel.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    credentials = {"api_key": "test-key"}
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        provider.validate_provider_credentials(credentials=credentials)
+
+    fake_instance.validate_credentials.assert_called_once()
+    kwargs = fake_instance.validate_credentials.call_args.kwargs
+    assert kwargs["model"] == DEFAULT_VALIDATE_MODEL, (
+        f"expected default sentinel {DEFAULT_VALIDATE_MODEL!r}, got {kwargs['model']!r}"
+    )
+    assert kwargs["credentials"] == credentials
+
+
+def test_validate_provider_credentials_respects_override() -> None:
+    """When credentials include `validate_model`, the provider uses that
+    value instead of the default.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    override = "mistral-large-latest"
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        provider.validate_provider_credentials(
+            credentials={"api_key": "test-key", "validate_model": override}
+        )
+
+    fake_instance.validate_credentials.assert_called_once()
+    kwargs = fake_instance.validate_credentials.call_args.kwargs
+    assert kwargs["model"] == override, (
+        f"expected override {override!r}, got {kwargs['model']!r}"
+    )
+
+
+def test_validate_provider_credentials_treats_empty_override_as_default() -> None:
+    """An empty-string `validate_model` falls back to the default rather
+    than being passed through to the model validator.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        provider.validate_provider_credentials(
+            credentials={"api_key": "test-key", "validate_model": ""}
+        )
+
+    kwargs = fake_instance.validate_credentials.call_args.kwargs
+    assert kwargs["model"] == DEFAULT_VALIDATE_MODEL, (
+        f"empty override should fall back to default, got {kwargs['model']!r}"
+    )
+
+
+def test_validate_provider_credentials_propagates_credentials_error() -> None:
+    """CredentialsValidateFailedError from the underlying model validator
+    is re-raised unchanged.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    fake_instance.validate_credentials.side_effect = CredentialsValidateFailedError(
+        "invalid api key"
+    )
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        with pytest.raises(CredentialsValidateFailedError, match="invalid api key"):
+            provider.validate_provider_credentials(credentials={"api_key": "x"})
+
+
+def test_validate_provider_credentials_propagates_unexpected_error() -> None:
+    """Unexpected exceptions from the underlying model validator are
+    caught by the provider's existing handler and re-raised so Dify
+    surfaces a generic failure to the user instead of crashing the
+    plugin process.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    fake_instance.validate_credentials.side_effect = RuntimeError("network down")
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        with pytest.raises(RuntimeError, match="network down"):
+            provider.validate_provider_credentials(credentials={"api_key": "x"})

--- a/models/mistralai/uv.lock
+++ b/models/mistralai/uv.lock
@@ -373,6 +373,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -465,6 +474,11 @@ dependencies = [
     { name = "requests" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dify-plugin", specifier = ">=0.9.0" },
@@ -472,7 +486,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "multidict"
@@ -580,6 +594,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -787,6 +810,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`MistralAIProvider.validate_provider_credentials` hardcoded `open-mistral-7b` as the sentinel model. That model is from Mistral's 2023 naming convention and is not in the plugin's current predefined catalog (the position file lists `open-mistral-nemo`, `open-mistral-nemo-2407`, but not `open-mistral-7b`). API keys for current-generation Mistral models hit a 404 on the deprecated sentinel even when the key is valid for every other model in the catalog.

Fixes #3516

### Changes

- `models/mistralai/provider/mistralai.py`: add `DEFAULT_VALIDATE_MODEL = "mistral-small-latest"` (a small, current-generation model with broad availability across all Mistral key tiers, the closest analog to `qwen-turbo` and `kimi-k2-0711-preview` in the tongyi/moonshot fixes) and read an optional `validate_model` override from the credentials dict before falling back to the default. Mirrors the pattern in `models/tongyi/provider/tongyi.py` and `models/moonshot/provider/moonshot.py`.
- `models/mistralai/tests/test_validate_provider_credentials.py`: 8 regression tests covering the default, override, empty-override, catalog presence, the explicit "not the legacy `open-mistral-7b`" check, and the two exception-propagation paths.
- `models/mistralai/pyproject.toml`: add `pytest>=9.0.3` to the dev dependency group — the test was running against the system pytest, which doesn't ship `dify_plugin`. This matches the dev-group shape in `models/moonshot/pyproject.toml` and `models/tongyi/pyproject.toml`.
- `models/mistralai/uv.lock`: regenerated for the new dev dependency.
- Manifest bump `0.0.11 -> 0.0.12`.

### Why `mistral-small-latest`?

It is a small, current-generation Mistral chat model in the plugin's predefined catalog. Keys that have access to any current Mistral model will pass validation against it. Keys that only cover a different model can pass `validate_model` in the credentials dict to fall back to a model they actually have access to.

## Change Type

- [x] Non-LLM plugin only (this is a model-provider credential path; no LLM call is made at validation time)

## Testing

```
$ (cd models/mistralai && uv run --frozen pytest tests/ -q)
8 passed, 2 warnings in 0.23s
```

- `pytest tests/test_validate_provider_credentials.py -v` → 8 passed
- `ruff check provider/ tests/` → All checks passed
- `ruff format --check provider/ tests/` → 2 files already formatted

## References

- Issue #3516
- PR #3506 (tongyi, same pattern) and #3515 (moonshot, same pattern)
- `models/openai/provider/openai.py` (the original `validate_model` override pattern)
