### PR TITLE
feat(bedrock): cache boto3 client and retry on expired AWS token

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.75
+version: 0.0.76
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -301,7 +301,44 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator]:
         """
-        Invoke large language model
+        Invoke large language model with automatic retry on expired credentials.
+
+        If the first attempt fails due to an expired AWS token, a fresh boto3 client
+        is created (re-reading ~/.aws/credentials from disk) and the call is retried once.
+        This handles saml2aws / AWS SSO token refresh transparently.
+        """
+        from provider.get_bedrock_client import is_expired_token_error, invalidate_client_cache
+
+        try:
+            return self._invoke_inner(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
+        except Exception as exc:
+            if is_expired_token_error(exc):
+                logger.warning("AWS token expired, invalidating client cache and retrying with refreshed credentials...")
+                invalidate_client_cache()
+                try:
+                    return self._invoke_inner(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
+                except Exception as retry_exc:
+                    if is_expired_token_error(retry_exc):
+                        raise InvokeAuthorizationError(
+                            "AWS credentials have expired. Please re-authenticate "
+                            "(e.g. saml2aws login) and try again."
+                        ) from None
+                    raise
+            raise
+
+    def _invoke_inner(
+        self,
+        model: str,
+        credentials: dict,
+        prompt_messages: list[PromptMessage],
+        model_parameters: dict,
+        tools: Optional[list[PromptMessageTool]] = None,
+        stop: Optional[list[str]] = None,
+        stream: bool = True,
+        user: Optional[str] = None,
+    ) -> Union[LLMResult, Generator]:
+        """
+        Inner invoke logic (no retry handling).
 
         :param model: model name
         :param credentials: model credentials

--- a/models/bedrock/provider/bedrock.yaml
+++ b/models/bedrock/provider/bedrock.yaml
@@ -66,6 +66,18 @@ provider_credential_schema:
       placeholder:
         en_US: Enter your Secret Access Key
         zh_Hans: 在此输入您的 Secret Access Key
+    - variable: aws_session_token
+      required: false
+      show_on:
+        - variable: auth_method
+          value: Access_Secret_Key
+      label:
+        en_US: Session Token (for temporary credentials from SSO/STS)
+        zh_Hans: Session Token（用于 SSO/STS 临时凭证）
+      type: secret-input
+      placeholder:
+        en_US: Enter your AWS Session Token (optional, for temporary credentials)
+        zh_Hans: 在此输入您的 AWS Session Token（可选，用于临时凭证）
     - variable: bedrock_api_key
       required: true
       show_on:

--- a/models/bedrock/provider/get_bedrock_client.py
+++ b/models/bedrock/provider/get_bedrock_client.py
@@ -1,13 +1,58 @@
 from collections.abc import Mapping
+from typing import Any
 
 import os
+import hashlib
 import boto3
 from botocore.config import Config
 
 from dify_plugin.errors.model import InvokeBadRequestError
 
 
+# Module-level client cache: maps a cache key to a boto3 client.
+# Invalidated on expired token errors via invalidate_client_cache().
+_client_cache: dict[str, Any] = {}
+
+
+def _build_cache_key(service_name: str, credentials: Mapping[str, str]) -> str:
+    """Build a deterministic cache key from service name and credential inputs."""
+    parts = [
+        service_name,
+        credentials.get("aws_region", ""),
+        credentials.get("auth_method", ""),
+        credentials.get("aws_access_key_id", ""),
+        credentials.get("bedrock_endpoint_url", ""),
+        credentials.get("bedrock_proxy_url", ""),
+    ]
+    raw = "|".join(parts)
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+def invalidate_client_cache() -> None:
+    """Clear the cached boto3 clients, forcing fresh credentials on next call."""
+    _client_cache.clear()
+
+
 def get_bedrock_client(service_name: str, credentials: Mapping[str, str]):
+    """
+    Get or create a boto3 client for Bedrock.
+
+    Clients are cached per (service, credentials) combination. On expired token
+    errors, call invalidate_client_cache() before retrying to force a fresh
+    client with re-read credentials from disk.
+    """
+    cache_key = _build_cache_key(service_name, credentials)
+
+    if cache_key in _client_cache:
+        return _client_cache[cache_key]
+
+    client = _create_bedrock_client(service_name, credentials)
+    _client_cache[cache_key] = client
+    return client
+
+
+def _create_bedrock_client(service_name: str, credentials: Mapping[str, str]):
+    """Create a new boto3 client (not cached — called by get_bedrock_client)."""
     region_name = credentials.get("aws_region")
     if not region_name:
         raise InvokeBadRequestError("aws_region is required")
@@ -58,14 +103,34 @@ def get_bedrock_client(service_name: str, credentials: Mapping[str, str]):
             os.environ.pop('AWS_BEARER_TOKEN_BEDROCK')
         aws_access_key_id = credentials.get("aws_access_key_id")
         aws_secret_access_key = credentials.get("aws_secret_access_key")
+        aws_session_token = credentials.get("aws_session_token")
         
         # Add credentials if provided
         if aws_access_key_id and aws_secret_access_key:
             client_kwargs['aws_access_key_id'] = aws_access_key_id
             client_kwargs['aws_secret_access_key'] = aws_secret_access_key
-    else: # auth_method == "IAM_Role"
+            if aws_session_token:
+                client_kwargs['aws_session_token'] = aws_session_token
+    else:  # auth_method == "IAM_Role"
         if 'AWS_BEARER_TOKEN_BEDROCK' in os.environ:
             os.environ.pop('AWS_BEARER_TOKEN_BEDROCK')
+        # Create a fresh boto3 session to read the latest credentials from disk.
+        # This ensures rotated tokens (saml2aws, aws sso) are picked up after
+        # cache invalidation.
+        session = boto3.Session()
+        creds = session.get_credentials()
+        if creds:
+            frozen = creds.get_frozen_credentials()
+            client_kwargs['aws_access_key_id'] = frozen.access_key
+            client_kwargs['aws_secret_access_key'] = frozen.secret_key
+            if frozen.token:
+                client_kwargs['aws_session_token'] = frozen.token
 
     client = boto3.client(**client_kwargs)
     return client
+
+
+def is_expired_token_error(exc: Exception) -> bool:
+    """Check if an exception indicates expired AWS credentials."""
+    msg = str(exc).lower()
+    return any(s in msg for s in ("expiredtoken", "expired", "security token", "the security token included in the request is expired"))

--- a/models/bedrock/pyproject.toml
+++ b/models/bedrock/pyproject.toml
@@ -17,4 +17,6 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=9.1.1",
+]

--- a/models/bedrock/tests/test_expired_token_retry.py
+++ b/models/bedrock/tests/test_expired_token_retry.py
@@ -1,0 +1,331 @@
+"""Unit tests for expired AWS token detection, client caching, and retry logic."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from provider.get_bedrock_client import (
+    is_expired_token_error,
+    get_bedrock_client,
+    invalidate_client_cache,
+    _client_cache,
+)
+
+
+class TestIsExpiredTokenError:
+    """Tests for the is_expired_token_error helper."""
+
+    def test_detects_expired_token_exception(self):
+        exc = Exception(
+            "An error occurred (ExpiredTokenException) when calling the "
+            "GetInferenceProfile operation: The security token included in "
+            "the request is expired"
+        )
+        assert is_expired_token_error(exc) is True
+
+    def test_detects_expired_keyword(self):
+        exc = Exception("Token has expired")
+        assert is_expired_token_error(exc) is True
+
+    def test_detects_security_token_keyword(self):
+        exc = Exception("The security token is invalid")
+        assert is_expired_token_error(exc) is True
+
+    def test_does_not_match_unrelated_error(self):
+        exc = Exception("Model not found: us.anthropic.claude-opus-4-8")
+        assert is_expired_token_error(exc) is False
+
+    def test_does_not_match_access_denied(self):
+        exc = Exception("AccessDeniedException: User is not authorized")
+        assert is_expired_token_error(exc) is False
+
+    def test_does_not_match_throttling(self):
+        exc = Exception("ThrottlingException: Rate exceeded")
+        assert is_expired_token_error(exc) is False
+
+    def test_case_insensitive(self):
+        exc = Exception("EXPIREDTOKENEXCEPTION: token expired")
+        assert is_expired_token_error(exc) is True
+
+
+class TestClientCaching:
+    """Tests for boto3 client caching and invalidation."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        _client_cache.clear()
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_same_credentials_returns_cached_client(self, mock_boto3):
+        """Repeated calls with same credentials should return the same client."""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_boto3.Session.return_value = MagicMock(
+            get_credentials=MagicMock(return_value=None)
+        )
+
+        credentials = {
+            "aws_region": "us-east-1",
+            "auth_method": "IAM_Role",
+        }
+
+        client1 = get_bedrock_client("bedrock-runtime", credentials)
+        client2 = get_bedrock_client("bedrock-runtime", credentials)
+
+        assert client1 is client2
+        # boto3.client should only be called once (cached on second call)
+        assert mock_boto3.client.call_count == 1
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_different_service_creates_separate_clients(self, mock_boto3):
+        """Different service names should get different cached clients."""
+        mock_boto3.client.side_effect = [MagicMock(), MagicMock()]
+        mock_boto3.Session.return_value = MagicMock(
+            get_credentials=MagicMock(return_value=None)
+        )
+
+        credentials = {
+            "aws_region": "us-east-1",
+            "auth_method": "IAM_Role",
+        }
+
+        client1 = get_bedrock_client("bedrock-runtime", credentials)
+        client2 = get_bedrock_client("bedrock", credentials)
+
+        assert client1 is not client2
+        assert mock_boto3.client.call_count == 2
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_invalidate_clears_cache(self, mock_boto3):
+        """After invalidation, next call creates a fresh client."""
+        mock_boto3.client.side_effect = [MagicMock(name="old"), MagicMock(name="new")]
+        mock_boto3.Session.return_value = MagicMock(
+            get_credentials=MagicMock(return_value=None)
+        )
+
+        credentials = {
+            "aws_region": "us-east-1",
+            "auth_method": "IAM_Role",
+        }
+
+        client1 = get_bedrock_client("bedrock-runtime", credentials)
+        invalidate_client_cache()
+        client2 = get_bedrock_client("bedrock-runtime", credentials)
+
+        assert client1 is not client2
+        assert mock_boto3.client.call_count == 2
+
+
+class TestGetBedrockClientIAMRole:
+    """Tests for IAM Role credential refresh in get_bedrock_client."""
+
+    def setup_method(self):
+        _client_cache.clear()
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_iam_role_creates_fresh_session(self, mock_boto3):
+        """IAM Role mode should create a fresh boto3.Session to read latest creds."""
+        mock_session = MagicMock()
+        mock_creds = MagicMock()
+        mock_frozen = MagicMock()
+        mock_frozen.access_key = "ASIAFRESHKEY"
+        mock_frozen.secret_key = "freshsecret"
+        mock_frozen.token = "freshtoken123"
+        mock_creds.get_frozen_credentials.return_value = mock_frozen
+        mock_session.get_credentials.return_value = mock_creds
+        mock_boto3.Session.return_value = mock_session
+        mock_boto3.client.return_value = MagicMock()
+
+        credentials = {
+            "aws_region": "us-east-1",
+            "auth_method": "IAM_Role",
+        }
+
+        get_bedrock_client("bedrock-runtime", credentials)
+
+        # Verify a fresh session was created
+        mock_boto3.Session.assert_called_once()
+        # Verify the frozen credentials were passed to the client
+        mock_boto3.client.assert_called_once()
+        call_kwargs = mock_boto3.client.call_args[1]
+        assert call_kwargs["aws_access_key_id"] == "ASIAFRESHKEY"
+        assert call_kwargs["aws_secret_access_key"] == "freshsecret"
+        assert call_kwargs["aws_session_token"] == "freshtoken123"
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_iam_role_no_session_token_when_long_lived(self, mock_boto3):
+        """Long-lived IAM creds (no token) should not set session token."""
+        mock_session = MagicMock()
+        mock_creds = MagicMock()
+        mock_frozen = MagicMock()
+        mock_frozen.access_key = "AKIALONGLIVEDKEY"
+        mock_frozen.secret_key = "longlivedsecret"
+        mock_frozen.token = None
+        mock_creds.get_frozen_credentials.return_value = mock_frozen
+        mock_session.get_credentials.return_value = mock_creds
+        mock_boto3.Session.return_value = mock_session
+        mock_boto3.client.return_value = MagicMock()
+
+        credentials = {
+            "aws_region": "us-east-1",
+            "auth_method": "IAM_Role",
+        }
+
+        get_bedrock_client("bedrock-runtime", credentials)
+
+        call_kwargs = mock_boto3.client.call_args[1]
+        assert call_kwargs["aws_access_key_id"] == "AKIALONGLIVEDKEY"
+        assert "aws_session_token" not in call_kwargs
+
+
+class TestGetBedrockClientAccessSecretKey:
+    """Tests for Access_Secret_Key mode with optional session token."""
+
+    def setup_method(self):
+        _client_cache.clear()
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_passes_session_token_when_provided(self, mock_boto3):
+        mock_boto3.client.return_value = MagicMock()
+
+        credentials = {
+            "aws_region": "us-east-1",
+            "auth_method": "Access_Secret_Key",
+            "aws_access_key_id": "ASIATEMPKEY",
+            "aws_secret_access_key": "tempsecret",
+            "aws_session_token": "temptoken456",
+        }
+
+        get_bedrock_client("bedrock-runtime", credentials)
+
+        call_kwargs = mock_boto3.client.call_args[1]
+        assert call_kwargs["aws_access_key_id"] == "ASIATEMPKEY"
+        assert call_kwargs["aws_secret_access_key"] == "tempsecret"
+        assert call_kwargs["aws_session_token"] == "temptoken456"
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_no_session_token_when_not_provided(self, mock_boto3):
+        mock_boto3.client.return_value = MagicMock()
+
+        credentials = {
+            "aws_region": "us-east-1",
+            "auth_method": "Access_Secret_Key",
+            "aws_access_key_id": "AKIAREGULARKEY",
+            "aws_secret_access_key": "regularsecret",
+        }
+
+        get_bedrock_client("bedrock-runtime", credentials)
+
+        call_kwargs = mock_boto3.client.call_args[1]
+        assert call_kwargs["aws_access_key_id"] == "AKIAREGULARKEY"
+        assert call_kwargs["aws_secret_access_key"] == "regularsecret"
+        assert "aws_session_token" not in call_kwargs
+
+
+class TestInvokeRetryOnExpiredToken:
+    """Tests for the _invoke retry-on-expired logic in the LLM class."""
+
+    def setup_method(self):
+        _client_cache.clear()
+
+    def _create_model_instance(self):
+        """Create a BedrockLargeLanguageModel with mocked parent __init__."""
+        from models.llm.llm import BedrockLargeLanguageModel
+
+        with patch("dify_plugin.LargeLanguageModel.__init__", return_value=None):
+            model = BedrockLargeLanguageModel.__new__(BedrockLargeLanguageModel)
+        return model
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_retry_calls_invoke_inner_twice_on_expired(self, mock_boto3):
+        """When first call fails with expired token, retry should succeed."""
+        model = self._create_model_instance()
+
+        call_count = {"n": 0}
+        expected_result = MagicMock()
+
+        def mock_invoke_inner(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise Exception(
+                    "ExpiredTokenException: The security token included in the request is expired"
+                )
+            return expected_result
+
+        with patch.object(model, "_invoke_inner", side_effect=mock_invoke_inner):
+            result = model._invoke(
+                model="test-model",
+                credentials={"aws_region": "us-east-1", "auth_method": "IAM_Role"},
+                prompt_messages=[],
+                model_parameters={},
+            )
+
+        assert result == expected_result
+        assert call_count["n"] == 2
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_retry_invalidates_client_cache(self, mock_boto3):
+        """On expired token, the client cache should be invalidated before retry."""
+        model = self._create_model_instance()
+
+        # Pre-populate cache
+        _client_cache["some_key"] = MagicMock()
+
+        def mock_invoke_inner(*args, **kwargs):
+            raise Exception(
+                "ExpiredTokenException: The security token included in the request is expired"
+            )
+
+        with patch.object(model, "_invoke_inner", side_effect=mock_invoke_inner):
+            with pytest.raises(Exception):
+                model._invoke(
+                    model="test-model",
+                    credentials={"aws_region": "us-east-1", "auth_method": "IAM_Role"},
+                    prompt_messages=[],
+                    model_parameters={},
+                )
+
+        # Cache should have been cleared
+        assert len(_client_cache) == 0
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_raises_auth_error_when_both_attempts_fail(self, mock_boto3):
+        """When both attempts fail with expired token, raise clear auth error."""
+        from dify_plugin.errors.model import InvokeAuthorizationError
+
+        model = self._create_model_instance()
+
+        def mock_invoke_inner(*args, **kwargs):
+            raise Exception(
+                "ExpiredTokenException: The security token included in the request is expired"
+            )
+
+        with patch.object(model, "_invoke_inner", side_effect=mock_invoke_inner):
+            with pytest.raises(InvokeAuthorizationError, match="re-authenticate"):
+                model._invoke(
+                    model="test-model",
+                    credentials={"aws_region": "us-east-1", "auth_method": "IAM_Role"},
+                    prompt_messages=[],
+                    model_parameters={},
+                )
+
+    @patch("provider.get_bedrock_client.boto3")
+    def test_non_expired_errors_propagate_immediately(self, mock_boto3):
+        """Non-expired errors should not trigger retry."""
+        model = self._create_model_instance()
+
+        call_count = {"n": 0}
+
+        def mock_invoke_inner(*args, **kwargs):
+            call_count["n"] += 1
+            raise Exception("ModelNotFoundException: Model not found")
+
+        with patch.object(model, "_invoke_inner", side_effect=mock_invoke_inner):
+            with pytest.raises(Exception, match="Model not found"):
+                model._invoke(
+                    model="test-model",
+                    credentials={"aws_region": "us-east-1", "auth_method": "IAM_Role"},
+                    prompt_messages=[],
+                    model_parameters={},
+                )
+
+        # Should only be called once — no retry for non-expired errors
+        assert call_count["n"] == 1

--- a/models/bedrock/uv.lock
+++ b/models/bedrock/uv.lock
@@ -49,6 +49,11 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aws-bedrock-token-generator", specifier = ">=1.1.0" },
@@ -60,7 +65,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
 
 [[package]]
 name = "blinker"
@@ -448,6 +453,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -736,6 +750,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -940,6 +963,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Caches the boto3 client for reuse across requests and adds automatic retry on `ExpiredTokenException` by invalidating the cache and re-reading credentials from disk.

## Problem

When using `saml2aws login` or `aws sso login`, credentials are written to `~/.aws/credentials` with a session token that expires (typically after 1 hour). The plugin previously created a new boto3 client on every request but cached credentials internally within the process. When the token expired, all subsequent calls failed with no recovery path.

## Changes

| File | Change |
|------|--------|
| `provider/get_bedrock_client.py` | Module-level client cache (keyed by service + credentials). Reuses client on happy path. |
| `provider/get_bedrock_client.py` | `invalidate_client_cache()` clears all cached clients before retry. |
| `provider/get_bedrock_client.py` | IAM Role mode: fresh `boto3.Session()` on cache miss to read latest creds from disk. |
| `provider/get_bedrock_client.py` | Access_Secret_Key mode: pass optional `aws_session_token`. |
| `provider/get_bedrock_client.py` | `is_expired_token_error()` helper for token expiry detection. |
| `models/llm/llm.py` | `_invoke` wraps `_invoke_inner` — on expired token, invalidates cache and retries once. |
| `provider/bedrock.yaml` | Added `aws_session_token` field to Access_Secret_Key auth mode. |
| `tests/test_expired_token_retry.py` | 18 unit tests covering all paths. |

## Behavior

```
Request 1:   disk read → create client → cache → success
Request 2:   cache hit → success (no disk I/O)
...
Request N:   cache hit → ExpiredTokenException
             → invalidate cache
             → disk read → new client → cache → retry → success
...
Request N+1: cache hit → success (using fresh creds)
```

If both attempts fail with expired token → raises clear `InvokeAuthorizationError`: *"AWS credentials have expired. Please re-authenticate and try again."*

## Testing

- [x] All 71 tests pass (53 existing + 18 new)
- [x] Tested end-to-end with Dify self-hosted (Docker Compose) + `~/.aws` mounted into plugin daemon
- [x] Verified token refresh works transparently after `saml2aws login`
- [x] Verified client is reused on happy path (no redundant disk reads)
- [x] Verified cache invalidation forces fresh credentials on retry

fixes #3519