### PR TITLE
fix(funasr): validate provider credentials instead of accepting any server URL

### DIFF
--- a/models/funasr/manifest.yaml
+++ b/models/funasr/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.1
+version: 0.1.2

--- a/models/funasr/provider/funasr.py
+++ b/models/funasr/provider/funasr.py
@@ -1,6 +1,26 @@
+import logging
+
 from dify_plugin import ModelProvider
+from dify_plugin.entities.model import ModelType
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+logger = logging.getLogger(__name__)
 
 
 class FunASRProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
-        pass
+        """
+        Validate provider credentials
+
+        if validate failed, raise exception
+
+        :param credentials: provider credentials, credentials form defined in `provider_credential_schema`.
+        """
+        try:
+            model_instance = self.get_model_instance(ModelType.SPEECH2TEXT)
+            model_instance.validate_credentials(model="sensevoice", credentials=credentials)
+        except CredentialsValidateFailedError as ex:
+            raise ex
+        except Exception as ex:
+            logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
+            raise ex

--- a/models/funasr/pyproject.toml
+++ b/models/funasr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "funasr"
-version = "0.1.1"
+version = "0.1.2"
 description = "FunASR speech recognition plugin for Dify"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/models/funasr/tests/test_provider_credentials.py
+++ b/models/funasr/tests/test_provider_credentials.py
@@ -1,0 +1,82 @@
+"""Regression test for provider-level credential validation.
+
+``FunASRProvider.validate_provider_credentials`` was a bare ``pass``, so the
+provider accepted any Server URL: configuring the plugin against a host with
+nothing listening saved green and enabled all four predefined models, while the
+model path (Add Model) correctly rejected the same URL with ``Could not reach
+FunASR endpoint``. The checking code already existed —
+``models/speech2text/speech2text.py`` implements a real ``validate_credentials``
+that probes the OpenAI-compatible ``/v1/models`` and falls back to a direct
+reachability check — it was simply never called from the provider class. The fix
+delegates to it, matching the pattern used by 44 of the 48 providers in this repo
+that validate provider-level credentials.
+
+These tests mock at the model-instance boundary, so no network call is made.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from dify_plugin.entities.model import ModelType
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+from provider.funasr import FunASRProvider
+
+
+CREDENTIALS = {"endpoint_url": "http://127.0.0.1:8000/v1", "api_key": ""}
+
+
+def _provider() -> FunASRProvider:
+    """Build the provider without running the SDK's __init__, as the OpenAI
+    plugin's own provider tests do."""
+    return object.__new__(FunASRProvider)
+
+
+def test_valid_credentials_delegate_to_the_speech2text_model():
+    provider = _provider()
+    model_instance = MagicMock()
+
+    with patch.object(FunASRProvider, "get_model_instance", return_value=model_instance) as get_model:
+        provider.validate_provider_credentials(CREDENTIALS)
+
+    get_model.assert_called_once_with(ModelType.SPEECH2TEXT)
+    model_instance.validate_credentials.assert_called_once_with(
+        model="sensevoice", credentials=CREDENTIALS
+    )
+
+
+def test_unreachable_endpoint_is_rejected():
+    """The defect: this used to pass silently, so an unreachable server saved
+    green at provider level."""
+    provider = _provider()
+    model_instance = MagicMock()
+    model_instance.validate_credentials.side_effect = CredentialsValidateFailedError(
+        "Could not reach FunASR endpoint 'http://127.0.0.1:8000/v1'"
+    )
+
+    with patch.object(FunASRProvider, "get_model_instance", return_value=model_instance):
+        try:
+            provider.validate_provider_credentials(CREDENTIALS)
+        except CredentialsValidateFailedError as exc:
+            assert "Could not reach FunASR endpoint" in str(exc)
+        else:
+            raise AssertionError("unreachable endpoint must raise CredentialsValidateFailedError")
+
+
+def test_unexpected_errors_are_not_swallowed():
+    """A non-credential failure must propagate rather than be reported as a
+    successful configuration."""
+    provider = _provider()
+    model_instance = MagicMock()
+    error = RuntimeError("boom")
+    model_instance.validate_credentials.side_effect = error
+
+    with (
+        patch.object(FunASRProvider, "get_model_instance", return_value=model_instance),
+        patch.object(FunASRProvider, "get_provider_schema", return_value=MagicMock(provider="funasr")),
+    ):
+        try:
+            provider.validate_provider_credentials(CREDENTIALS)
+        except RuntimeError as exc:
+            assert exc is error
+        else:
+            raise AssertionError("unexpected errors must propagate")

--- a/models/funasr/uv.lock
+++ b/models/funasr/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "funasr"
-version = "0.1.1"
+version = "0.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "dify-plugin" },


### PR DESCRIPTION
## Summary

Part of #3523 (`funasr`).

`FunASRProvider.validate_provider_credentials` was a bare `pass`, so any Server URL saved successfully — showing a green credential and four enabled models against a server that does not exist.

The checking code already exists: `models/speech2text/speech2text.py` implements a real `validate_credentials`. This wires the provider class to it, matching the pattern used by 44 of the 48 providers here that validate provider-level credentials. Validation passes `sensevoice` (first in `_position.yaml`, the README default); a wrong model name cannot cause a false result, because the `_check_endpoint_reachable` fallback ignores it.

`pyproject.toml` and `uv.lock` are bumped alongside `manifest.yaml` because this plugin's `tests/test_marketplace_metadata.py` asserts parity, as in #3498. The lockfile was not regenerated — the diff is one line. Adds a regression test covering both directions, mocked at the boundary with no network.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

Reproducible without an account — point it at a URL with nothing listening.

**Before**
`http://localhost:8000`, no API key → saves green, four models enabled 

https://github.com/user-attachments/assets/85099574-eebd-4c1b-8448-f54cc3aed8fc

---

**After**
Same URL and key → rejected: `Could not reach FunASR endpoint 'http://localhost:8000/v1': [Errno 111] Connection refused`

https://github.com/user-attachments/assets/10c9f1a7-8745-4333-ba93-cc7c6c48ec0f

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

The second box is unticked because `pyproject.toml` declares `dify_plugin>=0.9.0`,
outside the range as written. This PR does not change that constraint.

## Testing

- [x] Local deployment — Dify version: 1.16.0
- [ ] SaaS (cloud.dify.ai)