### PR TITLE
fix(huaweicloud_maas_hk): validate provider credentials instead of accepting any API key

### DIFF
--- a/models/huaweicloud_maas_hk/manifest.yaml
+++ b/models/huaweicloud_maas_hk/manifest.yaml
@@ -26,5 +26,5 @@ resource:
       enabled: true
       llm: true
 type: plugin
-version: 0.0.8
+version: 0.0.9
 created_at: 2025-11-08T12:32:17.824356+08:00

--- a/models/huaweicloud_maas_hk/provider/maas.py
+++ b/models/huaweicloud_maas_hk/provider/maas.py
@@ -8,4 +8,18 @@ logger = logging.getLogger(__name__)
 
 class HuaweiCloudMaasProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
-        pass
+        """
+        Validate provider credentials
+
+        if validate failed, raise exception
+
+        :param credentials: provider credentials, credentials form defined in `provider_credential_schema`.
+        """
+        try:
+            model_instance = self.get_model_instance(ModelType.LLM)
+            model_instance.validate_credentials(model="DeepSeek-R1", credentials=credentials)
+        except CredentialsValidateFailedError as ex:
+            raise ex
+        except Exception as ex:
+            logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
+            raise ex


### PR DESCRIPTION
## Summary

Part of #3523.

`HuaweiCloudMaasProvider.validate_provider_credentials` was a bare `pass`, so any API key saved successfully and the provider showed a green, fully configured credential. The class already imports `ModelType` and `CredentialsValidateFailedError` without using either.

This delegates to the plugin's existing `models/llm/llm.py` validator, matching the pattern used by 44 of the 48 providers here that validate provider-level credentials. Validation passes `DeepSeek-R1` — first in `models/llm/_position.yaml`, one of only five predefined models, all DeepSeek, and not deprecated. `supported_model_types` is `llm` only, so there is no ambiguity about which type to validate against.

Provider-level validation performs the same request the model-level validator already performs; this adds no new call path.

Filed separately from the mainland `huaweicloud_maas` fix: the two plugins share `provider/maas.py` byte-for-byte but differ in manifest, README, `llm.py` and catalog, and neither one's validation model exists in the other's model list.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

**Before**
Invalid API key → saves green, all models enabled

https://github.com/user-attachments/assets/6921a116-5b46-4c7b-aed9-22b77f0ea02d

---

**After**
Same key → rejected by the provider's own API

https://github.com/user-attachments/assets/3a07d9be-e048-4cd4-b330-f3e9c805e621

## LLM Plugin Checklist

No LLM behaviour is affected — this changes provider credential validation only.

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

The second box is unticked because `pyproject.toml` declares `dify_plugin>=0.9.0`, outside the range as written. This PR does not change that constraint.

## Testing

- [x] Local deployment — Dify version: 1.16.0
- [ ] SaaS (cloud.dify.ai)