### PR TITLE
fix(models): validate provider credentials in funasr, huaweicloud_maas, huaweicloud_maas_hk, perfxcloud

### DIFF
--- a/models/funasr/manifest.yaml
+++ b/models/funasr/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.1
+version: 0.1.2

--- a/models/funasr/provider/funasr.py
+++ b/models/funasr/provider/funasr.py
@@ -1,6 +1,26 @@
+import logging
+
 from dify_plugin import ModelProvider
+from dify_plugin.entities.model import ModelType
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+logger = logging.getLogger(__name__)
 
 
 class FunASRProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
-        pass
+        """
+        Validate provider credentials
+
+        if validate failed, raise exception
+
+        :param credentials: provider credentials, credentials form defined in `provider_credential_schema`.
+        """
+        try:
+            model_instance = self.get_model_instance(ModelType.SPEECH2TEXT)
+            model_instance.validate_credentials(model="sensevoice", credentials=credentials)
+        except CredentialsValidateFailedError as ex:
+            raise ex
+        except Exception as ex:
+            logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
+            raise ex

--- a/models/funasr/pyproject.toml
+++ b/models/funasr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "funasr"
-version = "0.1.1"
+version = "0.1.2"
 description = "FunASR speech recognition plugin for Dify"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/models/funasr/tests/conftest.py
+++ b/models/funasr/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))

--- a/models/funasr/tests/test_provider_credentials.py
+++ b/models/funasr/tests/test_provider_credentials.py
@@ -1,0 +1,82 @@
+"""Regression test for provider-level credential validation.
+
+``FunASRProvider.validate_provider_credentials`` was a bare ``pass``, so the
+provider accepted any Server URL: configuring the plugin against a host with
+nothing listening saved green and enabled all four predefined models, while the
+model path (Add Model) correctly rejected the same URL with ``Could not reach
+FunASR endpoint``. The checking code already existed —
+``models/speech2text/speech2text.py`` implements a real ``validate_credentials``
+that probes the OpenAI-compatible ``/v1/models`` and falls back to a direct
+reachability check — it was simply never called from the provider class. The fix
+delegates to it, matching the pattern used by 44 of the 48 providers in this repo
+that validate provider-level credentials.
+
+These tests mock at the model-instance boundary, so no network call is made.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from dify_plugin.entities.model import ModelType
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+from provider.funasr import FunASRProvider
+
+
+CREDENTIALS = {"endpoint_url": "http://127.0.0.1:8000/v1", "api_key": ""}
+
+
+def _provider() -> FunASRProvider:
+    """Build the provider without running the SDK's __init__, as the OpenAI
+    plugin's own provider tests do."""
+    return object.__new__(FunASRProvider)
+
+
+def test_valid_credentials_delegate_to_the_speech2text_model():
+    provider = _provider()
+    model_instance = MagicMock()
+
+    with patch.object(FunASRProvider, "get_model_instance", return_value=model_instance) as get_model:
+        provider.validate_provider_credentials(CREDENTIALS)
+
+    get_model.assert_called_once_with(ModelType.SPEECH2TEXT)
+    model_instance.validate_credentials.assert_called_once_with(
+        model="sensevoice", credentials=CREDENTIALS
+    )
+
+
+def test_unreachable_endpoint_is_rejected():
+    """The defect: this used to pass silently, so an unreachable server saved
+    green at provider level."""
+    provider = _provider()
+    model_instance = MagicMock()
+    model_instance.validate_credentials.side_effect = CredentialsValidateFailedError(
+        "Could not reach FunASR endpoint 'http://127.0.0.1:8000/v1'"
+    )
+
+    with patch.object(FunASRProvider, "get_model_instance", return_value=model_instance):
+        try:
+            provider.validate_provider_credentials(CREDENTIALS)
+        except CredentialsValidateFailedError as exc:
+            assert "Could not reach FunASR endpoint" in str(exc)
+        else:
+            raise AssertionError("unreachable endpoint must raise CredentialsValidateFailedError")
+
+
+def test_unexpected_errors_are_not_swallowed():
+    """A non-credential failure must propagate rather than be reported as a
+    successful configuration."""
+    provider = _provider()
+    model_instance = MagicMock()
+    error = RuntimeError("boom")
+    model_instance.validate_credentials.side_effect = error
+
+    with (
+        patch.object(FunASRProvider, "get_model_instance", return_value=model_instance),
+        patch.object(FunASRProvider, "get_provider_schema", return_value=MagicMock(provider="funasr")),
+    ):
+        try:
+            provider.validate_provider_credentials(CREDENTIALS)
+        except RuntimeError as exc:
+            assert exc is error
+        else:
+            raise AssertionError("unexpected errors must propagate")

--- a/models/funasr/uv.lock
+++ b/models/funasr/uv.lock
@@ -220,7 +220,7 @@ wheels = [
 
 [[package]]
 name = "funasr"
-version = "0.1.1"
+version = "0.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "dify-plugin" },

--- a/models/huaweicloud_maas/manifest.yaml
+++ b/models/huaweicloud_maas/manifest.yaml
@@ -26,5 +26,5 @@ resource:
       enabled: true
       llm: true
 type: plugin
-version: 0.0.23
+version: 0.0.24
 created_at: 2025-06-04T12:32:17.824356+08:00

--- a/models/huaweicloud_maas/provider/maas.py
+++ b/models/huaweicloud_maas/provider/maas.py
@@ -8,4 +8,18 @@ logger = logging.getLogger(__name__)
 
 class HuaweiCloudMaasProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
-        pass
+        """
+        Validate provider credentials
+
+        if validate failed, raise exception
+
+        :param credentials: provider credentials, credentials form defined in `provider_credential_schema`.
+        """
+        try:
+            model_instance = self.get_model_instance(ModelType.LLM)
+            model_instance.validate_credentials(model="openpangu-2.0-flash", credentials=credentials)
+        except CredentialsValidateFailedError as ex:
+            raise ex
+        except Exception as ex:
+            logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
+            raise ex

--- a/models/huaweicloud_maas_hk/manifest.yaml
+++ b/models/huaweicloud_maas_hk/manifest.yaml
@@ -26,5 +26,5 @@ resource:
       enabled: true
       llm: true
 type: plugin
-version: 0.0.8
+version: 0.0.9
 created_at: 2025-11-08T12:32:17.824356+08:00

--- a/models/huaweicloud_maas_hk/provider/maas.py
+++ b/models/huaweicloud_maas_hk/provider/maas.py
@@ -8,4 +8,18 @@ logger = logging.getLogger(__name__)
 
 class HuaweiCloudMaasProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
-        pass
+        """
+        Validate provider credentials
+
+        if validate failed, raise exception
+
+        :param credentials: provider credentials, credentials form defined in `provider_credential_schema`.
+        """
+        try:
+            model_instance = self.get_model_instance(ModelType.LLM)
+            model_instance.validate_credentials(model="DeepSeek-R1", credentials=credentials)
+        except CredentialsValidateFailedError as ex:
+            raise ex
+        except Exception as ex:
+            logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
+            raise ex

--- a/models/perfxcloud/manifest.yaml
+++ b/models/perfxcloud/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.12
+version: 0.0.13

--- a/models/perfxcloud/provider/perfxcloud.py
+++ b/models/perfxcloud/provider/perfxcloud.py
@@ -1,10 +1,26 @@
 import logging
 
 from dify_plugin.interfaces.model import ModelProvider
+from dify_plugin.entities.model import ModelType
+from dify_plugin.errors.model import CredentialsValidateFailedError
 
 logger = logging.getLogger(__name__)
 
 
 class PerfXCloudProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
-        pass
+        """
+        Validate provider credentials
+
+        if validate failed, raise exception
+
+        :param credentials: provider credentials, credentials form defined in `provider_credential_schema`.
+        """
+        try:
+            model_instance = self.get_model_instance(ModelType.LLM)
+            model_instance.validate_credentials(model="Qwen2.5-72B-Instruct", credentials=credentials)
+        except CredentialsValidateFailedError as ex:
+            raise ex
+        except Exception as ex:
+            logger.exception(f"{self.get_provider_schema().provider} credentials validate failed")
+            raise ex


### PR DESCRIPTION
## Summary

Fixes #3523.

This supersedes #3524, #3525 and #3526 — consolidated into this PR at the maintainer's request (*"Please fix the identical errors in the same PR"*).

`validate_provider_credentials` was a bare `pass` in all four plugins, so each accepted any provider credentials and displayed them as configured. All four now delegate to the model class's existing `validate_credentials`, matching the pattern used by 44 of the 48 providers in this repo that validate provider-level credentials.

| Plugin | Version | Validation model | A junk credential now returns |
| ------ | ------- | ---------------- | ----------------------------- |
| `funasr` | 0.1.1 → 0.1.2 | `sensevoice` (speech2text) | `Could not reach FunASR endpoint '…'` |
| `huaweicloud_maas` | 0.0.23 → 0.0.24 | `openpangu-2.0-flash` (llm) | upstream credential error instead of a green save |
| `huaweicloud_maas_hk` | 0.0.8 → 0.0.9 | `DeepSeek-R1` (llm) | upstream credential error instead of a green save |
| `perfxcloud` | 0.0.12 → 0.0.13 | `Qwen2.5-72B-Instruct` (llm) | upstream credential error instead of a green save |

`funasr` also gains a regression test covering both directions of `validate_provider_credentials`, plus a `tests/conftest.py` that inserts the plugin root on `sys.path` so the test resolves `provider.funasr` under the console-script invocation CI uses — the same shape `models/openai`, `models/anthropic` and `models/azure_openai` already use. Its `pyproject.toml` and `uv.lock` versions are bumped alongside `manifest.yaml` to satisfy the plugin's own `tests/test_marketplace_metadata.py` parity check. The suite is 7/7 under `uv run --frozen --with pytest pytest`.

**On the validation model name.** For the three LLM providers this is the first entry in the plugin's own `models/llm/_position.yaml`. For `funasr` the choice cannot cause a false pass at all: its `validate_credentials` falls back to `_check_endpoint_reachable`, which does not use the model name.

**`perfxcloud` caveat:** validation now costs a token against a 72B model. `Qwen2.5-7B-Instruct` is available as a cheaper sentinel if you would prefer it — happy to switch.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Videos are under per-plugin sub-headings rather than in the table above, because GitHub video attachments do not render inside table cells.

### funasr

**Before**

https://github.com/user-attachments/assets/85099574-eebd-4c1b-8448-f54cc3aed8fc

**After**

https://github.com/user-attachments/assets/10c9f1a7-8745-4333-ba93-cc7c6c48ec0f

### huaweicloud_maas

**Before**

https://github.com/user-attachments/assets/3ad0419d-5f61-47b9-88cd-6d0d5c3448b4

**After**

https://github.com/user-attachments/assets/98fd2c53-1310-4a2c-b797-b3f9236409b2

### huaweicloud_maas_hk

**Before**

https://github.com/user-attachments/assets/6921a116-5b46-4c7b-aed9-22b77f0ea02d

**After**

https://github.com/user-attachments/assets/3a07d9be-e048-4cd4-b330-f3e9c805e621

### perfxcloud

**Before**

https://github.com/user-attachments/assets/79c7d7af-5341-4830-8703-8f0a20147bd1

**After**

https://github.com/user-attachments/assets/b6725e6d-243f-4eff-908c-6f0881960020

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

This change is confined to provider-level credential validation and touches none of the areas above.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

All four plugins declare `dify_plugin>=0.9.0`, which is outside the range this checkbox states, so it is left unticked rather than ticked inaccurately. No dependency was changed by this PR.

## Testing

- [x] Local deployment — Dify version: 1.16.0
- [ ] SaaS (cloud.dify.ai)

Each plugin was packaged locally, installed into a Dify 1.16.0 instance, and configured with a junk credential; the before/after videos above are that session. All four were re-verified against this branch after rebasing onto `main`.

**On what the videos do and do not prove.** The rejection direction is fully reproducible without an account: FunASR's pair was captured with a junk credential against a URL with nothing listening. **The forward direction — that valid credentials still pass — is not verified for the three paid providers** (`huaweicloud_maas`, `huaweicloud_maas_hk`, `perfxcloud`), because I do not hold accounts on them. The change delegates to `validate_credentials` methods that already run in production for every customizable-model configuration, so no new code path is introduced, but I would rather state the gap than imply coverage that does not exist.