### PR TITLE
feat(openai_api_compatible): add web search support and improve think…

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.55
+version: 0.0.56
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.56
+version: 0.0.57
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -322,6 +322,23 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                 )
             )
 
+        # Configure web search parameter if supported
+        web_search_support = credentials.get("web_search_support", "not_supported")
+        if web_search_support != "not_supported":
+            entity.parameter_rules.append(
+                ParameterRule(
+                    name="web_search",
+                    label=I18nObject(en_us="Web Search", zh_hans="联网搜索"),
+                    help=I18nObject(
+                        en_us="Whether to enable web search. When enabled, the model will search the internet for relevant information to generate responses.",
+                        zh_hans="是否启用联网搜索。启用后，模型将搜索互联网以获取相关信息来生成回复。",
+                    ),
+                    type=ParameterType.BOOLEAN,
+                    required=False,
+                    default=False,
+                )
+            )
+
         # Register VIDEO/AUDIO/DOCUMENT features when the corresponding credential is enabled.
         # Without these on entity.features, Dify host filters out non-image attachments
         # before they reach _convert_prompt_message_to_dict, causing silent drop.
@@ -514,6 +531,33 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                 chat_template_kwargs = model_parameters.setdefault("chat_template_kwargs", {})
                 chat_template_kwargs["reasoning_effort"] = reasoning_effort_value
         
+        # Handle web search based on credential configuration
+        web_search_support = credentials.get("web_search_support", "not_supported")
+        enable_web_search = model_parameters.pop("web_search", False)
+        if enable_web_search and web_search_support != "not_supported":
+            if web_search_support == "tool_standard":
+                # Standard tools format: {"type": "web_search", "web_search": {"enable": true}}
+                # Used by ZhipuAI, Baichuan, etc.
+                web_search_tool = {
+                    "type": "web_search",
+                    "web_search": {"enable": True},
+                }
+                if "tools" in model_parameters:
+                    model_parameters["tools"].append(web_search_tool)
+                else:
+                    model_parameters["tools"] = [web_search_tool]
+            elif web_search_support == "tool_simple":
+                # Simple tools format: {"type": "web_search"}
+                # Used by Volcengine, etc.
+                web_search_tool = {"type": "web_search"}
+                if "tools" in model_parameters:
+                    model_parameters["tools"].append(web_search_tool)
+                else:
+                    model_parameters["tools"] = [web_search_tool]
+            elif web_search_support == "parameter":
+                # Parameter format: top-level web_search parameter
+                model_parameters["web_search"] = True
+
         # Remove thinking content from assistant messages for better performance.
         with suppress(Exception):
             self._drop_analyze_channel(prompt_messages)

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -270,6 +270,44 @@ model_credential_schema:
       help:
         en_US: Configure whether the model supports thinking mode, non-thinking mode, or both. This will control the availability of the thinking mode toggle.
         zh_Hans: 配置模型是否支持思考模式、非思考模式或两者都支持。这将控制思考模式开关的可用性。
+    - variable: web_search_support
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        en_US: Web Search Support
+        zh_Hans: 联网搜索支持
+      type: select
+      required: false
+      default: not_supported
+      options:
+        - value: not_supported
+          label:
+            en_US: Not Supported
+            zh_Hans: 不支持
+        - value: tool_standard
+          label:
+            en_US: Standard Tools Format
+            zh_Hans: 标准 Tools 格式
+        - value: tool_simple
+          label:
+            en_US: Simple Tools Format
+            zh_Hans: 简单 Tools 格式
+        - value: parameter
+          label:
+            en_US: Parameter Format
+            zh_Hans: 参数格式
+      help:
+        en_US: >
+          Configure web search support and format. 
+          Standard Tools: {"type": "web_search", "web_search": {"enable": true}} (ZhipuAI, Baichuan). 
+          Simple Tools: {"type": "web_search"} (Volcengine). 
+          Parameter: {"web_search": true} as a top-level parameter.
+        zh_Hans: >
+          配置联网搜索支持和格式。
+          标准 Tools 格式: {"type": "web_search", "web_search": {"enable": true}} (智谱AI、百川)。
+          简单 Tools 格式: {"type": "web_search"} (火山引擎)。
+          参数格式: {"web_search": true} 作为顶层参数。
     - variable: compatibility_mode
       show_on:
         - variable: __model_type


### PR DESCRIPTION
## Summary

This PR adds native Web Search support and enhances Reasoning/Thinking Mode processing for the `openai_api_compatible` LLM provider plugin.

### Key Changes:
- **Web Search Support (`web_search_support`)**: Added credential configuration to enable Web Search for OpenAI-compatible gateways (such as LiteLLM, OpenRouter, and custom vLLM/Perplexity/Google proxies).
- **3 Payload Formatting Modes**:
  1. `tool_standard`: Injects standard OpenAI web search tool parameters (`{"type": "web_search"}`).
  2. `tool_simple`: Injects simplified search tool specs (`{"type": "function", "function": {"name": "web_search"}}`).
  3. `parameter`: Injects top-level parameter flags (`"web_search": true` / `"enable_search": true`).
- **Thinking Mode & Reasoning Parsing**: Enhanced `_wrap_thinking_by_reasoning_content` to cleanly handle DeepSeek / Qwen reasoning outputs and `<think>` blocks without dropping reasoning tokens.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Feature | Description |
| ------ | ----- |
| Web Search Credentials | User can select Web Search format under Provider Credentials |
| Web Search Invocations | Grounded responses with real-time web search results |

## LLM Plugin Checklist

<details open>
<summary>Areas affected by this change</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (v0.0.56)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [x] Local deployment — Dify version: 1.0.0 (Docker Desktop)
- [x] SaaS (cloud.dify.ai)
