### PR TITLE
fix(voyage): input_type never reached the model; plus pricing, batching and the voyage-4 family

### DIFF
--- a/models/voyage/.difyignore
+++ b/models/voyage/.difyignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.env
+*.difypkg

--- a/models/voyage/README.md
+++ b/models/voyage/README.md
@@ -3,3 +3,58 @@
 Voyage model provider for Dify.
 
 This plugin enables Dify to use Voyage text embedding and rerank models.
+
+## Requirements
+
+`dify_plugin >= 0.10.0` is a hard floor. Earlier SDK releases dropped `input_type`
+between Dify and the plugin, so every search query was embedded with Voyage's
+*document* prompt instead of its *query* prompt. Voyage's two prompts are not
+interchangeable and the mismatch costs most of the retrieval quality.
+
+## Models
+
+| Model | Context | Dimensions | Notes |
+|---|---|---|---|
+| `voyage-4-large` | 32K | 1024 (256 / 512 / 2048) | best general-purpose retrieval |
+| `voyage-4` | 32K | 1024 (256 / 512 / 2048) | |
+| `voyage-4-lite` | 32K | 1024 (256 / 512 / 2048) | optimised for latency and cost |
+| `voyage-context-4` | 32K | 1024 (256 / 512 / 2048) | contextualised chunk embeddings |
+| `voyage-3.5`, `voyage-3.5-lite` | 32K | 1024 (256 / 512 / 2048) | previous generation |
+| `voyage-3`, `voyage-3-large`, `voyage-3-lite` | 32K | fixed | |
+| `voyage-code-2`, `voyage-code-3` | 16K / 32K | fixed | code retrieval |
+| `voyage-finance-2`, `voyage-law-2`, `voyage-multilingual-2` | 16K–32K | fixed | domain models |
+| `voyage-multimodal-3`, `voyage-multimodal-3.5` | 32K | fixed | text plus one image per call |
+| `rerank-2.5`, `rerank-2.5-lite`, `rerank-2`, `rerank-lite-2`, `rerank-1`, `rerank-lite-1` | 32K | — | rerankers |
+
+## Optional credentials
+
+| Credential | Applies to | Effect |
+|---|---|---|
+| `output_dimension` | voyage-4 and voyage-3.5 families | Matryoshka dimension: 256, 512, 1024 or 2048. Blank uses the model default of 1024. **Changing it after a knowledge base is indexed requires a full re-index** — Dify sizes the vector store from the first vector it sees. |
+| `output_dtype` | all embedding models | `float` (default), `int8`, `uint8`, `binary`, `ubinary`. Quantised types trade retrieval quality for storage. |
+| `contextualize_batch` | `voyage-context-*` only | See below. |
+| `image_url`, `image_base64` | `voyage-multimodal-*` only | Attaches one image to every text in the call. |
+
+## Contextualised embeddings
+
+`voyage-context-*` models embed a chunk with its neighbours in view, so a chunk that
+says "the same procedure applies" still carries what procedure was meant. The API takes
+chunks grouped by document: `inputs: [[chunk, chunk, ...], ...]`.
+
+Dify's embedding interface passes a flat list of texts with **no indication of where one
+document ends and the next begins**, so the plugin cannot reconstruct those groups. By
+default each text is sent as its own single-chunk group, which is exactly equivalent to
+the non-contextual endpoint and never lets one document's content bleed into another's.
+
+Setting `contextualize_batch` to `true` sends the whole batch as one document. That is
+correct only when a batch holds chunks of a single document — usually true during
+ingestion, since Dify indexes one document at a time, but not guaranteed. It is never
+applied to a query, which has no siblings to draw context from.
+
+## Request batching
+
+Every embedding model declares `max_chunks: 128`, so Dify batches 128 segments per call
+instead of the framework default of 1. Because Dify picks the batch size from that number
+alone and knows nothing about chunk length, the plugin re-splits each batch against
+Voyage's per-request token limit before sending. Long segments therefore cost extra
+requests rather than failing the ingest.

--- a/models/voyage/manifest.yaml
+++ b/models/voyage/manifest.yaml
@@ -12,7 +12,7 @@ meta:
   runner:
     entrypoint: main
     language: python
-    version: '3.10'
+    version: '3.12'
   version: 0.0.1
 name: voyage
 plugins:

--- a/models/voyage/models/text_embedding/_position.yaml
+++ b/models/voyage/models/text_embedding/_position.yaml
@@ -1,3 +1,7 @@
+- voyage-4-large
+- voyage-4
+- voyage-4-lite
+- voyage-context-4
 - voyage-multimodal-3.5
 - voyage-multimodal-3
 - voyage-3.5

--- a/models/voyage/models/text_embedding/text_embedding.py
+++ b/models/voyage/models/text_embedding/text_embedding.py
@@ -32,8 +32,11 @@ class VoyageTextEmbeddingModel(TextEmbeddingModel):
     max_texts_per_request: int = 1000
     default_token_limit: int = 120_000
     token_limits: dict[str, int] = {
+        "voyage-4": 320_000,
+        "voyage-4-lite": 1_000_000,
         "voyage-3.5": 320_000,
         "voyage-3.5-lite": 1_000_000,
+        # voyage-4-large and voyage-context-4 are both 120K, i.e. the default.
     }
     # The gpt2 estimator is not Voyage's tokenizer, so leave headroom for it to
     # under-count. Splitting one extra request is much cheaper than a failed ingest.
@@ -90,42 +93,71 @@ class VoyageTextEmbeddingModel(TextEmbeddingModel):
         base_url = credentials.get("base_url", self.api_base)
         base_url = base_url.removesuffix("/")
 
-        url = base_url + "/embeddings"
+        # The contextualised models take chunks grouped by document on a separate
+        # endpoint; everything else uses the flat one.
+        is_contextual = model.startswith("voyage-context-")
+        url = base_url + ("/contextualizedembeddings" if is_contextual else "/embeddings")
         headers = {"Authorization": "Bearer " + api_key, "Content-Type": "application/json"}
-
-        # Use framework's input type (automatic detection)
-        voyage_input_type = "null"
-        if input_type is not None:
-            voyage_input_type = input_type.value
 
         # Check if this is a multimodal model
         is_multimodal = model.startswith("voyage-multimodal")
         image_url = credentials.get("image_url", "") if is_multimodal else ""
         image_base64 = credentials.get("image_base64", "") if is_multimodal else ""
 
+        # Contextualising a batch is only meaningful when the texts are chunks of one
+        # document. Dify does not tell the plugin where document boundaries fall, so
+        # this stays opt-in -- and it never applies to a query, which has no siblings.
+        contextualize_batch = (
+            is_contextual
+            and str(credentials.get("contextualize_batch", "")).lower() in ("true", "1", "yes")
+            and input_type == EmbeddingInputType.DOCUMENT
+        )
+
         embeddings: list[list[float]] = []
         total_tokens = 0
 
         for batch in self._split_batches(model, texts):
             # Prepare input data
-            if is_multimodal and (image_url or image_base64):
+            if is_contextual:
+                # Each text is its own context group unless the batch is opted in.
+                payload = {"inputs": [batch] if contextualize_batch else [[t] for t in batch]}
+            elif is_multimodal and (image_url or image_base64):
                 # Multimodal input format
-                payload = []
+                entries = []
                 for text in batch:
                     entry = {"text": text}
                     if image_url:
                         entry["image_url"] = image_url
                     elif image_base64:
                         entry["image_base64"] = image_base64
-                    payload.append([entry])
+                    entries.append([entry])
+                payload = {"input": entries}
             else:
                 # Standard text embedding model, or text-only for a multimodal one
-                payload = batch
+                payload = {"input": batch}
 
-            data = {"model": model, "input": payload, "input_type": voyage_input_type}
+            data = {"model": model, **payload}
+            # Omit the key rather than sending the string "null", which the API rejects.
+            if input_type is not None:
+                data["input_type"] = input_type.value
+            if credentials.get("output_dimension"):
+                data["output_dimension"] = int(credentials["output_dimension"])
+            if credentials.get("output_dtype"):
+                data["output_dtype"] = credentials["output_dtype"]
 
             resp = self._post(url, headers, data)
-            embeddings.extend([float(v) for v in x["embedding"]] for x in resp["data"])
+            # The contextualised response nests one result object per input group.
+            # Sort by index at both levels: embeddings must come back in input order
+            # or every chunk in the batch is stored against the wrong segment.
+            if is_contextual:
+                rows = [
+                    x
+                    for group in sorted(resp["data"], key=lambda g: g["index"])
+                    for x in sorted(group["data"], key=lambda x: x["index"])
+                ]
+            else:
+                rows = sorted(resp["data"], key=lambda x: x["index"])
+            embeddings.extend([float(v) for v in x["embedding"]] for x in rows)
             total_tokens += resp["usage"]["total_tokens"]
 
         usage = self._calc_response_usage(model=model, credentials=credentials, tokens=total_tokens)

--- a/models/voyage/models/text_embedding/text_embedding.py
+++ b/models/voyage/models/text_embedding/text_embedding.py
@@ -26,6 +26,45 @@ class VoyageTextEmbeddingModel(TextEmbeddingModel):
 
     api_base: str = "https://api.voyageai.com/v1"
 
+    # Voyage accepts at most 1,000 texts per request, but the binding constraint is the
+    # total token count, which differs by model. Anything not listed gets the tightest
+    # published limit, since guessing high turns into a 400 mid-ingestion.
+    max_texts_per_request: int = 1000
+    default_token_limit: int = 120_000
+    token_limits: dict[str, int] = {
+        "voyage-3.5": 320_000,
+        "voyage-3.5-lite": 1_000_000,
+    }
+    # The gpt2 estimator is not Voyage's tokenizer, so leave headroom for it to
+    # under-count. Splitting one extra request is much cheaper than a failed ingest.
+    token_budget_margin: float = 0.8
+
+    def _split_batches(self, model: str, texts: list[str]) -> list[list[str]]:
+        """Split a batch into sub-batches that fit Voyage's per-request limits.
+
+        Dify caps a batch at the model's `max_chunks`, but it has no idea how large
+        those chunks are -- a knowledge base configured with 2,000-token segments can
+        blow past the token limit well before the chunk count matters. Splitting here
+        means `max_chunks` can be set for throughput without any risk of a 400.
+        """
+        budget = int(self.token_limits.get(model, self.default_token_limit) * self.token_budget_margin)
+
+        batches: list[list[str]] = []
+        current: list[str] = []
+        current_tokens = 0
+        for text in texts:
+            tokens = self._get_num_tokens_by_gpt2(text)
+            # A single text over budget still goes on its own; the API will reject it
+            # with a clearer message than anything invented here.
+            if current and (current_tokens + tokens > budget or len(current) >= self.max_texts_per_request):
+                batches.append(current)
+                current, current_tokens = [], 0
+            current.append(text)
+            current_tokens += tokens
+        if current:
+            batches.append(current)
+        return batches
+
     def _invoke(
         self,
         model: str,
@@ -61,32 +100,40 @@ class VoyageTextEmbeddingModel(TextEmbeddingModel):
 
         # Check if this is a multimodal model
         is_multimodal = model.startswith("voyage-multimodal")
+        image_url = credentials.get("image_url", "") if is_multimodal else ""
+        image_base64 = credentials.get("image_base64", "") if is_multimodal else ""
 
-        # Prepare input data
-        if is_multimodal:
-            # Check for image_url or image_base64 in credentials
-            image_url = credentials.get("image_url", "")
-            image_base64 = credentials.get("image_base64", "")
+        embeddings: list[list[float]] = []
+        total_tokens = 0
 
-            # Format input for multimodal model
-            if image_url or image_base64:
+        for batch in self._split_batches(model, texts):
+            # Prepare input data
+            if is_multimodal and (image_url or image_base64):
                 # Multimodal input format
-                input_list = []
-                for text in texts:
+                payload = []
+                for text in batch:
                     entry = {"text": text}
                     if image_url:
                         entry["image_url"] = image_url
                     elif image_base64:
                         entry["image_base64"] = image_base64
-                    input_list.append([entry])
-                data = {"model": model, "input": input_list, "input_type": voyage_input_type}
+                    payload.append([entry])
             else:
-                # Text-only for multimodal model
-                data = {"model": model, "input": texts, "input_type": voyage_input_type}
-        else:
-            # Standard text embedding model
-            data = {"model": model, "input": texts, "input_type": voyage_input_type}
+                # Standard text embedding model, or text-only for a multimodal one
+                payload = batch
 
+            data = {"model": model, "input": payload, "input_type": voyage_input_type}
+
+            resp = self._post(url, headers, data)
+            embeddings.extend([float(v) for v in x["embedding"]] for x in resp["data"])
+            total_tokens += resp["usage"]["total_tokens"]
+
+        usage = self._calc_response_usage(model=model, credentials=credentials, tokens=total_tokens)
+
+        return TextEmbeddingResult(model=model, embeddings=embeddings, usage=usage)
+
+    def _post(self, url: str, headers: dict, data: dict) -> dict:
+        """POST to Voyage and map transport and HTTP failures onto Dify's error types."""
         try:
             response = requests.post(url, headers=headers, data=dumps(data))
         except Exception as e:
@@ -94,8 +141,7 @@ class VoyageTextEmbeddingModel(TextEmbeddingModel):
 
         if response.status_code != 200:
             try:
-                resp = response.json()
-                msg = resp["detail"]
+                msg = response.json()["detail"]
                 if response.status_code == 401:
                     raise InvokeAuthorizationError(msg)
                 elif response.status_code == 429:
@@ -110,19 +156,9 @@ class VoyageTextEmbeddingModel(TextEmbeddingModel):
                 )
 
         try:
-            resp = response.json()
-            embeddings = resp["data"]
-            usage = resp["usage"]
+            return response.json()
         except Exception as e:
             raise InvokeServerUnavailableError(f"Failed to convert response to json: {e} with text: {response.text}")
-
-        usage = self._calc_response_usage(model=model, credentials=credentials, tokens=usage["total_tokens"])
-
-        result = TextEmbeddingResult(
-            model=model, embeddings=[[float(data) for data in x["embedding"]] for x in embeddings], usage=usage
-        )
-
-        return result
 
     def get_num_tokens(self, model: str, credentials: dict, texts: list[str]) -> list[int]:
         """

--- a/models/voyage/models/text_embedding/voyage-3-large.yaml
+++ b/models/voyage/models/text_embedding/voyage-3-large.yaml
@@ -3,6 +3,6 @@ model_type: text-embedding
 model_properties:
   context_size: 32000
 pricing:
-  input: '0.18'
-  unit: '1000000'
+  input: '0.00018'
+  unit: '0.001'
   currency: USD

--- a/models/voyage/models/text_embedding/voyage-3-large.yaml
+++ b/models/voyage/models/text_embedding/voyage-3-large.yaml
@@ -2,6 +2,7 @@ model: voyage-3-large
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00018'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-3-lite.yaml
+++ b/models/voyage/models/text_embedding/voyage-3-lite.yaml
@@ -2,6 +2,7 @@ model: voyage-3-lite
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00002'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-3.5-lite.yaml
+++ b/models/voyage/models/text_embedding/voyage-3.5-lite.yaml
@@ -3,6 +3,6 @@ model_type: text-embedding
 model_properties:
   context_size: 32000
 pricing:
-  input: '0.02'
-  unit: '1000000'
+  input: '0.00002'
+  unit: '0.001'
   currency: USD

--- a/models/voyage/models/text_embedding/voyage-3.5-lite.yaml
+++ b/models/voyage/models/text_embedding/voyage-3.5-lite.yaml
@@ -2,6 +2,7 @@ model: voyage-3.5-lite
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00002'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-3.5.yaml
+++ b/models/voyage/models/text_embedding/voyage-3.5.yaml
@@ -2,6 +2,7 @@ model: voyage-3.5
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00006'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-3.5.yaml
+++ b/models/voyage/models/text_embedding/voyage-3.5.yaml
@@ -3,6 +3,6 @@ model_type: text-embedding
 model_properties:
   context_size: 32000
 pricing:
-  input: '0.06'
-  unit: '1000000'
+  input: '0.00006'
+  unit: '0.001'
   currency: USD

--- a/models/voyage/models/text_embedding/voyage-3.yaml
+++ b/models/voyage/models/text_embedding/voyage-3.yaml
@@ -2,6 +2,7 @@ model: voyage-3
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00006'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-4-large.yaml
+++ b/models/voyage/models/text_embedding/voyage-4-large.yaml
@@ -1,0 +1,9 @@
+model: voyage-4-large
+model_type: text-embedding
+model_properties:
+  context_size: 32000
+  max_chunks: 128
+pricing:
+  input: '0.00012'
+  unit: '0.001'
+  currency: USD

--- a/models/voyage/models/text_embedding/voyage-4-lite.yaml
+++ b/models/voyage/models/text_embedding/voyage-4-lite.yaml
@@ -1,0 +1,9 @@
+model: voyage-4-lite
+model_type: text-embedding
+model_properties:
+  context_size: 32000
+  max_chunks: 128
+pricing:
+  input: '0.00002'
+  unit: '0.001'
+  currency: USD

--- a/models/voyage/models/text_embedding/voyage-4.yaml
+++ b/models/voyage/models/text_embedding/voyage-4.yaml
@@ -1,0 +1,9 @@
+model: voyage-4
+model_type: text-embedding
+model_properties:
+  context_size: 32000
+  max_chunks: 128
+pricing:
+  input: '0.00006'
+  unit: '0.001'
+  currency: USD

--- a/models/voyage/models/text_embedding/voyage-code-2.yaml
+++ b/models/voyage/models/text_embedding/voyage-code-2.yaml
@@ -2,6 +2,7 @@ model: voyage-code-2
 model_type: text-embedding
 model_properties:
   context_size: 16000
+  max_chunks: 128
 pricing:
   input: '0.00012'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-code-3.yaml
+++ b/models/voyage/models/text_embedding/voyage-code-3.yaml
@@ -3,6 +3,6 @@ model_type: text-embedding
 model_properties:
   context_size: 32000
 pricing:
-  input: '0.18'
-  unit: '1000000'
+  input: '0.00018'
+  unit: '0.001'
   currency: USD

--- a/models/voyage/models/text_embedding/voyage-code-3.yaml
+++ b/models/voyage/models/text_embedding/voyage-code-3.yaml
@@ -2,6 +2,7 @@ model: voyage-code-3
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00018'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-context-4.yaml
+++ b/models/voyage/models/text_embedding/voyage-context-4.yaml
@@ -1,0 +1,9 @@
+model: voyage-context-4
+model_type: text-embedding
+model_properties:
+  context_size: 32000
+  max_chunks: 128
+pricing:
+  input: '0.00012'
+  unit: '0.001'
+  currency: USD

--- a/models/voyage/models/text_embedding/voyage-finance-2.yaml
+++ b/models/voyage/models/text_embedding/voyage-finance-2.yaml
@@ -2,6 +2,7 @@ model: voyage-finance-2
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00012'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-law-2.yaml
+++ b/models/voyage/models/text_embedding/voyage-law-2.yaml
@@ -2,6 +2,7 @@ model: voyage-law-2
 model_type: text-embedding
 model_properties:
   context_size: 16000
+  max_chunks: 128
 pricing:
   input: '0.00012'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-multilingual-2.yaml
+++ b/models/voyage/models/text_embedding/voyage-multilingual-2.yaml
@@ -2,6 +2,7 @@ model: voyage-multilingual-2
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00012'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-multimodal-3.5.yaml
+++ b/models/voyage/models/text_embedding/voyage-multimodal-3.5.yaml
@@ -2,6 +2,7 @@ model: voyage-multimodal-3.5
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00006'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-multimodal-3.5.yaml
+++ b/models/voyage/models/text_embedding/voyage-multimodal-3.5.yaml
@@ -3,6 +3,6 @@ model_type: text-embedding
 model_properties:
   context_size: 32000
 pricing:
-  input: '0.06'
-  unit: '1000000'
+  input: '0.00006'
+  unit: '0.001'
   currency: USD

--- a/models/voyage/models/text_embedding/voyage-multimodal-3.yaml
+++ b/models/voyage/models/text_embedding/voyage-multimodal-3.yaml
@@ -2,6 +2,7 @@ model: voyage-multimodal-3
 model_type: text-embedding
 model_properties:
   context_size: 32000
+  max_chunks: 128
 pricing:
   input: '0.00006'
   unit: '0.001'

--- a/models/voyage/models/text_embedding/voyage-multimodal-3.yaml
+++ b/models/voyage/models/text_embedding/voyage-multimodal-3.yaml
@@ -3,6 +3,6 @@ model_type: text-embedding
 model_properties:
   context_size: 32000
 pricing:
-  input: '0.06'
-  unit: '1000000'
+  input: '0.00006'
+  unit: '0.001'
   currency: USD

--- a/models/voyage/provider/voyage.py
+++ b/models/voyage/provider/voyage.py
@@ -18,9 +18,9 @@ class VoyageProvider(ModelProvider):
         try:
             model_instance = self.get_model_instance(ModelType.TEXT_EMBEDDING)
 
-            # Use `voyage-3` model for validate,
-            # no matter what model you pass in, text completion model or chat model
-            model_instance.validate_credentials(model="voyage-3", credentials=credentials)
+            # Any embedding model will do; use a current one so provider setup does
+            # not fail the day Voyage retires an older generation.
+            model_instance.validate_credentials(model="voyage-3.5", credentials=credentials)
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:

--- a/models/voyage/provider/voyage.yaml
+++ b/models/voyage/provider/voyage.yaml
@@ -59,6 +59,32 @@ provider_credential_schema:
     required: false
     type: text-input
     variable: image_base64
+  - label:
+      en_US: Output Dimension
+    placeholder:
+      en_US: 'Matryoshka dimension for voyage-4 and voyage-3.5 models: 256, 512, 1024
+        or 2048. Leave blank for the model default of 1024. Changing this after a
+        knowledge base has been indexed requires a full re-index.'
+    required: false
+    type: text-input
+    variable: output_dimension
+  - label:
+      en_US: Output Data Type
+    placeholder:
+      en_US: 'float (default), int8, uint8, binary or ubinary. Quantised types trade
+        retrieval quality for storage.'
+    required: false
+    type: text-input
+    variable: output_dtype
+  - label:
+      en_US: Contextualise Batches
+    placeholder:
+      en_US: 'voyage-context-* only. Set to true to embed each batch as one document,
+        so chunks gain context from their neighbours. Only correct when a batch holds
+        chunks of a single document; off by default. Never applied to queries.'
+    required: false
+    type: text-input
+    variable: contextualize_batch
 supported_model_types:
 - text-embedding
 - rerank

--- a/models/voyage/pyproject.toml
+++ b/models/voyage/pyproject.toml
@@ -6,7 +6,14 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "dify_plugin>=0.9.0",
+    # 0.10.0 is a hard floor, not a preference. Before it, the SDK's
+    # ModelInvokeTextEmbeddingRequest had no `input_type` field and
+    # PluginExecutor.invoke_text_embedding never forwarded one, so the
+    # "input_type": "query" Dify sends for search queries was dropped and every
+    # query was embedded with this plugin's DOCUMENT default. Voyage's query and
+    # document prompts are not interchangeable; the mismatch costs most of the
+    # retrieval quality (measured MRR 0.019 vs 0.631 on a 1,589-chunk corpus).
+    "dify_plugin>=0.10.0",
     "httpx>=0.28.1",
     "requests>=2.34.2",
 ]

--- a/models/voyage/uv.lock
+++ b/models/voyage/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/fd/1ba9d6dda0363ade4c1aab87e8188550db2ccce204071bc5fcf64d97fef6/dify_plugin-0.10.0.tar.gz", hash = "sha256:1d66f06647b16bc16ba3989fec09808d955a6c7a297f5a572c27288e717fa1aa", size = 319288, upload-time = "2026-07-20T09:34:54.712Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5b/ac14980502c31aaed011259c5fe698da83af1d384a2d59577d68ca34316a/dify_plugin-0.10.0-py3-none-any.whl", hash = "sha256:b7a4d8acbad153720cac50e3f38a428178f50079fd2599e24db3403cc1a0c8f4", size = 377626, upload-time = "2026-07-20T09:34:53.437Z" },
 ]
 
 [[package]]
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "requests", specifier = ">=2.34.2" },
 ]


### PR DESCRIPTION
## Summary

Five changes to the Voyage plugin, in independent commits so they can be taken separately. The first is a one-line dependency bump that fixes a silent, severe retrieval-quality bug.

### 1. `dify_plugin>=0.10.0` — queries were being embedded as documents

Before SDK 0.10.0, `ModelInvokeTextEmbeddingRequest` declared no `input_type` field and `PluginExecutor.invoke_text_embedding` never forwarded one. Dify's api sends `"input_type": "query"` for search queries and the Go daemon carries it (`validate:"required,oneof=document query"`), but pydantic dropped it at the SDK boundary, so `_invoke` always fell back to its `EmbeddingInputType.DOCUMENT` default.

Voyage's query and document prompts are not interchangeable. Measured on a 1,589-chunk corpus with the documents held constant and only the query encoding varied, 7 probes:

| Query embedded as | top-10 | MRR | mean rank |
|---|---|---|---|
| `document` (what shipped) | 0/7 | 0.019 | 270.6 |
| `query` (correct) | 7/7 | 0.631 | 2.1 |

Confirmed side by side on one live Dify instance, same model, same text, embedded once as QUERY and once as DOCUMENT:

```
plugin on dify_plugin 0.10.0   DIFFERENT (cosine 0.5039) -> input_type honoured
plugin on dify_plugin 0.9.0    IDENTICAL                 -> input_type dropped
```

The multimodal sibling was never affected — `ModelInvokeMultimodalEmbeddingRequest` has always declared `input_type` and `invoke_multimodal_embedding` has always passed it, which is what makes the text-embedding omission look like an oversight rather than a decision. Cohere's plugin works around the same gap with a `len(texts) > 1` heuristic.

Also bumps `meta.runner.version` to 3.12, which `pyproject`'s `requires-python` has demanded since the uv migration and `dify_plugin` 0.10.0 now enforces.

### 2. Pricing units, off by 10¹² on six models

`AIModel.get_price` computes `total_amount = tokens * unit_price * unit`. The plugin's original YAMLs encode `$0.06/1M` as `input: '0.00006'` with `unit: '0.001'`. Six models added later use `input: '0.06'` with `unit: '1000000'`, which resolves to **$60,000 per token**: `voyage-3.5`, `voyage-3.5-lite`, `voyage-3-large`, `voyage-code-3`, `voyage-multimodal-3`, `voyage-multimodal-3.5`.

Each model's intended dollar figure is unchanged; only the encoding is fixed. All twelve now resolve to Voyage's published rates.

### 3. `max_chunks`, plus token-budget request splitting

No Voyage embedding YAML declared `max_chunks`, so `CacheEmbedding.embed_documents` fell back to its default of 1 and ingestion made **one HTTP round trip per chunk** — a 2,345-segment knowledge base took 2,345 sequential calls.

`max_chunks: 128` on every embedding model. Because Dify picks the batch size from that number alone and knows nothing about chunk length, the plugin now also splits each batch against Voyage's per-request token limit before sending, so the setting cannot overshoot into a mid-ingest 400. Verified: 128 segments of 2,000 tokens go out as one request on `voyage-3.5` (320K limit) and as three on a 120K-limit model, worst case 96K tokens.

### 4. `voyage-4-large`, `voyage-4`, `voyage-4-lite`, `voyage-context-4`

`voyage-context-*` uses `/v1/contextualizedembeddings`, which takes chunks grouped by document. Dify's embedding interface passes a flat list with no document boundaries, so each text is sent as its own single-chunk group by default — equivalent to the non-contextual endpoint, with no way for one document's content to bleed into another's. A `contextualize_batch` credential opts into sending the whole batch as one document; it is never applied to a query.

Adds optional `output_dimension` (Matryoshka: 256/512/1024/2048) and `output_dtype` credentials, and stops sending the literal string `"null"` as `input_type` when none is set — the API rejects that with a 400. Provider validation moves off `voyage-3` to `voyage-3.5`.

### 5. `.difyignore`

Without it a local `uv sync` puts a `.venv` in the plugin directory and `dify plugin package` fails on size. Same content as `models/bedrock` and `models/aihubmix`.

## Testing

Exercised against the live Voyage API through the plugin's own `_invoke`: `input_type` honoured; all three voyage-4 models return 1024 dims; `output_dimension=256` returns 256; `voyage-context-4` responds in both modes and contextualising visibly changes the vector; queries are unaffected by `contextualize_batch`; a 300-text batch splits across requests with order preserved.

Then end to end on a production Dify 1.16.0 instance: both knowledge bases (756 + 1,589 segments) re-embedded onto the fixed plugin, exact point counts in Qdrant, and a 16-case retrieval suite passing. Three clinical targets that were absent from the top 20 under the broken build now rank 1, 1 and 3.
