### PR TITLE
fix(bedrock): refresh IAM-Role credentials per-call via fresh boto3.Session

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.75
+version: 0.0.76
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/provider/get_bedrock_client.py
+++ b/models/bedrock/provider/get_bedrock_client.py
@@ -67,5 +67,14 @@ def get_bedrock_client(service_name: str, credentials: Mapping[str, str]):
         if 'AWS_BEARER_TOKEN_BEDROCK' in os.environ:
             os.environ.pop('AWS_BEARER_TOKEN_BEDROCK')
 
+    if auth_method == "IAM_Role":
+        # Build the client from a fresh boto3.Session so disk-refreshed
+        # credentials (saml2aws login, aws sso login, etc.) are picked up
+        # on every invocation. boto3's default session caches credentials
+        # in-process, which would otherwise keep a stale ExpiredTokenException
+        # in flight until the plugin process restarts.
+        session = boto3.Session()
+        return session.client(**client_kwargs)
+
     client = boto3.client(**client_kwargs)
     return client

--- a/models/bedrock/pyproject.toml
+++ b/models/bedrock/pyproject.toml
@@ -17,4 +17,6 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=9.0.3",
+]

--- a/models/bedrock/tests/test_get_bedrock_client.py
+++ b/models/bedrock/tests/test_get_bedrock_client.py
@@ -1,0 +1,227 @@
+"""Unit tests for provider.get_bedrock_client.
+
+Covers the three authentication paths and the IAM-Role freshness fix from
+issue #3519 (ExpiredTokenException when using SSO/SAML temporary
+credentials with `saml2aws login` / `aws sso login`).
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dify_plugin.errors.model import InvokeBadRequestError
+
+_CLIENT_PATH = (
+    Path(__file__).resolve().parent.parent / "provider" / "get_bedrock_client.py"
+)
+_spec = importlib.util.spec_from_file_location("get_bedrock_client", _CLIENT_PATH)
+get_bedrock_client = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(get_bedrock_client)
+
+
+_BASE_CREDENTIALS = {
+    "aws_region": "us-east-1",
+}
+
+
+def _client_mock(*, session_calls: list | None = None) -> MagicMock:
+    """Return a MagicMock boto3.client with optional session call tracking."""
+    return MagicMock(name="boto3.client")
+
+
+class TestRegionAndEndpointValidation:
+    def test_missing_aws_region_raises(self) -> None:
+        with pytest.raises(InvokeBadRequestError, match="aws_region is required"):
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", {})
+
+    def test_both_endpoint_and_proxy_raises(self) -> None:
+        creds = {
+            **_BASE_CREDENTIALS,
+            "bedrock_endpoint_url": "https://example.com",
+            "bedrock_proxy_url": "proxy.example.com:8080",
+        }
+        with pytest.raises(InvokeBadRequestError, match="Cannot use both"):
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+
+
+class TestApiKeyMode:
+    def setup_method(self) -> None:
+        # Make sure no leftover bearer token from a prior test leaks in.
+        os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+
+    def teardown_method(self) -> None:
+        os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+
+    def test_missing_bedrock_api_key_raises(self) -> None:
+        creds = {**_BASE_CREDENTIALS, "auth_method": "API_Key"}
+        with pytest.raises(InvokeBadRequestError, match="bedrock_api_key is required"):
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+
+    def test_api_key_sets_bearer_token_env(self) -> None:
+        creds = {
+            **_BASE_CREDENTIALS,
+            "auth_method": "API_Key",
+            "bedrock_api_key": "sk-test-1234",
+        }
+        with patch.object(
+            get_bedrock_client.boto3, "client", return_value=MagicMock()
+        ) as mock_client:
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+        assert os.environ["AWS_BEARER_TOKEN_BEDROCK"] == "sk-test-1234"
+        mock_client.assert_called_once()
+
+
+class TestAccessSecretKeyMode:
+    def test_explicit_keys_passed_to_client(self) -> None:
+        creds = {
+            **_BASE_CREDENTIALS,
+            "auth_method": "Access_Secret_Key",
+            "aws_access_key_id": "AKIA-TEST",
+            "aws_secret_access_key": "secret-test",
+        }
+        with patch.object(
+            get_bedrock_client.boto3, "client", return_value=MagicMock()
+        ) as mock_client:
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+        kwargs = mock_client.call_args.kwargs
+        assert kwargs["aws_access_key_id"] == "AKIA-TEST"
+        assert kwargs["aws_secret_access_key"] == "secret-test"
+
+    def test_default_auth_method_is_access_secret_key(self) -> None:
+        # When auth_method is missing, default to Access_Secret_Key.
+        creds = {
+            **_BASE_CREDENTIALS,
+            "aws_access_key_id": "AKIA-DEFAULT",
+            "aws_secret_access_key": "secret-default",
+        }
+        with patch.object(
+            get_bedrock_client.boto3, "client", return_value=MagicMock()
+        ) as mock_client:
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+        kwargs = mock_client.call_args.kwargs
+        assert kwargs["aws_access_key_id"] == "AKIA-DEFAULT"
+
+
+class TestIamRoleMode:
+    """IAM-Role mode relies on the default credential chain (saml2aws,
+    aws sso, IMDS, etc.). The fix from issue #3519 ensures each call
+    builds the client from a fresh boto3.Session so disk-refreshed
+    credentials are picked up on every invocation.
+    """
+
+    def setup_method(self) -> None:
+        os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+
+    def teardown_method(self) -> None:
+        os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+
+    def test_iam_role_uses_fresh_boto3_session(self) -> None:
+        creds = {**_BASE_CREDENTIALS, "auth_method": "IAM_Role"}
+
+        with (
+            patch.object(
+                get_bedrock_client.boto3, "Session", return_value=MagicMock()
+            ) as mock_session_cls,
+            patch.object(
+                MagicMock(), "client", return_value=MagicMock()
+            ) as mock_session_client,
+        ):
+            mock_session = mock_session_cls.return_value
+            mock_session.client = mock_session_client
+
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+
+        # Each IAM-Role call must construct a fresh Session so disk-
+        # refreshed credentials are picked up.
+        mock_session_cls.assert_called_once_with()
+        mock_session_client.assert_called_once()
+
+    def test_iam_role_does_not_use_default_boto3_client(self) -> None:
+        # The default `boto3.client(...)` path uses the default session
+        # and caches credentials in-process — the bug from #3519. After
+        # the fix, the IAM-Role branch must NOT go through that path.
+        creds = {**_BASE_CREDENTIALS, "auth_method": "IAM_Role"}
+
+        with (
+            patch.object(
+                get_bedrock_client.boto3, "client", return_value=MagicMock()
+            ) as mock_default_client,
+            patch.object(
+                get_bedrock_client.boto3, "Session", return_value=MagicMock()
+            ) as mock_session_cls,
+        ):
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+
+        mock_default_client.assert_not_called()
+        mock_session_cls.assert_called_once()
+
+    def test_iam_role_pops_stale_bearer_token(self) -> None:
+        # If a previous API_Key auth set AWS_BEARER_TOKEN_BEDROCK, the
+        # IAM-Role branch must clear it so boto3's default chain is used.
+        os.environ["AWS_BEARER_TOKEN_BEDROCK"] = "stale-key"
+        creds = {**_BASE_CREDENTIALS, "auth_method": "IAM_Role"}
+
+        with patch.object(
+            get_bedrock_client.boto3, "Session", return_value=MagicMock()
+        ) as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+
+        assert "AWS_BEARER_TOKEN_BEDROCK" not in os.environ
+
+    def test_two_consecutive_iam_role_calls_make_two_sessions(self) -> None:
+        # The whole point of the fix: a second call after the user
+        # refreshes credentials externally must build a second Session
+        # (so it re-reads the credentials file).
+        creds = {**_BASE_CREDENTIALS, "auth_method": "IAM_Role"}
+
+        with patch.object(
+            get_bedrock_client.boto3, "Session", return_value=MagicMock()
+        ) as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+
+        assert mock_session_cls.call_count == 2
+
+
+class TestEndpointUrl:
+    def test_endpoint_url_only_applies_to_bedrock_runtime(self) -> None:
+        creds = {
+            **_BASE_CREDENTIALS,
+            "auth_method": "Access_Secret_Key",
+            "aws_access_key_id": "AKIA",
+            "aws_secret_access_key": "secret",
+            "bedrock_endpoint_url": "https://vpce.example.com",
+        }
+        with patch.object(
+            get_bedrock_client.boto3, "client", return_value=MagicMock()
+        ) as mock_client:
+            get_bedrock_client.get_bedrock_client("bedrock", creds)
+        # Non-runtime service should NOT receive the endpoint URL.
+        assert "endpoint_url" not in mock_client.call_args.kwargs
+
+    def test_endpoint_url_applied_to_bedrock_runtime(self) -> None:
+        creds = {
+            **_BASE_CREDENTIALS,
+            "auth_method": "Access_Secret_Key",
+            "aws_access_key_id": "AKIA",
+            "aws_secret_access_key": "secret",
+            "bedrock_endpoint_url": "https://vpce.example.com",
+        }
+        with patch.object(
+            get_bedrock_client.boto3, "client", return_value=MagicMock()
+        ) as mock_client:
+            get_bedrock_client.get_bedrock_client("bedrock-runtime", creds)
+        assert (
+            mock_client.call_args.kwargs["endpoint_url"] == "https://vpce.example.com"
+        )

--- a/models/bedrock/uv.lock
+++ b/models/bedrock/uv.lock
@@ -49,6 +49,11 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aws-bedrock-token-generator", specifier = ">=1.1.0" },
@@ -60,7 +65,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "blinker"
@@ -448,6 +453,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -736,6 +750,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -940,6 +963,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The IAM-Role auth path in `models/bedrock/provider/get_bedrock_client.py` was calling `boto3.client(...)` directly, which uses boto3's default session. That session caches credentials in-process, so a `saml2aws login` / `aws sso login` / IMDS refresh after the plugin process started never reached the Bedrock client. Users with SSO/SAML temporary credentials hit `ExpiredTokenException: The security token included in the request is expired` and had to restart the plugin daemon to recover.

Fixes #3519

### Changes

- `models/bedrock/provider/get_bedrock_client.py`: when `auth_method == "IAM_Role"`, build the client from a fresh `boto3.Session()` instead of going through the default session. Each call re-reads the credentials file (or IMDS / SSO cache), so externally-refreshed tokens are picked up immediately. The `Access_Secret_Key` and `API_Key` paths are unchanged — they pass explicit credentials or bearer token and don't depend on the default credential chain.
- `models/bedrock/tests/test_get_bedrock_client.py`: 12 regression tests covering the three auth paths, the IAM-Role freshness behavior, and the endpoint-URL rules. The `test_two_consecutive_iam_role_calls_make_two_sessions` test pins the whole point of the fix: a second call after the user refreshes credentials externally must build a second Session so it re-reads the file.
- `models/bedrock/pyproject.toml`: add `pytest>=9.0.3` to the dev dependency group. Matches the pattern in `models/tongyi/pyproject.toml`, `models/moonshot/pyproject.toml`, `models/mistralai/pyproject.toml`. The bedrock plugin had no pytest in dev before this PR, so its existing tests were running against the system pytest.
- `models/bedrock/uv.lock`: regenerated for the new dev dependency.
- Manifest bump `0.0.75 -> 0.0.76`.

### Why a fresh `boto3.Session()` and not a retry wrapper?

The reporter's fix plan offered both:

1. IAM-Role mode: fresh `boto3.Session()` per call
2. Retry wrapper around `_invoke` that catches `ExpiredTokenException` and retries with a fresh client

Option 1 is the cleaner fix because it makes every call naturally correct — the next invocation already has fresh credentials, with no special-case error handling in the hot path. Option 2 would work but adds branching to the LLM invoke code for a corner case that the auth layer can handle upstream.

## Change Type

- [x] Non-LLM plugin only (this is the IAM-Role auth path; the LLM invoke code is unchanged)

## Testing

```
$ (cd models/bedrock && uv run --frozen pytest tests/ -q)
65 passed, 2 warnings in 0.32s
```

- `pytest tests/test_get_bedrock_client.py -v` → 12 passed
- `ruff check tests/test_get_bedrock_client.py` → All checks passed
- `ruff format --check tests/test_get_bedrock_client.py` → 1 file already formatted
- Full `pytest tests/` (including pre-existing tests) → 65 passed

## Backward compatibility

No breaking change. The `Access_Secret_Key` and `API_Key` paths produce the same client as before. The IAM-Role path now produces a client backed by a fresh `boto3.Session()` instead of the default session, which is functionally equivalent for the first call and strictly better on every subsequent call after a credential refresh.

## References

- Issue #3519
- Reporter's proposed fix in the issue body
