### PR TITLE
fix(cot_agent): preserve streamed thinking block closure

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.40
+version: 0.0.41
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/strategies/function_calling.py
+++ b/agent-strategies/cot_agent/strategies/function_calling.py
@@ -29,6 +29,10 @@ from dify_plugin.interfaces.agent import (
 )
 from pydantic import BaseModel
 
+THINK_START = "<think>"
+THINK_END = "</think>"
+
+
 class LogMetadata:
     """Metadata keys for logging"""
     STARTED_AT = "started_at"
@@ -93,6 +97,27 @@ class FunctionCallingParams(BaseModel):
 class FunctionCallingAgentStrategy(AgentStrategy):
     query: str = ""
     instruction: str | None = ""
+
+    @staticmethod
+    def _get_streaming_content_state(
+        *,
+        content: str,
+        function_call_state: bool,
+        thinking_started: bool,
+        iteration_step: int,
+        max_iteration_steps: int,
+    ) -> tuple[bool, bool]:
+        should_stream = (
+            not function_call_state
+            or iteration_step == max_iteration_steps
+            or (thinking_started and content.strip() == THINK_END)
+        )
+        if should_stream:
+            if content.strip() == THINK_START:
+                thinking_started = True
+            elif content.strip() == THINK_END:
+                thinking_started = False
+        return should_stream, thinking_started
 
     @property
     def _user_prompt_message(self) -> UserPromptMessage:
@@ -196,6 +221,7 @@ class FunctionCallingAgentStrategy(AgentStrategy):
 
             # save full response
             response = ""
+            thinking_started = False
 
             # save tool call names and inputs
             tool_call_names = ""
@@ -216,20 +242,31 @@ class FunctionCallingAgentStrategy(AgentStrategy):
                         if isinstance(chunk.delta.message.content, list):
                             for content in chunk.delta.message.content:
                                 response += content.data
-                                if (
-                                    not function_call_state
-                                    or iteration_step == max_iteration_steps
-                                ):
+                                should_stream, thinking_started = (
+                                    self._get_streaming_content_state(
+                                        content=content.data,
+                                        function_call_state=function_call_state,
+                                        thinking_started=thinking_started,
+                                        iteration_step=iteration_step,
+                                        max_iteration_steps=max_iteration_steps,
+                                    )
+                                )
+                                if should_stream:
                                     yield self.create_text_message(content.data)
                         else:
-                            response += str(chunk.delta.message.content)
-                            if (
-                                not function_call_state
-                                or iteration_step == max_iteration_steps
-                            ):
-                                yield self.create_text_message(
-                                    str(chunk.delta.message.content)
+                            response_content = str(chunk.delta.message.content)
+                            response += response_content
+                            should_stream, thinking_started = (
+                                self._get_streaming_content_state(
+                                    content=response_content,
+                                    function_call_state=function_call_state,
+                                    thinking_started=thinking_started,
+                                    iteration_step=iteration_step,
+                                    max_iteration_steps=max_iteration_steps,
                                 )
+                            )
+                            if should_stream:
+                                yield self.create_text_message(response_content)
 
                     if chunk.delta.usage:
                         self.increase_usage(llm_usage, chunk.delta.usage)

--- a/agent-strategies/cot_agent/tests/test_function_calling.py
+++ b/agent-strategies/cot_agent/tests/test_function_calling.py
@@ -135,6 +135,35 @@ class TestFunctionCallingToolCallParsing(unittest.TestCase):
 
         self.assertIn("Failed to parse tool-call arguments as JSON", str(ctx.exception))
 
+    def test_only_thinking_end_streams_after_tool_call(self):
+        thinking_started = False
+        streamed_content = []
+
+        for function_call_state, content in [
+            (False, "<think>\n"),
+            (False, "Analyzing the request."),
+            (True, "Hidden intermediate content"),
+            (True, "\n</think>"),
+        ]:
+            should_stream, thinking_started = (
+                self.strategy._get_streaming_content_state(
+                    content=content,
+                    function_call_state=function_call_state,
+                    thinking_started=thinking_started,
+                    iteration_step=1,
+                    max_iteration_steps=3,
+                )
+            )
+            if should_stream:
+                streamed_content.append(content)
+
+        response = "".join(streamed_content)
+        self.assertEqual(
+            response,
+            "<think>\nAnalyzing the request.\n</think>",
+        )
+        self.assertFalse(thinking_started)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Preserve a streamed `</think>` delimiter after a tool call when its corresponding `<think>` delimiter has already been emitted.

This prevents malformed COT output while keeping other post-tool-call content suppressed.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| `<think>...` <img width="1223" height="1266" alt="image" src="https://github.com/user-attachments/assets/6629507b-b80f-433e-b915-fc6d20dd8047" /> | `<think>...</think>` <img width="401" height="680" alt="image" src="https://github.com/user-attachments/assets/065e783b-aac6-4041-8653-740c2658e49e" /> |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

## Testing

- [ ] Local deployment — Dify version:
- [ ] SaaS (cloud.dify.ai)

Unit tests: 9 passed.
