### PR TITLE
fix(aws_tools): refresh boto3 credentials per-call in Bedrock-family tools (apply_guardrail, bedrock_retrieve, bedrock_retrieve_and_generate)

### DIFF
--- a/tools/aws/manifest.yaml
+++ b/tools/aws/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.29
+version: 0.0.30
 type: plugin
 author: langgenius
 name: aws_tools

--- a/tools/aws/pyproject.toml
+++ b/tools/aws/pyproject.toml
@@ -24,4 +24,6 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=9.0.3",
+]

--- a/tools/aws/tests/test_boto3_fresh_session.py
+++ b/tools/aws/tests/test_boto3_fresh_session.py
@@ -1,0 +1,251 @@
+"""Regression tests for the boto3 client construction in Bedrock-family tools.
+
+Covers the fix from issue #3544 (the same `ExpiredTokenException` bug
+that was fixed for the bedrock model plugin in PR #3535 / #3519):
+`boto3.client(...)` uses the default session which caches credentials
+in-process, so a `saml2aws login` / `aws sso login` / IMDS refresh after
+the plugin process started never reaches the Bedrock client.
+
+The fix builds the client from a fresh `boto3.Session()` on every
+invocation. In `bedrock_retrieve.py` and `bedrock_retrieve_and_generate.py`
+the on-instance `self.bedrock_client` cache was also removed, since
+even a fresh session would be ignored once the instance held a stale
+client.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add the tools dir to sys.path so the tool modules can import.
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+# Stub the dify_plugin SDK so the tool modules import without booting
+# the SDK. Same pattern used in tools/aws/tests/__init__.py-equivalent
+# fixtures across this repo.
+_dify_plugin = sys.modules.get("dify_plugin") or type(sys)("dify_plugin")
+
+
+class _FakeToolInvokeMessage:
+    pass
+
+
+class _FakeTool:
+    def create_text_message(self, text: str):
+        return ("text", text)
+
+
+_dify_plugin.Tool = _FakeTool  # type: ignore[attr-defined]
+_dify_plugin_entities = sys.modules.get("dify_plugin.entities") or type(sys)(
+    "dify_plugin.entities"
+)
+_dify_plugin_entities_tool = sys.modules.get("dify_plugin.entities.tool") or type(sys)(
+    "dify_plugin.entities.tool"
+)
+_dify_plugin_entities_tool.ToolInvokeMessage = _FakeToolInvokeMessage
+_dify_plugin.entities = _dify_plugin_entities  # type: ignore[attr-defined]
+_dify_plugin.entities.tool = _dify_plugin_entities_tool  # type: ignore[attr-defined]
+sys.modules.setdefault("dify_plugin", _dify_plugin)
+sys.modules.setdefault("dify_plugin.entities", _dify_plugin_entities)
+sys.modules.setdefault("dify_plugin.entities.tool", _dify_plugin_entities_tool)
+
+# The three tools import boto3 at module scope; we patch boto3.Session
+# per-test instead of stubbing the import.
+
+apply_guardrail = importlib.import_module("apply_guardrail")
+bedrock_retrieve = importlib.import_module("bedrock_retrieve")
+bedrock_retrieve_and_generate = importlib.import_module("bedrock_retrieve_and_generate")
+
+
+def _patched_boto3_session() -> tuple[MagicMock, MagicMock]:
+    """Replace boto3.Session with a mock that returns a mock session.
+
+    Returns (session_cls, session_mock). Each call to boto3.Session()
+    returns a fresh MagicMock that exposes .client(...).
+    """
+    session_mock = MagicMock(name="boto3.Session")
+    client_mock = MagicMock(name="boto3.Session.client")
+    session_mock.client.return_value = client_mock
+    session_cls = MagicMock(name="boto3.client", return_value=session_mock)
+    return session_cls, session_mock, client_mock
+
+
+def _consume(generator):
+    """Drain a Tool._invoke generator and return the list of messages."""
+    return list(generator)
+
+
+class TestApplyGuardrailUsesFreshSession:
+    def test_each_invoke_creates_a_fresh_boto3_session(self) -> None:
+        """apply_guardrail's _invoke must call boto3.Session() (not
+        boto3.client) so the default-session credential cache is
+        bypassed on every call.
+        """
+        tool = apply_guardrail.ApplyGuardrailTool.__new__(
+            apply_guardrail.ApplyGuardrailTool
+        )
+        tool.runtime = MagicMock()
+        tool.session = MagicMock()
+        tool.create_text_message = _FakeTool().create_text_message
+
+        with patch.object(
+            apply_guardrail.boto3, "Session", return_value=MagicMock()
+        ) as session_cls:
+            mock_session = session_cls.return_value
+            mock_session.client.return_value = MagicMock(
+                apply_guardrail=MagicMock(
+                    return_value={"action": "NONE", "outputs": [], "assessments": []}
+                )
+            )
+            params = {
+                "guardrail_id": "g1",
+                "guardrail_version": "v1",
+                "source": "INPUT",
+                "text": "hello",
+                "aws_region": "us-east-1",
+            }
+            _consume(tool._invoke(tool_parameters=params))
+
+        session_cls.assert_called_once()
+        mock_session.client.assert_called_once()
+
+    def test_does_not_call_default_boto3_client(self) -> None:
+        """Sanity: the fixed path must NOT go through boto3.client()."""
+        tool = apply_guardrail.ApplyGuardrailTool.__new__(
+            apply_guardrail.ApplyGuardrailTool
+        )
+        tool.runtime = MagicMock()
+        tool.session = MagicMock()
+        tool.create_text_message = _FakeTool().create_text_message
+
+        with (
+            patch.object(
+                apply_guardrail.boto3, "client", return_value=MagicMock()
+            ) as default_client,
+            patch.object(apply_guardrail.boto3, "Session", return_value=MagicMock()),
+        ):
+            mock_session = apply_guardrail.boto3.Session.return_value
+            mock_session.client.return_value = MagicMock(
+                apply_guardrail=MagicMock(
+                    return_value={"action": "NONE", "outputs": [], "assessments": []}
+                )
+            )
+            params = {
+                "guardrail_id": "g1",
+                "guardrail_version": "v1",
+                "source": "INPUT",
+                "text": "hello",
+                "aws_region": "us-east-1",
+            }
+            _consume(tool._invoke(tool_parameters=params))
+
+        default_client.assert_not_called()
+
+
+class TestBedrockRetrieveRemovesInstanceCache:
+    def test_does_not_assign_self_bedrock_client(self) -> None:
+        """bedrock_retrieve previously cached the client on self.bedrock_client,
+        which combined with the default-session credential cache made
+        ExpiredTokenException sticky. The fix removes the cache.
+        """
+        tool = bedrock_retrieve.BedrockRetrieveTool.__new__(
+            bedrock_retrieve.BedrockRetrieveTool
+        )
+        tool.runtime = MagicMock()
+        tool.session = MagicMock()
+        tool.create_text_message = _FakeTool().create_text_message
+        # Pre-set the attribute to assert it stays None (not re-cached).
+        tool.bedrock_client = None
+
+        with patch.object(
+            bedrock_retrieve.boto3, "Session", return_value=MagicMock()
+        ) as session_cls:
+            mock_session = session_cls.return_value
+            mock_session.client.return_value = MagicMock(
+                retrieve=MagicMock(return_value={"retrievalResults": []})
+            )
+            params = {
+                "aws_region": "us-east-1",
+                "knowledge_base_id": "kb1",
+                "retrieval_query": "test",
+            }
+            # We don't care about the full result; just verify self.bedrock_client
+            # remains None after the invoke.
+            try:
+                _consume(tool._invoke(tool_parameters=params))
+            except Exception:
+                # The mocked retrieve response may not be fully fleshed out;
+                # the assertion below is what we care about.
+                pass
+
+        assert tool.bedrock_client is None, (
+            "bedrock_retrieve must not cache the boto3 client on self; "
+            "the cache combined with the default-session credential cache "
+            "made ExpiredTokenException sticky (see #3544, #3535)."
+        )
+
+    def test_bedrock_retrieve_session_uses_bedrock_agent_runtime(self) -> None:
+        """The fresh session must call client(service_name='bedrock-agent-runtime')
+        — the service the tool actually uses, not bedrock-runtime.
+        """
+        tool = bedrock_retrieve.BedrockRetrieveTool.__new__(
+            bedrock_retrieve.BedrockRetrieveTool
+        )
+        tool.runtime = MagicMock()
+        tool.session = MagicMock()
+        tool.create_text_message = _FakeTool().create_text_message
+
+        with patch.object(
+            bedrock_retrieve.boto3, "Session", return_value=MagicMock()
+        ) as session_cls:
+            mock_session = session_cls.return_value
+            mock_session.client.return_value = MagicMock(
+                retrieve=MagicMock(return_value={"retrievalResults": []})
+            )
+            params = {
+                "aws_region": "us-east-1",
+                "knowledge_base_id": "kb1",
+                "retrieval_query": "test",
+            }
+            try:
+                _consume(tool._invoke(tool_parameters=params))
+            except Exception:
+                pass
+
+        mock_session.client.assert_called_once()
+        kwargs = mock_session.client.call_args.kwargs
+        assert kwargs.get("service_name") == "bedrock-agent-runtime"
+
+
+class TestBedrockRetrieveAndGenerateRemovesInstanceCache:
+    def test_does_not_assign_self_bedrock_client(self) -> None:
+        """Same fix as bedrock_retrieve: remove the on-instance client cache."""
+        tool = bedrock_retrieve_and_generate.BedrockRetrieveAndGenerateTool.__new__(
+            bedrock_retrieve_and_generate.BedrockRetrieveAndGenerateTool
+        )
+        tool.runtime = MagicMock()
+        tool.session = MagicMock()
+        tool.create_text_message = _FakeTool().create_text_message
+        tool.bedrock_client = None
+
+        with patch.object(
+            bedrock_retrieve_and_generate.boto3, "Session", return_value=MagicMock()
+        ) as session_cls:
+            mock_session = session_cls.return_value
+            mock_session.client.return_value = MagicMock(
+                retrieve_and_generate=MagicMock(
+                    return_value={"output": {"text": ""}, "citations": []}
+                )
+            )
+            params = {"aws_region": "us-east-1", "input": "hi"}
+            try:
+                _consume(tool._invoke(tool_parameters=params))
+            except Exception:
+                pass
+
+        assert tool.bedrock_client is None, (
+            "bedrock_retrieve_and_generate must not cache the boto3 client on self."
+        )

--- a/tools/aws/tools/apply_guardrail.py
+++ b/tools/aws/tools/apply_guardrail.py
@@ -13,6 +13,7 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 class GuardrailParameters(BaseModel):
     guardrail_id: str = Field(..., description="The identifier of the guardrail")
     guardrail_version: str = Field(..., description="The version of the guardrail")
@@ -22,9 +23,7 @@ class GuardrailParameters(BaseModel):
 
 
 class ApplyGuardrailTool(Tool):
-    def _invoke(
-        self, tool_parameters: dict[str, Any]
-    ) -> Generator[ToolInvokeMessage]:
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         """
         Invoke the ApplyGuardrail tool
         """
@@ -32,8 +31,15 @@ class ApplyGuardrailTool(Tool):
             # Validate and parse input parameters
             params = GuardrailParameters(**tool_parameters)
 
-            # Initialize AWS client
-            bedrock_client = boto3.client("bedrock-runtime", region_name=params.aws_region)
+            # Initialize AWS client. Build from a fresh boto3.Session so
+            # disk-refreshed credentials (saml2aws login, aws sso login, IMDS)
+            # are picked up on every invocation — boto3's default session
+            # caches credentials in-process, which would otherwise keep a
+            # stale ExpiredTokenException in flight until the plugin daemon
+            # restarts. Same fix as bedrock model plugin PR #3535.
+            bedrock_client = boto3.Session().client(
+                "bedrock-runtime", region_name=params.aws_region
+            )
 
             # Apply guardrail
             response = bedrock_client.apply_guardrail(
@@ -47,12 +53,18 @@ class ApplyGuardrailTool(Tool):
 
             # Check for empty response
             if not response:
-                yield self.create_text_message(text="Received empty response from AWS Bedrock.")
+                yield self.create_text_message(
+                    text="Received empty response from AWS Bedrock."
+                )
 
             # Process the result
             action = response.get("action", "No action specified")
             outputs = response.get("outputs", [])
-            output = outputs[0].get("text", "No output received") if outputs else "No output received"
+            output = (
+                outputs[0].get("text", "No output received")
+                if outputs
+                else "No output received"
+            )
             assessments = response.get("assessments", [])
 
             # Format assessments
@@ -66,7 +78,9 @@ class ApplyGuardrailTool(Tool):
                                 f" Action: {topic['action']}"
                             )
                     else:
-                        formatted_assessments.append(f"Policy: {policy_type}, Data: {policy_data}")
+                        formatted_assessments.append(
+                            f"Policy: {policy_type}, Data: {policy_data}"
+                        )
 
             result = f"Action: {action}\n "
             result += f"Output: {output}\n "

--- a/tools/aws/tools/bedrock_retrieve.py
+++ b/tools/aws/tools/bedrock_retrieve.py
@@ -8,23 +8,25 @@ import boto3
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
+
 class BedrockRetrieveTool(Tool):
-    bedrock_client: Any = None
     knowledge_base_id: str = None
     topk: int = None
 
     def convert_to_dify_kb_format(self, kb_repsonse):
         result_array = []
-        for idx, item in enumerate(kb_repsonse['retrievalResults']):
+        for idx, item in enumerate(kb_repsonse["retrievalResults"]):
             # 提取基础字段
-            source_uri = item['location']['s3Location']['uri']
-            page_number = item['metadata'].get('x-amz-bedrock-kb-document-page-number', 0)
-            data_source_id = item['metadata'].get('x-amz-bedrock-kb-data-source-id', '')
-            chunk_id = item['metadata'].get('x-amz-bedrock-kb-chunk-id','')
-            score = item.get('score', 0.0)
+            source_uri = item["location"]["s3Location"]["uri"]
+            page_number = item["metadata"].get(
+                "x-amz-bedrock-kb-document-page-number", 0
+            )
+            data_source_id = item["metadata"].get("x-amz-bedrock-kb-data-source-id", "")
+            chunk_id = item["metadata"].get("x-amz-bedrock-kb-chunk-id", "")
+            score = item.get("score", 0.0)
 
             # 生成动态字段
-            document_name = source_uri.split('/')[-1]
+            document_name = source_uri.split("/")[-1]
 
             # 构建元数据
             metadata = {
@@ -33,12 +35,12 @@ class BedrockRetrieveTool(Tool):
                 "dataset_name": "BedRock knowledge base",
                 "document_id": document_name,
                 "document_name": document_name,
-                "document_data_source_type": item['content']['type'],
+                "document_data_source_type": item["content"]["type"],
                 "segment_id": chunk_id,
                 "retriever_from": "workflow",
                 "score": round(score, 6),
                 "segment_hit_count": 1,  # 示例值递增
-                "segment_word_count": len(item['content']['text']),  # 计算词数
+                "segment_word_count": len(item["content"]["text"]),  # 计算词数
                 "segment_position": page_number,
                 "doc_metadata": {
                     "tag": "bedrock knowledge base",
@@ -46,22 +48,25 @@ class BedrockRetrieveTool(Tool):
                     "uploader": "advantage",
                     "upload_date": int(1715299200),  # 固定时间戳
                     "document_name": document_name,
-                    "last_update_date": int(1715299200)
+                    "last_update_date": int(1715299200),
                 },
-                "position": idx + 1
+                "position": idx + 1,
             }
 
-            if item['content']['text'].strip() != "" :
-                result_array.append({
-                    "content": item['content']['text'],
-                    "title": f"{document_name}",  # 添加默认扩展名
-                    "metadata": metadata
-                })
+            if item["content"]["text"].strip() != "":
+                result_array.append(
+                    {
+                        "content": item["content"]["text"],
+                        "title": f"{document_name}",  # 添加默认扩展名
+                        "metadata": metadata,
+                    }
+                )
 
         return result_array
 
     def _bedrock_retrieve(
         self,
+        bedrock_client,
         query_input: str,
         knowledge_base_id: str,
         num_results: int,
@@ -76,11 +81,16 @@ class BedrockRetrieveTool(Tool):
                 raise RuntimeException("search_type should be HYBRID or SEMANTIC")
 
             retrieval_configuration = {
-                "vectorSearchConfiguration": {"numberOfResults": num_results, "overrideSearchType": search_type}
+                "vectorSearchConfiguration": {
+                    "numberOfResults": num_results,
+                    "overrideSearchType": search_type,
+                }
             }
 
             if rerank_model_id != "default":
-                model_for_rerank_arn = f"arn:aws:bedrock:us-west-2::foundation-model/{rerank_model_id}"
+                model_for_rerank_arn = (
+                    f"arn:aws:bedrock:us-west-2::foundation-model/{rerank_model_id}"
+                )
                 rerankingConfiguration = {
                     "bedrockRerankingConfiguration": {
                         "numberOfRerankedResults": num_results,
@@ -89,14 +99,20 @@ class BedrockRetrieveTool(Tool):
                     "type": "BEDROCK_RERANKING_MODEL",
                 }
 
-                retrieval_configuration["vectorSearchConfiguration"]["rerankingConfiguration"] = rerankingConfiguration
-                retrieval_configuration["vectorSearchConfiguration"]["numberOfResults"] = num_results * 5
+                retrieval_configuration["vectorSearchConfiguration"][
+                    "rerankingConfiguration"
+                ] = rerankingConfiguration
+                retrieval_configuration["vectorSearchConfiguration"][
+                    "numberOfResults"
+                ] = num_results * 5
 
             # 如果有元数据过滤条件，则添加到检索配置中
             if metadata_filter:
-                retrieval_configuration["vectorSearchConfiguration"]["filter"] = metadata_filter
+                retrieval_configuration["vectorSearchConfiguration"]["filter"] = (
+                    metadata_filter
+                )
 
-            response = self.bedrock_client.retrieve(
+            response = bedrock_client.retrieve(
                 knowledgeBaseId=knowledge_base_id,
                 retrievalQuery=retrieval_query,
                 retrievalConfiguration=retrieval_configuration,
@@ -115,25 +131,38 @@ class BedrockRetrieveTool(Tool):
         """
         invoke tools
         """
+        bedrock_client = None
         try:
             line = 0
-            # Initialize Bedrock client if not already initialized
-            if not self.bedrock_client:
-                aws_region = tool_parameters.get("aws_region")
-                aws_access_key_id = tool_parameters.get("aws_access_key_id")
-                aws_secret_access_key = tool_parameters.get("aws_secret_access_key")
+            # Build a fresh boto3 client on every invocation so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked up
+            # without a plugin restart. The previous code cached the client
+            # on self.bedrock_client, which combined with the default
+            # session's in-process credential cache made ExpiredTokenException
+            # sticky. Same fix as bedrock model plugin PR #3535.
+            aws_region = tool_parameters.get("aws_region")
+            aws_access_key_id = tool_parameters.get("aws_access_key_id")
+            aws_secret_access_key = tool_parameters.get("aws_secret_access_key")
 
-                client_kwargs = {"service_name": "bedrock-agent-runtime", "region_name": aws_region or None}
+            client_kwargs = {
+                "service_name": "bedrock-agent-runtime",
+                "region_name": aws_region or None,
+            }
 
-                # Only add credentials if both access key and secret key are provided
-                if aws_access_key_id and aws_secret_access_key:
-                    client_kwargs.update(
-                        {"aws_access_key_id": aws_access_key_id, "aws_secret_access_key": aws_secret_access_key}
-                    )
+            # Only add credentials if both access key and secret key are provided
+            if aws_access_key_id and aws_secret_access_key:
+                client_kwargs.update(
+                    {
+                        "aws_access_key_id": aws_access_key_id,
+                        "aws_secret_access_key": aws_secret_access_key,
+                    }
+                )
 
-                self.bedrock_client = boto3.client(**client_kwargs)
+            bedrock_client = boto3.Session().client(**client_kwargs)
         except Exception as e:
-            yield self.create_text_message(f"Failed to initialize Bedrock client: {str(e)}")
+            yield self.create_text_message(
+                f"Failed to initialize Bedrock client: {str(e)}"
+            )
 
         try:
             line = 1
@@ -153,13 +182,16 @@ class BedrockRetrieveTool(Tool):
 
             # 获取元数据过滤条件（如果存在）
             metadata_filter_str = tool_parameters.get("metadata_filter")
-            metadata_filter = json.loads(metadata_filter_str) if metadata_filter_str else None
+            metadata_filter = (
+                json.loads(metadata_filter_str) if metadata_filter_str else None
+            )
 
             search_type = tool_parameters.get("search_type")
             rerank_model_id = tool_parameters.get("rerank_model_id")
 
             line = 4
             retrieved_docs = self._bedrock_retrieve(
+                bedrock_client=bedrock_client,
                 query_input=query,
                 knowledge_base_id=self.knowledge_base_id,
                 num_results=self.topk,
@@ -171,7 +203,7 @@ class BedrockRetrieveTool(Tool):
             line = 5
             result_type = tool_parameters.get("result_type")
             if result_type == "json":
-                json_result = { "results" : retrieved_docs }
+                json_result = {"results": retrieved_docs}
                 yield self.create_json_message(json_result)
             else:
                 text = ""
@@ -197,5 +229,7 @@ class BedrockRetrieveTool(Tool):
             raise ValueError("query is required")
 
         metadata_filter_str = parameters.get("metadata_filter")
-        if metadata_filter_str and not isinstance(json.loads(metadata_filter_str), dict):
+        if metadata_filter_str and not isinstance(
+            json.loads(metadata_filter_str), dict
+        ):
             raise ValueError("metadata_filter must be a valid JSON object")

--- a/tools/aws/tools/bedrock_retrieve_and_generate.py
+++ b/tools/aws/tools/bedrock_retrieve_and_generate.py
@@ -7,9 +7,8 @@ import boto3
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-class BedrockRetrieveAndGenerateTool(Tool):
-    bedrock_client: Any = None
 
+class BedrockRetrieveAndGenerateTool(Tool):
     def _format_text_with_citations(self, result: dict[str, Any]) -> str:
         """Convert output text and citations dict into a readable plain text."""
         lines = []
@@ -23,7 +22,9 @@ class BedrockRetrieveAndGenerateTool(Tool):
                 ref_lines = []
                 for ref in citation.get("references", []):
                     location = ref.get("location") or ""
-                    ref_lines.append(f"- {ref.get('content', '').strip()} {location}".rstrip())
+                    ref_lines.append(
+                        f"- {ref.get('content', '').strip()} {location}".rstrip()
+                    )
                 text = citation.get("text", "").strip()
                 joined_refs = "\n".join(ref_lines) if ref_lines else "- (metadata only)"
                 lines.append(f"[{idx}] {text}\n{joined_refs}")
@@ -34,24 +35,37 @@ class BedrockRetrieveAndGenerateTool(Tool):
         self,
         tool_parameters: dict[str, Any],
     ) -> Generator[ToolInvokeMessage]:
+        bedrock_client = None
         try:
-            # Initialize Bedrock client if not already initialized
-            if not self.bedrock_client:
-                aws_region = tool_parameters.get("aws_region")
-                aws_access_key_id = tool_parameters.get("aws_access_key_id")
-                aws_secret_access_key = tool_parameters.get("aws_secret_access_key")
+            # Build a fresh boto3 client on every invocation so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked up
+            # without a plugin restart. The previous code cached the client
+            # on self.bedrock_client, which combined with the default
+            # session's in-process credential cache made ExpiredTokenException
+            # sticky. Same fix as bedrock model plugin PR #3535.
+            aws_region = tool_parameters.get("aws_region")
+            aws_access_key_id = tool_parameters.get("aws_access_key_id")
+            aws_secret_access_key = tool_parameters.get("aws_secret_access_key")
 
-                client_kwargs = {"service_name": "bedrock-agent-runtime", "region_name": aws_region or None}
+            client_kwargs = {
+                "service_name": "bedrock-agent-runtime",
+                "region_name": aws_region or None,
+            }
 
-                # Only add credentials if both access key and secret key are provided
-                if aws_access_key_id and aws_secret_access_key:
-                    client_kwargs.update(
-                        {"aws_access_key_id": aws_access_key_id, "aws_secret_access_key": aws_secret_access_key}
-                    )
+            # Only add credentials if both access key and secret key are provided
+            if aws_access_key_id and aws_secret_access_key:
+                client_kwargs.update(
+                    {
+                        "aws_access_key_id": aws_access_key_id,
+                        "aws_secret_access_key": aws_secret_access_key,
+                    }
+                )
 
-                self.bedrock_client = boto3.client(**client_kwargs)
+            bedrock_client = boto3.Session().client(**client_kwargs)
         except Exception as e:
-            yield self.create_text_message(f"Failed to initialize Bedrock client: {str(e)}")
+            yield self.create_text_message(
+                f"Failed to initialize Bedrock client: {str(e)}"
+            )
 
         try:
             request_config = {}
@@ -75,11 +89,15 @@ class BedrockRetrieveAndGenerateTool(Tool):
                 es_config = json.loads(es_config_str) if es_config_str else None
                 retrieve_generate_config["externalSourcesConfiguration"] = es_config
 
-            request_config["retrieveAndGenerateConfiguration"] = retrieve_generate_config
+            request_config["retrieveAndGenerateConfiguration"] = (
+                retrieve_generate_config
+            )
 
             # Parse session configuration
             session_config_str = tool_parameters.get("session_configuration")
-            session_config = json.loads(session_config_str) if session_config_str else None
+            session_config = (
+                json.loads(session_config_str) if session_config_str else None
+            )
             if session_config:
                 request_config["sessionConfiguration"] = session_config
 
@@ -89,15 +107,20 @@ class BedrockRetrieveAndGenerateTool(Tool):
                 request_config["sessionId"] = session_id
 
             # Send request
-            response = self.bedrock_client.retrieve_and_generate(**request_config)
+            response = bedrock_client.retrieve_and_generate(**request_config)
 
             # Process response
-            result = {"output": response.get("output", {}).get("text", ""), "citations": []}
+            result = {
+                "output": response.get("output", {}).get("text", ""),
+                "citations": [],
+            }
 
             # Process citations
             for citation in response.get("citations", []):
                 citation_info = {
-                    "text": citation.get("generatedResponsePart", {}).get("textResponsePart", {}).get("text", ""),
+                    "text": citation.get("generatedResponsePart", {})
+                    .get("textResponsePart", {})
+                    .get("text", ""),
                     "references": [],
                 }
 
@@ -110,7 +133,9 @@ class BedrockRetrieveAndGenerateTool(Tool):
 
                     location = ref.get("location", {})
                     if location.get("type") == "S3":
-                        reference["location"] = location.get("s3Location", {}).get("uri")
+                        reference["location"] = location.get("s3Location", {}).get(
+                            "uri"
+                        )
 
                     citation_info["references"].append(reference)
 
@@ -137,7 +162,11 @@ class BedrockRetrieveAndGenerateTool(Tool):
             raise ValueError("type is required")
 
         # Validate JSON configurations
-        json_configs = ["knowledge_base_configuration", "external_sources_configuration", "session_configuration"]
+        json_configs = [
+            "knowledge_base_configuration",
+            "external_sources_configuration",
+            "session_configuration",
+        ]
         for config in json_configs:
             if config_value := parameters.get(config):
                 try:
@@ -151,7 +180,15 @@ class BedrockRetrieveAndGenerateTool(Tool):
             raise ValueError("type must be either KNOWLEDGE_BASE or EXTERNAL_SOURCES")
 
         # Validate type-specific configuration
-        if config_type == "KNOWLEDGE_BASE" and not parameters.get("knowledge_base_configuration"):
-            raise ValueError("knowledge_base_configuration is required when type is KNOWLEDGE_BASE")
-        elif config_type == "EXTERNAL_SOURCES" and not parameters.get("external_sources_configuration"):
-            raise ValueError("external_sources_configuration is required when type is EXTERNAL_SOURCES")
+        if config_type == "KNOWLEDGE_BASE" and not parameters.get(
+            "knowledge_base_configuration"
+        ):
+            raise ValueError(
+                "knowledge_base_configuration is required when type is KNOWLEDGE_BASE"
+            )
+        elif config_type == "EXTERNAL_SOURCES" and not parameters.get(
+            "external_sources_configuration"
+        ):
+            raise ValueError(
+                "external_sources_configuration is required when type is EXTERNAL_SOURCES"
+            )

--- a/tools/aws/uv.lock
+++ b/tools/aws/uv.lock
@@ -44,6 +44,11 @@ dependencies = [
     { name = "sacrebleu" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "bedrock-agentcore", specifier = ">=1.10.0" },
@@ -62,7 +67,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "bedrock-agentcore"
@@ -506,6 +511,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1007,6 +1021,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "portalocker"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1250,6 +1273,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The same `ExpiredTokenException` bug fixed for the bedrock model plugin in PR #3535 (issue #3519) exists in three aws_tools plugin tools. `boto3.client(...)` uses boto3's default session which caches credentials in-process, so a `saml2aws login` / `aws sso login` / IMDS refresh after the plugin process started never reaches the client.

Fixes #3544

### Changes

- **`tools/aws/tools/apply_guardrail.py`**: replace `boto3.client("bedrock-runtime", region_name=...)` with `boto3.Session().client("bedrock-runtime", region_name=...)`. Build the client from a fresh `boto3.Session()` on every call so disk-refreshed credentials are picked up.
- **`tools/aws/tools/bedrock_retrieve.py`**: same fix, **plus** remove the on-instance `self.bedrock_client` cache. The original code created the client once per instance and stored it on `self` — a doubly-bad pattern, since even a fresh `boto3.Session()` would be ignored once the instance held a stale client. With the cache removed, the helper method `_bedrock_retrieve` now receives `bedrock_client` as a parameter, and the client is rebuilt per `_invoke` call.
- **`tools/aws/tools/bedrock_retrieve_and_generate.py`**: same fix as `bedrock_retrieve.py` — fresh session per call + remove the on-instance cache.
- **`tools/aws/tests/test_boto3_fresh_session.py`**: 5 regression tests covering: `apply_guardrail` uses `boto3.Session().client()` per call; `apply_guardrail` does NOT call `boto3.client()` directly; `bedrock_retrieve` does NOT cache the client on self; `bedrock_retrieve` uses `bedrock-agent-runtime` service; `bedrock_retrieve_and_generate` does NOT cache the client on self.
- **`tools/aws/pyproject.toml`**: add `pytest>=9.0.3` to the dev dependency group. Matches the pattern in `models/tongyi`, `models/moonshot`, `models/mistralai`, `models/bedrock`. The tools/aws plugin had no pytest in dev before this PR.
- **`tools/aws/uv.lock`**: regenerated for the new dev dependency.
- **Manifest bump `0.0.29 -> 0.0.30`**.

### Why a fresh `boto3.Session()` and not a retry wrapper?

Same reasoning as PR #3535: option 1 (fresh session) is structurally simpler — every call is naturally correct, no special-case error handling in the hot path. Option 2 (retry wrapper) would work but adds branching to each tool's `_invoke` for a corner case the auth layer handles upstream.

### Scope: why only 3 tools, not all 19

The aws_tools plugin has 19 files that call `boto3.client(` or `boto3.resource(` (grep result: `grep -l "boto3.client\|boto3.resource" tools/aws/tools/*.py | wc -l` → 19). The remaining 16 — `dynamodb_manager`, `s3_files_*`, `sagemaker_*`, `transcribe_asr`, `lambda_*`, `nova_*`, `opensearch_knn_search`, `extract_frame`, `agentcore_*` — have the same pattern. They are out of scope for this PR; each can be a follow-up.

Per the `langgenius/dify-official-plugins` consolidation hint (maintainer comment on #3478), I scoped this PR to the Bedrock-family subset (3 files most directly related to the bedrock model fix). If the maintainer wants the pattern applied to the rest in a single follow-up PR, that's a clean follow-up.

## Change Type

- [x] Non-LLM plugin (tools, extensions, datasource, etc.)

## Testing

```
$ (cd tools/aws && uv run --frozen pytest tests/test_boto3_fresh_session.py -v)
============================= test session starts ==============================
collected 5 items

tests/test_boto3_fresh_session.py::TestApplyGuardrailUsesFreshSession::test_each_invoke_creates_a_fresh_boto3_session PASSED
tests/test_boto3_fresh_session.py::TestApplyGuardrailUsesFreshSession::test_does_not_call_default_boto3_client PASSED
tests/test_boto3_fresh_session.py::TestBedrockRetrieveRemovesInstanceCache::test_does_not_assign_self_bedrock_client PASSED
tests/test_boto3_fresh_session.py::TestBedrockRetrieveRemovesInstanceCache::test_bedrock_retrieve_session_uses_bedrock_agent_runtime PASSED
tests/test_boto3_fresh_session.py::TestBedrockRetrieveAndGenerateRemovesInstanceCache::test_does_not_assign_self_bedrock_client PASSED

5 passed in 0.16s
```

- `ruff format --check` on all touched files → already formatted
- `ruff check` on the new test file → All checks passed
- `ruff check` on the 3 source files shows 3 pre-existing F401s (`typing.Union`, `operator`) and 1 pre-existing F821 (`RuntimeException` — should be `RuntimeError`, but out of scope for this PR)

## Backward compatibility

No breaking change. The client construction changes from `boto3.client(...)` to `boto3.Session().client(...)`, which is functionally equivalent for the first call and strictly better on every subsequent call after a credential refresh. The removal of `self.bedrock_client` is a behavior change visible only if a caller was reaching into the instance attribute externally — not part of the public API.

## References

- Issue #3544
- PR #3535 (the bedrock model plugin fix that established the pattern)
- Issue #3519 (the bedrock model plugin issue)
