### PR TITLE
fix(openai_api_compatible): allow suppressing the top-level user parameter

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.57
+version: 0.0.58
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -578,6 +578,12 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             if "max_completion_tokens" not in model_parameters and "max_tokens" in model_parameters:
                 model_parameters["max_completion_tokens"] = model_parameters.pop("max_tokens")
 
+        # The base SDK adds a top-level "user" to the request body whenever user is truthy.
+        # Some OpenAI-compatible gateways reject that optional parameter outright, so allow
+        # the credential to suppress it. Default keeps today's behaviour: user is still sent.
+        if credentials.get("user_identity_support", "support") == "no_support":
+            user = None
+
         result = super()._invoke(
             model, credentials, prompt_messages, model_parameters, tools, stop, stream, user
         )

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -356,6 +356,34 @@ model_credential_schema:
       help:
         en_US: Some OpenAI-compatible endpoints require max_completion_tokens (Responses API). Choose explicitly if auto-detection is wrong.
         zh_Hans: 一些兼容端要求使用 max_completion_tokens（Responses API）。若自动判断不准确，可在此显式指定。
+    - variable: user_identity_support
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        en_US: User Identity Support
+        zh_Hans: 用户标识支持
+      type: select
+      required: false
+      default: support
+      help:
+        en_US: >
+          Whether the endpoint accepts the optional top-level user parameter.
+          Some OpenAI-compatible gateways reject it as an unsupported parameter.
+          Choose Not Support to omit it from the request body.
+        zh_Hans: >
+          端点是否接受可选的顶层 user 参数。
+          部分 OpenAI 兼容网关会将其视为不支持的参数而拒绝请求。
+          选择「不支持」可将其从请求体中省略。
+      options:
+        - value: support
+          label:
+            en_US: Support
+            zh_Hans: 支持
+        - value: no_support
+          label:
+            en_US: Not Support
+            zh_Hans: 不支持
     - variable: function_calling_type
       show_on:
         - variable: __model_type

--- a/models/openai_api_compatible/tests/test_user_identity_support.py
+++ b/models/openai_api_compatible/tests/test_user_identity_support.py
@@ -1,0 +1,104 @@
+"""Unit tests for the user_identity_support credential.
+
+The base SDK adds a top-level "user" to the request body whenever the user
+argument is truthy. Some OpenAI-compatible gateways reject that optional
+parameter, so the credential lets an operator suppress it. Default must keep
+today's behaviour: the parameter is still sent.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from dify_plugin.entities.model.message import UserPromptMessage
+from dify_plugin.interfaces.model.openai_compatible.llm import OAICompatLargeLanguageModel
+
+from models.llm.llm import OpenAILargeLanguageModel
+
+
+class TestUserIdentitySupport(unittest.TestCase):
+    """The credential gates the user argument passed down to the base implementation."""
+
+    def setUp(self):
+        # AIModel.__init__ requires model_schemas; pass an empty list to satisfy it.
+        self.model = OpenAILargeLanguageModel(model_schemas=[])
+        self.base_credentials = {
+            "endpoint_url": "https://api.example.com/v1/",
+            "api_key": "test-key",
+            "mode": "chat",
+        }
+
+    def _invoke_with(self, credentials):
+        """Invoke and return the user value the base implementation received."""
+        with patch.object(OAICompatLargeLanguageModel, "_invoke") as mock_super_invoke:
+            self.model._invoke(
+                model="test-model",
+                credentials=credentials,
+                prompt_messages=[UserPromptMessage(content="hi")],
+                model_parameters={},
+                stream=False,
+                user="dify-user-42",
+            )
+        mock_super_invoke.assert_called_once()
+        # _invoke is forwarded positionally: (model, credentials, prompt_messages,
+        # model_parameters, tools, stop, stream, user)
+        return mock_super_invoke.call_args[0][7]
+
+    def test_user_sent_when_credential_absent(self):
+        """Default behaviour is unchanged for existing configurations."""
+        self.assertEqual(self._invoke_with(dict(self.base_credentials)), "dify-user-42")
+
+    def test_user_sent_when_credential_supports_it(self):
+        """Explicit 'support' keeps the parameter."""
+        credentials = dict(self.base_credentials, user_identity_support="support")
+        self.assertEqual(self._invoke_with(credentials), "dify-user-42")
+
+    def test_user_omitted_when_credential_disables_it(self):
+        """'no_support' drops the parameter, so the SDK never adds it to the body."""
+        credentials = dict(self.base_credentials, user_identity_support="no_support")
+        self.assertIsNone(self._invoke_with(credentials))
+
+
+class TestUserIdentitySupportPayload(unittest.TestCase):
+    """End-to-end over the SDK's own body construction: the key is absent, not empty."""
+
+    def setUp(self):
+        self.model = OpenAILargeLanguageModel(model_schemas=[])
+        self.base_credentials = {
+            "endpoint_url": "https://api.example.com/v1/",
+            "api_key": "test-key",
+            "mode": "chat",
+        }
+
+    def _captured_body(self, credentials):
+        """Invoke for real down to the HTTP call and return the JSON body posted."""
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured.update(kwargs.get("json") or {})
+            raise RuntimeError("stop-after-body-built")
+
+        with patch("requests.post", side_effect=fake_post):
+            with self.assertRaises(Exception):
+                self.model._invoke(
+                    model="test-model",
+                    credentials=credentials,
+                    prompt_messages=[UserPromptMessage(content="hi")],
+                    model_parameters={},
+                    stream=False,
+                    user="dify-user-42",
+                )
+        return captured
+
+    def test_payload_includes_user_by_default(self):
+        body = self._captured_body(dict(self.base_credentials))
+        self.assertIn("user", body)
+        self.assertEqual(body["user"], "dify-user-42")
+
+    def test_payload_omits_user_when_disabled(self):
+        credentials = dict(self.base_credentials, user_identity_support="no_support")
+        body = self._captured_body(credentials)
+        self.assertNotIn("user", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a `user_identity_support` credential to the `openai_api_compatible` model credential
schema so the optional top-level `user` parameter can be omitted from chat-completion
requests. Fixes #3555.

When Dify invokes a model through this plugin, it passes its internal end-user identifier
down as `user`, and that value reaches the configured endpoint **verbatim**. Captured from
a local endpoint standing in for a third-party gateway (identifier replaced here):

```json
{
  "model": "...",
  "stream": true,
  "temperature": 0.7,
  "messages": [{"role": "user", "content": "hello"}],
  "user": "00000000-0000-0000-0000-000000000000"
}
```

`models/openai_api_compatible/models/llm/llm.py` accepts `user` in `_invoke` and forwards it
to `super()._invoke(...)`. The base implementation in
`dify_plugin/interfaces/model/openai_compatible/llm.py` then does:

```python
if user:
    data["user"] = user
```

There is no transformation and no condition, and this plugin exposes no credential to
suppress it. By way of contrast, `models/openai` — the provider talking to a first-party
API — passes the same value through `_user_digest()` (a SHA-256 hexdigest) before sending,
and only sends `user` at all when `openai_api_base` is set, preferring `safety_identifier`
and `prompt_cache_key` otherwise:

```python
def _add_identity(params: dict, user: str | None, credentials: dict) -> None:
    if not user:
        return
    digest = _user_digest(user)
    if credentials.get("openai_api_base"):
        params["user"] = digest
    else:
        params.setdefault("safety_identifier", digest)
        params.setdefault("prompt_cache_key", digest)
```

So the provider intended for arbitrary third-party endpoints is the one that sends the
identifier unhashed with no way to disable it, while the one talking to OpenAI directly
hashes it and chooses the field.

Secondly — and this is what #3555 reports — some OpenAI-compatible gateways reject the
optional `user` parameter outright. Because the field is added unconditionally, such an
endpoint fails every invocation through this plugin rather than some. Note that credential
validation posts a `ping` with no end-user identifier, so saving the model configuration
succeeds and the failure only appears at run time.

The change is small: one credential in `provider/openai_api_compatible.yaml`, and one
conditional in `_invoke` that clears `user` before delegating to the base implementation.

**The credential defaults to `support`, not to the `no_support` value its `*_support`
neighbours default to, because unlike those toggles it describes a parameter the plugin
already sends today — defaulting it off would silently change the request body for every
existing model configuration, so the default is the one that changes nothing.**

The toggle otherwise mirrors the existing `*_support` selects (`vision_support`,
`audio_support`, `document_support`) in type, option vocabulary and `show_on` gating, and is
placed next to `token_param_name`, the other credential in this schema that exists to
reshape the request body for a gateway divergence.

Prior art for accommodating an endpoint divergence with a credential on this plugin: #3092
(`encoding_format`), #2771 (`max_completion_tokens`), #2867 (`max_chunks`), #2718 and #3381
(reasoning/thinking).

**Limits of this change, stated plainly.** I do not have a NewAPI endpoint and did **not**
reproduce the reported 400 firsthand. What I tested against is a local stub that returns
`400 {"error":{"message":"Unsupported parameter: user"}}` when the request body carries a
top-level `user` key — the failure *class*, not NewAPI. Separately, the field is set in
[`dify-plugin-sdks`](https://github.com/langgenius/dify-plugin-sdks), not in this
repository. This change is therefore plugin-local: it fixes `openai_api_compatible` and
leaves every other OpenAI-compatible provider that inherits the same base class unchanged.
A maintainer may well prefer the gate to live in the SDK instead, where it would cover all
of them at once; I'm happy to close this and open it there if that's the call.

This PR was written with AI assistance. The diff, the test and the before/after payload
capture were reviewed by me before submitting.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

**Credential form, before — the whole form for an LLM model, top to bottom. No user-parameter control anywhere in it.**

<img width="643" height="962" alt="openai-compatible-before-1" src="https://github.com/user-attachments/assets/44dc67ad-d69f-4824-bc88-87ba3047712a" />

<img width="643" height="964" alt="openai-compatible-before-2" src="https://github.com/user-attachments/assets/eb53dad9-8034-4a13-a19c-cc30bafaae90" />

<img width="640" height="959" alt="openai-compatible-before-3" src="https://github.com/user-attachments/assets/7870615d-1a66-4f9b-a2c3-7112e25bf202" />

**Credential form, after — `User Identity Support` between `Token parameter name` and `Function Call Type`, defaulting to Support**

<img width="642" height="959" alt="openai-compatible-after-1" src="https://github.com/user-attachments/assets/2bee96f6-6436-4d59-9902-72928debed9c" />

**Request bodies, both settings.** Two models against the same endpoint, one at the default and one set to Not Support. Identical apart from the `user` key — present on the first, absent on the second.

<img width="1280" height="1257" alt="openai-compatible-payloads" src="https://github.com/user-attachments/assets/aa9f7453-d1f8-41ac-b93e-abd7f2e358ef" />

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.57 → 0.0.58
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

> Left unticked rather than ticked inaccurately: this plugin's `pyproject.toml` 
> already declares `dify_plugin>=0.9.0`, locked to 0.9.0 in `uv.lock`, which 
> is outside the range printed in the template. This PR changes neither file. 
> Happy to adjust if the pin should move.

## Testing

- [x] Local deployment — Dify version: 1.16.0
- [ ] SaaS (cloud.dify.ai)

Tested against a self-hosted Dify with the packaged plugin at 0.0.58. Two models were
configured side by side against the same local echo endpoint — one with User Identity
Support at its default, one set to Not Support — and each run through a chatflow. The
captured request bodies differ only in the `user` key: present on the first, absent on the
second. Configuring two models rather than editing one avoids any question of cached
credentials. A model pointed at an unrelated local OpenAI-compatible server, with the
toggle untouched, was unaffected.

The stub gateway described above was exercised separately by invoking the plugin directly
over HTTP rather than through the UI: at the default it returns 400, and with the toggle
set to Not Support the same call returns 200.

Unit tests added at `models/openai_api_compatible/tests/test_user_identity_support.py` — five
cases covering the credential absent, `support`, and `no_support`, asserting both the value
handed to the base implementation and the JSON body actually posted. The plugin's full suite
is 34 passing. Reverting the `_invoke` conditional fails two of the five and no others.