### PR TITLE
fix(sagemaker): per-invocation boto3.Session() for text_embedding/tts/rerank/speech2text

### DIFF
--- a/models/sagemaker/manifest.yaml
+++ b/models/sagemaker/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.17
+version: 0.0.18
 type: plugin
 author: langgenius
 name: sagemaker

--- a/models/sagemaker/models/rerank/rerank.py
+++ b/models/sagemaker/models/rerank/rerank.py
@@ -3,8 +3,6 @@ import logging
 import operator
 from typing import Any, Optional
 
-import boto3  # type: ignore
-
 from dify_plugin import RerankModel
 from dify_plugin.entities.model import AIModelEntity, FetchFrom, I18nObject, ModelType
 from dify_plugin.entities.model.rerank import RerankDocument, RerankResult
@@ -18,6 +16,8 @@ from dify_plugin.errors.model import (
     InvokeServerUnavailableError,
 )
 
+from provider.sagemaker import get_sagemaker_client
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,11 +26,15 @@ class SageMakerRerankModel(RerankModel):
     Model class for SageMaker rerank model.
     """
 
-    sagemaker_client: Any = None
-
-    def _sagemaker_rerank(self, query_input: str, docs: list[str], rerank_endpoint: str):
+    def _sagemaker_rerank(
+        self,
+        query_input: str,
+        docs: list[str],
+        rerank_endpoint: str,
+        sagemaker_client: Any,
+    ):
         inputs = [query_input] * len(docs)
-        response_model = self.sagemaker_client.invoke_endpoint(
+        response_model = sagemaker_client.invoke_endpoint(
             EndpointName=rerank_endpoint,
             Body=json.dumps({"inputs": inputs, "docs": docs}),
             ContentType="application/json",
@@ -62,45 +66,28 @@ class SageMakerRerankModel(RerankModel):
         :param user: unique user id
         :return: rerank result
         """
-        line = 0
         try:
             if len(docs) == 0:
                 return RerankResult(model=model, docs=docs)
 
-            line = 1
-            if not self.sagemaker_client:
-                access_key = credentials.get("aws_access_key_id")
-                secret_key = credentials.get("aws_secret_access_key")
-                aws_region = credentials.get("aws_region")
-                if aws_region:
-                    if access_key and secret_key:
-                        self.sagemaker_client = boto3.client(
-                            "sagemaker-runtime",
-                            aws_access_key_id=access_key,
-                            aws_secret_access_key=secret_key,
-                            region_name=aws_region,
-                        )
-                    else:
-                        self.sagemaker_client = boto3.client("sagemaker-runtime", region_name=aws_region)
-                else:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime")
-
-            line = 2
-
             sagemaker_endpoint = credentials.get("sagemaker_endpoint")
+            sagemaker_client = get_sagemaker_client("sagemaker-runtime", credentials)
             candidate_docs = []
 
-            scores = self._sagemaker_rerank(query, docs, sagemaker_endpoint)
+            scores = self._sagemaker_rerank(
+                query, docs, sagemaker_endpoint, sagemaker_client
+            )
             for idx in range(len(scores)):
                 candidate_docs.append({"content": docs[idx], "score": scores[idx]})
 
             sorted(candidate_docs, key=operator.itemgetter("score"), reverse=True)
 
-            line = 3
             rerank_documents = []
             for idx, result in enumerate(candidate_docs):
                 rerank_document = RerankDocument(
-                    index=idx, text=result.get("content"), score=result.get("score", -100.0)
+                    index=idx,
+                    text=result.get("content"),
+                    score=result.get("score", -100.0),
                 )
 
                 if score_threshold is not None:
@@ -113,7 +100,9 @@ class SageMakerRerankModel(RerankModel):
 
         except Exception as e:
             logger.exception(f"Failed to invoke rerank model, model: {model}")
-            raise InvokeError(f"Failed to invoke rerank model, model: {model}, error: {str(e)}")
+            raise InvokeError(
+                f"Failed to invoke rerank model, model: {model}, error: {str(e)}"
+            )
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
         """
@@ -157,7 +146,9 @@ class SageMakerRerankModel(RerankModel):
             InvokeBadRequestError: [InvokeBadRequestError, KeyError, ValueError],
         }
 
-    def get_customizable_model_schema(self, model: str, credentials: dict) -> Optional[AIModelEntity]:
+    def get_customizable_model_schema(
+        self, model: str, credentials: dict
+    ) -> Optional[AIModelEntity]:
         """
         used to define customizable model schema
         """

--- a/models/sagemaker/models/speech2text/speech2text.py
+++ b/models/sagemaker/models/speech2text/speech2text.py
@@ -1,10 +1,8 @@
 import json
 import logging
-from typing import IO, Any, Optional
+from typing import IO, Optional
 
-import boto3  # type: ignore
-
-from provider.sagemaker import generate_presigned_url, buffer_to_s3
+from provider.sagemaker import buffer_to_s3, get_sagemaker_client
 
 from dify_plugin.entities.model import AIModelEntity, FetchFrom, I18nObject, ModelType
 from dify_plugin.errors.model import (
@@ -26,10 +24,9 @@ class SageMakerSpeech2TextModel(Speech2TextModel):
     Model class for Xinference speech to text model.
     """
 
-    sagemaker_client: Any = None
-    s3_client: Any = None
-
-    def _invoke(self, model: str, credentials: dict, file: IO[bytes], user: Optional[str] = None) -> str:
+    def _invoke(
+        self, model: str, credentials: dict, file: IO[bytes], user: Optional[str] = None
+    ) -> str:
         """
         Invoke speech2text model
 
@@ -42,47 +39,34 @@ class SageMakerSpeech2TextModel(Speech2TextModel):
         asr_text = None
 
         try:
-            if not self.sagemaker_client:
-                access_key = credentials.get("aws_access_key_id")
-                secret_key = credentials.get("aws_secret_access_key")
-                aws_region = credentials.get("aws_region")
-                if aws_region:
-                    if access_key and secret_key:
-                        self.sagemaker_client = boto3.client(
-                            "sagemaker-runtime",
-                            aws_access_key_id=access_key,
-                            aws_secret_access_key=secret_key,
-                            region_name=aws_region,
-                        )
-                        self.s3_client = boto3.client(
-                            "s3", aws_access_key_id=access_key, aws_secret_access_key=secret_key, region_name=aws_region
-                        )
-                    else:
-                        self.sagemaker_client = boto3.client("sagemaker-runtime", region_name=aws_region)
-                        self.s3_client = boto3.client("s3", region_name=aws_region)
-                else:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime")
-                    self.s3_client = boto3.client("s3")
+            s3_client = get_sagemaker_client("s3", credentials)
+            sagemaker_client = get_sagemaker_client("sagemaker-runtime", credentials)
 
             s3_prefix = "dify/speech2text/"
             sagemaker_endpoint = credentials.get("sagemaker_endpoint")
             bucket = credentials.get("audio_s3_cache_bucket")
-            
+
             if bucket:
                 # For FunASR Model
-                object_key = buffer_to_s3(self.s3_client, file, bucket, s3_prefix)
-                payload = {"bucket_name": bucket, "s3_key" : object_key}
-                # s3_presign_url = generate_presigned_url(self.s3_client, file, bucket, s3_prefix)
+                object_key = buffer_to_s3(s3_client, file, bucket, s3_prefix)
+                payload = {"bucket_name": bucket, "s3_key": object_key}
+                # s3_presign_url = generate_presigned_url(s3_client, file, bucket, s3_prefix)
                 # payload = {"audio_s3_presign_uri": s3_presign_url}
-                response_model = self.sagemaker_client.invoke_endpoint(
-                    EndpointName=sagemaker_endpoint, Body=json.dumps(payload), ContentType="application/json"
+                response_model = sagemaker_client.invoke_endpoint(
+                    EndpointName=sagemaker_endpoint,
+                    Body=json.dumps(payload),
+                    ContentType="application/json",
                 )
                 json_str = response_model["Body"].read().decode("utf8")
                 json_obj = json.loads(json_str)
                 asr_text = json_obj["text"]
             else:
                 # For Whisper Model
-                resp = self.sagemaker_client.invoke_endpoint(EndpointName=sagemaker_endpoint, Body=file.read(), ContentType='audio/x-audio')
+                resp = sagemaker_client.invoke_endpoint(
+                    EndpointName=sagemaker_endpoint,
+                    Body=file.read(),
+                    ContentType="audio/x-audio",
+                )
                 json_obj = json.loads(resp["Body"].read().decode("utf8"))
                 asr_text = json_obj["text"]
 
@@ -120,7 +104,9 @@ class SageMakerSpeech2TextModel(Speech2TextModel):
             InvokeBadRequestError: [InvokeBadRequestError, KeyError, ValueError],
         }
 
-    def get_customizable_model_schema(self, model: str, credentials: dict) -> Optional[AIModelEntity]:
+    def get_customizable_model_schema(
+        self, model: str, credentials: dict
+    ) -> Optional[AIModelEntity]:
         """
         used to define customizable model schema
         """

--- a/models/sagemaker/models/text_embedding/text_embedding.py
+++ b/models/sagemaker/models/text_embedding/text_embedding.py
@@ -2,9 +2,8 @@ import itertools
 import json
 import logging
 import time
-from typing import Any, Optional
+from typing import Optional
 
-import boto3  # type: ignore
 from dify_plugin.entities.model import (
     AIModelEntity,
     EmbeddingInputType,
@@ -14,7 +13,10 @@ from dify_plugin.entities.model import (
     ModelType,
     PriceType,
 )
-from dify_plugin.entities.model.text_embedding import EmbeddingUsage, TextEmbeddingResult
+from dify_plugin.entities.model.text_embedding import (
+    EmbeddingUsage,
+    TextEmbeddingResult,
+)
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,
     InvokeAuthorizationError,
@@ -25,6 +27,8 @@ from dify_plugin.errors.model import (
     InvokeServerUnavailableError,
 )
 from dify_plugin.interfaces.model.text_embedding_model import TextEmbeddingModel
+
+from provider.sagemaker import get_sagemaker_client
 
 BATCH_SIZE = 20
 CONTEXT_SIZE = 8192
@@ -45,12 +49,17 @@ class SageMakerEmbeddingModel(TextEmbeddingModel):
     Model class for Cohere text embedding model.
     """
 
-    sagemaker_client: Any = None
-
     def _sagemaker_embedding(self, sm_client, endpoint_name, content_list: list[str]):
         response_model = sm_client.invoke_endpoint(
             EndpointName=endpoint_name,
-            Body=json.dumps({"inputs": content_list, "parameters": {}, "is_query": False, "instruction": ""}),
+            Body=json.dumps(
+                {
+                    "inputs": content_list,
+                    "parameters": {},
+                    "is_query": False,
+                    "instruction": "",
+                }
+            ),
             ContentType="application/json",
         )
         json_str = response_model["Body"].read().decode("utf8")
@@ -78,54 +87,39 @@ class SageMakerEmbeddingModel(TextEmbeddingModel):
         """
         # get model properties
         try:
-            line = 1
-            if not self.sagemaker_client:
-                access_key = credentials.get("aws_access_key_id")
-                secret_key = credentials.get("aws_secret_access_key")
-                aws_region = credentials.get("aws_region")
-                if aws_region:
-                    if access_key and secret_key:
-                        self.sagemaker_client = boto3.client(
-                            "sagemaker-runtime",
-                            aws_access_key_id=access_key,
-                            aws_secret_access_key=secret_key,
-                            region_name=aws_region,
-                        )
-                    else:
-                        self.sagemaker_client = boto3.client("sagemaker-runtime", region_name=aws_region)
-                else:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime")
-
-            line = 2
             sagemaker_endpoint = credentials.get("sagemaker_endpoint")
-
-            line = 3
+            sagemaker_client = get_sagemaker_client("sagemaker-runtime", credentials)
             truncated_texts = [item[:CONTEXT_SIZE] for item in texts]
 
-            batches = batch_generator((text for text in truncated_texts), batch_size=BATCH_SIZE)
+            batches = batch_generator(
+                (text for text in truncated_texts), batch_size=BATCH_SIZE
+            )
             all_embeddings = []
 
-            line = 4
             for batch in batches:
-                embeddings = self._sagemaker_embedding(self.sagemaker_client, sagemaker_endpoint, batch)
+                embeddings = self._sagemaker_embedding(
+                    sagemaker_client, sagemaker_endpoint, batch
+                )
                 all_embeddings.extend(embeddings)
 
-            line = 5
             # calc usage
             usage = self._calc_response_usage(
                 model=model,
                 credentials=credentials,
                 tokens=0,  # It's not SAAS API, usage is meaningless
             )
-            line = 6
 
-            return TextEmbeddingResult(embeddings=all_embeddings, usage=usage, model=model)
+            return TextEmbeddingResult(
+                embeddings=all_embeddings, usage=usage, model=model
+            )
 
         except Exception as e:
-            logger.exception(f"Failed to invoke text embedding model, model: {model}, line: {line}")
+            logger.exception(f"Failed to invoke text embedding model, model: {model}")
             raise InvokeError(str(e))
 
-    def get_num_tokens(self, model: str, credentials: dict, texts: list[str]) -> list[int]:
+    def get_num_tokens(
+        self, model: str, credentials: dict, texts: list[str]
+    ) -> list[int]:
         """
         Get number of tokens for given prompt messages
 
@@ -149,7 +143,9 @@ class SageMakerEmbeddingModel(TextEmbeddingModel):
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 
-    def _calc_response_usage(self, model: str, credentials: dict, tokens: int) -> EmbeddingUsage:
+    def _calc_response_usage(
+        self, model: str, credentials: dict, tokens: int
+    ) -> EmbeddingUsage:
         """
         Calculate response usage
 
@@ -160,7 +156,10 @@ class SageMakerEmbeddingModel(TextEmbeddingModel):
         """
         # get input price info
         input_price_info = self.get_price(
-            model=model, credentials=credentials, price_type=PriceType.INPUT, tokens=tokens
+            model=model,
+            credentials=credentials,
+            price_type=PriceType.INPUT,
+            tokens=tokens,
         )
 
         # transform usage
@@ -186,7 +185,9 @@ class SageMakerEmbeddingModel(TextEmbeddingModel):
             InvokeBadRequestError: [KeyError],
         }
 
-    def get_customizable_model_schema(self, model: str, credentials: dict) -> Optional[AIModelEntity]:
+    def get_customizable_model_schema(
+        self, model: str, credentials: dict
+    ) -> Optional[AIModelEntity]:
         """
         used to define customizable model schema
         """

--- a/models/sagemaker/models/tts/tts.py
+++ b/models/sagemaker/models/tts/tts.py
@@ -5,7 +5,6 @@ import logging
 from enum import Enum
 from typing import Any, Optional
 
-import boto3  # type: ignore
 import requests
 
 from dify_plugin.entities.model import AIModelEntity, FetchFrom, I18nObject, ModelType
@@ -19,7 +18,10 @@ from dify_plugin.errors.model import (
 )
 from dify_plugin.interfaces.model.tts_model import TTSModel
 
+from provider.sagemaker import get_sagemaker_client
+
 logger = logging.getLogger(__name__)
+
 
 class TTSModelType(Enum):
     PresetVoice = "PresetVoice"
@@ -29,10 +31,6 @@ class TTSModelType(Enum):
 
 
 class SageMakerText2SpeechModel(TTSModel):
-    sagemaker_client: Any = None
-    s3_client: Any = None
-    comprehend_client: Any = None
-
     def __init__(self, model_schemas: list[AIModelEntity]) -> None:
         super().__init__(model_schemas)
         self.model_voices = {
@@ -48,7 +46,10 @@ class SageMakerText2SpeechModel(TTSModel):
                     {"name": "中文女", "value": "中文女"},
                     {"name": "粤语女", "value": "粤语女"},
                 ],
-                "en-US": [{"name": "英文男", "value": "英文男"}, {"name": "英文女", "value": "英文女"}],
+                "en-US": [
+                    {"name": "英文男", "value": "英文男"},
+                    {"name": "英文女", "value": "英文女"},
+                ],
                 "ja-JP": [{"name": "日语男", "value": "日语男"}],
                 "ko-KR": [{"name": "韩语女", "value": "韩语女"}],
             },
@@ -64,10 +65,18 @@ class SageMakerText2SpeechModel(TTSModel):
         """
         pass
 
-    def _detect_lang_code(self, content: str, map_dict: Optional[dict] = None):
-        map_dict = {"zh": "<|zh|>", "en": "<|en|>", "ja": "<|jp|>", "zh-TW": "<|yue|>", "ko": "<|ko|>"}
+    def _detect_lang_code(
+        self, content: str, comprehend_client: Any, map_dict: Optional[dict] = None
+    ):
+        map_dict = {
+            "zh": "<|zh|>",
+            "en": "<|en|>",
+            "ja": "<|jp|>",
+            "zh-TW": "<|yue|>",
+            "ko": "<|ko|>",
+        }
 
-        response = self.comprehend_client.detect_dominant_language(Text=content)
+        response = comprehend_client.detect_dominant_language(Text=content)
         language_code = response["Languages"][0]["LanguageCode"]
 
         return map_dict.get(language_code, "<|zh|>")
@@ -80,21 +89,44 @@ class SageMakerText2SpeechModel(TTSModel):
         prompt_text: str,
         prompt_audio: str,
         instruct_text: str,
+        comprehend_client: Any,
     ):
         if model_type == TTSModelType.PresetVoice.value and model_role:
             return {"tts_text": content_text, "role": model_role}
         if model_type == TTSModelType.CloneVoice.value and prompt_text and prompt_audio:
-            return {"tts_text": content_text, "prompt_text": prompt_text, "prompt_audio": prompt_audio}
+            return {
+                "tts_text": content_text,
+                "prompt_text": prompt_text,
+                "prompt_audio": prompt_audio,
+            }
         if model_type == TTSModelType.CloneVoice_CrossLingual.value and prompt_audio:
-            lang_tag = self._detect_lang_code(content_text)
-            return {"tts_text": f"{content_text}", "prompt_audio": prompt_audio, "lang_tag": lang_tag}
-        if model_type == TTSModelType.InstructVoice.value and instruct_text and model_role:
-            return {"tts_text": content_text, "role": model_role, "instruct_text": instruct_text}
+            lang_tag = self._detect_lang_code(content_text, comprehend_client)
+            return {
+                "tts_text": f"{content_text}",
+                "prompt_audio": prompt_audio,
+                "lang_tag": lang_tag,
+            }
+        if (
+            model_type == TTSModelType.InstructVoice.value
+            and instruct_text
+            and model_role
+        ):
+            return {
+                "tts_text": content_text,
+                "role": model_role,
+                "instruct_text": instruct_text,
+            }
 
         raise RuntimeError(f"Invalid params for {model_type}")
 
     def _invoke(
-        self, model: str, tenant_id: str, credentials: dict, content_text: str, voice: str, user: Optional[str] = None
+        self,
+        model: str,
+        tenant_id: str,
+        credentials: dict,
+        content_text: str,
+        voice: str,
+        user: Optional[str] = None,
     ):
         """
         _invoke text2speech model
@@ -107,46 +139,31 @@ class SageMakerText2SpeechModel(TTSModel):
         :param user: unique user id
         :return: text translated to audio file
         """
-        if not self.sagemaker_client:
-            access_key = credentials.get("aws_access_key_id")
-            secret_key = credentials.get("aws_secret_access_key")
-            aws_region = credentials.get("aws_region")
-            if aws_region:
-                if access_key and secret_key:
-                    self.sagemaker_client = boto3.client(
-                        "sagemaker-runtime",
-                        aws_access_key_id=access_key,
-                        aws_secret_access_key=secret_key,
-                        region_name=aws_region,
-                    )
-                    self.s3_client = boto3.client(
-                        "s3", aws_access_key_id=access_key, aws_secret_access_key=secret_key, region_name=aws_region
-                    )
-                    self.comprehend_client = boto3.client(
-                        "comprehend",
-                        aws_access_key_id=access_key,
-                        aws_secret_access_key=secret_key,
-                        region_name=aws_region,
-                    )
-                else:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime", region_name=aws_region)
-                    self.s3_client = boto3.client("s3", region_name=aws_region)
-                    self.comprehend_client = boto3.client("comprehend", region_name=aws_region)
-            else:
-                self.sagemaker_client = boto3.client("sagemaker-runtime")
-                self.s3_client = boto3.client("s3")
-                self.comprehend_client = boto3.client("comprehend")
+        sagemaker_client = get_sagemaker_client("sagemaker-runtime", credentials)
+        comprehend_client = get_sagemaker_client("comprehend", credentials)
 
         model_type = credentials.get("audio_model_type", "PresetVoice")
         prompt_text = credentials.get("prompt_text")
         prompt_audio = credentials.get("prompt_audio")
         instruct_text = credentials.get("instruct_text")
         sagemaker_endpoint = credentials.get("sagemaker_endpoint")
-        payload = self._build_tts_payload(model_type, content_text, voice, prompt_text, prompt_audio, instruct_text)
+        payload = self._build_tts_payload(
+            model_type,
+            content_text,
+            voice,
+            prompt_text,
+            prompt_audio,
+            instruct_text,
+            comprehend_client,
+        )
 
-        return self._tts_invoke_streaming(model_type, payload, sagemaker_endpoint)
+        return self._tts_invoke_streaming(
+            model_type, payload, sagemaker_endpoint, sagemaker_client
+        )
 
-    def get_customizable_model_schema(self, model: str, credentials: dict) -> Optional[AIModelEntity]:
+    def get_customizable_model_schema(
+        self, model: str, credentials: dict
+    ) -> Optional[AIModelEntity]:
         """
         used to define customizable model schema
         """
@@ -191,7 +208,9 @@ class SageMakerText2SpeechModel(TTSModel):
     def _get_model_workers_limit(self, model: str, credentials: dict) -> int:
         return 5
 
-    def get_tts_model_voices(self, model: str, credentials: dict, language: Optional[str] = None) -> list:
+    def get_tts_model_voices(
+        self, model: str, credentials: dict, language: Optional[str] = None
+    ) -> list:
         audio_model_name = "CosyVoice"
         for key, voices in self.model_voices.items():
             if key in audio_model_name:
@@ -202,8 +221,8 @@ class SageMakerText2SpeechModel(TTSModel):
 
         return self.model_voices["__default"]["all"]
 
-    def _invoke_sagemaker(self, payload: dict, endpoint: str):
-        response_model = self.sagemaker_client.invoke_endpoint(
+    def _invoke_sagemaker(self, payload: dict, endpoint: str, sagemaker_client: Any):
+        response_model = sagemaker_client.invoke_endpoint(
             EndpointName=endpoint,
             Body=json.dumps(payload),
             ContentType="application/json",
@@ -212,7 +231,13 @@ class SageMakerText2SpeechModel(TTSModel):
         json_obj = json.loads(json_str)
         return json_obj
 
-    def _tts_invoke_streaming(self, model_type: str, payload: dict, sagemaker_endpoint: str) -> Any:
+    def _tts_invoke_streaming(
+        self,
+        model_type: str,
+        payload: dict,
+        sagemaker_endpoint: str,
+        sagemaker_client: Any,
+    ) -> Any:
         """
         _tts_invoke_streaming text2speech model
 
@@ -230,10 +255,14 @@ class SageMakerText2SpeechModel(TTSModel):
             word_limit = self._get_model_word_limit(model="", credentials={})
             content_text = payload.get("tts_text")
             if len(content_text) > word_limit:
-                split_sentences = self._split_text_into_sentences(content_text, max_length=word_limit)
+                split_sentences = self._split_text_into_sentences(
+                    content_text, max_length=word_limit
+                )
                 sentences = [f"{lang_tag}{s}" for s in split_sentences if len(s)]
                 len_sent = len(sentences)
-                executor = concurrent.futures.ThreadPoolExecutor(max_workers=min(4, len_sent))
+                executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=min(4, len_sent)
+                )
                 payloads = [copy.deepcopy(payload) for i in range(len_sent)]
                 for idx in range(len_sent):
                     payloads[idx]["tts_text"] = sentences[idx]
@@ -243,6 +272,7 @@ class SageMakerText2SpeechModel(TTSModel):
                         self._invoke_sagemaker,
                         payload=payload,
                         endpoint=sagemaker_endpoint,
+                        sagemaker_client=sagemaker_client,
                     )
                     for payload in payloads
                 ]
@@ -253,7 +283,9 @@ class SageMakerText2SpeechModel(TTSModel):
                     for i in range(0, len(audio_bytes), 1024):
                         yield audio_bytes[i : i + 1024]
             else:
-                resp = self._invoke_sagemaker(payload, sagemaker_endpoint)
+                resp = self._invoke_sagemaker(
+                    payload, sagemaker_endpoint, sagemaker_client
+                )
                 audio_bytes = requests.get(resp.get("s3_presign_url")).content
 
                 for i in range(0, len(audio_bytes), 1024):

--- a/models/sagemaker/provider/sagemaker.py
+++ b/models/sagemaker/provider/sagemaker.py
@@ -3,11 +3,46 @@ import uuid
 from collections.abc import Mapping
 from typing import IO, Any
 
+import boto3
+
 from dify_plugin import ModelProvider
-from dify_plugin.entities.model import ModelType
-from dify_plugin.errors.model import CredentialsValidateFailedError
 
 logger = logging.getLogger(__name__)
+
+
+def get_sagemaker_client(service_name: str, credentials: Mapping[str, str]) -> Any:
+    """Build a fresh boto3 client for a SageMaker-related service.
+
+    Each call constructs a new ``boto3.Session`` so disk-refreshed
+    credentials (``aws sso login``, ``saml2aws login``, refreshed IMDS
+    role) are picked up on every invocation. boto3's default session
+    resolves credentials once per process and reuses them, which would
+    otherwise keep a stale ``ExpiredTokenException`` in flight until the
+    plugin process restarts.
+
+    Mirrors the shape of ``models/bedrock/provider/get_bedrock_client.py``
+    (PR #3535) and the ``tools/aws`` boto3 fix (PR #3545).
+
+    :param service_name: the AWS service name (e.g. ``"sagemaker-runtime"``,
+        ``"s3"``, ``"comprehend"``).
+    :param credentials: provider credentials mapping. Recognised keys are
+        ``aws_access_key_id``, ``aws_secret_access_key``, and ``aws_region``.
+    :return: a fresh boto3 client.
+    """
+    aws_region = credentials.get("aws_region")
+    access_key = credentials.get("aws_access_key_id")
+    secret_key = credentials.get("aws_secret_access_key")
+
+    if access_key and secret_key:
+        session = boto3.Session(
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name=aws_region,
+        )
+    else:
+        session = boto3.Session(region_name=aws_region)
+    return session.client(service_name)
+
 
 class SageMakerProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
@@ -20,20 +55,27 @@ class SageMakerProvider(ModelProvider):
         """
         pass
 
+
 def buffer_to_s3(s3_client: Any, file: IO[bytes], bucket: str, s3_prefix: str) -> str:
     """
     return s3_uri of this file
     """
     s3_key = f"{s3_prefix}{uuid.uuid4()}.mp3"
-    s3_client.put_object(Body=file.read(), Bucket=bucket, Key=s3_key, ContentType="audio/mp3")
+    s3_client.put_object(
+        Body=file.read(), Bucket=bucket, Key=s3_key, ContentType="audio/mp3"
+    )
     return s3_key
 
 
-def generate_presigned_url(s3_client: Any, file: IO[bytes], bucket_name: str, s3_prefix: str, expiration=600):
+def generate_presigned_url(
+    s3_client: Any, file: IO[bytes], bucket_name: str, s3_prefix: str, expiration=600
+):
     object_key = buffer_to_s3(s3_client, file, bucket_name, s3_prefix)
     try:
         response = s3_client.generate_presigned_url(
-            "get_object", Params={"Bucket": bucket_name, "Key": object_key}, ExpiresIn=expiration
+            "get_object",
+            Params={"Bucket": bucket_name, "Key": object_key},
+            ExpiresIn=expiration,
         )
     except Exception as e:
         print(f"Error generating presigned URL: {e}")

--- a/models/sagemaker/pyproject.toml
+++ b/models/sagemaker/pyproject.toml
@@ -16,4 +16,6 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=9.0.3",
+]

--- a/models/sagemaker/tests/test_get_sagemaker_client.py
+++ b/models/sagemaker/tests/test_get_sagemaker_client.py
@@ -1,0 +1,165 @@
+"""Unit tests for provider.sagemaker.get_sagemaker_client.
+
+The helper builds a fresh ``boto3.Session`` on every call so disk-refreshed
+credentials (``aws sso login``, ``saml2aws login``, refreshed IMDS role) are
+picked up by the next SageMaker invocation. The pre-fix code constructed
+the client via ``boto3.client(...)`` (default session) and cached it on the
+model instance, which left stale credentials in flight until the plugin
+process was restarted.
+"""
+
+import importlib.util
+from collections.abc import Mapping
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_PROVIDER_PATH = Path(__file__).resolve().parent.parent / "provider" / "sagemaker.py"
+_spec = importlib.util.spec_from_file_location("sagemaker_provider", _PROVIDER_PATH)
+sagemaker_provider = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sagemaker_provider)
+
+
+def _credentials(
+    *,
+    access_key: str | None = None,
+    secret_key: str | None = None,
+    region: str | None = "us-east-1",
+) -> Mapping[str, str]:
+    creds: dict[str, str] = {}
+    if access_key is not None:
+        creds["aws_access_key_id"] = access_key
+    if secret_key is not None:
+        creds["aws_secret_access_key"] = secret_key
+    if region is not None:
+        creds["aws_region"] = region
+    return creds
+
+
+class TestExplicitKeys:
+    def test_passes_access_key_and_secret_to_session(self) -> None:
+        with patch.object(
+            sagemaker_provider.boto3, "Session", return_value=MagicMock()
+        ) as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            sagemaker_provider.get_sagemaker_client(
+                "sagemaker-runtime",
+                _credentials(
+                    access_key="AKIA-TEST", secret_key="secret-test", region="us-west-2"
+                ),
+            )
+
+        mock_session_cls.assert_called_once_with(
+            aws_access_key_id="AKIA-TEST",
+            aws_secret_access_key="secret-test",
+            region_name="us-west-2",
+        )
+        mock_session.client.assert_called_once_with("sagemaker-runtime")
+
+    def test_session_uses_requested_service(self) -> None:
+        with patch.object(
+            sagemaker_provider.boto3, "Session", return_value=MagicMock()
+        ) as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            sagemaker_provider.get_sagemaker_client("s3", _credentials())
+
+        mock_session.client.assert_called_once_with("s3")
+
+
+class TestCredentialChain:
+    """When no explicit keys are provided, the helper falls back to the
+    default credential chain (``aws sso``, ``saml2aws``, IMDS). It must
+    still build a fresh ``boto3.Session`` so refreshed credentials are
+    picked up.
+    """
+
+    def test_uses_session_without_explicit_keys(self) -> None:
+        with patch.object(
+            sagemaker_provider.boto3, "Session", return_value=MagicMock()
+        ) as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            sagemaker_provider.get_sagemaker_client("sagemaker-runtime", _credentials())
+
+        mock_session_cls.assert_called_once_with(region_name="us-east-1")
+        mock_session.client.assert_called_once_with("sagemaker-runtime")
+
+    def test_uses_session_without_region(self) -> None:
+        with patch.object(
+            sagemaker_provider.boto3, "Session", return_value=MagicMock()
+        ) as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            sagemaker_provider.get_sagemaker_client(
+                "comprehend", _credentials(region=None)
+            )
+
+        mock_session_cls.assert_called_once_with(region_name=None)
+        mock_session.client.assert_called_once_with("comprehend")
+
+
+class TestBypassesDefaultSession:
+    """The pre-fix code went through ``boto3.client(...)``, which uses
+    boto3's default session. The default session caches credentials
+    in-process, which is exactly the bug. The helper must NOT use the
+    default session.
+    """
+
+    def test_does_not_use_default_boto3_client(self) -> None:
+        with (
+            patch.object(
+                sagemaker_provider.boto3, "client", return_value=MagicMock()
+            ) as mock_default_client,
+            patch.object(
+                sagemaker_provider.boto3, "Session", return_value=MagicMock()
+            ) as mock_session_cls,
+        ):
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            sagemaker_provider.get_sagemaker_client("sagemaker-runtime", _credentials())
+
+        mock_default_client.assert_not_called()
+        mock_session_cls.assert_called_once()
+
+
+class TestPerCallSession:
+    """The whole point of the fix: each call must build a fresh session
+    so a credential refresh takes effect on the next invocation.
+    """
+
+    def test_two_consecutive_calls_make_two_sessions(self) -> None:
+        with patch.object(
+            sagemaker_provider.boto3, "Session", return_value=MagicMock()
+        ) as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            sagemaker_provider.get_sagemaker_client("sagemaker-runtime", _credentials())
+            sagemaker_provider.get_sagemaker_client("sagemaker-runtime", _credentials())
+
+        assert mock_session_cls.call_count == 2
+
+    def test_two_consecutive_calls_with_different_regions(self) -> None:
+        with patch.object(
+            sagemaker_provider.boto3, "Session", return_value=MagicMock()
+        ) as mock_session_cls:
+            mock_session = mock_session_cls.return_value
+            mock_session.client = MagicMock(return_value=MagicMock())
+
+            sagemaker_provider.get_sagemaker_client(
+                "sagemaker-runtime", _credentials(region="us-east-1")
+            )
+            sagemaker_provider.get_sagemaker_client(
+                "sagemaker-runtime", _credentials(region="eu-west-1")
+            )
+
+        assert mock_session_cls.call_count == 2
+        # Second call should pass the new region.
+        second_call_kwargs = mock_session_cls.call_args_list[1].kwargs
+        assert second_call_kwargs["region_name"] == "eu-west-1"

--- a/models/sagemaker/uv.lock
+++ b/models/sagemaker/uv.lock
@@ -107,7 +107,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and sys_platform == 'win32'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -264,6 +264,11 @@ dependencies = [
     { name = "sagemaker" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.43.13" },
@@ -274,7 +279,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "dill"
@@ -526,6 +531,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ee/eb/58c2ab27ee628ad801f56d4017fe62afab0293116f6d0b08f1d5bd46e06f/importlib_metadata-6.11.0.tar.gz", hash = "sha256:1231cf92d825c9e03cfc4da076a16de6422c863558229ea0b22b675657463443", size = 54593, upload-time = "2023-12-03T17:33:10.693Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/9b/ecce94952ab5ea74c31dcf9ccf78ccd484eebebef06019bf8cb579ab4519/importlib_metadata-6.11.0-py3-none-any.whl", hash = "sha256:f0afba6205ad8f8947c7d338b5342d5db2afbfd82f9cbef7879a9539cc12eb9b", size = 23427, upload-time = "2023-12-03T17:33:08.965Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -842,10 +856,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.14'" },
-    { name = "pytz", marker = "python_full_version >= '3.14'" },
-    { name = "tzdata", marker = "python_full_version >= '3.14'" },
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -894,9 +908,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
-    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32')" },
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -963,6 +977,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1239,6 +1262,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #3560

The four non-LLM model files in `models/sagemaker/models/*` (`text_embedding`, `tts`, `rerank`, `speech2text`) cached the boto3 client on the instance (`self.sagemaker_client`, `self.s3_client`, `self.comprehend_client`) and built it via `boto3.client(...)`. boto3's default session resolves credentials once per process and reuses them, so a fresh `aws sso login`, `saml2aws login`, or refreshed IMDS role was not picked up — the cached client kept stale credentials and the next invocation returned `ExpiredTokenException` until the plugin process was restarted.

This mirrors the fix already landed for `models/bedrock` (PR #3535) and `tools/aws` (PR #3545 and the in-progress batch under issue #3544), but the SageMaker provider was not part of either scope.

- Add a `get_sagemaker_client(service_name, credentials)` helper to `models/sagemaker/provider/sagemaker.py` that returns a fresh `boto3.Session().client(service_name, ...)` per call.
- Remove the class-level client attributes and the `if not self.<x>_client:` lazy-init blocks from `text_embedding.py`, `tts.py`, `rerank.py`, and `speech2text.py`.
- Each model file now builds its clients at the top of `_invoke` and passes them to the helper methods that need them. `tts.py` threads the `sagemaker_client` through `_tts_invoke_streaming` / `_invoke_sagemaker` and the `comprehend_client` through `_build_tts_payload` / `_detect_lang_code`; `rerank.py` threads the client through `_sagemaker_rerank`.
- Add 7 in-process regression tests at `models/sagemaker/tests/test_get_sagemaker_client.py` mirroring `models/bedrock/tests/test_get_bedrock_client.py` from PR #3535.
- Add `pytest>=9.0.3` to the dev dependency group so the in-process tests pick up `dify_plugin`. Matches the dev-group shape in `models/bedrock/pyproject.toml`, `models/moonshot/pyproject.toml`, and `models/tongyi/pyproject.toml`.
- Bump `models/sagemaker/manifest.yaml` from 0.0.17 to 0.0.18.

The SageMaker LLM at `models/sagemaker/models/llm/llm.py` is intentionally not touched — it already uses `boto3.Session()` with `RefreshableCredentials` for the assume-role path, and its `if self.access_key != credentials.get(...)` cache check is sufficient for the simpler cases it handles. A separate PR can address the LLM's static-credentials-expiration case if it turns out to be a problem in practice.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

N/A — the change is to credential-handling code paths that don't have a visible UI surface. Verification is in the regression tests below.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.) — credential refresh on every invocation
- [ ] New models / model parameter fixes

</details>

The "Other LLM functionality" item refers to the credential-refresh behavior; the affected model types are text-embedding, rerank, tts, and speech2text. The LLM (`models/sagemaker/models/llm/llm.py`) is intentionally not in scope here.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.17 → 0.0.18
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` — already at `dify_plugin>=0.9.0`, which satisfies the constraint.

## Testing

- [x] Local deployment — Dify version: not applicable (plugin is invoked by Dify, not Dify itself; the fix is verified by in-process tests)
- [ ] SaaS (cloud.dify.ai)

### Local verification

- `uv run pytest tests/ -v` — 7/7 pass
  - `TestExplicitKeys::test_passes_access_key_and_secret_to_session`
  - `TestExplicitKeys::test_session_uses_requested_service`
  - `TestCredentialChain::test_uses_session_without_explicit_keys`
  - `TestCredentialChain::test_uses_session_without_region`
  - `TestBypassesDefaultSession::test_does_not_use_default_boto3_client`
  - `TestPerCallSession::test_two_consecutive_calls_make_two_sessions`
  - `TestPerCallSession::test_two_consecutive_calls_with_different_regions`
- `uv run ruff check provider/ models/rerank/ models/speech2text/ models/text_embedding/ models/tts/ tests/` — clean
- `uv run ruff format --check .` on the touched files — clean
- Pre-existing F401/F841 issues in `models/llm/llm.py` (`re`, `DefaultParameterName`, unused `e`) are intentionally not addressed here — that file is not in scope for this fix.
