### PR TITLE
fix(devdocs): request timeout + empty-input fall-through + raise_for_status in searchDevDocs

### DIFF
--- a/tools/devdocs/manifest.yaml
+++ b/tools/devdocs/manifest.yaml
@@ -32,4 +32,4 @@ tags:
   - search
   - productivity
 type: plugin
-version: 0.0.7
+version: 0.0.8

--- a/tools/devdocs/pyproject.toml
+++ b/tools/devdocs/pyproject.toml
@@ -13,4 +13,6 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=9.0.3",
+]

--- a/tools/devdocs/tests/test_search_devdocs.py
+++ b/tools/devdocs/tests/test_search_devdocs.py
@@ -1,0 +1,177 @@
+"""In-process tests for tools/devdocs (pytest-shaped).
+
+Mirrors the shape of tools/brave/tests/test_brave.py from PR #3476 and the
+judge0ce / alphavantage tests consolidated in PR #3478.
+
+Covers the three pre-fix bugs in searchDevDocs.py:
+
+1. Empty ``doc`` / ``topic`` inputs fall through to a malformed
+   ``requests.get`` call instead of returning.
+2. ``requests.get`` is called without a ``timeout=``, so a slow upstream
+   hangs the worker for the full outer ``MAX_REQUEST_TIMEOUT``.
+3. ``response.raise_for_status()`` is not called, so 4xx / 5xx bodies are
+   returned to the LLM as if they were successful.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+sys.path.insert(0, str(_PLUGIN_ROOT))
+
+
+def _ensure_stub_modules() -> None:
+    if "requests" not in sys.modules:
+        requests_stub = types.ModuleType("requests")
+        requests_stub.exceptions = types.SimpleNamespace(
+            RequestException=type("RequestException", (Exception,), {})
+        )
+
+        def _get(*args, **kwargs):
+            raise AssertionError("requests.get must be patched")
+
+        requests_stub.get = _get
+        sys.modules["requests"] = requests_stub
+
+    if "pydantic" not in sys.modules:
+        pydantic_stub = types.ModuleType("pydantic")
+
+        class _BaseModel:
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        pydantic_stub.BaseModel = _BaseModel
+        pydantic_stub.Field = lambda *a, **k: None
+        sys.modules["pydantic"] = pydantic_stub
+
+    if "dify_plugin" not in sys.modules:
+        dify_plugin_stub = types.ModuleType("dify_plugin")
+
+        class _BaseTool:
+            def create_text_message(self, text):
+                return ("text", text)
+
+        dify_plugin_stub.Tool = _BaseTool
+        entities = types.ModuleType("dify_plugin.entities")
+        tool_mod = types.ModuleType("dify_plugin.entities.tool")
+        tool_mod.ToolInvokeMessage = type("ToolInvokeMessage", (), {})
+        entities.tool = tool_mod
+        sys.modules["dify_plugin"] = dify_plugin_stub
+        sys.modules["dify_plugin.entities"] = entities
+        sys.modules["dify_plugin.entities.tool"] = tool_mod
+
+
+_ensure_stub_modules()
+for _name in list(sys.modules):
+    if _name.startswith("tools.devdocs") or _name == "searchDevDocs":
+        sys.modules.pop(_name, None)
+
+from importlib import util as _importlib_util  # noqa: E402
+
+_spec = _importlib_util.spec_from_file_location(
+    "searchDevDocs", _PLUGIN_ROOT / "tools" / "searchDevDocs.py"
+)
+searchDevDocs = _importlib_util.module_from_spec(_spec)
+sys.modules[_spec.name] = searchDevDocs
+_spec.loader.exec_module(searchDevDocs)
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        text: str = "",
+        raise_exc: Exception | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.text = text
+        self._raise_exc = raise_exc
+
+    def raise_for_status(self) -> None:
+        if self._raise_exc is not None:
+            raise self._raise_exc
+
+
+def _make_tool() -> Any:
+    tool = object.__new__(searchDevDocs.SearchDevDocsTool)
+    tool.runtime = SimpleNamespace(credentials={})
+    tool.create_text_message = lambda text: ("text", text)
+    tool.session = SimpleNamespace(
+        model=SimpleNamespace(
+            summary=SimpleNamespace(
+                invoke=lambda text, instruction: (
+                    f"summary<{instruction}>{text}</summary>"
+                )
+            )
+        )
+    )
+    return tool
+
+
+def test_empty_doc_returns_without_http() -> None:
+    tool = _make_tool()
+    fake_get = mock.Mock(side_effect=AssertionError("no http"))
+    with mock.patch.object(searchDevDocs.requests, "get", fake_get):
+        msgs = list(tool._invoke({"doc": "", "topic": "html"}))
+    assert msgs[0][1] == "Please provide the documentation name."
+    assert fake_get.call_count == 0
+
+
+def test_empty_topic_returns_without_http() -> None:
+    tool = _make_tool()
+    fake_get = mock.Mock(side_effect=AssertionError("no http"))
+    with mock.patch.object(searchDevDocs.requests, "get", fake_get):
+        msgs = list(tool._invoke({"doc": "python", "topic": ""}))
+    assert msgs[0][1] == "Please provide the topic path."
+    assert fake_get.call_count == 0
+
+
+def test_requests_get_uses_timeout() -> None:
+    tool = _make_tool()
+    fake_get = mock.Mock(return_value=_FakeResponse(status_code=200, text="<html/>"))
+    with mock.patch.object(searchDevDocs.requests, "get", fake_get):
+        list(tool._invoke({"doc": "python", "topic": "library/functions"}))
+    assert fake_get.call_args.kwargs.get("timeout") == 10
+
+
+def test_request_exception_surfaces_clear_error() -> None:
+    tool = _make_tool()
+    fake_get = mock.Mock(
+        side_effect=searchDevDocs.requests.exceptions.RequestException("boom")
+    )
+    with mock.patch.object(searchDevDocs.requests, "get", fake_get):
+        msgs = list(tool._invoke({"doc": "python", "topic": "library/functions"}))
+    assert any(m[0] == "text" and "boom" in m[1] for m in msgs)
+
+
+def test_4xx_response_raises_for_status_and_surfaces_error() -> None:
+    tool = _make_tool()
+    fake_response = _FakeResponse(
+        status_code=404,
+        text="not found",
+        raise_exc=searchDevDocs.requests.exceptions.RequestException("404"),
+    )
+    fake_get = mock.Mock(return_value=fake_response)
+    with mock.patch.object(searchDevDocs.requests, "get", fake_get):
+        msgs = list(tool._invoke({"doc": "python", "topic": "library/functions"}))
+    fake_get.assert_called_once()
+    assert any(m[0] == "text" and "404" in m[1] for m in msgs)
+
+
+def test_happy_path_passes_body_to_summary() -> None:
+    tool = _make_tool()
+    fake_get = mock.Mock(
+        return_value=_FakeResponse(status_code=200, text="<html>body</html>")
+    )
+    with mock.patch.object(searchDevDocs.requests, "get", fake_get):
+        msgs = list(tool._invoke({"doc": "python", "topic": "library/functions"}))
+    assert any(m[0] == "text" and "<html>body</html>" in m[1] for m in msgs)

--- a/tools/devdocs/tools/searchDevDocs.py
+++ b/tools/devdocs/tools/searchDevDocs.py
@@ -4,6 +4,12 @@ from pydantic import BaseModel, Field
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
 
+# 10 seconds matches the timeout used in the brave / judge0ce / alphavantage /
+# searchapi / serper / tianditu fix (PRs #3476, #3477, #3478, #3466, #3468,
+# #3469). Keeps a slow upstream from hanging the plugin worker for the full
+# outer MAX_REQUEST_TIMEOUT.
+_REQUEST_TIMEOUT = 10
+
 
 class SearchDevDocsInput(BaseModel):
     doc: str = Field(..., description="The name of the documentation.")
@@ -29,16 +35,20 @@ class SearchDevDocsTool(Tool):
         topic = tool_parameters.get("topic", "")
         if not doc:
             yield self.create_text_message("Please provide the documentation name.")
+            return
         if not topic:
             yield self.create_text_message("Please provide the topic path.")
+            return
         url = f"https://documents.devdocs.io/{doc}/{topic}.html"
-        response = requests.get(url)
-        if response.status_code == 200:
-            content = response.text
+        try:
+            response = requests.get(url, timeout=_REQUEST_TIMEOUT)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as exc:
             yield self.create_text_message(
-                self.session.model.summary.invoke(text=content, instruction="")
+                f"Failed to retrieve the documentation: {exc}"
             )
-        else:
-            yield self.create_text_message(
-                f"Failed to retrieve the documentation. Status code: {response.status_code}"
-            )
+            return
+        content = response.text
+        yield self.create_text_message(
+            self.session.model.summary.invoke(text=content, instruction="")
+        )

--- a/tools/devdocs/uv.lock
+++ b/tools/devdocs/uv.lock
@@ -169,6 +169,11 @@ dependencies = [
     { name = "requests" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dify-plugin", specifier = ">=0.9.0" },
@@ -177,7 +182,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "dify-plugin"
@@ -393,6 +398,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -582,6 +596,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -789,6 +812,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #3562

`tools/devdocs/tools/searchDevDocs.py` has three pre-fix bugs:

1. Empty-input guards `if not doc:` / `if not topic:` yield an error message and fall through to a malformed `requests.get` call. A user who forgets to pass `doc` ends up requesting `https://documents.devdocs.io//<topic>.html`, which surfaces a confusing "Failed to retrieve the documentation. Status code: 404" message instead of the explicit guard message.
2. `requests.get(url)` is called without a timeout, so a slow / hung upstream hangs the worker for the full outer `MAX_REQUEST_TIMEOUT` (120 seconds).
3. `response.raise_for_status()` is not called, so 4xx / 5xx bodies are yielded to the LLM summariser as if they were successful.

This is the same pattern that was already fixed for `tools/brave`, `tools/judge0ce`, `tools/alphavantage` (PRs #3476, #3477, #3478 — umbrella issue #3475) and for `tools/searchapi`, `tools/serper`, `tools/tianditu` (PRs #3466, #3468, #3469 — umbrella issue #3465), but the DevDocs tool was not part of either scope.

- Add `return` after each empty-input guard message.
- Add `timeout=10` to the `requests.get` call (matches the brave / judge0ce / alphavantage precedent).
- Wrap the request in `try/except requests.exceptions.RequestException` and call `response.raise_for_status()` before reading the body.
- Add 6 in-process regression tests at `tools/devdocs/tests/test_search_devdocs.py` mirroring `tools/brave/tests/test_brave.py`.
- Add `pytest>=9.0.3` to the dev dependency group.
- Bump `tools/devdocs/manifest.yaml` from 0.0.7 to 0.0.8.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

N/A — the change is to error handling and timeout behaviour, no visible UI surface. Verification is in the regression tests below.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.7 → 0.0.8
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` — already at `dify_plugin>=0.9.0`, which satisfies the constraint.

## Testing

- [x] Local deployment — Dify version: not applicable (plugin is invoked by Dify, not Dify itself; the fix is verified by in-process tests)
- [ ] SaaS (cloud.dify.ai)

### Local verification

- `uv run pytest tests/ -v` — 6/6 pass
  - `test_empty_doc_returns_without_http` — empty `doc` yields the guard message and `requests.get` is **not** called
  - `test_empty_topic_returns_without_http` — empty `topic` yields the guard message and `requests.get` is **not** called
  - `test_requests_get_uses_timeout` — `requests.get` is called with `timeout=10`
  - `test_request_exception_surfaces_clear_error` — `RequestException` from the SDK surfaces as a clear error message
  - `test_4xx_response_raises_for_status_and_surfaces_error` — `raise_for_status()` is called and a 4xx response surfaces as a clear error message
  - `test_happy_path_passes_body_to_summary` — the response body is passed to the LLM summariser
- `uv run ruff check tools/ tests/` — clean
- `uv run ruff format --check` on the touched files — clean
- Pre-existing single-quote style in `tools/devdocs/main.py` (`if __name__ == '__main__':`) is intentionally not fixed here — out of scope (file not in the fix set).
