### PR TITLE
fix(tongyi): correct pricing for qwen3.6 and qwen3.7 families

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.2.5
+version: 0.2.6
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/models/llm/qwen3.6-flash-2026-04-16.yaml
+++ b/models/tongyi/models/llm/qwen3.6-flash-2026-04-16.yaml
@@ -123,7 +123,7 @@ parameter_rules:
       zh_Hans: 以 JSON 字符串格式输入额外的 HTTP 请求头，这些请求头将包含在 API 请求中。
       en_US: Enter extra HTTP headers in JSON string format, which will be included in the API request.
 pricing:
-  input: '0.0002'
-  output: '0.002'
+  input: '0.0012'
+  output: '0.0072'
   unit: '0.001'
   currency: RMB

--- a/models/tongyi/models/llm/qwen3.6-flash.yaml
+++ b/models/tongyi/models/llm/qwen3.6-flash.yaml
@@ -123,7 +123,7 @@ parameter_rules:
       zh_Hans: 以 JSON 字符串格式输入额外的 HTTP 请求头，这些请求头将包含在 API 请求中。
       en_US: Enter extra HTTP headers in JSON string format, which will be included in the API request.
 pricing:
-  input: '0.0002'
-  output: '0.002'
+  input: '0.0012'
+  output: '0.0072'
   unit: '0.001'
   currency: RMB

--- a/models/tongyi/models/llm/qwen3.6-plus-2026-04-02.yaml
+++ b/models/tongyi/models/llm/qwen3.6-plus-2026-04-02.yaml
@@ -123,7 +123,7 @@ parameter_rules:
       zh_Hans: 以 JSON 字符串格式输入额外的 HTTP 请求头，这些请求头将包含在 API 请求中。
       en_US: Enter extra HTTP headers in JSON string format, which will be included in the API request.
 pricing:
-  input: '0.0008'
-  output: '0.0048'
+  input: '0.002'
+  output: '0.012'
   unit: '0.001'
   currency: RMB

--- a/models/tongyi/models/llm/qwen3.6-plus.yaml
+++ b/models/tongyi/models/llm/qwen3.6-plus.yaml
@@ -123,7 +123,7 @@ parameter_rules:
       zh_Hans: 以 JSON 字符串格式输入额外的 HTTP 请求头，这些请求头将包含在 API 请求中。
       en_US: Enter extra HTTP headers in JSON string format, which will be included in the API request.
 pricing:
-  input: '0.0008'
-  output: '0.0048'
+  input: '0.002'
+  output: '0.012'
   unit: '0.001'
   currency: RMB

--- a/models/tongyi/models/llm/qwen3.7-max.yaml
+++ b/models/tongyi/models/llm/qwen3.7-max.yaml
@@ -122,7 +122,7 @@ parameter_rules:
       zh_Hans: 以 JSON 字符串格式输入额外的 HTTP 请求头，这些请求头将包含在 API 请求中。
       en_US: Enter extra HTTP headers in JSON string format, which will be included in the API request.
 pricing:
-  input: '0.00165'
-  output: '0.004951'
+  input: '0.012'
+  output: '0.036'
   unit: '0.001'
   currency: USD

--- a/models/tongyi/models/llm/qwen3.7-plus-2026-05-26.yaml
+++ b/models/tongyi/models/llm/qwen3.7-plus-2026-05-26.yaml
@@ -124,7 +124,7 @@ parameter_rules:
       zh_Hans: 以 JSON 字符串格式输入额外的 HTTP 请求头，这些请求头将包含在 API 请求中。
       en_US: Enter extra HTTP headers in JSON string format, which will be included in the API request.
 pricing:
-  input: '0.0008'
-  output: '0.0032'
+  input: '0.002'
+  output: '0.008'
   unit: '0.001'
   currency: RMB

--- a/models/tongyi/models/llm/qwen3.7-plus.yaml
+++ b/models/tongyi/models/llm/qwen3.7-plus.yaml
@@ -124,7 +124,7 @@ parameter_rules:
       zh_Hans: 以 JSON 字符串格式输入额外的 HTTP 请求头，这些请求头将包含在 API 请求中。
       en_US: Enter extra HTTP headers in JSON string format, which will be included in the API request.
 pricing:
-  input: '0.0008'
-  output: '0.0032'
+  input: '0.002'
+  output: '0.008'
   unit: '0.001'
   currency: RMB


### PR DESCRIPTION
## Summary

Correct the pricing configuration for Qwen 3.6 and Qwen 3.7 family models in the Tongyi provider to align with the official API pricing. The previously configured prices were significantly lower than the actual official rates, leading to inaccurate token cost calculation.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

N/A (pricing configuration fix for YAML files)

## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [x] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.14.2
- [ ] SaaS (cloud.dify.ai)
