### PR TITLE
feat(slack): rework Slack plugin with full Web API support (20 tools)

### DIFF
--- a/tools/slack/.difyignore
+++ b/tools/slack/.difyignore
@@ -1,0 +1,177 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Vscode
+.vscode/
+
+# Git
+.git/
+.gitignore
+.github/
+
+# Mac
+.DS_Store
+
+# Windows
+Thumbs.db
+
+# Dify plugin packages
+#  To prevent packaging repetitively
+*.difypkg

--- a/tools/slack/.env.example
+++ b/tools/slack/.env.example
@@ -1,4 +1,0 @@
-INSTALL_METHOD=remote
-REMOTE_INSTALL_HOST=debug-plugin.dify.dev
-REMOTE_INSTALL_PORT=5003
-REMOTE_INSTALL_KEY=********-****-****-****-************

--- a/tools/slack/PRIVACY.md
+++ b/tools/slack/PRIVACY.md
@@ -1,0 +1,32 @@
+# Privacy Policy
+
+## Data Collection
+
+This plugin does not collect or store any personal data on its own. To operate, it requires a Slack credential that you provide:
+
+- A **Slack Bot User OAuth Token** (`xoxb-...`), or
+- A **Slack Incoming Webhook URL**.
+
+These credentials are stored and managed by your Dify instance and are used only to authenticate requests to Slack.
+
+## Data Processing
+
+When you invoke a tool, the parameters you supply (such as channel IDs, message text, timestamps, user IDs, emails, or file contents) are sent directly to the Slack Web API in order to perform the requested action. The plugin acts only as a pass-through between Dify and Slack and does not retain any of this data after a request completes.
+
+## Third-party Services
+
+This plugin communicates with **Slack** (https://slack.com). Your use of Slack is governed by Slack's Privacy Policy: https://slack.com/trust/privacy/privacy-policy
+
+## Data Retention
+
+The plugin itself retains no data. Credentials are retained by your Dify instance for as long as the plugin is configured. Any content sent to or retrieved from Slack is subject to Slack's own retention policies.
+
+## User Rights
+
+Because the plugin stores no data of its own, requests regarding data access, correction, or deletion should be directed to your Dify administrator (for stored credentials) and to Slack (for data held in your workspace).
+
+## Contact Information
+
+For privacy-related questions about this plugin, please contact the plugin author via the Dify Marketplace listing.
+
+Last updated: 2025-07-31

--- a/tools/slack/README.md
+++ b/tools/slack/README.md
@@ -101,7 +101,7 @@ settings:
 
 #### Then, in Dify
 
-5. Install the Slack plugin and paste the token into the **Access Token** field. (A user token starting with `xoxp-` is also accepted, matching n8n's "Slack API" credential.)
+5. Install the Slack plugin and paste the token into the **Access Token** field. (A user token starting with `xoxp-` is also accepted, in which case actions run as the authorizing user.)
 6. Invite the bot to any channel it needs to act in (`/invite @your-bot`).
 
 > **Note:** You must click **Install to Workspace** *after* adding scopes for the `xoxb-` token to appear. Changing scopes later requires re-installing the app.

--- a/tools/slack/README.md
+++ b/tools/slack/README.md
@@ -1,23 +1,122 @@
-# Overview
-Slack is a cloud-based team communication platform designed to enhance collaboration and streamline workflows within organizations. 
+# Slack
 
-You can use the Slack tool to send messages in a channel via a bot with the output variables from Dify workflow.
+**Author:** langgenius
+**Type:** tool
 
-# Configure
-Create an application in Slack
-1. Log in to the [Slack API platform](https://api.slack.com/apps).
-2. Click **Create an App**.
-![](./_assets/slack_create_app.PNG)
-3. Click **From scratch**.
-4. Enter the App Name and select a workspace, then click **Create App**.
-![](./_assets/slack_name_app.png)
-5. Go to app settings page. Click **Incoming Webhooks** in the app settings page's left navigation bar. 
-6. Enable **Activate Incoming Webhooks**. At the bottom of the page, click Add New Webhook to Workspace and select an app publishing channel.
-![](./_assets/slack_incoming_webhooks.PNG)
-7. Return to **Incoming Webhooks**, and copy the webhook URL.
+## Overview
 
-## Configure Slack tool
-1. Install Slack tool from Marketplace.
-![](./_assets/slack_install.PNG)
-2. Add Slack node to workflows.
-3. Paste **Incoming Webhook**.
+Slack is a cloud-based team communication platform. This plugin lets Dify apps and agents interact with a Slack workspace through the **Slack Web API** using a Bot User OAuth Token, covering messages, channels, users, reactions, and files. It also keeps the classic **Incoming Webhook** tool for simple one-way message posting.
+
+## Tools
+
+### Messages
+- **Send Message** – post a message to a channel, group, or DM (`chat.postMessage`), with optional threaded reply.
+- **Update Message** – edit a message the bot posted (`chat.update`).
+- **Delete Message** – delete a message (`chat.delete`).
+- **Get Message Permalink** – get a permalink URL for a message (`chat.getPermalink`).
+- **Schedule Message** – schedule a message for future delivery (`chat.scheduleMessage`).
+- **Incoming Webhook** – post a message via an Incoming Webhook URL (no bot token needed).
+
+### Channels
+- **List Channels** – list conversations (`conversations.list`).
+- **Get Channel Info** – channel metadata (`conversations.info`).
+- **Create Channel** – create a public or private channel (`conversations.create`).
+- **Get Channel History** – fetch recent messages (`conversations.history`).
+- **Get Thread Replies** – fetch replies in a thread (`conversations.replies`).
+- **Invite Users to Channel** – add users to a channel (`conversations.invite`).
+- **Archive Channel** – archive a channel (`conversations.archive`).
+- **Set Channel Topic** – set a channel's topic (`conversations.setTopic`).
+
+### Reactions
+- **Add Reaction** – add an emoji reaction (`reactions.add`).
+- **Remove Reaction** – remove an emoji reaction (`reactions.remove`).
+
+### Users
+- **List Users** – list workspace members (`users.list`).
+- **Get User Info** – get a user's profile (`users.info`).
+- **Look Up User by Email** – find a user by email (`users.lookupByEmail`).
+
+### Files
+- **Upload File** – upload a file and optionally share it to a channel (`files.getUploadURLExternal` + `files.completeUploadExternal`).
+
+## Configuration
+
+### Option A — Bot User OAuth Token (recommended, unlocks all tools)
+
+Go to the [Slack API platform](https://api.slack.com/apps) and click **Create New App**. Slack offers two ways to create the app — either works:
+
+#### Fastest — "From a manifest" (pre-fills all scopes)
+
+1. Choose **From a manifest**, select your workspace, and paste the manifest below.
+2. Click **Next → Create**.
+3. On the app page, click **Install to Workspace** and authorize.
+4. Open **OAuth & Permissions** and copy the **Bot User OAuth Token** (starts with `xoxb-`).
+
+```yaml
+display_information:
+  name: Dify Slack
+features:
+  bot_user:
+    display_name: Dify Slack
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - chat:write
+      - channels:read
+      - groups:read
+      - channels:manage
+      - groups:write
+      - channels:history
+      - groups:history
+      - reactions:write
+      - users:read
+      - users:read.email
+      - files:write
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false
+```
+
+> Paste it exactly as-is. The `features.bot_user` block is required — Slack rejects a manifest that requests `bot` scopes without declaring a bot user. Also note Slack's manifest editor does not accept inline `#` comments, so the block above is comment-free; each scope's purpose is listed in the table under the "Blank app" section below.
+
+#### Manual — "Blank app" (the new name for "From scratch")
+
+1. Choose **Blank app**, name it, and pick your workspace.
+2. Go to **OAuth & Permissions → Scopes → Bot Token Scopes** and add the scopes for the tools you need:
+
+   | Scope | Enables |
+   |---|---|
+   | `chat:write` | send / update / delete / schedule messages, get permalink |
+   | `channels:read`, `groups:read` | list & read channels |
+   | `channels:manage`, `groups:write` | create / archive / set-topic / invite |
+   | `channels:history`, `groups:history` | read channel history & thread replies |
+   | `reactions:write` | add / remove reactions |
+   | `users:read`, `users:read.email` | list / get / look-up users |
+   | `files:write` | upload files |
+
+3. Click **Install to Workspace** and authorize.
+4. Copy the **Bot User OAuth Token** (starts with `xoxb-`).
+
+#### Then, in Dify
+
+5. Install the Slack plugin and paste the token into the **Access Token** field. (A user token starting with `xoxp-` is also accepted, matching n8n's "Slack API" credential.)
+6. Invite the bot to any channel it needs to act in (`/invite @your-bot`).
+
+> **Note:** You must click **Install to Workspace** *after* adding scopes for the `xoxb-` token to appear. Changing scopes later requires re-installing the app.
+
+### Option B — Incoming Webhook (Incoming Webhook tool only)
+
+1. In your Slack app settings, enable **Incoming Webhooks** and **Add New Webhook to Workspace**.
+2. Copy the webhook URL (starts with `https://hooks.slack.com/`).
+3. Provide it as the `webhook_url` parameter of the **Incoming Webhook** tool.
+
+## Notes
+
+- Bot tokens cannot use `search.messages` (that requires a user token), so message search is not included.
+- The bot must be a member of a channel to read its history or post to it (unless the channel is public and your scopes allow it).
+
+## Privacy
+
+See [PRIVACY.md](PRIVACY.md).

--- a/tools/slack/manifest.yaml
+++ b/tools/slack/manifest.yaml
@@ -37,4 +37,4 @@ tags:
   - productivity
 type: plugin
 privacy: PRIVACY.md
-version: 0.1.0
+version: 0.2.0

--- a/tools/slack/manifest.yaml
+++ b/tools/slack/manifest.yaml
@@ -1,14 +1,16 @@
 author: langgenius
 created_at: "2024-09-20T08:03:44.658609186Z"
 description:
-  en_US: Slack Webhook
-  pt_BR: Slack Webhook
-  zh_Hans: Slack Webhook
+  en_US: Interact with Slack - send and manage messages, channels, users, reactions and files via the Slack Web API, or post via an Incoming Webhook.
+  zh_Hans: 与 Slack 交互 - 通过 Slack Web API 发送和管理消息、频道、用户、表情回应和文件，或通过 Incoming Webhook 发送消息。
+  ja_JP: Slack と連携 - Slack Web API を通じてメッセージ、チャンネル、ユーザー、リアクション、ファイルを送信・管理したり、Incoming Webhook を通じて投稿したりできます。
+  ko_KR: Slack과 연동 - Slack Web API를 통해 메시지, 채널, 사용자, 반응, 파일을 전송 및 관리하거나 Incoming Webhook을 통해 게시합니다.
 icon: icon.svg
 label:
   en_US: Slack
-  pt_BR: Slack
   zh_Hans: Slack
+  ja_JP: Slack
+  ko_KR: Slack
 meta:
   arch:
     - amd64
@@ -34,4 +36,5 @@ tags:
   - social
   - productivity
 type: plugin
-version: 0.0.9
+privacy: PRIVACY.md
+version: 0.1.0

--- a/tools/slack/provider/slack.py
+++ b/tools/slack/provider/slack.py
@@ -1,20 +1,23 @@
-from tools.slack_webhook import SlackWebhookTool
+from typing import Any
+
 from dify_plugin import ToolProvider
+from dify_plugin.errors.tool import ToolProviderCredentialValidationError
+
+from slack_api import SlackApiError, SlackClient
 
 
 class SlackProvider(ToolProvider):
-    tool_parameters = [
-        {
-            "name": "webhook_url",
-            "type": "string",
-            "required": True,
-            "description": "Slack webhook URL for sending messages"
-        }
-    ]
-
-    def _validate_credentials(self, credentials: dict) -> None:
-        if 'webhook_url' not in credentials:
-            raise ValueError("webhook_url is required in credentials")
-        webhook_url = credentials['webhook_url']
-        if not isinstance(webhook_url, str) or not webhook_url.startswith('https://hooks.slack.com/'):
-            raise ValueError("Invalid Slack webhook URL format")
+    def _validate_credentials(self, credentials: dict[str, Any]) -> None:
+        access_token = credentials.get("access_token")
+        if not access_token:
+            raise ToolProviderCredentialValidationError(
+                "Slack Access Token (access_token) is required."
+            )
+        try:
+            SlackClient(access_token).auth_test()
+        except SlackApiError as e:
+            raise ToolProviderCredentialValidationError(
+                f"Invalid Slack Access Token: {e.slack_error}"
+            )
+        except Exception as e:
+            raise ToolProviderCredentialValidationError(str(e))

--- a/tools/slack/provider/slack.yaml
+++ b/tools/slack/provider/slack.yaml
@@ -1,5 +1,5 @@
 identity:
-  author: Pan YANG
+  author: langgenius
   name: slack
   label:
     en_US: Slack

--- a/tools/slack/provider/slack.yaml
+++ b/tools/slack/provider/slack.yaml
@@ -1,32 +1,61 @@
-credentials_for_provider:
-  webhook_url:
-    type: secret-input
-    required: true
-    label:
-      en_US: "Slack Webhook URL"
-      zh_Hans: "Slack Webhook URL"
-      pt_BR: "URL do Webhook do Slack"
-    description:
-      en_US: "Slack Webhook URL"
-      zh_Hans: "Slack Webhook URL"
-      pt_BR: "URL do Webhook do Slack"
-extra:
-  python:
-    source: provider/slack.py
 identity:
   author: Pan YANG
-  description:
-    en_US: Slack Webhook
-    pt_BR: Slack Webhook
-    zh_Hans: Slack Webhook
-  icon: icon.svg
+  name: slack
   label:
     en_US: Slack
-    pt_BR: Slack
     zh_Hans: Slack
-  name: slack
+    ja_JP: Slack
+    ko_KR: Slack
+  description:
+    en_US: Interact with Slack workspaces - send and manage messages, channels, users, reactions and files via the Slack Web API.
+    zh_Hans: 与 Slack 工作区交互 - 通过 Slack Web API 发送和管理消息、频道、用户、表情回应和文件。
+    ja_JP: Slack ワークスペースと連携 - Slack Web API を通じてメッセージ、チャンネル、ユーザー、リアクション、ファイルを送信・管理します。
+    ko_KR: Slack 워크스페이스와 연동 - Slack Web API를 통해 메시지, 채널, 사용자, 반응, 파일을 전송 및 관리합니다.
+  icon: icon.svg
   tags:
     - social
     - productivity
+credentials_for_provider:
+  access_token:
+    type: secret-input
+    required: true
+    label:
+      en_US: Access Token
+      zh_Hans: 访问令牌
+      ja_JP: アクセストークン
+      ko_KR: 액세스 토큰
+    placeholder:
+      en_US: xoxb-your-access-token
+      zh_Hans: xoxb-你的访问令牌
+      ja_JP: xoxb-あなたのアクセストークン
+      ko_KR: xoxb-당신의-액세스-토큰
+    help:
+      en_US: Create a Slack App, add the required Bot Token Scopes (e.g. chat:write, channels:read, users:read, reactions:write, files:write), install it to your workspace, and copy the Bot User OAuth Token that starts with xoxb-.
+      zh_Hans: 创建一个 Slack 应用，添加所需的机器人令牌权限（如 chat:write、channels:read、users:read、reactions:write、files:write），将其安装到工作区，然后复制以 xoxb- 开头的机器人用户 OAuth 令牌。
+      ja_JP: "Slack アプリを作成し、必要なボットトークンスコープ (例: chat:write、channels:read、users:read、reactions:write、files:write) を追加し、ワークスペースにインストールして、xoxb- で始まるボットユーザー OAuth トークンをコピーしてください。"
+      ko_KR: "Slack 앱을 생성하고 필요한 봇 토큰 스코프 (예: chat:write, channels:read, users:read, reactions:write, files:write) 를 추가한 후 워크스페이스에 설치하고 xoxb- 로 시작하는 봇 사용자 OAuth 토큰을 복사하세요."
+    url: https://api.slack.com/apps
 tools:
+  - tools/send_message.yaml
+  - tools/update_message.yaml
+  - tools/delete_message.yaml
+  - tools/get_permalink.yaml
+  - tools/schedule_message.yaml
+  - tools/list_channels.yaml
+  - tools/get_channel_info.yaml
+  - tools/create_channel.yaml
+  - tools/get_channel_history.yaml
+  - tools/get_thread_replies.yaml
+  - tools/invite_to_channel.yaml
+  - tools/archive_channel.yaml
+  - tools/set_channel_topic.yaml
+  - tools/add_reaction.yaml
+  - tools/remove_reaction.yaml
+  - tools/list_users.yaml
+  - tools/get_user_info.yaml
+  - tools/lookup_user_by_email.yaml
+  - tools/upload_file.yaml
   - tools/slack_webhook.yaml
+extra:
+  python:
+    source: provider/slack.py

--- a/tools/slack/pyproject.toml
+++ b/tools/slack/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.10.0",
     "httpx>=0.28.1",
 ]
 

--- a/tools/slack/slack_api/__init__.py
+++ b/tools/slack/slack_api/__init__.py
@@ -1,0 +1,3 @@
+from slack_api.client import SlackApiError, SlackClient
+
+__all__ = ["SlackClient", "SlackApiError"]

--- a/tools/slack/slack_api/__init__.py
+++ b/tools/slack/slack_api/__init__.py
@@ -1,3 +1,3 @@
-from slack_api.client import SlackApiError, SlackClient
+from slack_api.client import ChannelSelectMixin, SlackApiError, SlackClient
 
-__all__ = ["SlackClient", "SlackApiError"]
+__all__ = ["SlackClient", "SlackApiError", "ChannelSelectMixin"]

--- a/tools/slack/slack_api/client.py
+++ b/tools/slack/slack_api/client.py
@@ -1,0 +1,135 @@
+import json
+from typing import Any, Optional
+
+import httpx
+
+SLACK_API_BASE = "https://slack.com/api"
+
+
+class SlackApiError(Exception):
+    """Raised when the Slack Web API returns an error or is unreachable."""
+
+    def __init__(self, message: str, response: Optional[dict] = None):
+        super().__init__(message)
+        self.slack_error = message
+        self.response = response
+
+
+class SlackClient:
+    """A thin wrapper around the Slack Web API using a Bot User OAuth Token.
+
+    All standard methods are called via POST with a JSON body and Bearer
+    authentication, which Slack supports for the chat.*, conversations.*,
+    reactions.* and users.* families used by this plugin.
+    """
+
+    def __init__(self, token: str, timeout: float = 30.0):
+        if not token:
+            raise SlackApiError("A Slack Bot User OAuth Token is required.")
+        self.token = token
+        self.timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json; charset=utf-8",
+        }
+
+    def api_call(self, method: str, payload: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+        """Call a Slack Web API method and return its parsed JSON payload.
+
+        Raises SlackApiError if the request fails or Slack responds with ok=false.
+        """
+        # Drop None values so optional parameters are simply omitted.
+        body = {k: v for k, v in (payload or {}).items() if v is not None}
+        url = f"{SLACK_API_BASE}/{method}"
+        try:
+            resp = httpx.post(url, headers=self._headers(), json=body, timeout=self.timeout)
+        except httpx.HTTPError as e:
+            raise SlackApiError(f"HTTP error calling {method}: {e}")
+
+        try:
+            data = resp.json()
+        except Exception:
+            raise SlackApiError(f"Invalid response from Slack for {method}: {resp.text}")
+
+        if not data.get("ok"):
+            raise SlackApiError(data.get("error", "unknown_error"), response=data)
+        return data
+
+    def auth_test(self) -> dict[str, Any]:
+        """Validate the token and return the authed identity (team, user, etc.)."""
+        return self.api_call("auth.test")
+
+    def _form_call(self, method: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Call a Slack Web API method with a form-encoded body (Bearer auth)."""
+        body = {k: v for k, v in data.items() if v is not None}
+        url = f"{SLACK_API_BASE}/{method}"
+        try:
+            resp = httpx.post(
+                url,
+                headers={"Authorization": f"Bearer {self.token}"},
+                data=body,
+                timeout=self.timeout,
+            )
+        except httpx.HTTPError as e:
+            raise SlackApiError(f"HTTP error calling {method}: {e}")
+        try:
+            payload = resp.json()
+        except Exception:
+            raise SlackApiError(f"Invalid response from Slack for {method}: {resp.text}")
+        if not payload.get("ok"):
+            raise SlackApiError(payload.get("error", "unknown_error"), response=payload)
+        return payload
+
+    def upload_file(
+        self,
+        *,
+        filename: str,
+        data: bytes,
+        title: Optional[str] = None,
+        channel: Optional[str] = None,
+        initial_comment: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Upload a file using Slack's modern external-upload flow.
+
+        1. files.getUploadURLExternal to obtain a one-time upload URL and file id.
+        2. POST the raw bytes to that URL.
+        3. files.completeUploadExternal to finalize and optionally share to a channel.
+        """
+        # Step 1: request an upload URL.
+        step1 = self._form_call(
+            "files.getUploadURLExternal",
+            {"filename": filename, "length": len(data)},
+        )
+        upload_url = step1.get("upload_url")
+        file_id = step1.get("file_id")
+        if not upload_url or not file_id:
+            raise SlackApiError("Slack did not return an upload URL.", response=step1)
+
+        # Step 2: upload the raw file bytes to the returned URL.
+        try:
+            up = httpx.post(
+                upload_url,
+                files={"file": (filename, data)},
+                timeout=self.timeout,
+            )
+        except httpx.HTTPError as e:
+            raise SlackApiError(f"HTTP error uploading file bytes: {e}")
+        if up.status_code != 200:
+            raise SlackApiError(
+                f"File byte upload failed with status {up.status_code}: {up.text}"
+            )
+
+        # Step 3: complete the upload and optionally share it.
+        file_entry: dict[str, Any] = {"id": file_id}
+        if title:
+            file_entry["title"] = title
+        return self._form_call(
+            "files.completeUploadExternal",
+            {
+                "files": json.dumps([file_entry]),
+                "channel_id": channel,
+                "initial_comment": initial_comment,
+            },
+        )

--- a/tools/slack/slack_api/client.py
+++ b/tools/slack/slack_api/client.py
@@ -24,8 +24,11 @@ class SlackClient:
     """
 
     def __init__(self, token: str, timeout: float = 30.0):
+        # Strip stray whitespace/newlines that often sneak in when pasting a token,
+        # which would otherwise make an illegal Authorization header value.
+        token = (token or "").strip()
         if not token:
-            raise SlackApiError("A Slack Bot User OAuth Token is required.")
+            raise SlackApiError("A Slack access token is required.")
         self.token = token
         self.timeout = timeout
 
@@ -60,6 +63,29 @@ class SlackClient:
     def auth_test(self) -> dict[str, Any]:
         """Validate the token and return the authed identity (team, user, etc.)."""
         return self.api_call("auth.test")
+
+    def list_channel_options(
+        self, types: str = "public_channel,private_channel", max_pages: int = 10
+    ) -> list[dict[str, str]]:
+        """Return channels the token can access as [{'id','name'}], paginated.
+
+        Used to populate dynamic-select channel parameters in the tools.
+        """
+        options: list[dict[str, str]] = []
+        cursor: Optional[str] = None
+        for _ in range(max_pages):
+            resp = self.api_call(
+                "conversations.list",
+                {"types": types, "limit": 200, "cursor": cursor, "exclude_archived": True},
+            )
+            for ch in resp.get("channels", []):
+                cid = ch.get("id")
+                if cid:
+                    options.append({"id": cid, "name": ch.get("name") or cid})
+            cursor = (resp.get("response_metadata") or {}).get("next_cursor") or None
+            if not cursor:
+                break
+        return options
 
     def _form_call(self, method: str, data: dict[str, Any]) -> dict[str, Any]:
         """Call a Slack Web API method with a form-encoded body (Bearer auth)."""
@@ -133,3 +159,39 @@ class SlackClient:
                 "initial_comment": initial_comment,
             },
         )
+
+
+class ChannelSelectMixin:
+    """Mixin for Tools whose `channel` parameter is a dynamic-select.
+
+    Implements `_fetch_parameter_options` so Dify can populate the dropdown with
+    every channel the configured access token can see.
+    """
+
+    def _fetch_parameter_options(self, parameter: str):
+        from dify_plugin.entities import I18nObject, ParameterOption
+
+        if parameter != "channel":
+            return []
+        token = (self.runtime.credentials or {}).get("access_token")
+        if not token:
+            raise ValueError("A Slack Access Token is required to list channels.")
+        try:
+            channels = SlackClient(token).list_channel_options()
+        except SlackApiError as e:
+            # Surface the real reason (e.g. missing_scope) instead of an empty dropdown.
+            resp = e.response or {}
+            detail = ""
+            if resp.get("needed") is not None or resp.get("provided") is not None:
+                detail = (
+                    f" (needed: {resp.get('needed')}; provided: {resp.get('provided')})"
+                )
+            raise ValueError(
+                f"Could not list channels: {e.slack_error}{detail}. "
+                "Ensure the token has the 'channels:read' and 'groups:read' scopes, "
+                "then reinstall the app."
+            )
+        return [
+            ParameterOption(value=c["id"], label=I18nObject(en_us=c["name"]))
+            for c in channels
+        ]

--- a/tools/slack/tools/add_reaction.py
+++ b/tools/slack/tools/add_reaction.py
@@ -1,0 +1,42 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class AddReactionTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        timestamp = (tool_parameters.get("timestamp") or "").strip()
+        name = (tool_parameters.get("name") or "").strip().strip(":")
+
+        if not channel or not timestamp or not name:
+            yield self.create_text_message(
+                "The 'channel', 'timestamp' and 'name' parameters are all required."
+            )
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "reactions.add",
+                {"channel": channel, "timestamp": timestamp, "name": name},
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to add reaction: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        yield self.create_text_message(f"Added :{name}: to message {timestamp}.")
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/add_reaction.py
+++ b/tools/slack/tools/add_reaction.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class AddReactionTool(Tool):
+class AddReactionTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/add_reaction.yaml
+++ b/tools/slack/tools/add_reaction.yaml
@@ -1,0 +1,64 @@
+identity:
+  name: add_reaction
+  author: Pan YANG
+  label:
+    en_US: Add Reaction
+    zh_Hans: 添加表情回应
+    ja_JP: リアクションを追加
+    ko_KR: 리액션 추가
+description:
+  human:
+    en_US: Add an emoji reaction to a message.
+    zh_Hans: 为一条消息添加表情回应。
+    ja_JP: メッセージに絵文字リアクションを追加します。
+    ko_KR: 메시지에 이모지 리액션을 추가합니다.
+  llm: Adds an emoji reaction to a message using reactions.add. Requires the channel ID, the message timestamp, and the emoji name (without surrounding colons, e.g. thumbsup).
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID that contains the message.
+      zh_Hans: 包含该消息的频道 ID。
+      ja_JP: メッセージが含まれるチャンネルID。
+      ko_KR: 메시지가 포함된 채널 ID.
+    llm_description: The channel ID (e.g. C0123456789) that contains the message to react to.
+    form: llm
+  - name: timestamp
+    type: string
+    required: true
+    label:
+      en_US: Message Timestamp
+      zh_Hans: 消息时间戳
+      ja_JP: メッセージのタイムスタンプ
+      ko_KR: 메시지 타임스탬프
+    human_description:
+      en_US: The ts (timestamp) of the message to react to.
+      zh_Hans: 要回应的消息 ts（时间戳）。
+      ja_JP: リアクションを付けるメッセージのts（タイムスタンプ）。
+      ko_KR: 리액션을 추가할 메시지의 ts(타임스탬프).
+    llm_description: The timestamp (ts) identifying the message, e.g. 1405894322.002768.
+    form: llm
+  - name: name
+    type: string
+    required: true
+    label:
+      en_US: Emoji Name
+      zh_Hans: 表情名称
+      ja_JP: 絵文字名
+      ko_KR: 이모지 이름
+    human_description:
+      en_US: The emoji name without colons (e.g. thumbsup, white_check_mark).
+      zh_Hans: 不带冒号的表情名称（如 thumbsup、white_check_mark）。
+      ja_JP: "コロンを付けない絵文字名（例: thumbsup、white_check_mark）。"
+      ko_KR: "콜론 없는 이모지 이름(예: thumbsup, white_check_mark)."
+    llm_description: The emoji name without surrounding colons, e.g. thumbsup or white_check_mark.
+    form: llm
+extra:
+  python:
+    source: tools/add_reaction.py

--- a/tools/slack/tools/add_reaction.yaml
+++ b/tools/slack/tools/add_reaction.yaml
@@ -1,6 +1,6 @@
 identity:
   name: add_reaction
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Add Reaction
     zh_Hans: 添加表情回应
@@ -15,7 +15,7 @@ description:
   llm: Adds an emoji reaction to a message using reactions.add. Requires the channel ID, the message timestamp, and the emoji name (without surrounding colons, e.g. thumbsup).
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/archive_channel.py
+++ b/tools/slack/tools/archive_channel.py
@@ -1,0 +1,34 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class ArchiveChannelTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        if not channel:
+            yield self.create_text_message("The 'channel' parameter is required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call("conversations.archive", {"channel": channel})
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to archive channel: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        yield self.create_text_message(f"Channel {channel} archived.")
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/archive_channel.py
+++ b/tools/slack/tools/archive_channel.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class ArchiveChannelTool(Tool):
+class ArchiveChannelTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/archive_channel.yaml
+++ b/tools/slack/tools/archive_channel.yaml
@@ -1,6 +1,6 @@
 identity:
   name: archive_channel
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Archive Channel
     zh_Hans: 归档频道
@@ -15,7 +15,7 @@ description:
   llm: Archives a channel using conversations.archive. Requires the channel ID.
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/archive_channel.yaml
+++ b/tools/slack/tools/archive_channel.yaml
@@ -1,0 +1,34 @@
+identity:
+  name: archive_channel
+  author: Pan YANG
+  label:
+    en_US: Archive Channel
+    zh_Hans: 归档频道
+    ja_JP: チャンネルをアーカイブ
+    ko_KR: 채널 보관
+description:
+  human:
+    en_US: Archive a channel.
+    zh_Hans: 归档一个频道。
+    ja_JP: チャンネルをアーカイブします。
+    ko_KR: 채널을 보관합니다.
+  llm: Archives a channel using conversations.archive. Requires the channel ID.
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID to archive (e.g. C0123456789).
+      zh_Hans: 要归档的频道 ID（如 C0123456789）。
+      ja_JP: "アーカイブするチャンネルID（例: C0123456789）。"
+      ko_KR: "보관할 채널 ID(예: C0123456789)."
+    llm_description: The channel ID (e.g. C0123456789) to archive.
+    form: llm
+extra:
+  python:
+    source: tools/archive_channel.py

--- a/tools/slack/tools/create_channel.py
+++ b/tools/slack/tools/create_channel.py
@@ -1,0 +1,41 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class CreateChannelTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        name = (tool_parameters.get("name") or "").strip()
+        is_private = bool(tool_parameters.get("is_private", False))
+
+        if not name:
+            yield self.create_text_message("The 'name' parameter is required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "conversations.create", {"name": name, "is_private": is_private}
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to create channel: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        ch = resp.get("channel", {})
+        yield self.create_text_message(
+            f"Channel {ch.get('name')} created (id: {ch.get('id')})."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/create_channel.yaml
+++ b/tools/slack/tools/create_channel.yaml
@@ -1,0 +1,50 @@
+identity:
+  name: create_channel
+  author: Pan YANG
+  label:
+    en_US: Create Channel
+    zh_Hans: 创建频道
+    ja_JP: チャンネルの作成
+    ko_KR: 채널 생성
+description:
+  human:
+    en_US: Create a new public or private channel.
+    zh_Hans: 创建一个新的公开或私有频道。
+    ja_JP: 新しいパブリックまたはプライベートチャンネルを作成します。
+    ko_KR: 새로운 공개 또는 비공개 채널을 생성합니다.
+  llm: Creates a new channel using conversations.create. Requires a channel name (lowercase, no spaces or periods, up to 80 characters). Set is_private to true to create a private channel.
+parameters:
+  - name: name
+    type: string
+    required: true
+    label:
+      en_US: Channel Name
+      zh_Hans: 频道名称
+      ja_JP: チャンネル名
+      ko_KR: 채널 이름
+    human_description:
+      en_US: The name of the channel to create. Must be lowercase, without spaces or periods, and up to 80 characters.
+      zh_Hans: 要创建的频道名称。必须为小写，不含空格或句点，最多 80 个字符。
+      ja_JP: 作成するチャンネルの名前。小文字で、スペースやピリオドを含まず、最大 80 文字までにする必要があります。
+      ko_KR: 생성할 채널의 이름입니다. 소문자여야 하며 공백이나 마침표를 포함할 수 없고 최대 80자까지 가능합니다.
+    llm_description: The new channel name. Must be lowercase, contain no spaces or periods, and be at most 80 characters.
+    form: llm
+  - name: is_private
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Private Channel
+      zh_Hans: 私有频道
+      ja_JP: プライベートチャンネル
+      ko_KR: 비공개 채널
+    human_description:
+      en_US: Whether to create a private channel. Defaults to false (public).
+      zh_Hans: 是否创建私有频道。默认为 false（公开）。
+      ja_JP: プライベートチャンネルを作成するかどうか。デフォルトは false（パブリック）です。
+      ko_KR: 비공개 채널을 생성할지 여부입니다. 기본값은 false（공개）입니다.
+    llm_description: Set to true to create a private channel; false creates a public channel.
+    form: llm
+extra:
+  python:
+    source: tools/create_channel.py

--- a/tools/slack/tools/create_channel.yaml
+++ b/tools/slack/tools/create_channel.yaml
@@ -1,6 +1,6 @@
 identity:
   name: create_channel
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Create Channel
     zh_Hans: 创建频道

--- a/tools/slack/tools/delete_message.py
+++ b/tools/slack/tools/delete_message.py
@@ -1,0 +1,38 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class DeleteMessageTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        ts = (tool_parameters.get("ts") or "").strip()
+
+        if not channel or not ts:
+            yield self.create_text_message("Both 'channel' and 'ts' are required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call("chat.delete", {"channel": channel, "ts": ts})
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to delete message: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        yield self.create_text_message(
+            f"Message {resp.get('ts')} deleted from {resp.get('channel')}."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/delete_message.py
+++ b/tools/slack/tools/delete_message.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class DeleteMessageTool(Tool):
+class DeleteMessageTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/delete_message.yaml
+++ b/tools/slack/tools/delete_message.yaml
@@ -1,0 +1,49 @@
+identity:
+  name: delete_message
+  author: Pan YANG
+  label:
+    en_US: Delete Message
+    zh_Hans: 删除消息
+    ja_JP: メッセージを削除
+    ko_KR: 메시지 삭제
+description:
+  human:
+    en_US: Delete a message from a Slack channel.
+    zh_Hans: 从 Slack 频道删除一条消息。
+    ja_JP: Slack チャンネルからメッセージを削除します。
+    ko_KR: Slack 채널에서 메시지를 삭제합니다.
+  llm: Deletes a message using chat.delete. Requires the channel ID and the ts (timestamp) of the message to delete. A bot token can only delete messages it posted.
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID that contains the message to delete.
+      zh_Hans: 包含要删除消息的频道 ID。
+      ja_JP: 削除するメッセージが含まれるチャンネル ID。
+      ko_KR: 삭제할 메시지가 있는 채널 ID입니다.
+    llm_description: The channel ID (e.g. C0123456789) that contains the message to delete.
+    form: llm
+  - name: ts
+    type: string
+    required: true
+    label:
+      en_US: Message Timestamp
+      zh_Hans: 消息时间戳
+      ja_JP: メッセージのタイムスタンプ
+      ko_KR: 메시지 타임스탬프
+    human_description:
+      en_US: The ts (timestamp) of the message to delete.
+      zh_Hans: 要删除消息的 ts（时间戳）。
+      ja_JP: 削除するメッセージの ts（タイムスタンプ）。
+      ko_KR: 삭제할 메시지의 ts(타임스탬프)입니다.
+    llm_description: The timestamp (ts) identifying the message to delete, e.g. 1405894322.002768.
+    form: llm
+extra:
+  python:
+    source: tools/delete_message.py

--- a/tools/slack/tools/delete_message.yaml
+++ b/tools/slack/tools/delete_message.yaml
@@ -1,6 +1,6 @@
 identity:
   name: delete_message
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Delete Message
     zh_Hans: 删除消息
@@ -15,7 +15,7 @@ description:
   llm: Deletes a message using chat.delete. Requires the channel ID and the ts (timestamp) of the message to delete. A bot token can only delete messages it posted.
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/get_channel_history.py
+++ b/tools/slack/tools/get_channel_history.py
@@ -1,0 +1,46 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class GetChannelHistoryTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        if not channel:
+            yield self.create_text_message("The 'channel' parameter is required.")
+            return
+
+        oldest = (tool_parameters.get("oldest") or "").strip() or None
+        latest = (tool_parameters.get("latest") or "").strip() or None
+        try:
+            limit = int(tool_parameters.get("limit") or 20)
+        except (TypeError, ValueError):
+            limit = 20
+        limit = max(1, min(limit, 1000))
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "conversations.history",
+                {"channel": channel, "limit": limit, "oldest": oldest, "latest": latest},
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to get channel history: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        messages = resp.get("messages", [])
+        yield self.create_text_message(f"Retrieved {len(messages)} message(s) from {channel}.")
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/get_channel_history.py
+++ b/tools/slack/tools/get_channel_history.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class GetChannelHistoryTool(Tool):
+class GetChannelHistoryTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/get_channel_history.yaml
+++ b/tools/slack/tools/get_channel_history.yaml
@@ -1,0 +1,80 @@
+identity:
+  name: get_channel_history
+  author: Pan YANG
+  label:
+    en_US: Get Channel History
+    zh_Hans: 获取频道历史消息
+    ja_JP: チャンネル履歴の取得
+    ko_KR: 채널 기록 가져오기
+description:
+  human:
+    en_US: Fetch recent messages from a channel.
+    zh_Hans: 获取频道中的近期消息。
+    ja_JP: チャンネルの最近のメッセージを取得します。
+    ko_KR: 채널의 최근 메시지를 가져옵니다.
+  llm: Retrieves a channel's message history using conversations.history. Requires the channel ID. Supports limit and optional oldest/latest Unix timestamps to bound the range.
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID to read history from (e.g. C0123456789).
+      zh_Hans: 要读取历史消息的频道 ID（如 C0123456789）。
+      ja_JP: 履歴を読み取るチャンネル ID（例：C0123456789）。
+      ko_KR: 기록을 읽어올 채널 ID（예：C0123456789）.
+    llm_description: The channel ID (e.g. C0123456789) whose message history should be fetched.
+    form: llm
+  - name: limit
+    type: number
+    required: false
+    default: 20
+    label:
+      en_US: Limit
+      zh_Hans: 数量限制
+      ja_JP: 上限
+      ko_KR: 제한
+    human_description:
+      en_US: Maximum number of messages to return (1-1000). Defaults to 20.
+      zh_Hans: 返回消息的最大数量（1-1000）。默认为 20。
+      ja_JP: 返すメッセージの最大数（1〜1000）。デフォルトは 20 です。
+      ko_KR: 반환할 메시지의 최대 개수（1-1000）. 기본값은 20입니다.
+    llm_description: Maximum number of messages to return, between 1 and 1000. Defaults to 20.
+    form: llm
+  - name: oldest
+    type: string
+    required: false
+    label:
+      en_US: Oldest Timestamp
+      zh_Hans: 最早时间戳
+      ja_JP: 最古のタイムスタンプ
+      ko_KR: 가장 오래된 타임스탬프
+    human_description:
+      en_US: Only include messages after this Unix timestamp (inclusive).
+      zh_Hans: 仅包含此 Unix 时间戳之后（含）的消息。
+      ja_JP: この Unix タイムスタンプ以降（含む）のメッセージのみを含めます。
+      ko_KR: 이 Unix 타임스탬프 이후（포함）의 메시지만 포함합니다.
+    llm_description: Optional. Only return messages at or after this Unix epoch timestamp (e.g. 1405894322.002768).
+    form: llm
+  - name: latest
+    type: string
+    required: false
+    label:
+      en_US: Latest Timestamp
+      zh_Hans: 最晚时间戳
+      ja_JP: 最新のタイムスタンプ
+      ko_KR: 가장 최근 타임스탬프
+    human_description:
+      en_US: Only include messages before this Unix timestamp.
+      zh_Hans: 仅包含此 Unix 时间戳之前的消息。
+      ja_JP: この Unix タイムスタンプより前のメッセージのみを含めます。
+      ko_KR: 이 Unix 타임스탬프 이전의 메시지만 포함합니다.
+    llm_description: Optional. Only return messages at or before this Unix epoch timestamp.
+    form: llm
+extra:
+  python:
+    source: tools/get_channel_history.py

--- a/tools/slack/tools/get_channel_history.yaml
+++ b/tools/slack/tools/get_channel_history.yaml
@@ -1,6 +1,6 @@
 identity:
   name: get_channel_history
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Get Channel History
     zh_Hans: 获取频道历史消息
@@ -15,7 +15,7 @@ description:
   llm: Retrieves a channel's message history using conversations.history. Requires the channel ID. Supports limit and optional oldest/latest Unix timestamps to bound the range.
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/get_channel_info.py
+++ b/tools/slack/tools/get_channel_info.py
@@ -1,0 +1,37 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class GetChannelInfoTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        if not channel:
+            yield self.create_text_message("The 'channel' parameter is required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call("conversations.info", {"channel": channel})
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to get channel info: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        ch = resp.get("channel", {})
+        yield self.create_text_message(
+            f"Channel {ch.get('name')} (id: {ch.get('id')}), members: {ch.get('num_members', 'n/a')}."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/get_channel_info.py
+++ b/tools/slack/tools/get_channel_info.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class GetChannelInfoTool(Tool):
+class GetChannelInfoTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/get_channel_info.yaml
+++ b/tools/slack/tools/get_channel_info.yaml
@@ -1,0 +1,34 @@
+identity:
+  name: get_channel_info
+  author: Pan YANG
+  label:
+    en_US: Get Channel Info
+    zh_Hans: 获取频道信息
+    ja_JP: チャンネル情報の取得
+    ko_KR: 채널 정보 가져오기
+description:
+  human:
+    en_US: Retrieve detailed information about a channel.
+    zh_Hans: 获取某个频道的详细信息。
+    ja_JP: チャンネルの詳細情報を取得します。
+    ko_KR: 채널에 대한 상세 정보를 가져옵니다.
+  llm: Retrieves metadata about a channel using conversations.info. Requires the channel ID.
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID to look up (e.g. C0123456789).
+      zh_Hans: 要查询的频道 ID（如 C0123456789）。
+      ja_JP: 照会するチャンネル ID（例：C0123456789）。
+      ko_KR: 조회할 채널 ID（예：C0123456789）.
+    llm_description: The channel ID (e.g. C0123456789) to retrieve information about.
+    form: llm
+extra:
+  python:
+    source: tools/get_channel_info.py

--- a/tools/slack/tools/get_channel_info.yaml
+++ b/tools/slack/tools/get_channel_info.yaml
@@ -1,6 +1,6 @@
 identity:
   name: get_channel_info
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Get Channel Info
     zh_Hans: 获取频道信息
@@ -15,7 +15,7 @@ description:
   llm: Retrieves metadata about a channel using conversations.info. Requires the channel ID.
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/get_permalink.py
+++ b/tools/slack/tools/get_permalink.py
@@ -1,0 +1,38 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class GetPermalinkTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        message_ts = (tool_parameters.get("message_ts") or "").strip()
+
+        if not channel or not message_ts:
+            yield self.create_text_message("Both 'channel' and 'message_ts' are required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "chat.getPermalink", {"channel": channel, "message_ts": message_ts}
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to get permalink: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        yield self.create_text_message(resp.get("permalink", ""))
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/get_permalink.py
+++ b/tools/slack/tools/get_permalink.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class GetPermalinkTool(Tool):
+class GetPermalinkTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/get_permalink.yaml
+++ b/tools/slack/tools/get_permalink.yaml
@@ -1,6 +1,6 @@
 identity:
   name: get_permalink
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Get Message Permalink
     zh_Hans: 获取消息永久链接
@@ -15,7 +15,7 @@ description:
   llm: Returns a permalink URL for a specific message using chat.getPermalink. Requires the channel ID and the message ts (timestamp).
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/get_permalink.yaml
+++ b/tools/slack/tools/get_permalink.yaml
@@ -1,0 +1,49 @@
+identity:
+  name: get_permalink
+  author: Pan YANG
+  label:
+    en_US: Get Message Permalink
+    zh_Hans: 获取消息永久链接
+    ja_JP: メッセージのパーマリンクを取得
+    ko_KR: 메시지 고정 링크 가져오기
+description:
+  human:
+    en_US: Retrieve a permalink URL for a specific message.
+    zh_Hans: 获取特定消息的永久链接 URL。
+    ja_JP: 特定のメッセージのパーマリンク URL を取得します。
+    ko_KR: 특정 메시지의 고정 링크 URL을 가져옵니다.
+  llm: Returns a permalink URL for a specific message using chat.getPermalink. Requires the channel ID and the message ts (timestamp).
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID that contains the message.
+      zh_Hans: 包含该消息的频道 ID。
+      ja_JP: メッセージが含まれるチャンネル ID。
+      ko_KR: 메시지가 있는 채널 ID입니다.
+    llm_description: The channel ID (e.g. C0123456789) that contains the message.
+    form: llm
+  - name: message_ts
+    type: string
+    required: true
+    label:
+      en_US: Message Timestamp
+      zh_Hans: 消息时间戳
+      ja_JP: メッセージのタイムスタンプ
+      ko_KR: 메시지 타임스탬프
+    human_description:
+      en_US: The ts (timestamp) of the message to get a permalink for.
+      zh_Hans: 要获取永久链接的消息 ts（时间戳）。
+      ja_JP: パーマリンクを取得するメッセージの ts（タイムスタンプ）。
+      ko_KR: 고정 링크를 가져올 메시지의 ts(타임스탬프)입니다.
+    llm_description: The timestamp (ts) identifying the message, e.g. 1405894322.002768.
+    form: llm
+extra:
+  python:
+    source: tools/get_permalink.py

--- a/tools/slack/tools/get_thread_replies.py
+++ b/tools/slack/tools/get_thread_replies.py
@@ -1,0 +1,47 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class GetThreadRepliesTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        ts = (tool_parameters.get("ts") or "").strip()
+        if not channel or not ts:
+            yield self.create_text_message("Both 'channel' and 'ts' are required.")
+            return
+
+        try:
+            limit = int(tool_parameters.get("limit") or 100)
+        except (TypeError, ValueError):
+            limit = 100
+        limit = max(1, min(limit, 1000))
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "conversations.replies",
+                {"channel": channel, "ts": ts, "limit": limit},
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to get thread replies: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        messages = resp.get("messages", [])
+        yield self.create_text_message(
+            f"Retrieved {len(messages)} message(s) in thread {ts}."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/get_thread_replies.py
+++ b/tools/slack/tools/get_thread_replies.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class GetThreadRepliesTool(Tool):
+class GetThreadRepliesTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/get_thread_replies.yaml
+++ b/tools/slack/tools/get_thread_replies.yaml
@@ -1,6 +1,6 @@
 identity:
   name: get_thread_replies
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Get Thread Replies
     zh_Hans: 获取线程回复
@@ -15,7 +15,7 @@ description:
   llm: Retrieves the replies of a threaded conversation using conversations.replies. Requires the channel ID and the parent message ts (timestamp).
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/get_thread_replies.yaml
+++ b/tools/slack/tools/get_thread_replies.yaml
@@ -1,0 +1,65 @@
+identity:
+  name: get_thread_replies
+  author: Pan YANG
+  label:
+    en_US: Get Thread Replies
+    zh_Hans: 获取线程回复
+    ja_JP: スレッド返信の取得
+    ko_KR: 스레드 답글 가져오기
+description:
+  human:
+    en_US: Fetch all replies in a message thread.
+    zh_Hans: 获取某条消息线程中的所有回复。
+    ja_JP: メッセージスレッド内のすべての返信を取得します。
+    ko_KR: 메시지 스레드의 모든 답글을 가져옵니다.
+  llm: Retrieves the replies of a threaded conversation using conversations.replies. Requires the channel ID and the parent message ts (timestamp).
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID that contains the thread.
+      zh_Hans: 包含该线程的频道 ID。
+      ja_JP: スレッドを含むチャンネル ID。
+      ko_KR: 스레드가 포함된 채널 ID입니다.
+    llm_description: The channel ID (e.g. C0123456789) that contains the thread.
+    form: llm
+  - name: ts
+    type: string
+    required: true
+    label:
+      en_US: Parent Message Timestamp
+      zh_Hans: 父消息时间戳
+      ja_JP: 親メッセージのタイムスタンプ
+      ko_KR: 상위 메시지 타임스탬프
+    human_description:
+      en_US: The ts (timestamp) of the thread's parent message.
+      zh_Hans: 线程父消息的 ts（时间戳）。
+      ja_JP: スレッドの親メッセージの ts（タイムスタンプ）。
+      ko_KR: 스레드 상위 메시지의 ts（타임스탬프）입니다.
+    llm_description: The parent message timestamp (ts) identifying the thread, e.g. 1405894322.002768.
+    form: llm
+  - name: limit
+    type: number
+    required: false
+    default: 100
+    label:
+      en_US: Limit
+      zh_Hans: 数量限制
+      ja_JP: 上限
+      ko_KR: 제한
+    human_description:
+      en_US: Maximum number of replies to return (1-1000). Defaults to 100.
+      zh_Hans: 返回回复的最大数量（1-1000）。默认为 100。
+      ja_JP: 返す返信の最大数（1〜1000）。デフォルトは 100 です。
+      ko_KR: 반환할 답글의 최대 개수（1-1000）. 기본값은 100입니다.
+    llm_description: Maximum number of messages to return, between 1 and 1000. Defaults to 100.
+    form: llm
+extra:
+  python:
+    source: tools/get_thread_replies.py

--- a/tools/slack/tools/get_user_info.py
+++ b/tools/slack/tools/get_user_info.py
@@ -1,0 +1,37 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class GetUserInfoTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        user = (tool_parameters.get("user") or "").strip()
+        if not user:
+            yield self.create_text_message("The 'user' parameter is required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call("users.info", {"user": user})
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to get user info: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        u = resp.get("user", {})
+        yield self.create_text_message(
+            f"User {u.get('name')} (id: {u.get('id')}, real_name: {u.get('real_name', '')})."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/get_user_info.yaml
+++ b/tools/slack/tools/get_user_info.yaml
@@ -1,6 +1,6 @@
 identity:
   name: get_user_info
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Get User Info
     zh_Hans: 获取用户信息

--- a/tools/slack/tools/get_user_info.yaml
+++ b/tools/slack/tools/get_user_info.yaml
@@ -1,0 +1,34 @@
+identity:
+  name: get_user_info
+  author: Pan YANG
+  label:
+    en_US: Get User Info
+    zh_Hans: 获取用户信息
+    ja_JP: ユーザー情報を取得
+    ko_KR: 사용자 정보 가져오기
+description:
+  human:
+    en_US: Retrieve detailed information about a user.
+    zh_Hans: 获取某个用户的详细信息。
+    ja_JP: ユーザーの詳細情報を取得します。
+    ko_KR: 사용자에 대한 상세 정보를 가져옵니다.
+  llm: Retrieves information about a user (profile, name, timezone, etc.) using users.info. Requires the user ID.
+parameters:
+  - name: user
+    type: string
+    required: true
+    label:
+      en_US: User ID
+      zh_Hans: 用户 ID
+      ja_JP: ユーザー ID
+      ko_KR: 사용자 ID
+    human_description:
+      en_US: The user ID to look up (e.g. U0123456789).
+      zh_Hans: 要查询的用户 ID（如 U0123456789）。
+      ja_JP: "検索するユーザー ID（例: U0123456789）。"
+      ko_KR: "조회할 사용자 ID(예: U0123456789)."
+    llm_description: The Slack user ID (e.g. U0123456789) to retrieve information about.
+    form: llm
+extra:
+  python:
+    source: tools/get_user_info.py

--- a/tools/slack/tools/invite_to_channel.py
+++ b/tools/slack/tools/invite_to_channel.py
@@ -1,0 +1,45 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class InviteToChannelTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        users_raw = (tool_parameters.get("users") or "").strip()
+        if not channel or not users_raw:
+            yield self.create_text_message("Both 'channel' and 'users' are required.")
+            return
+
+        users = ",".join(u.strip() for u in users_raw.split(",") if u.strip())
+        if not users:
+            yield self.create_text_message("No valid user IDs were provided.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "conversations.invite", {"channel": channel, "users": users}
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to invite users: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        ch = resp.get("channel", {})
+        yield self.create_text_message(
+            f"Invited users to {ch.get('name', channel)}."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/invite_to_channel.py
+++ b/tools/slack/tools/invite_to_channel.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class InviteToChannelTool(Tool):
+class InviteToChannelTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/invite_to_channel.yaml
+++ b/tools/slack/tools/invite_to_channel.yaml
@@ -1,6 +1,6 @@
 identity:
   name: invite_to_channel
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Invite Users to Channel
     zh_Hans: 邀请用户加入频道
@@ -15,7 +15,7 @@ description:
   llm: Invites users to a channel using conversations.invite. Requires the channel ID and one or more user IDs (comma-separated).
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/invite_to_channel.yaml
+++ b/tools/slack/tools/invite_to_channel.yaml
@@ -1,0 +1,49 @@
+identity:
+  name: invite_to_channel
+  author: Pan YANG
+  label:
+    en_US: Invite Users to Channel
+    zh_Hans: 邀请用户加入频道
+    ja_JP: ユーザーをチャンネルに招待
+    ko_KR: 사용자를 채널에 초대
+description:
+  human:
+    en_US: Invite one or more users to a channel.
+    zh_Hans: 邀请一个或多个用户加入频道。
+    ja_JP: 1人以上のユーザーをチャンネルに招待します。
+    ko_KR: 한 명 이상의 사용자를 채널에 초대합니다.
+  llm: Invites users to a channel using conversations.invite. Requires the channel ID and one or more user IDs (comma-separated).
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID to invite users to (e.g. C0123456789).
+      zh_Hans: 要邀请用户加入的频道 ID（如 C0123456789）。
+      ja_JP: "ユーザーを招待するチャンネルID（例: C0123456789）。"
+      ko_KR: "사용자를 초대할 채널 ID(예: C0123456789)."
+    llm_description: The channel ID (e.g. C0123456789) to invite users into.
+    form: llm
+  - name: users
+    type: string
+    required: true
+    label:
+      en_US: User IDs
+      zh_Hans: 用户 ID
+      ja_JP: ユーザーID
+      ko_KR: 사용자 ID
+    human_description:
+      en_US: Comma-separated list of user IDs to invite (e.g. U0123,U0456). Up to 1000 users.
+      zh_Hans: 要邀请的用户 ID 的逗号分隔列表（如 U0123,U0456）。最多 1000 个用户。
+      ja_JP: "招待するユーザーIDのカンマ区切りリスト（例: U0123,U0456）。最大1000人まで。"
+      ko_KR: "초대할 사용자 ID의 쉼표로 구분된 목록(예: U0123,U0456). 최대 1000명."
+    llm_description: A comma-separated list of Slack user IDs (e.g. U0123456789) to invite into the channel.
+    form: llm
+extra:
+  python:
+    source: tools/invite_to_channel.py

--- a/tools/slack/tools/list_channels.py
+++ b/tools/slack/tools/list_channels.py
@@ -1,0 +1,45 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class ListChannelsTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        types = (tool_parameters.get("types") or "").strip() or None
+        cursor = (tool_parameters.get("cursor") or "").strip() or None
+        try:
+            limit = int(tool_parameters.get("limit") or 100)
+        except (TypeError, ValueError):
+            limit = 100
+        limit = max(1, min(limit, 1000))
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "conversations.list",
+                {"types": types, "limit": limit, "cursor": cursor},
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to list channels: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        channels = resp.get("channels", [])
+        summary_lines = [
+            f"- {c.get('name', '(no name)')} (id: {c.get('id')})" for c in channels
+        ]
+        header = f"Found {len(channels)} channel(s):"
+        yield self.create_text_message("\n".join([header, *summary_lines]))
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/list_channels.yaml
+++ b/tools/slack/tools/list_channels.yaml
@@ -1,6 +1,6 @@
 identity:
   name: list_channels
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: List Channels
     zh_Hans: 列出频道

--- a/tools/slack/tools/list_channels.yaml
+++ b/tools/slack/tools/list_channels.yaml
@@ -1,0 +1,65 @@
+identity:
+  name: list_channels
+  author: Pan YANG
+  label:
+    en_US: List Channels
+    zh_Hans: 列出频道
+    ja_JP: チャンネル一覧
+    ko_KR: 채널 목록
+description:
+  human:
+    en_US: List channels in the Slack workspace.
+    zh_Hans: 列出 Slack 工作区中的频道。
+    ja_JP: Slack ワークスペース内のチャンネルを一覧表示します。
+    ko_KR: Slack 워크스페이스의 채널을 나열합니다.
+  llm: Lists conversations (channels) in the workspace using conversations.list. Supports filtering by types and pagination via limit and cursor.
+parameters:
+  - name: types
+    type: string
+    required: false
+    label:
+      en_US: Channel Types
+      zh_Hans: 频道类型
+      ja_JP: チャンネルタイプ
+      ko_KR: 채널 유형
+    human_description:
+      en_US: Comma-separated list of channel types to include. Options - public_channel, private_channel, mpim, im. Defaults to public_channel.
+      zh_Hans: 要包含的频道类型的逗号分隔列表。选项 - public_channel、private_channel、mpim、im。默认为 public_channel。
+      ja_JP: 含めるチャンネルタイプのカンマ区切りリスト。オプション - public_channel、private_channel、mpim、im。デフォルトは public_channel です。
+      ko_KR: 포함할 채널 유형의 쉼표로 구분된 목록입니다. 옵션 - public_channel, private_channel, mpim, im. 기본값은 public_channel입니다.
+    llm_description: Comma-separated channel types to include, chosen from public_channel, private_channel, mpim, im. Defaults to public_channel when omitted.
+    form: llm
+  - name: limit
+    type: number
+    required: false
+    default: 100
+    label:
+      en_US: Limit
+      zh_Hans: 数量限制
+      ja_JP: 上限
+      ko_KR: 제한
+    human_description:
+      en_US: Maximum number of channels to return (1-1000). Defaults to 100.
+      zh_Hans: 返回频道的最大数量（1-1000）。默认为 100。
+      ja_JP: 返すチャンネルの最大数（1〜1000）。デフォルトは 100 です。
+      ko_KR: 반환할 채널의 최대 개수（1-1000）. 기본값은 100입니다.
+    llm_description: Maximum number of channels to return, between 1 and 1000. Defaults to 100.
+    form: llm
+  - name: cursor
+    type: string
+    required: false
+    label:
+      en_US: Cursor
+      zh_Hans: 游标
+      ja_JP: カーソル
+      ko_KR: 커서
+    human_description:
+      en_US: Pagination cursor (next_cursor) returned by a previous call.
+      zh_Hans: 上一次调用返回的分页游标（next_cursor）。
+      ja_JP: 前回の呼び出しで返されたページネーションカーソル（next_cursor）。
+      ko_KR: 이전 호출에서 반환된 페이지네이션 커서（next_cursor）.
+    llm_description: Pagination cursor from a previous response's response_metadata.next_cursor to fetch the next page.
+    form: llm
+extra:
+  python:
+    source: tools/list_channels.py

--- a/tools/slack/tools/list_users.py
+++ b/tools/slack/tools/list_users.py
@@ -1,0 +1,43 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class ListUsersTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        cursor = (tool_parameters.get("cursor") or "").strip() or None
+        try:
+            limit = int(tool_parameters.get("limit") or 100)
+        except (TypeError, ValueError):
+            limit = 100
+        limit = max(1, min(limit, 1000))
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call("users.list", {"limit": limit, "cursor": cursor})
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to list users: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        members = resp.get("members", [])
+        summary_lines = [
+            f"- {m.get('name')} (id: {m.get('id')}, real_name: {m.get('real_name', '')})"
+            for m in members
+        ]
+        yield self.create_text_message(
+            "\n".join([f"Found {len(members)} user(s):", *summary_lines])
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/list_users.yaml
+++ b/tools/slack/tools/list_users.yaml
@@ -1,0 +1,50 @@
+identity:
+  name: list_users
+  author: Pan YANG
+  label:
+    en_US: List Users
+    zh_Hans: 列出用户
+    ja_JP: ユーザー一覧
+    ko_KR: 사용자 목록
+description:
+  human:
+    en_US: List members of the Slack workspace.
+    zh_Hans: 列出 Slack 工作区的成员。
+    ja_JP: Slack ワークスペースのメンバーを一覧表示します。
+    ko_KR: Slack 워크스페이스의 멤버를 나열합니다.
+  llm: Lists all users in the workspace using users.list. Supports pagination via limit and cursor.
+parameters:
+  - name: limit
+    type: number
+    required: false
+    default: 100
+    label:
+      en_US: Limit
+      zh_Hans: 数量限制
+      ja_JP: 上限数
+      ko_KR: 개수 제한
+    human_description:
+      en_US: Maximum number of users to return (1-1000). Defaults to 100.
+      zh_Hans: 返回用户的最大数量（1-1000）。默认为 100。
+      ja_JP: 返すユーザーの最大数（1〜1000）。デフォルトは 100 です。
+      ko_KR: 반환할 사용자의 최대 개수(1~1000). 기본값은 100입니다.
+    llm_description: Maximum number of users to return, between 1 and 1000. Defaults to 100.
+    form: llm
+  - name: cursor
+    type: string
+    required: false
+    label:
+      en_US: Cursor
+      zh_Hans: 游标
+      ja_JP: カーソル
+      ko_KR: 커서
+    human_description:
+      en_US: Pagination cursor (next_cursor) returned by a previous call.
+      zh_Hans: 上一次调用返回的分页游标（next_cursor）。
+      ja_JP: 前回の呼び出しで返されたページネーションカーソル（next_cursor）。
+      ko_KR: 이전 호출에서 반환된 페이지네이션 커서(next_cursor).
+    llm_description: Pagination cursor from a previous response's response_metadata.next_cursor to fetch the next page.
+    form: llm
+extra:
+  python:
+    source: tools/list_users.py

--- a/tools/slack/tools/list_users.yaml
+++ b/tools/slack/tools/list_users.yaml
@@ -1,6 +1,6 @@
 identity:
   name: list_users
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: List Users
     zh_Hans: 列出用户

--- a/tools/slack/tools/lookup_user_by_email.py
+++ b/tools/slack/tools/lookup_user_by_email.py
@@ -1,0 +1,37 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class LookupUserByEmailTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        email = (tool_parameters.get("email") or "").strip()
+        if not email:
+            yield self.create_text_message("The 'email' parameter is required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call("users.lookupByEmail", {"email": email})
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to look up user: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        u = resp.get("user", {})
+        yield self.create_text_message(
+            f"Found user {u.get('name')} (id: {u.get('id')}) for {email}."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/lookup_user_by_email.yaml
+++ b/tools/slack/tools/lookup_user_by_email.yaml
@@ -1,0 +1,34 @@
+identity:
+  name: lookup_user_by_email
+  author: Pan YANG
+  label:
+    en_US: Look Up User by Email
+    zh_Hans: 通过邮箱查找用户
+    ja_JP: メールアドレスでユーザーを検索
+    ko_KR: 이메일로 사용자 찾기
+description:
+  human:
+    en_US: Find a Slack user by their email address.
+    zh_Hans: 通过电子邮箱地址查找 Slack 用户。
+    ja_JP: メールアドレスで Slack ユーザーを検索します。
+    ko_KR: 이메일 주소로 Slack 사용자를 찾습니다.
+  llm: Finds a workspace user by email address using users.lookupByEmail. Requires the email. Returns the matching user's profile including their user ID.
+parameters:
+  - name: email
+    type: string
+    required: true
+    label:
+      en_US: Email
+      zh_Hans: 邮箱
+      ja_JP: メールアドレス
+      ko_KR: 이메일
+    human_description:
+      en_US: The email address of the user to find.
+      zh_Hans: 要查找用户的电子邮箱地址。
+      ja_JP: 検索するユーザーのメールアドレス。
+      ko_KR: 찾을 사용자의 이메일 주소.
+    llm_description: The email address to look up, e.g. user@example.com.
+    form: llm
+extra:
+  python:
+    source: tools/lookup_user_by_email.py

--- a/tools/slack/tools/lookup_user_by_email.yaml
+++ b/tools/slack/tools/lookup_user_by_email.yaml
@@ -1,6 +1,6 @@
 identity:
   name: lookup_user_by_email
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Look Up User by Email
     zh_Hans: 通过邮箱查找用户

--- a/tools/slack/tools/remove_reaction.py
+++ b/tools/slack/tools/remove_reaction.py
@@ -1,0 +1,42 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class RemoveReactionTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        timestamp = (tool_parameters.get("timestamp") or "").strip()
+        name = (tool_parameters.get("name") or "").strip().strip(":")
+
+        if not channel or not timestamp or not name:
+            yield self.create_text_message(
+                "The 'channel', 'timestamp' and 'name' parameters are all required."
+            )
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "reactions.remove",
+                {"channel": channel, "timestamp": timestamp, "name": name},
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to remove reaction: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        yield self.create_text_message(f"Removed :{name}: from message {timestamp}.")
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/remove_reaction.py
+++ b/tools/slack/tools/remove_reaction.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class RemoveReactionTool(Tool):
+class RemoveReactionTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/remove_reaction.yaml
+++ b/tools/slack/tools/remove_reaction.yaml
@@ -1,6 +1,6 @@
 identity:
   name: remove_reaction
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Remove Reaction
     zh_Hans: 移除表情回应
@@ -15,7 +15,7 @@ description:
   llm: Removes an emoji reaction from a message using reactions.remove. Requires the channel ID, the message timestamp, and the emoji name (without colons).
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/remove_reaction.yaml
+++ b/tools/slack/tools/remove_reaction.yaml
@@ -1,0 +1,64 @@
+identity:
+  name: remove_reaction
+  author: Pan YANG
+  label:
+    en_US: Remove Reaction
+    zh_Hans: 移除表情回应
+    ja_JP: リアクションを削除
+    ko_KR: 리액션 제거
+description:
+  human:
+    en_US: Remove an emoji reaction from a message.
+    zh_Hans: 从一条消息移除表情回应。
+    ja_JP: メッセージから絵文字リアクションを削除します。
+    ko_KR: 메시지에서 이모지 리액션을 제거합니다.
+  llm: Removes an emoji reaction from a message using reactions.remove. Requires the channel ID, the message timestamp, and the emoji name (without colons).
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID that contains the message.
+      zh_Hans: 包含该消息的频道 ID。
+      ja_JP: メッセージが含まれるチャンネルID。
+      ko_KR: 메시지가 포함된 채널 ID.
+    llm_description: The channel ID (e.g. C0123456789) that contains the message.
+    form: llm
+  - name: timestamp
+    type: string
+    required: true
+    label:
+      en_US: Message Timestamp
+      zh_Hans: 消息时间戳
+      ja_JP: メッセージのタイムスタンプ
+      ko_KR: 메시지 타임스탬프
+    human_description:
+      en_US: The ts (timestamp) of the message.
+      zh_Hans: 该消息的 ts（时间戳）。
+      ja_JP: メッセージのts（タイムスタンプ）。
+      ko_KR: 메시지의 ts(타임스탬프).
+    llm_description: The timestamp (ts) identifying the message, e.g. 1405894322.002768.
+    form: llm
+  - name: name
+    type: string
+    required: true
+    label:
+      en_US: Emoji Name
+      zh_Hans: 表情名称
+      ja_JP: 絵文字名
+      ko_KR: 이모지 이름
+    human_description:
+      en_US: The emoji name without colons (e.g. thumbsup).
+      zh_Hans: 不带冒号的表情名称（如 thumbsup）。
+      ja_JP: "コロンを付けない絵文字名（例: thumbsup）。"
+      ko_KR: "콜론 없는 이모지 이름(예: thumbsup)."
+    llm_description: The emoji name without surrounding colons, e.g. thumbsup.
+    form: llm
+extra:
+  python:
+    source: tools/remove_reaction.py

--- a/tools/slack/tools/schedule_message.py
+++ b/tools/slack/tools/schedule_message.py
@@ -1,0 +1,55 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class ScheduleMessageTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        text = tool_parameters.get("text") or ""
+        post_at = tool_parameters.get("post_at")
+
+        if not channel:
+            yield self.create_text_message("The 'channel' parameter is required.")
+            return
+        if not text:
+            yield self.create_text_message("The 'text' parameter is required.")
+            return
+        if post_at in (None, ""):
+            yield self.create_text_message("The 'post_at' parameter is required.")
+            return
+
+        try:
+            post_at_int = int(post_at)
+        except (TypeError, ValueError):
+            yield self.create_text_message("'post_at' must be a Unix epoch timestamp in seconds.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "chat.scheduleMessage",
+                {"channel": channel, "text": text, "post_at": post_at_int},
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to schedule message: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        yield self.create_text_message(
+            f"Message scheduled in {resp.get('channel')} "
+            f"(scheduled_message_id: {resp.get('scheduled_message_id')}, post_at: {resp.get('post_at')})."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/schedule_message.py
+++ b/tools/slack/tools/schedule_message.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class ScheduleMessageTool(Tool):
+class ScheduleMessageTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/schedule_message.yaml
+++ b/tools/slack/tools/schedule_message.yaml
@@ -1,0 +1,64 @@
+identity:
+  name: schedule_message
+  author: Pan YANG
+  label:
+    en_US: Schedule Message
+    zh_Hans: 定时发送消息
+    ja_JP: メッセージを予約送信
+    ko_KR: 메시지 예약
+description:
+  human:
+    en_US: Schedule a message to be sent to a channel at a future time.
+    zh_Hans: 安排一条消息在未来某个时间发送到频道。
+    ja_JP: 将来の指定した時刻にチャンネルへメッセージを送信するよう予約します。
+    ko_KR: 나중에 지정한 시각에 채널로 메시지를 보내도록 예약합니다.
+  llm: Schedules a message for future delivery using chat.scheduleMessage. Requires the channel, the message text, and post_at as a Unix epoch timestamp (in seconds) in the future.
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel, private group, or user (DM) to send the message to.
+      zh_Hans: 发送消息的频道、私有群组或用户（私信）。
+      ja_JP: メッセージを送信するチャンネル、プライベートグループ、またはユーザー（DM）。
+      ko_KR: "메시지를 보낼 채널, 비공개 그룹 또는 사용자(DM)입니다."
+    llm_description: The target channel ID (e.g. C0123456789) or channel name (e.g. #general).
+    form: llm
+  - name: text
+    type: string
+    required: true
+    label:
+      en_US: Message Text
+      zh_Hans: 消息内容
+      ja_JP: メッセージ本文
+      ko_KR: 메시지 내용
+    human_description:
+      en_US: The text of the message to schedule.
+      zh_Hans: 要定时发送的消息文本。
+      ja_JP: 予約送信するメッセージのテキスト。
+      ko_KR: 예약 전송할 메시지의 텍스트입니다.
+    llm_description: The message body to schedule. Supports Slack mrkdwn formatting.
+    form: llm
+  - name: post_at
+    type: number
+    required: true
+    label:
+      en_US: Post At (Unix Timestamp)
+      zh_Hans: 发送时间（Unix 时间戳）
+      ja_JP: 送信時刻（Unix タイムスタンプ）
+      ko_KR: 전송 시각(Unix 타임스탬프)
+    human_description:
+      en_US: The time to send the message, as a Unix epoch timestamp in seconds. Must be in the future and within 120 days.
+      zh_Hans: 发送消息的时间，Unix 纪元时间戳（秒）。必须在未来且不超过 120 天。
+      ja_JP: メッセージを送信する時刻。Unix エポックタイムスタンプ（秒）で指定します。将来かつ 120 日以内である必要があります。
+      ko_KR: 메시지를 보낼 시각으로, Unix 에포크 타임스탬프(초)로 지정합니다. 미래 시점이면서 120일 이내여야 합니다.
+    llm_description: The Unix epoch timestamp in seconds at which to send the message. Must be a future time no more than 120 days ahead.
+    form: llm
+extra:
+  python:
+    source: tools/schedule_message.py

--- a/tools/slack/tools/schedule_message.yaml
+++ b/tools/slack/tools/schedule_message.yaml
@@ -1,6 +1,6 @@
 identity:
   name: schedule_message
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Schedule Message
     zh_Hans: 定时发送消息
@@ -15,7 +15,7 @@ description:
   llm: Schedules a message for future delivery using chat.scheduleMessage. Requires the channel, the message text, and post_at as a Unix epoch timestamp (in seconds) in the future.
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/send_message.py
+++ b/tools/slack/tools/send_message.py
@@ -1,0 +1,45 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class SendMessageTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        text = tool_parameters.get("text") or ""
+        thread_ts = (tool_parameters.get("thread_ts") or "").strip() or None
+
+        if not channel:
+            yield self.create_text_message("The 'channel' parameter is required.")
+            return
+        if not text:
+            yield self.create_text_message("The 'text' parameter is required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "chat.postMessage",
+                {"channel": channel, "text": text, "thread_ts": thread_ts},
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to send message: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        yield self.create_text_message(
+            f"Message sent to {resp.get('channel')} (ts: {resp.get('ts')})."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/send_message.py
+++ b/tools/slack/tools/send_message.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class SendMessageTool(Tool):
+class SendMessageTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/send_message.yaml
+++ b/tools/slack/tools/send_message.yaml
@@ -1,0 +1,64 @@
+identity:
+  name: send_message
+  author: Pan YANG
+  label:
+    en_US: Send Message
+    zh_Hans: 发送消息
+    ja_JP: メッセージを送信
+    ko_KR: 메시지 보내기
+description:
+  human:
+    en_US: Send a message to a Slack channel, private group, or direct message.
+    zh_Hans: 向 Slack 频道、私有群组或私信发送消息。
+    ja_JP: Slack のチャンネル、プライベートグループ、またはダイレクトメッセージにメッセージを送信します。
+    ko_KR: Slack 채널, 비공개 그룹 또는 다이렉트 메시지로 메시지를 보냅니다.
+  llm: Sends a message to a Slack conversation using chat.postMessage. Requires the target channel (channel ID like C0123456789, or a #channel-name) and the message text. Optionally reply inside a thread by passing thread_ts.
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel, private group, or user (DM) to send the message to. Accepts a channel ID (e.g. C0123456789) or a channel name (e.g. #general).
+      zh_Hans: 发送消息的频道、私有群组或用户（私信）。接受频道 ID（如 C0123456789）或频道名称（如 #general）。
+      ja_JP: "メッセージを送信するチャンネル、プライベートグループ、またはユーザー（DM）。チャンネル ID（例: C0123456789）またはチャンネル名（例: #general）を指定できます。"
+      ko_KR: "메시지를 보낼 채널, 비공개 그룹 또는 사용자(DM)입니다. 채널 ID(예: C0123456789) 또는 채널 이름(예: #general)을 사용할 수 있습니다."
+    llm_description: The target channel to post to. Prefer a channel ID such as C0123456789; a channel name like #general is also accepted.
+    form: llm
+  - name: text
+    type: string
+    required: true
+    label:
+      en_US: Message Text
+      zh_Hans: 消息内容
+      ja_JP: メッセージ本文
+      ko_KR: 메시지 내용
+    human_description:
+      en_US: The text of the message to send. Supports Slack mrkdwn formatting.
+      zh_Hans: 要发送的消息文本，支持 Slack mrkdwn 格式。
+      ja_JP: 送信するメッセージのテキスト。Slack の mrkdwn 形式に対応しています。
+      ko_KR: 보낼 메시지의 텍스트입니다. Slack mrkdwn 서식을 지원합니다.
+    llm_description: The message body to post. Supports Slack mrkdwn formatting.
+    form: llm
+  - name: thread_ts
+    type: string
+    required: false
+    label:
+      en_US: Thread Timestamp
+      zh_Hans: 线程时间戳
+      ja_JP: スレッドのタイムスタンプ
+      ko_KR: 스레드 타임스탬프
+    human_description:
+      en_US: Optional. The ts of a parent message to reply to it in a thread.
+      zh_Hans: 可选。要回复的父消息的 ts，用于在线程中回复。
+      ja_JP: 任意。スレッド内で返信する対象となる親メッセージの ts。
+      ko_KR: 선택 사항. 스레드에서 답글을 달 상위 메시지의 ts입니다.
+    llm_description: Optional parent message timestamp (ts). Provide it to post this message as a threaded reply.
+    form: llm
+extra:
+  python:
+    source: tools/send_message.py

--- a/tools/slack/tools/send_message.yaml
+++ b/tools/slack/tools/send_message.yaml
@@ -1,6 +1,6 @@
 identity:
   name: send_message
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Send Message
     zh_Hans: 发送消息
@@ -15,7 +15,7 @@ description:
   llm: Sends a message to a Slack conversation using chat.postMessage. Requires the target channel (channel ID like C0123456789, or a #channel-name) and the message text. Optionally reply inside a thread by passing thread_ts.
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/set_channel_topic.py
+++ b/tools/slack/tools/set_channel_topic.py
@@ -1,0 +1,40 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class SetChannelTopicTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        topic = tool_parameters.get("topic") or ""
+        if not channel:
+            yield self.create_text_message("The 'channel' parameter is required.")
+            return
+        if not topic:
+            yield self.create_text_message("The 'topic' parameter is required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "conversations.setTopic", {"channel": channel, "topic": topic}
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to set topic: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        yield self.create_text_message(f"Topic updated for {channel}.")
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/set_channel_topic.py
+++ b/tools/slack/tools/set_channel_topic.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class SetChannelTopicTool(Tool):
+class SetChannelTopicTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/set_channel_topic.yaml
+++ b/tools/slack/tools/set_channel_topic.yaml
@@ -1,0 +1,49 @@
+identity:
+  name: set_channel_topic
+  author: Pan YANG
+  label:
+    en_US: Set Channel Topic
+    zh_Hans: 设置频道话题
+    ja_JP: チャンネルのトピックを設定
+    ko_KR: 채널 주제 설정
+description:
+  human:
+    en_US: Set the topic for a channel.
+    zh_Hans: 设置频道的话题。
+    ja_JP: チャンネルのトピックを設定します。
+    ko_KR: 채널의 주제를 설정합니다.
+  llm: Sets a channel's topic using conversations.setTopic. Requires the channel ID and the new topic text.
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID whose topic will be set (e.g. C0123456789).
+      zh_Hans: 要设置话题的频道 ID（如 C0123456789）。
+      ja_JP: "トピックを設定するチャンネルID（例: C0123456789）。"
+      ko_KR: "주제를 설정할 채널 ID(예: C0123456789)."
+    llm_description: The channel ID (e.g. C0123456789) whose topic should be set.
+    form: llm
+  - name: topic
+    type: string
+    required: true
+    label:
+      en_US: Topic
+      zh_Hans: 话题
+      ja_JP: トピック
+      ko_KR: 주제
+    human_description:
+      en_US: The new topic text (up to 250 characters).
+      zh_Hans: 新的话题文本（最多 250 个字符）。
+      ja_JP: 新しいトピックのテキスト（最大250文字）。
+      ko_KR: 새 주제 텍스트(최대 250자).
+    llm_description: The new channel topic text, up to 250 characters.
+    form: llm
+extra:
+  python:
+    source: tools/set_channel_topic.py

--- a/tools/slack/tools/set_channel_topic.yaml
+++ b/tools/slack/tools/set_channel_topic.yaml
@@ -1,6 +1,6 @@
 identity:
   name: set_channel_topic
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Set Channel Topic
     zh_Hans: 设置频道话题
@@ -15,7 +15,7 @@ description:
   llm: Sets a channel's topic using conversations.setTopic. Requires the channel ID and the new topic text.
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/slack_webhook.yaml
+++ b/tools/slack/tools/slack_webhook.yaml
@@ -1,8 +1,9 @@
 description:
   human:
     en_US: Sending a message on Slack via the Incoming Webhook
-    pt_BR: Sending a message on Slack via the Incoming Webhook
     zh_Hans: 通过入站 Webhook 在 Slack 上发送消息
+    ja_JP: Incoming Webhook を通じて Slack にメッセージを送信します
+    ko_KR: Incoming Webhook을 통해 Slack에 메시지를 전송합니다
   llm: A tool for sending messages to a chat on Slack.
 extra:
   python:
@@ -12,35 +13,41 @@ identity:
   icon: icon.svg
   label:
     en_US: Incoming Webhook to send message
-    pt_BR: Incoming Webhook to send message
     zh_Hans: 通过入站 Webhook 发送消息
+    ja_JP: メッセージ送信用 Incoming Webhook
+    ko_KR: 메시지 전송용 Incoming Webhook
   description:
     en_US: Send a message to a Slack channel using webhook
     zh_Hans: 使用 webhook 发送消息到 Slack 频道
-    pt_BR: Enviar uma mensagem para um canal do Slack usando webhook
+    ja_JP: Webhook を使用して Slack チャンネルにメッセージを送信します
+    ko_KR: Webhook을 사용하여 Slack 채널에 메시지를 전송합니다
   name: slack_webhook
 parameters:
   - form: form
     human_description:
       en_US: Slack Incoming Webhook url
-      pt_BR: Slack Incoming Webhook url
       zh_Hans: Slack 入站 Webhook 的 url
+      ja_JP: Slack Incoming Webhook の URL
+      ko_KR: Slack Incoming Webhook URL
     label:
       en_US: Slack Incoming Webhook url
-      pt_BR: Slack Incoming Webhook url
       zh_Hans: Slack 入站 Webhook 的 url
+      ja_JP: Slack Incoming Webhook の URL
+      ko_KR: Slack Incoming Webhook URL
     name: webhook_url
     required: true
     type: string
   - form: llm
     human_description:
       en_US: Content to sent to the channel or person.
-      pt_BR: Content to sent to the channel or person.
       zh_Hans: 消息内容文本
+      ja_JP: チャンネルまたは個人に送信するコンテンツ。
+      ko_KR: 채널 또는 개인에게 전송할 콘텐츠입니다.
     label:
       en_US: content
-      pt_BR: content
       zh_Hans: 消息内容
+      ja_JP: コンテンツ
+      ko_KR: 콘텐츠
     llm_description: Content of the message
     name: content
     required: true

--- a/tools/slack/tools/slack_webhook.yaml
+++ b/tools/slack/tools/slack_webhook.yaml
@@ -9,7 +9,7 @@ extra:
   python:
     source: tools/slack_webhook.py
 identity:
-  author: Pan YANG
+  author: langgenius
   icon: icon.svg
   label:
     en_US: Incoming Webhook to send message

--- a/tools/slack/tools/update_message.py
+++ b/tools/slack/tools/update_message.py
@@ -1,0 +1,44 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from slack_api import SlackApiError, SlackClient
+
+
+class UpdateMessageTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        channel = (tool_parameters.get("channel") or "").strip()
+        ts = (tool_parameters.get("ts") or "").strip()
+        text = tool_parameters.get("text") or ""
+
+        if not channel or not ts:
+            yield self.create_text_message("Both 'channel' and 'ts' are required.")
+            return
+        if not text:
+            yield self.create_text_message("The 'text' parameter is required.")
+            return
+
+        try:
+            client = SlackClient(token)
+            resp = client.api_call(
+                "chat.update", {"channel": channel, "ts": ts, "text": text}
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to update message: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        yield self.create_text_message(
+            f"Message {resp.get('ts')} in {resp.get('channel')} updated."
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/update_message.py
+++ b/tools/slack/tools/update_message.py
@@ -3,10 +3,10 @@ from typing import Any, Generator
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class UpdateMessageTool(Tool):
+class UpdateMessageTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/update_message.yaml
+++ b/tools/slack/tools/update_message.yaml
@@ -1,0 +1,64 @@
+identity:
+  name: update_message
+  author: Pan YANG
+  label:
+    en_US: Update Message
+    zh_Hans: 更新消息
+    ja_JP: メッセージを更新
+    ko_KR: 메시지 업데이트
+description:
+  human:
+    en_US: Edit an existing message that was posted by the bot.
+    zh_Hans: 编辑机器人已发送的现有消息。
+    ja_JP: ボットが投稿した既存のメッセージを編集します。
+    ko_KR: 봇이 게시한 기존 메시지를 편집합니다.
+  llm: Updates the text of an existing Slack message using chat.update. Requires the channel ID and the ts (timestamp) of the message to edit, plus the new text.
+parameters:
+  - name: channel
+    type: string
+    required: true
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: The channel ID that contains the message to update.
+      zh_Hans: 包含要更新消息的频道 ID。
+      ja_JP: 更新するメッセージが含まれるチャンネル ID。
+      ko_KR: 업데이트할 메시지가 있는 채널 ID입니다.
+    llm_description: The channel ID (e.g. C0123456789) that contains the message to edit.
+    form: llm
+  - name: ts
+    type: string
+    required: true
+    label:
+      en_US: Message Timestamp
+      zh_Hans: 消息时间戳
+      ja_JP: メッセージのタイムスタンプ
+      ko_KR: 메시지 타임스탬프
+    human_description:
+      en_US: The ts (timestamp) of the message to update.
+      zh_Hans: 要更新消息的 ts（时间戳）。
+      ja_JP: 更新するメッセージの ts（タイムスタンプ）。
+      ko_KR: 업데이트할 메시지의 ts(타임스탬프)입니다.
+    llm_description: The timestamp (ts) identifying the message to edit, e.g. 1405894322.002768.
+    form: llm
+  - name: text
+    type: string
+    required: true
+    label:
+      en_US: New Message Text
+      zh_Hans: 新消息内容
+      ja_JP: 新しいメッセージ本文
+      ko_KR: 새 메시지 내용
+    human_description:
+      en_US: The new text that will replace the current message content.
+      zh_Hans: 用于替换当前消息内容的新文本。
+      ja_JP: 現在のメッセージ内容を置き換える新しいテキスト。
+      ko_KR: 현재 메시지 내용을 대체할 새 텍스트입니다.
+    llm_description: The new message body. Supports Slack mrkdwn formatting.
+    form: llm
+extra:
+  python:
+    source: tools/update_message.py

--- a/tools/slack/tools/update_message.yaml
+++ b/tools/slack/tools/update_message.yaml
@@ -1,6 +1,6 @@
 identity:
   name: update_message
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Update Message
     zh_Hans: 更新消息
@@ -15,7 +15,7 @@ description:
   llm: Updates the text of an existing Slack message using chat.update. Requires the channel ID and the ts (timestamp) of the message to edit, plus the new text.
 parameters:
   - name: channel
-    type: string
+    type: dynamic-select
     required: true
     label:
       en_US: Channel

--- a/tools/slack/tools/upload_file.py
+++ b/tools/slack/tools/upload_file.py
@@ -1,0 +1,56 @@
+from typing import Any, Generator
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+from dify_plugin.file.file import File
+
+from slack_api import SlackApiError, SlackClient
+
+
+class UploadFileTool(Tool):
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
+        token = self.runtime.credentials.get("access_token")
+        if not token:
+            yield self.create_text_message("Slack Access Token is required.")
+            return
+
+        file: File = tool_parameters.get("file")
+        if not file:
+            yield self.create_text_message("The 'file' parameter is required.")
+            return
+
+        data = file.blob
+        if not data:
+            yield self.create_text_message("The provided file is empty.")
+            return
+
+        filename = file.filename or "upload"
+        channel = (tool_parameters.get("channel") or "").strip() or None
+        title = (tool_parameters.get("title") or "").strip() or None
+        initial_comment = (tool_parameters.get("initial_comment") or "").strip() or None
+
+        try:
+            client = SlackClient(token)
+            resp = client.upload_file(
+                filename=filename,
+                data=data,
+                title=title,
+                channel=channel,
+                initial_comment=initial_comment,
+            )
+        except SlackApiError as e:
+            yield self.create_text_message(f"Failed to upload file: {e.slack_error}")
+            return
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+        files = resp.get("files", [])
+        file_id = files[0].get("id") if files else None
+        yield self.create_text_message(
+            f"File '{filename}' uploaded successfully"
+            + (f" (file id: {file_id})." if file_id else ".")
+        )
+        yield self.create_json_message(resp)

--- a/tools/slack/tools/upload_file.py
+++ b/tools/slack/tools/upload_file.py
@@ -4,10 +4,10 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.file.file import File
 
-from slack_api import SlackApiError, SlackClient
+from slack_api import ChannelSelectMixin, SlackApiError, SlackClient
 
 
-class UploadFileTool(Tool):
+class UploadFileTool(ChannelSelectMixin, Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:

--- a/tools/slack/tools/upload_file.yaml
+++ b/tools/slack/tools/upload_file.yaml
@@ -1,0 +1,79 @@
+identity:
+  name: upload_file
+  author: Pan YANG
+  label:
+    en_US: Upload File
+    zh_Hans: 上传文件
+    ja_JP: ファイルをアップロード
+    ko_KR: 파일 업로드
+description:
+  human:
+    en_US: Upload a file to Slack and optionally share it to a channel.
+    zh_Hans: 上传文件到 Slack，并可选择分享到某个频道。
+    ja_JP: Slack にファイルをアップロードし、必要に応じてチャンネルに共有します。
+    ko_KR: Slack에 파일을 업로드하고 선택적으로 채널에 공유합니다.
+  llm: Uploads a file to Slack using the external upload flow (files.getUploadURLExternal and files.completeUploadExternal). Requires a file. Optionally share it to a channel with a title and an initial comment.
+parameters:
+  - name: file
+    type: file
+    required: true
+    label:
+      en_US: File
+      zh_Hans: 文件
+      ja_JP: ファイル
+      ko_KR: 파일
+    human_description:
+      en_US: The file to upload to Slack.
+      zh_Hans: 要上传到 Slack 的文件。
+      ja_JP: Slack にアップロードするファイル。
+      ko_KR: Slack에 업로드할 파일.
+    llm_description: The file to upload to Slack. Accepts documents, images, and other file types.
+    form: llm
+  - name: channel
+    type: string
+    required: false
+    label:
+      en_US: Channel
+      zh_Hans: 频道
+      ja_JP: チャンネル
+      ko_KR: 채널
+    human_description:
+      en_US: Optional channel ID to share the uploaded file to (e.g. C0123456789).
+      zh_Hans: 可选，分享上传文件的频道 ID（如 C0123456789）。
+      ja_JP: "アップロードしたファイルを共有するチャンネル ID（任意、例: C0123456789）。"
+      ko_KR: "업로드한 파일을 공유할 채널 ID(선택 사항, 예: C0123456789)."
+    llm_description: Optional channel ID (e.g. C0123456789) to share the uploaded file to.
+    form: llm
+  - name: title
+    type: string
+    required: false
+    label:
+      en_US: Title
+      zh_Hans: 标题
+      ja_JP: タイトル
+      ko_KR: 제목
+    human_description:
+      en_US: Optional title for the uploaded file.
+      zh_Hans: 上传文件的可选标题。
+      ja_JP: アップロードするファイルのタイトル（任意）。
+      ko_KR: 업로드한 파일의 제목(선택 사항).
+    llm_description: Optional display title for the uploaded file.
+    form: llm
+  - name: initial_comment
+    type: string
+    required: false
+    label:
+      en_US: Initial Comment
+      zh_Hans: 初始评论
+      ja_JP: 初期コメント
+      ko_KR: 초기 댓글
+    human_description:
+      en_US: Optional message text to post along with the file.
+      zh_Hans: 与文件一起发布的可选消息文本。
+      ja_JP: ファイルと一緒に投稿するメッセージテキスト（任意）。
+      ko_KR: 파일과 함께 게시할 메시지 텍스트(선택 사항).
+    llm_description: Optional comment text posted together with the shared file.
+    form: llm
+extra:
+  python:
+    source: tools/upload_file.py

--- a/tools/slack/tools/upload_file.yaml
+++ b/tools/slack/tools/upload_file.yaml
@@ -1,6 +1,6 @@
 identity:
   name: upload_file
-  author: Pan YANG
+  author: langgenius
   label:
     en_US: Upload File
     zh_Hans: 上传文件
@@ -30,7 +30,7 @@ parameters:
     llm_description: The file to upload to Slack. Accepts documents, images, and other file types.
     form: llm
   - name: channel
-    type: string
+    type: dynamic-select
     required: false
     label:
       en_US: Channel

--- a/tools/slack/uv.lock
+++ b/tools/slack/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpkt" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/fd/1ba9d6dda0363ade4c1aab87e8188550db2ccce204071bc5fcf64d97fef6/dify_plugin-0.10.0.tar.gz", hash = "sha256:1d66f06647b16bc16ba3989fec09808d955a6c7a297f5a572c27288e717fa1aa", size = 319288, upload-time = "2026-07-20T09:34:54.712Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5b/ac14980502c31aaed011259c5fe698da83af1d384a2d59577d68ca34316a/dify_plugin-0.10.0-py3-none-any.whl", hash = "sha256:b7a4d8acbad153720cac50e3f38a428178f50079fd2599e24db3403cc1a0c8f4", size = 377626, upload-time = "2026-07-20T09:34:53.437Z" },
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.0" },
     { name = "httpx", specifier = ">=0.28.1" },
 ]
 


### PR DESCRIPTION
## Summary

Reworks the **Slack** tool plugin from a single Incoming Webhook sender into a full **Slack Web API** integration, authenticated with a Slack access token (Bot `xoxb-` or User `xoxp-`). The legacy Incoming Webhook tool is kept for backward compatibility.

**What's new**
- **20 tools** — Messages (send / update / delete / permalink / schedule), Channels (list / info / create / history / thread replies / invite / archive / set topic), Reactions (add / remove), Users (list / info / lookup by email), Files (upload), plus the legacy Incoming Webhook.
- **Dynamic channel dropdowns** — every `channel` parameter is a `dynamic-select` populated from `conversations.list`.
- **Robust auth** — token whitespace auto-stripped; channel-listing failures surface the real Slack error (e.g. `missing_scope` with needed/provided).
- **i18n** in en / zh-Hans / ja / ko; README ships a ready-to-paste Slack **app manifest** for one-step scope setup.

This is a significant rework of the existing plugin (top-level `version` bumped to `0.2.0`); previous webhook-only behavior is preserved via the Incoming Webhook tool. Validated with `dify plugin package`.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| Incoming Webhook only | 
<img width="726" height="864" alt="image" src="https://github.com/user-attachments/assets/2447ab8b-4f9e-46a4-9ee0-054d1ecf82e8" /> |

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (now `0.2.0`, was `0.0.9`)
- [x] `dify_plugin` declared in `pyproject.toml` (`dify_plugin>=0.10.0`) and locked in `uv.lock`

## Testing

- [x] Local deployment — Dify version: <1.16.1>
- [ ] SaaS (cloud.dify.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

