### PR TITLE
feat(minimax): support M3 documents and hidden thinking

### DIFF
--- a/models/minimax/manifest.yaml
+++ b/models/minimax/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.23
+version: 0.0.24

--- a/models/minimax/models/llm/_functional.py
+++ b/models/minimax/models/llm/_functional.py
@@ -1,0 +1,257 @@
+"""Pure transformations used by the MiniMax LLM adapter.
+
+Keep provider I/O in ``llm.py`` and put deterministic data-to-data operations here.
+This makes the adapter easier to reason about, compose, and test without an API client.
+"""
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from itertools import chain, groupby
+from types import MappingProxyType
+from typing import Any
+
+from dify_plugin.entities.model.message import (
+    DocumentPromptMessageContent,
+    ImagePromptMessageContent,
+    TextPromptMessageContent,
+    VideoPromptMessageContent,
+)
+
+MODEL_ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        "minimax-m3": "MiniMax-M3",
+        "minimax-m2.7": "MiniMax-M2.7",
+        "minimax-m2.7-highspeed": "MiniMax-M2.7-highspeed",
+        "minimax-m2.7lightning": "MiniMax-M2.7-highspeed",
+        "minimax-m2.7-lightning": "MiniMax-M2.7-highspeed",
+        "minimax-m2.5": "MiniMax-M2.5",
+        "minimax-m2.5lightning": "MiniMax-M2.5-highspeed",
+        "minimax-m2.5-lightning": "MiniMax-M2.5-highspeed",
+        "minimax-m2.1": "MiniMax-M2.1",
+        "minimax-m2.1-lightning": "MiniMax-M2.1-highspeed",
+        "minimax-m2": "MiniMax-M2",
+        "minimax-m2-her": "MiniMax-M2",
+        "minimax-m1": "MiniMax-M2.5",
+    }
+)
+
+FINISH_REASONS: Mapping[str, str] = MappingProxyType(
+    {"end_turn": "stop", "stop_sequence": "stop", "max_tokens": "length", "tool_use": "tool_calls"}
+)
+
+MEDIA_KINDS: Mapping[str, str] = MappingProxyType(
+    {
+        "image": "image",
+        "image_url": "image",
+        "video": "video",
+        "video_url": "video",
+        "document": "document",
+        "document_url": "document",
+    }
+)
+
+MEDIA_CONTENT_TYPES = (
+    (ImagePromptMessageContent, "image"),
+    (VideoPromptMessageContent, "video"),
+    (DocumentPromptMessageContent, "document"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationOptions:
+    """Normalized generation policy, independent of SDK request objects."""
+
+    max_tokens: int
+    thinking: Any
+    thinking_budget: int
+    exclude_reasoning_tokens: bool
+    sampling: tuple[tuple[str, Any], ...]
+
+
+def resolve_model_name(model: str) -> str:
+    return MODEL_ALIASES.get(model, MODEL_ALIASES.get(model.lower(), model))
+
+
+def generation_options(parameters: Mapping[str, Any], request_model: str) -> GenerationOptions:
+    """Normalize parameters without changing the caller-owned mapping."""
+
+    values = dict(parameters)
+    raw_max_tokens = next(
+        (
+            values[name]
+            for name in ("max_tokens", "max_tokens_to_sample", "max_output_tokens")
+            if name in values
+        ),
+        1024,
+    )
+    max_tokens = int(raw_max_tokens or 1024)
+
+    return GenerationOptions(
+        max_tokens=max_tokens if max_tokens > 0 else 1024,
+        thinking=values.get("thinking"),
+        thinking_budget=int(values.get("thinking_budget", 1024) or 1024),
+        exclude_reasoning_tokens=(
+            values.get("exclude_reasoning_tokens", request_model == "MiniMax-M3") is True
+        ),
+        sampling=tuple(
+            (name, values[name])
+            for name in ("temperature", "top_p", "top_k")
+            if values.get(name) is not None
+        ),
+    )
+
+
+def normalize_thinking_payload(
+    *, thinking: Any, thinking_budget: int, request_model: str
+) -> dict[str, Any] | None:
+    if isinstance(thinking, dict):
+        return dict(thinking)
+
+    thinking_type = thinking.strip().lower() if isinstance(thinking, str) else thinking
+    if thinking_type == "adaptive":
+        return {"type": "adaptive"}
+    if thinking_type is True or thinking_type in ("enabled", "true"):
+        if request_model == "MiniMax-M3":
+            return {"type": "adaptive"}
+        return {"type": "enabled", "budget_tokens": max(1024, thinking_budget)}
+    return None
+
+
+def content_type_value(content_type: Any) -> Any:
+    return getattr(content_type, "value", content_type)
+
+
+def _nested_url(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        return str(value.get("url") or "")
+    return ""
+
+
+def _mapping_media_data(content: Mapping[str, Any], media_kind: str) -> str:
+    direct = content.get("data") or content.get("url")
+    return str(direct) if direct else _nested_url(content.get(f"{media_kind}_url"))
+
+
+def media_source(data: str) -> dict[str, Any]:
+    if data.startswith("data:") and ";base64," in data:
+        header, encoded = data.split(";base64,", 1)
+        return {"type": "base64", "media_type": header.removeprefix("data:"), "data": encoded}
+    return {"type": "url", "url": data}
+
+
+def user_content_block(content: Any) -> dict[str, Any] | None:
+    """Convert one Dify content value into one MiniMax content block."""
+
+    if isinstance(content, TextPromptMessageContent):
+        return {"type": "text", "text": content.data}
+
+    for content_class, media_kind in MEDIA_CONTENT_TYPES:
+        if isinstance(content, content_class):
+            data = content.data.strip()
+            return {"type": media_kind, "source": media_source(data)} if data else None
+
+    if isinstance(content, Mapping):
+        content_kind = content_type_value(content.get("type"))
+        if content_kind == "text":
+            return {"type": "text", "text": str(content.get("data") or content.get("text") or "")}
+        if media_kind := MEDIA_KINDS.get(content_kind):
+            data = _mapping_media_data(content, media_kind).strip()
+            return {"type": media_kind, "source": media_source(data)} if data else None
+        return None
+
+    content_kind = content_type_value(getattr(content, "type", None))
+    if content_kind == "text":
+        return {"type": "text", "text": str(getattr(content, "data", ""))}
+    if media_kind := MEDIA_KINDS.get(content_kind):
+        data = str(getattr(content, "data", "")).strip()
+        return {"type": media_kind, "source": media_source(data)} if data else None
+    return None
+
+
+def normalize_content_blocks(content: Any) -> list[dict[str, Any]]:
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    if isinstance(content, list):
+        return [item for item in content if isinstance(item, dict)]
+    return []
+
+
+def merge_consecutive_messages(messages: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group adjacent messages by role without mutating any input message."""
+
+    return [
+        {
+            "role": role,
+            "content": list(
+                chain.from_iterable(
+                    normalize_content_blocks(message.get("content")) for message in group
+                )
+            ),
+        }
+        for role, group in groupby(messages, key=lambda message: message.get("role"))
+    ]
+
+
+def text_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+
+    def text_fragment(item: Any) -> str:
+        if isinstance(item, TextPromptMessageContent):
+            return item.data
+        if isinstance(item, Mapping) and content_type_value(item.get("type")) == "text":
+            return str(item.get("data") or item.get("text") or "")
+        if content_type_value(getattr(item, "type", None)) == "text":
+            return str(getattr(item, "data", getattr(item, "text", "")))
+        return ""
+
+    return " ".join(filter(None, map(text_fragment, content)))
+
+
+def parse_json_object(arguments: str) -> dict[str, Any]:
+    try:
+        value = json.loads(arguments or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return {"raw": arguments}
+    return value if isinstance(value, dict) else {"value": value}
+
+
+def render_assistant_text(
+    thinking_blocks: Sequence[Mapping[str, Any]], text_chunks: Sequence[str], *, hide_thinking: bool
+) -> str:
+    answer = "".join(text_chunks)
+    if hide_thinking:
+        return answer
+
+    thinking = "".join(
+        (
+            str(block.get("thinking", ""))
+            if block.get("type") == "thinking"
+            else "[Redacted thinking]" if block.get("type") == "redacted_thinking" else ""
+        )
+        for block in thinking_blocks
+    )
+    return f"<think>{thinking}</think>\n{answer}" if thinking else answer
+
+
+def normalize_anthropic_endpoint(endpoint_url: Any) -> str:
+    endpoint = str(endpoint_url or "https://api.minimax.io").strip()
+    if not endpoint.startswith(("http://", "https://")):
+        endpoint = f"https://{endpoint}"
+    endpoint = endpoint.rstrip("/")
+    return endpoint if endpoint.endswith("/anthropic") else f"{endpoint}/anthropic"
+
+
+def convert_finish_reason(finish_reason: str | None) -> str | None:
+    return FINISH_REASONS.get(finish_reason, finish_reason) if finish_reason else None
+
+
+def index_sort_key(value: str) -> tuple[int, int | str]:
+    return (0, int(value)) if value.isdigit() else (1, value)

--- a/models/minimax/models/llm/llm.py
+++ b/models/minimax/models/llm/llm.py
@@ -8,6 +8,7 @@ from anthropic.types import Message
 from dify_plugin.entities.model.llm import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
+    DocumentPromptMessageContent,
     ImagePromptMessageContent,
     PromptMessage,
     PromptMessageTool,
@@ -93,6 +94,9 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
         thinking = model_parameters.pop("thinking", None)
         thinking_budget = int(model_parameters.pop("thinking_budget", 1024) or 1024)
+        exclude_reasoning_tokens = model_parameters.pop(
+            "exclude_reasoning_tokens", request_model == "MiniMax-M3"
+        )
 
         max_tokens = int(model_parameters.pop("max_tokens", 1024) or 1024)
         if max_tokens <= 0:
@@ -135,6 +139,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 credentials=credentials,
                 response=response,
                 tools=tools,
+                exclude_reasoning_tokens=exclude_reasoning_tokens is True,
             )
 
         response = client.messages.create(stream=False, **request_kwargs)
@@ -144,6 +149,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             credentials=credentials,
             response=response,
             tools=tools,
+            exclude_reasoning_tokens=exclude_reasoning_tokens is True,
         )
 
     def validate_credentials(self, model: str, credentials: Mapping[str, Any]) -> None:
@@ -278,6 +284,8 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             return self._create_media_content_block("image", content.data)
         if isinstance(content, VideoPromptMessageContent):
             return self._create_media_content_block("video", content.data)
+        if isinstance(content, DocumentPromptMessageContent):
+            return self._create_media_content_block("document", content.data)
 
         if isinstance(content, dict):
             content_type = content.get("type")
@@ -292,6 +300,9 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             if self._is_content_type(content_type, "video", "video_url"):
                 video_url = self._extract_media_url(content, "video_url")
                 return self._create_media_content_block("video", str(video_url or ""))
+            if self._is_content_type(content_type, "document", "document_url"):
+                document_url = self._extract_media_url(content, "document_url")
+                return self._create_media_content_block("document", str(document_url or ""))
             return None
 
         content_type = getattr(content, "type", None)
@@ -301,6 +312,10 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             return self._create_media_content_block("image", str(getattr(content, "data", "")))
         if self._is_content_type(content_type, "video"):
             return self._create_media_content_block("video", str(getattr(content, "data", "")))
+        if self._is_content_type(content_type, "document"):
+            return self._create_media_content_block(
+                "document", str(getattr(content, "data", ""))
+            )
         return None
 
     def _is_content_type(self, content_type: Any, *expected: str) -> bool:
@@ -442,6 +457,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         credentials: dict,
         response: Message,
         tools: Optional[list[PromptMessageTool]] = None,
+        exclude_reasoning_tokens: bool = False,
     ) -> LLMResult:
         text_chunks: list[str] = []
         tool_calls: list[AssistantPromptMessage.ToolCall] = []
@@ -499,7 +515,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
         # 构建包含思考内容的完整文本
         assistant_text = ""
-        if thinking_blocks:
+        if thinking_blocks and not exclude_reasoning_tokens:
             # 将所有思考内容用<think>标签包裹
             thinking_contents = []
             for block in thinking_blocks:
@@ -562,6 +578,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         credentials: dict,
         response: Stream,
         tools: Optional[list[PromptMessageTool]] = None,
+        exclude_reasoning_tokens: bool = False,
     ) -> Generator[LLMResultChunk, None, None]:
         input_tokens = 0
         output_tokens = 0
@@ -581,6 +598,8 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             if is_reasoning_started != 1:
                 return None
             is_reasoning_started = 2
+            if exclude_reasoning_tokens:
+                return None
             return LLMResultChunk(
                 model=model,
                 prompt_messages=prompt_messages,
@@ -657,7 +676,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                     )
                 elif getattr(block, "type", "") == "thinking":
                     # 开始思考块时,输出<think>标签
-                    if is_reasoning_started == 0:
+                    if is_reasoning_started == 0 and not exclude_reasoning_tokens:
                         yield LLMResultChunk(
                             model=model,
                             prompt_messages=prompt_messages,
@@ -730,7 +749,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                         prev = str(thinking_block.get("thinking", ""))
                         thinking_block["thinking"] = prev + thinking
                         # 实时输出思考内容
-                        if is_reasoning_started == 0:
+                        if is_reasoning_started == 0 and not exclude_reasoning_tokens:
                             yield LLMResultChunk(
                                 model=model,
                                 prompt_messages=prompt_messages,
@@ -740,14 +759,15 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                                 ),
                             )
                             is_reasoning_started = 1
-                        yield LLMResultChunk(
-                            model=model,
-                            prompt_messages=prompt_messages,
-                            delta=LLMResultChunkDelta(
-                                index=event_index,
-                                message=AssistantPromptMessage(content=thinking),
-                            ),
-                        )
+                        if not exclude_reasoning_tokens:
+                            yield LLMResultChunk(
+                                model=model,
+                                prompt_messages=prompt_messages,
+                                delta=LLMResultChunkDelta(
+                                    index=event_index,
+                                    message=AssistantPromptMessage(content=thinking),
+                                ),
+                            )
                 elif delta_type == "signature_delta":
                     signature = getattr(delta, "signature", "")
                     thinking_block = streamed_thinking_blocks.get(str(event_index))

--- a/models/minimax/models/llm/llm.py
+++ b/models/minimax/models/llm/llm.py
@@ -1,6 +1,6 @@
 import json
-from collections.abc import Generator, Sequence
-from typing import Any, Mapping, Optional, Union
+from collections.abc import Generator, Mapping, Sequence
+from typing import Any
 
 import anthropic
 from anthropic import Anthropic, Stream
@@ -8,15 +8,11 @@ from anthropic.types import Message
 from dify_plugin.entities.model.llm import LLMResult, LLMResultChunk, LLMResultChunkDelta
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
-    DocumentPromptMessageContent,
-    ImagePromptMessageContent,
     PromptMessage,
     PromptMessageTool,
     SystemPromptMessage,
-    TextPromptMessageContent,
     ToolPromptMessage,
     UserPromptMessage,
-    VideoPromptMessageContent,
 )
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,
@@ -29,24 +25,23 @@ from dify_plugin.errors.model import (
 )
 from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
 
+from models.llm._functional import (
+    convert_finish_reason,
+    generation_options,
+    index_sort_key,
+    merge_consecutive_messages,
+    normalize_anthropic_endpoint,
+    normalize_thinking_payload,
+    parse_json_object,
+    render_assistant_text,
+    resolve_model_name,
+    text_content,
+    user_content_block,
+)
+
 
 class MinimaxLargeLanguageModel(LargeLanguageModel):
     _OPAQUE_ANTHROPIC_CONTENT_KEY = "minimax_anthropic_content"
-    _MODEL_ALIASES = {
-        "minimax-m3": "MiniMax-M3",
-        "minimax-m2.7": "MiniMax-M2.7",
-        "minimax-m2.7-highspeed": "MiniMax-M2.7-highspeed",
-        "minimax-m2.7lightning": "MiniMax-M2.7-highspeed",
-        "minimax-m2.7-lightning": "MiniMax-M2.7-highspeed",
-        "minimax-m2.5": "MiniMax-M2.5",
-        "minimax-m2.5lightning": "MiniMax-M2.5-highspeed",
-        "minimax-m2.5-lightning": "MiniMax-M2.5-highspeed",
-        "minimax-m2.1": "MiniMax-M2.1",
-        "minimax-m2.1-lightning": "MiniMax-M2.1-highspeed",
-        "minimax-m2": "MiniMax-M2",
-        "minimax-m2-her": "MiniMax-M2",
-        "minimax-m1": "MiniMax-M2.5",
-    }
 
     def _invoke(
         self,
@@ -54,11 +49,11 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         credentials: dict,
         prompt_messages: list[PromptMessage],
         model_parameters: dict,
-        tools: Optional[list[PromptMessageTool]] = None,
-        stop: Optional[list[str]] = None,
+        tools: list[PromptMessageTool] | None = None,
+        stop: list[str] | None = None,
         stream: bool = True,
-        user: Optional[str] = None,
-    ) -> Union[LLMResult, Generator]:
+        user: str | None = None,
+    ) -> LLMResult | Generator:
         return self._chat_generate(
             model=model,
             credentials=credentials,
@@ -77,37 +72,22 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         credentials: dict[str, Any],
         prompt_messages: Sequence[PromptMessage],
         model_parameters: dict[str, Any],
-        tools: Optional[list[PromptMessageTool]] = None,
-        stop: Optional[Sequence[str]] = None,
+        tools: list[PromptMessageTool] | None = None,
+        stop: Sequence[str] | None = None,
         stream: bool = True,
-        user: Optional[str] = None,
-    ) -> Union[LLMResult, Generator]:
+        user: str | None = None,
+    ) -> LLMResult | Generator:
         request_model = self._resolve_model_name(model)
         credentials_kwargs = self._to_credential_kwargs(credentials)
         client = Anthropic(**credentials_kwargs)
-
-        model_parameters = dict(model_parameters)
-        if "max_tokens_to_sample" in model_parameters and "max_tokens" not in model_parameters:
-            model_parameters["max_tokens"] = model_parameters.pop("max_tokens_to_sample")
-        if "max_output_tokens" in model_parameters and "max_tokens" not in model_parameters:
-            model_parameters["max_tokens"] = model_parameters.pop("max_output_tokens")
-
-        thinking = model_parameters.pop("thinking", None)
-        thinking_budget = int(model_parameters.pop("thinking_budget", 1024) or 1024)
-        exclude_reasoning_tokens = model_parameters.pop(
-            "exclude_reasoning_tokens", request_model == "MiniMax-M3"
-        )
-
-        max_tokens = int(model_parameters.pop("max_tokens", 1024) or 1024)
-        if max_tokens <= 0:
-            max_tokens = 1024
+        options = generation_options(model_parameters, request_model)
 
         system, prompt_message_dicts = self._convert_prompt_messages(prompt_messages)
 
         request_kwargs: dict[str, Any] = {
             "model": request_model,
             "messages": prompt_message_dicts,
-            "max_tokens": max_tokens,
+            "max_tokens": options.max_tokens,
         }
 
         if system:
@@ -117,16 +97,14 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         if user:
             request_kwargs["metadata"] = {"user_id": user}
         thinking_payload = self._normalize_thinking_payload(
-            thinking=thinking,
-            thinking_budget=thinking_budget,
+            thinking=options.thinking,
+            thinking_budget=options.thinking_budget,
             request_model=request_model,
         )
         if thinking_payload:
             request_kwargs["thinking"] = thinking_payload
 
-        for key in ("temperature", "top_p", "top_k"):
-            if key in model_parameters and model_parameters[key] is not None:
-                request_kwargs[key] = model_parameters[key]
+        request_kwargs.update(options.sampling)
 
         if tools:
             request_kwargs["tools"] = self._transform_tool_prompt(tools)
@@ -139,7 +117,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 credentials=credentials,
                 response=response,
                 tools=tools,
-                exclude_reasoning_tokens=exclude_reasoning_tokens is True,
+                exclude_reasoning_tokens=options.exclude_reasoning_tokens,
             )
 
         response = client.messages.create(stream=False, **request_kwargs)
@@ -149,7 +127,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             credentials=credentials,
             response=response,
             tools=tools,
-            exclude_reasoning_tokens=exclude_reasoning_tokens is True,
+            exclude_reasoning_tokens=options.exclude_reasoning_tokens,
         )
 
     def validate_credentials(self, model: str, credentials: Mapping[str, Any]) -> None:
@@ -159,28 +137,27 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
         try:
             client.messages.create(
-                model=request_model,
-                max_tokens=8,
-                messages=[{"role": "user", "content": "ping"}],
+                model=request_model, max_tokens=8, messages=[{"role": "user", "content": "ping"}]
             )
         except (anthropic.AuthenticationError, anthropic.PermissionDeniedError) as ex:
-            raise CredentialsValidateFailedError(str(ex))
+            raise CredentialsValidateFailedError(str(ex)) from ex
         except Exception as ex:
-            raise CredentialsValidateFailedError(str(ex))
+            raise CredentialsValidateFailedError(str(ex)) from ex
 
     def get_num_tokens(
         self,
         model: str,
         credentials: dict,
         prompt_messages: list[PromptMessage],
-        tools: Optional[list[PromptMessageTool]] = None,
+        tools: list[PromptMessageTool] | None = None,
     ) -> int:
-        prompt = "\n".join(self._extract_text_content(message.content) for message in prompt_messages)
+        prompt = "\n".join(
+            self._extract_text_content(message.content) for message in prompt_messages
+        )
         return self._get_num_tokens_by_gpt2(prompt)
 
     def _convert_prompt_messages(
-        self,
-        prompt_messages: Sequence[PromptMessage],
+        self, prompt_messages: Sequence[PromptMessage]
     ) -> tuple[str, list[dict[str, Any]]]:
         system_parts: list[str] = []
         message_dicts: list[dict[str, Any]] = []
@@ -206,7 +183,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
 
     def _convert_prompt_message_to_anthropic_message(
         self, prompt_message: PromptMessage
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         if isinstance(prompt_message, UserPromptMessage):
             return {
                 "role": "user",
@@ -233,18 +210,12 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             if prompt_message.tool_calls:
                 for tool_call in prompt_message.tool_calls:
                     arguments = tool_call.function.arguments or "{}"
-                    try:
-                        input_payload = json.loads(arguments)
-                    except Exception:
-                        input_payload = {"raw": arguments}
-                    if not isinstance(input_payload, dict):
-                        input_payload = {"value": input_payload}
                     content_blocks.append(
                         {
                             "type": "tool_use",
                             "id": tool_call.id,
                             "name": tool_call.function.name,
-                            "input": input_payload,
+                            "input": self._parse_tool_arguments(arguments),
                         }
                     )
 
@@ -267,133 +238,23 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         if not isinstance(content, list):
             return [{"type": "text", "text": self._extract_text_content(content)}]
 
-        content_blocks: list[dict[str, Any]] = []
-        for item in content:
-            block = self._convert_user_content_block(item)
-            if block is not None:
-                content_blocks.append(block)
+        content_blocks = [
+            block
+            for item in content
+            if (block := self._convert_user_content_block(item)) is not None
+        ]
+        return content_blocks or [{"type": "text", "text": ""}]
 
-        if not content_blocks:
-            return [{"type": "text", "text": ""}]
-        return content_blocks
-
-    def _convert_user_content_block(self, content: Any) -> Optional[dict[str, Any]]:
-        if isinstance(content, TextPromptMessageContent):
-            return {"type": "text", "text": content.data}
-        if isinstance(content, ImagePromptMessageContent):
-            return self._create_media_content_block("image", content.data)
-        if isinstance(content, VideoPromptMessageContent):
-            return self._create_media_content_block("video", content.data)
-        if isinstance(content, DocumentPromptMessageContent):
-            return self._create_media_content_block("document", content.data)
-
-        if isinstance(content, dict):
-            content_type = content.get("type")
-            if self._is_content_type(content_type, "text"):
-                return {
-                    "type": "text",
-                    "text": str(content.get("data") or content.get("text") or ""),
-                }
-            if self._is_content_type(content_type, "image", "image_url"):
-                image_url = self._extract_media_url(content, "image_url")
-                return self._create_media_content_block("image", str(image_url or ""))
-            if self._is_content_type(content_type, "video", "video_url"):
-                video_url = self._extract_media_url(content, "video_url")
-                return self._create_media_content_block("video", str(video_url or ""))
-            if self._is_content_type(content_type, "document", "document_url"):
-                document_url = self._extract_media_url(content, "document_url")
-                return self._create_media_content_block("document", str(document_url or ""))
-            return None
-
-        content_type = getattr(content, "type", None)
-        if self._is_content_type(content_type, "text"):
-            return {"type": "text", "text": str(getattr(content, "data", ""))}
-        if self._is_content_type(content_type, "image"):
-            return self._create_media_content_block("image", str(getattr(content, "data", "")))
-        if self._is_content_type(content_type, "video"):
-            return self._create_media_content_block("video", str(getattr(content, "data", "")))
-        if self._is_content_type(content_type, "document"):
-            return self._create_media_content_block(
-                "document", str(getattr(content, "data", ""))
-            )
-        return None
-
-    def _is_content_type(self, content_type: Any, *expected: str) -> bool:
-        content_type_value = getattr(content_type, "value", content_type)
-        return content_type_value in expected
-
-    def _extract_media_url(self, content: dict[str, Any], media_key: str) -> Any:
-        media_url = content.get("data") or content.get("url")
-        if media_url:
-            return media_url
-
-        media_value = content.get(media_key)
-        if isinstance(media_value, dict):
-            return media_value.get("url")
-        if isinstance(media_value, str):
-            return media_value
-        return None
-
-    def _create_media_content_block(self, block_type: str, data: str) -> Optional[dict[str, Any]]:
-        data = data.strip()
-        if not data:
-            return None
-        return {"type": block_type, "source": self._create_media_source(data)}
-
-    def _create_media_source(self, data: str) -> dict[str, Any]:
-        if data.startswith("data:") and ";base64," in data:
-            header, encoded = data.split(";base64,", 1)
-            return {
-                "type": "base64",
-                "media_type": header.removeprefix("data:"),
-                "data": encoded,
-            }
-        return {"type": "url", "url": data}
+    def _convert_user_content_block(self, content: Any) -> dict[str, Any] | None:
+        return user_content_block(content)
 
     def _merge_consecutive_messages(
         self, message_dicts: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        merged: list[dict[str, Any]] = []
-        for message in message_dicts:
-            role = message.get("role")
-            content = self._normalize_content_blocks(message.get("content"))
-            if not merged or merged[-1].get("role") != role:
-                merged.append({"role": role, "content": content})
-            else:
-                merged[-1]["content"].extend(content)
-        return merged
-
-    def _normalize_content_blocks(self, content: Any) -> list[dict[str, Any]]:
-        if isinstance(content, str):
-            return [{"type": "text", "text": content}]
-        if isinstance(content, list):
-            normalized: list[dict[str, Any]] = []
-            for item in content:
-                if isinstance(item, dict):
-                    normalized.append(item)
-            return normalized
-        return []
+        return merge_consecutive_messages(message_dicts)
 
     def _extract_text_content(self, content: Any) -> str:
-        if content is None:
-            return ""
-        if isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            text_parts: list[str] = []
-            for item in content:
-                if isinstance(item, TextPromptMessageContent):
-                    text_parts.append(item.data)
-                elif isinstance(item, dict):
-                    if item.get("type") == "text":
-                        text_parts.append(str(item.get("data") or item.get("text") or ""))
-                elif hasattr(item, "type") and getattr(item, "type", None) == "text":
-                    if hasattr(item, "data"):
-                        text_parts.append(str(item.data))
-                    elif hasattr(item, "text"):
-                        text_parts.append(str(item.text))
-            return " ".join(part for part in text_parts if part)
-        return str(content)
+        return text_content(content)
 
     def _transform_tool_prompt(self, tools: list[PromptMessageTool]) -> list[dict[str, Any]]:
         transformed_tools: list[dict[str, Any]] = []
@@ -417,13 +278,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         return transformed_tools
 
     def _parse_tool_arguments(self, arguments: str) -> dict[str, Any]:
-        try:
-            input_payload = json.loads(arguments or "{}")
-        except Exception:
-            return {"raw": arguments}
-        if not isinstance(input_payload, dict):
-            return {"value": input_payload}
-        return input_payload
+        return parse_json_object(arguments)
 
     def _get_opaque_anthropic_content(
         self, prompt_message: AssistantPromptMessage
@@ -456,7 +311,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         prompt_messages: list[PromptMessage],
         credentials: dict,
         response: Message,
-        tools: Optional[list[PromptMessageTool]] = None,
+        tools: list[PromptMessageTool] | None = None,
         exclude_reasoning_tokens: bool = False,
     ) -> LLMResult:
         text_chunks: list[str] = []
@@ -502,8 +357,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                         id=getattr(block, "id", ""),
                         type="function",
                         function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                            name=getattr(block, "name", ""),
-                            arguments=json.dumps(input_payload),
+                            name=getattr(block, "name", ""), arguments=json.dumps(input_payload)
                         ),
                     )
                 )
@@ -513,41 +367,23 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         else:
             self._set_previous_thinking_blocks([])
 
-        # 构建包含思考内容的完整文本
-        assistant_text = ""
-        if thinking_blocks and not exclude_reasoning_tokens:
-            # 将所有思考内容用<think>标签包裹
-            thinking_contents = []
-            for block in thinking_blocks:
-                if block.get("type") == "thinking":
-                    thinking_contents.append(block.get("thinking", ""))
-                elif block.get("type") == "redacted_thinking":
-                    thinking_contents.append("[Redacted thinking]")
-
-            if thinking_contents:
-                assistant_text = "<think>" + "".join(thinking_contents) + "</think>\n"
-
-        # 添加正常文本内容
-        assistant_text += "".join(text_chunks)
+        assistant_text = render_assistant_text(
+            thinking_blocks, text_chunks, hide_thinking=exclude_reasoning_tokens
+        )
 
         opaque_body = None
         if response_content_blocks:
             opaque_body = {self._OPAQUE_ANTHROPIC_CONTENT_KEY: response_content_blocks}
 
         assistant_message = AssistantPromptMessage(
-            content=assistant_text,
-            tool_calls=tool_calls,
-            opaque_body=opaque_body,
+            content=assistant_text, tool_calls=tool_calls, opaque_body=opaque_body
         )
 
         prompt_tokens = int(getattr(response.usage, "input_tokens", 0) or 0)
         completion_tokens = int(getattr(response.usage, "output_tokens", 0) or 0)
         if prompt_tokens == 0:
             prompt_tokens = self.get_num_tokens(
-                model=model,
-                credentials=credentials,
-                prompt_messages=prompt_messages,
-                tools=tools,
+                model=model, credentials=credentials, prompt_messages=prompt_messages, tools=tools
             )
         if completion_tokens == 0:
             completion_tokens = self.get_num_tokens(
@@ -565,10 +401,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         )
 
         return LLMResult(
-            model=model,
-            prompt_messages=prompt_messages,
-            message=assistant_message,
-            usage=usage,
+            model=model, prompt_messages=prompt_messages, message=assistant_message, usage=usage
         )
 
     def _handle_chat_generate_stream_response(
@@ -577,23 +410,21 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
         prompt_messages: list[PromptMessage],
         credentials: dict,
         response: Stream,
-        tools: Optional[list[PromptMessageTool]] = None,
+        tools: list[PromptMessageTool] | None = None,
         exclude_reasoning_tokens: bool = False,
     ) -> Generator[LLMResultChunk, None, None]:
         input_tokens = 0
         output_tokens = 0
-        finish_reason: Optional[str] = None
+        finish_reason: str | None = None
         streamed_text: list[str] = []
         streamed_tool_calls: dict[str, AssistantPromptMessage.ToolCall] = {}
         streamed_tool_input_buffers: dict[str, str] = {}
         streamed_tool_input_fallbacks: dict[str, str] = {}
         streamed_content_blocks: dict[str, dict[str, Any]] = {}
         streamed_thinking_blocks: dict[str, dict[str, Any]] = {}
-        current_thinking_blocks: list[dict[str, Any]] = []
-        emitted_final = False
         is_reasoning_started = 0  # 0 not started, 1 started, 2 ended
 
-        def close_reasoning_chunk(index: int = 0) -> Optional[LLMResultChunk]:
+        def close_reasoning_chunk(index: int = 0) -> LLMResultChunk | None:
             nonlocal is_reasoning_started
             if is_reasoning_started != 1:
                 return None
@@ -604,41 +435,56 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 model=model,
                 prompt_messages=prompt_messages,
                 delta=LLMResultChunkDelta(
-                    index=index,
-                    message=AssistantPromptMessage(content="\n</think>\n"),
+                    index=index, message=AssistantPromptMessage(content="\n</think>\n")
+                ),
+            )
+
+        def tool_arguments(index: str) -> str:
+            return (
+                streamed_tool_input_buffers.get(index)
+                or streamed_tool_input_fallbacks.get(index)
+                or "{}"
+            )
+
+        def finalize_tool_call(index: str) -> AssistantPromptMessage.ToolCall:
+            seed = streamed_tool_calls[index]
+            return AssistantPromptMessage.ToolCall(
+                id=seed.id,
+                type="function",
+                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                    name=seed.function.name, arguments=tool_arguments(index)
                 ),
             )
 
         def finalize_tool_calls() -> list[AssistantPromptMessage.ToolCall]:
-            final_tool_calls: list[AssistantPromptMessage.ToolCall] = []
-            for index in sorted(
-                streamed_tool_calls,
-                key=lambda value: (0, int(value)) if value.isdigit() else (1, value),
-            ):
-                tool_call = streamed_tool_calls[index]
-                arguments = (
-                    streamed_tool_input_buffers.get(index)
-                    or streamed_tool_input_fallbacks.get(index)
-                    or "{}"
-                )
-                tool_call.function.arguments = arguments
-                content_block = streamed_content_blocks.get(index)
-                if content_block is not None and content_block.get("type") == "tool_use":
-                    content_block["input"] = self._parse_tool_arguments(arguments)
-                final_tool_calls.append(tool_call)
-            return final_tool_calls
+            return [
+                finalize_tool_call(index)
+                for index in sorted(streamed_tool_calls, key=index_sort_key)
+            ]
 
-        def build_opaque_body() -> Optional[dict[str, Any]]:
+        def finalized_content_block(index: str) -> dict[str, Any]:
+            block = streamed_content_blocks[index]
+            if block.get("type") != "tool_use":
+                return block
+            return {**block, "input": self._parse_tool_arguments(tool_arguments(index))}
+
+        def ordered_content_blocks() -> list[dict[str, Any]]:
+            return [
+                finalized_content_block(index)
+                for index in sorted(streamed_content_blocks, key=index_sort_key)
+            ]
+
+        def thinking_content_blocks() -> list[dict[str, Any]]:
+            return [
+                block
+                for block in ordered_content_blocks()
+                if block.get("type") in {"thinking", "redacted_thinking"}
+            ]
+
+        def build_opaque_body() -> dict[str, Any] | None:
             if not streamed_content_blocks:
                 return None
-            content_blocks = [
-                streamed_content_blocks[index]
-                for index in sorted(
-                    streamed_content_blocks,
-                    key=lambda value: (0, int(value)) if value.isdigit() else (1, value),
-                )
-            ]
-            return {self._OPAQUE_ANTHROPIC_CONTENT_KEY: content_blocks}
+            return {self._OPAQUE_ANTHROPIC_CONTENT_KEY: ordered_content_blocks()}
 
         for event in response:
             event_type = getattr(event, "type", "")
@@ -670,8 +516,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                         id=getattr(block, "id", index),
                         type="function",
                         function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                            name=getattr(block, "name", ""),
-                            arguments="",
+                            name=getattr(block, "name", ""), arguments=""
                         ),
                     )
                 elif getattr(block, "type", "") == "thinking":
@@ -681,8 +526,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                             model=model,
                             prompt_messages=prompt_messages,
                             delta=LLMResultChunkDelta(
-                                index=0,
-                                message=AssistantPromptMessage(content="<think>\n"),
+                                index=0, message=AssistantPromptMessage(content="<think>\n")
                             ),
                         )
                         is_reasoning_started = 1
@@ -693,11 +537,9 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                     }
                     streamed_content_blocks[index] = thinking_block
                     streamed_thinking_blocks[index] = thinking_block
-                    current_thinking_blocks.append(thinking_block)
                 elif getattr(block, "type", "") == "redacted_thinking":
                     thinking_block = {"type": "redacted_thinking"}
                     streamed_content_blocks[index] = thinking_block
-                    current_thinking_blocks.append(thinking_block)
                 elif getattr(block, "type", "") == "text":
                     streamed_content_blocks[index] = {
                         "type": "text",
@@ -719,17 +561,18 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                             yield closing_chunk
                         streamed_text.append(text)
                         content_block = streamed_content_blocks.setdefault(
-                            str(event_index),
-                            {"type": "text", "text": ""},
+                            str(event_index), {"type": "text", "text": ""}
                         )
                         if content_block.get("type") == "text":
-                            content_block["text"] = str(content_block.get("text", "")) + text
+                            streamed_content_blocks[str(event_index)] = {
+                                **content_block,
+                                "text": str(content_block.get("text", "")) + text,
+                            }
                         yield LLMResultChunk(
                             model=model,
                             prompt_messages=prompt_messages,
                             delta=LLMResultChunkDelta(
-                                index=event_index,
-                                message=AssistantPromptMessage(content=text),
+                                index=event_index, message=AssistantPromptMessage(content=text)
                             ),
                         )
                 elif delta_type == "thinking_delta":
@@ -738,16 +581,15 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                         index = str(event_index)
                         thinking_block = streamed_thinking_blocks.get(index)
                         if thinking_block is None:
-                            thinking_block = {
-                                "type": "thinking",
-                                "thinking": "",
-                                "signature": "",
-                            }
+                            thinking_block = {"type": "thinking", "thinking": "", "signature": ""}
                             streamed_content_blocks[index] = thinking_block
                             streamed_thinking_blocks[index] = thinking_block
-                            current_thinking_blocks.append(thinking_block)
-                        prev = str(thinking_block.get("thinking", ""))
-                        thinking_block["thinking"] = prev + thinking
+                        thinking_block = {
+                            **thinking_block,
+                            "thinking": str(thinking_block.get("thinking", "")) + thinking,
+                        }
+                        streamed_content_blocks[index] = thinking_block
+                        streamed_thinking_blocks[index] = thinking_block
                         # 实时输出思考内容
                         if is_reasoning_started == 0 and not exclude_reasoning_tokens:
                             yield LLMResultChunk(
@@ -772,7 +614,9 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                     signature = getattr(delta, "signature", "")
                     thinking_block = streamed_thinking_blocks.get(str(event_index))
                     if signature and thinking_block is not None:
-                        thinking_block["signature"] = signature
+                        thinking_block = {**thinking_block, "signature": signature}
+                        streamed_content_blocks[str(event_index)] = thinking_block
+                        streamed_thinking_blocks[str(event_index)] = thinking_block
                 elif delta_type == "input_json_delta":
                     partial_json = getattr(delta, "partial_json", "")
                     if partial_json:
@@ -789,8 +633,7 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                                 id=f"tool_{index}",
                                 type="function",
                                 function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                                    name="",
-                                    arguments="",
+                                    name="", arguments=""
                                 ),
                             )
                         streamed_tool_input_buffers[index] = (
@@ -803,176 +646,88 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
                 finish_reason = self._convert_finish_reason(getattr(delta, "stop_reason", None))
                 usage = getattr(event, "usage", None)
                 if usage is not None:
-                    output_tokens = int(getattr(usage, "output_tokens", output_tokens) or output_tokens)
+                    output_tokens = int(
+                        getattr(usage, "output_tokens", output_tokens) or output_tokens
+                    )
                 continue
 
             if event_type == "message_stop":
                 closing_chunk = close_reasoning_chunk(0)
                 if closing_chunk is not None:
                     yield closing_chunk
-                assistant_text = "".join(streamed_text)
-                if input_tokens == 0:
-                    input_tokens = self.get_num_tokens(
-                        model=model,
-                        credentials=credentials,
-                        prompt_messages=prompt_messages,
-                        tools=tools,
-                    )
-                if output_tokens == 0:
-                    output_tokens = self._get_num_tokens_by_gpt2(assistant_text)
+                break
 
-                usage = self._calc_response_usage(
-                    model=model,
-                    credentials=credentials,
-                    prompt_tokens=input_tokens,
-                    completion_tokens=output_tokens,
-                )
+        closing_chunk = close_reasoning_chunk(0)
+        if closing_chunk is not None:
+            yield closing_chunk
 
-                final_tool_calls = finalize_tool_calls()
-
-                if final_tool_calls and current_thinking_blocks:
-                    self._set_previous_thinking_blocks(current_thinking_blocks)
-                else:
-                    self._set_previous_thinking_blocks([])
-
-                yield LLMResultChunk(
-                    model=model,
-                    prompt_messages=prompt_messages,
-                    delta=LLMResultChunkDelta(
-                        index=0,
-                        message=AssistantPromptMessage(
-                            content="",
-                            tool_calls=final_tool_calls,
-                            opaque_body=build_opaque_body(),
-                        ),
-                        usage=usage,
-                        finish_reason=finish_reason or "stop",
-                    ),
-                )
-                emitted_final = True
-
-        if not emitted_final:
-            closing_chunk = close_reasoning_chunk(0)
-            if closing_chunk is not None:
-                yield closing_chunk
-            assistant_text = "".join(streamed_text)
-            if input_tokens == 0:
-                input_tokens = self.get_num_tokens(
-                    model=model,
-                    credentials=credentials,
-                    prompt_messages=prompt_messages,
-                    tools=tools,
-                )
-            if output_tokens == 0:
-                output_tokens = self._get_num_tokens_by_gpt2(assistant_text)
-
-            usage = self._calc_response_usage(
-                model=model,
-                credentials=credentials,
-                prompt_tokens=input_tokens,
-                completion_tokens=output_tokens,
+        assistant_text = "".join(streamed_text)
+        if input_tokens == 0:
+            input_tokens = self.get_num_tokens(
+                model=model, credentials=credentials, prompt_messages=prompt_messages, tools=tools
             )
+        if output_tokens == 0:
+            output_tokens = self._get_num_tokens_by_gpt2(assistant_text)
 
-            final_tool_calls = finalize_tool_calls()
+        usage = self._calc_response_usage(
+            model=model,
+            credentials=credentials,
+            prompt_tokens=input_tokens,
+            completion_tokens=output_tokens,
+        )
+        final_tool_calls = finalize_tool_calls()
+        current_thinking_blocks = thinking_content_blocks()
+        self._set_previous_thinking_blocks(current_thinking_blocks if final_tool_calls else [])
 
-            if final_tool_calls and current_thinking_blocks:
-                self._set_previous_thinking_blocks(current_thinking_blocks)
-            else:
-                self._set_previous_thinking_blocks([])
-
-            yield LLMResultChunk(
-                model=model,
-                prompt_messages=prompt_messages,
-                delta=LLMResultChunkDelta(
-                    index=0,
-                    message=AssistantPromptMessage(
-                        content="",
-                        tool_calls=final_tool_calls,
-                        opaque_body=build_opaque_body(),
-                    ),
-                    usage=usage,
-                    finish_reason=finish_reason or "stop",
+        yield LLMResultChunk(
+            model=model,
+            prompt_messages=prompt_messages,
+            delta=LLMResultChunkDelta(
+                index=0,
+                message=AssistantPromptMessage(
+                    content="", tool_calls=final_tool_calls, opaque_body=build_opaque_body()
                 ),
-            )
+                usage=usage,
+                finish_reason=finish_reason or "stop",
+            ),
+        )
 
     def _get_previous_thinking_blocks(self) -> list[dict[str, Any]]:
         raw_blocks = getattr(self, "_previous_thinking_blocks", None)
-        if not isinstance(raw_blocks, list):
-            return []
-        thinking_blocks: list[dict[str, Any]] = []
-        for item in raw_blocks:
-            if isinstance(item, dict):
-                thinking_blocks.append(item)
-        return thinking_blocks
+        return (
+            [item for item in raw_blocks if isinstance(item, dict)]
+            if isinstance(raw_blocks, list)
+            else []
+        )
 
     def _set_previous_thinking_blocks(self, thinking_blocks: list[dict[str, Any]]) -> None:
-        setattr(self, "_previous_thinking_blocks", thinking_blocks)
+        self._previous_thinking_blocks = list(thinking_blocks)
 
     def _normalize_thinking_payload(
-        self,
-        *,
-        thinking: Any,
-        thinking_budget: int,
-        request_model: str,
-    ) -> Optional[dict[str, Any]]:
-        if isinstance(thinking, dict):
-            return thinking
-
-        if isinstance(thinking, str):
-            thinking_type = thinking.strip().lower()
-            if thinking_type == "adaptive":
-                return {"type": "adaptive"}
-            if thinking_type in {"enabled", "true"}:
-                if request_model == "MiniMax-M3":
-                    return {"type": "adaptive"}
-                return {"type": "enabled", "budget_tokens": max(1024, thinking_budget)}
-            if thinking_type in {"disabled", "false", "none", "off"}:
-                return None
-
-        if thinking is True:
-            if request_model == "MiniMax-M3":
-                return {"type": "adaptive"}
-            return {"type": "enabled", "budget_tokens": max(1024, thinking_budget)}
-        return None
+        self, *, thinking: Any, thinking_budget: int, request_model: str
+    ) -> dict[str, Any] | None:
+        return normalize_thinking_payload(
+            thinking=thinking, thinking_budget=thinking_budget, request_model=request_model
+        )
 
     def _to_credential_kwargs(self, credentials: Mapping[str, Any]) -> dict[str, Any]:
         api_key = str(credentials.get("minimax_api_key") or "").strip()
         if not api_key:
             raise CredentialsValidateFailedError("Invalid API key")
 
-        endpoint_url = str(credentials.get("endpoint_url") or "https://api.minimax.io").strip()
-        if not endpoint_url.startswith("http://") and not endpoint_url.startswith("https://"):
-            endpoint_url = f"https://{endpoint_url}"
-        endpoint_url = endpoint_url.rstrip("/")
-        if not endpoint_url.endswith("/anthropic"):
-            endpoint_url = f"{endpoint_url}/anthropic"
+        endpoint_url = normalize_anthropic_endpoint(credentials.get("endpoint_url"))
 
         return {
             "api_key": api_key,
             "base_url": endpoint_url,
-            "default_headers": {
-                "Authorization": f"Bearer {api_key}",
-            },
+            "default_headers": {"Authorization": f"Bearer {api_key}"},
         }
 
     def _resolve_model_name(self, model: str) -> str:
-        if model in self._MODEL_ALIASES:
-            return self._MODEL_ALIASES[model]
-        model_lower = model.lower()
-        if model_lower in self._MODEL_ALIASES:
-            return self._MODEL_ALIASES[model_lower]
-        return model
+        return resolve_model_name(model)
 
-    def _convert_finish_reason(self, finish_reason: Optional[str]) -> Optional[str]:
-        if finish_reason is None:
-            return None
-        mapping = {
-            "end_turn": "stop",
-            "stop_sequence": "stop",
-            "max_tokens": "length",
-            "tool_use": "tool_calls",
-        }
-        return mapping.get(finish_reason, finish_reason)
+    def _convert_finish_reason(self, finish_reason: str | None) -> str | None:
+        return convert_finish_reason(finish_reason)
 
     @property
     def _invoke_error_mapping(self) -> dict[type[InvokeError], list[type[Exception]]]:
@@ -980,7 +735,10 @@ class MinimaxLargeLanguageModel(LargeLanguageModel):
             InvokeConnectionError: [anthropic.APIConnectionError],
             InvokeServerUnavailableError: [anthropic.InternalServerError],
             InvokeRateLimitError: [anthropic.RateLimitError],
-            InvokeAuthorizationError: [anthropic.AuthenticationError, anthropic.PermissionDeniedError],
+            InvokeAuthorizationError: [
+                anthropic.AuthenticationError,
+                anthropic.PermissionDeniedError,
+            ],
             InvokeBadRequestError: [
                 anthropic.BadRequestError,
                 anthropic.NotFoundError,

--- a/models/minimax/models/llm/minimax-m3.yaml
+++ b/models/minimax/models/llm/minimax-m3.yaml
@@ -6,6 +6,7 @@ features:
   - agent-thought
   - vision
   - video
+  - document
   - tool-call
   - stream-tool-call
 model_properties:
@@ -40,6 +41,16 @@ parameter_rules:
       zh_Hans: 启用 MiniMax-M3 自适应思考。
     options:
       - adaptive
+  - name: exclude_reasoning_tokens
+    label:
+      en_US: Hide the thought process
+      zh_Hans: 隐藏思考过程
+    type: boolean
+    default: true
+    required: false
+    help:
+      en_US: Whether to hide the thought process.
+      zh_Hans: 是否隐藏思考过程。
 # Official pricing is tiered; this flat estimate uses the standard <=512k input-token tier.
 pricing:
   input: "4.2"

--- a/models/minimax/tests/test_functional.py
+++ b/models/minimax/tests/test_functional.py
@@ -1,0 +1,104 @@
+import sys
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models.llm._functional import (
+    convert_finish_reason,
+    generation_options,
+    merge_consecutive_messages,
+    normalize_anthropic_endpoint,
+    parse_json_object,
+    render_assistant_text,
+    resolve_model_name,
+    user_content_block,
+)
+
+
+def test_generation_options_are_immutable_and_data_driven() -> None:
+    parameters = {
+        "max_output_tokens": 2048,
+        "thinking": "adaptive",
+        "exclude_reasoning_tokens": False,
+        "temperature": 0,
+        "top_p": None,
+    }
+    original = deepcopy(parameters)
+
+    options = generation_options(parameters, "MiniMax-M3")
+
+    assert parameters == original
+    assert options.max_tokens == 2048
+    assert options.thinking == "adaptive"
+    assert options.exclude_reasoning_tokens is False
+    assert options.sampling == (("temperature", 0),)
+
+
+def test_generation_options_follow_alias_precedence_and_m3_defaults() -> None:
+    options = generation_options(
+        {"max_tokens": 4096, "max_tokens_to_sample": 2048, "max_output_tokens": 1024}, "MiniMax-M3"
+    )
+
+    assert options.max_tokens == 4096
+    assert options.exclude_reasoning_tokens is True
+
+
+def test_model_and_finish_reason_dispatch_are_table_driven() -> None:
+    assert resolve_model_name("MINIMAX-M3") == "MiniMax-M3"
+    assert resolve_model_name("custom-model") == "custom-model"
+    assert convert_finish_reason("tool_use") == "tool_calls"
+    assert convert_finish_reason("custom") == "custom"
+    assert convert_finish_reason(None) is None
+
+
+def test_content_conversion_accepts_mapping_and_object_shapes() -> None:
+    assert user_content_block(
+        {"type": "document_url", "document_url": {"url": "https://example.com/report.pdf"}}
+    ) == {"type": "document", "source": {"type": "url", "url": "https://example.com/report.pdf"}}
+    assert user_content_block(SimpleNamespace(type="image", data="data:image/png;base64,AAAA")) == {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"},
+    }
+    assert user_content_block({"type": "unknown", "data": "ignored"}) is None
+
+
+def test_message_grouping_does_not_mutate_inputs() -> None:
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "one"}]},
+        {"role": "user", "content": "two"},
+        {"role": "assistant", "content": [{"type": "text", "text": "three"}]},
+    ]
+    original = deepcopy(messages)
+
+    grouped = merge_consecutive_messages(messages)
+
+    assert messages == original
+    assert grouped == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "one"}, {"type": "text", "text": "two"}],
+        },
+        {"role": "assistant", "content": [{"type": "text", "text": "three"}]},
+    ]
+
+
+def test_reasoning_rendering_is_a_pure_visibility_policy() -> None:
+    thinking = [{"type": "thinking", "thinking": "reason"}, {"type": "redacted_thinking"}]
+    answer = ["Visible", " answer"]
+
+    assert render_assistant_text(thinking, answer, hide_thinking=True) == "Visible answer"
+    assert render_assistant_text(thinking, answer, hide_thinking=False) == (
+        "<think>reason[Redacted thinking]</think>\nVisible answer"
+    )
+
+
+def test_endpoint_and_json_normalization_are_total_functions() -> None:
+    assert normalize_anthropic_endpoint("api.example.com/") == ("https://api.example.com/anthropic")
+    assert normalize_anthropic_endpoint("https://api.example.com/anthropic") == (
+        "https://api.example.com/anthropic"
+    )
+    assert parse_json_object('{"query":"m3"}') == {"query": "m3"}
+    assert parse_json_object("[1,2]") == {"value": [1, 2]}
+    assert parse_json_object("not json") == {"raw": "not json"}

--- a/models/minimax/tests/test_m3_payload.py
+++ b/models/minimax/tests/test_m3_payload.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import yaml
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
+    DocumentPromptMessageContent,
     ImagePromptMessageContent,
     TextPromptMessageContent,
     UserPromptMessage,
@@ -43,6 +44,7 @@ def test_m3_yaml_parameters_match_official_limits() -> None:
         "agent-thought",
         "vision",
         "video",
+        "document",
         "tool-call",
         "stream-tool-call",
     ]
@@ -54,6 +56,7 @@ def test_m3_yaml_parameters_match_official_limits() -> None:
     assert rules["top_p"]["default"] == 0.95
     assert rules["max_tokens"]["max"] == 524288
     assert rules["thinking"]["options"] == ["adaptive"]
+    assert rules["exclude_reasoning_tokens"]["default"] is True
 
 
 def test_m3_thinking_uses_adaptive_or_omits_unsupported_modes() -> None:
@@ -113,6 +116,12 @@ def test_m3_multimodal_user_message_uses_anthropic_sources() -> None:
                 base64_data="AAAA",
                 mime_type="video/mp4",
             ),
+            DocumentPromptMessageContent(
+                format="base64",
+                base64_data="BBBB",
+                mime_type="application/pdf",
+                filename="report.pdf",
+            ),
         ]
     )
 
@@ -137,6 +146,42 @@ def test_m3_multimodal_user_message_uses_anthropic_sources() -> None:
                     "data": "AAAA",
                 },
             },
+            {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": "BBBB",
+                },
+            },
+        ],
+    }
+
+
+def test_m3_document_url_uses_anthropic_source() -> None:
+    message = UserPromptMessage(
+        content=[
+            DocumentPromptMessageContent(
+                format="url",
+                url="https://example.com/report.pdf",
+                mime_type="application/pdf",
+                filename="report.pdf",
+            )
+        ]
+    )
+
+    converted = _llm()._convert_prompt_message_to_anthropic_message(message)
+
+    assert converted == {
+        "role": "user",
+        "content": [
+            {
+                "type": "document",
+                "source": {
+                    "type": "url",
+                    "url": "https://example.com/report.pdf",
+                },
+            }
         ],
     }
 
@@ -352,6 +397,58 @@ def test_stream_thinking_closes_before_tool_call_without_text_delta() -> None:
     }
 
 
+def test_stream_can_hide_thinking_without_dropping_opaque_content() -> None:
+    llm = _llm()
+    events = [
+        _event("message_start", message=SimpleNamespace(usage=_usage())),
+        _event(
+            "content_block_start",
+            index=0,
+            content_block=SimpleNamespace(type="thinking", signature="sig"),
+        ),
+        _event(
+            "content_block_delta",
+            index=0,
+            delta=SimpleNamespace(type="thinking_delta", thinking="hidden reason"),
+        ),
+        _event(
+            "content_block_start",
+            index=1,
+            content_block=SimpleNamespace(type="text", text=""),
+        ),
+        _event(
+            "content_block_delta",
+            index=1,
+            delta=SimpleNamespace(type="text_delta", text="Visible answer"),
+        ),
+        _event(
+            "message_delta",
+            delta=SimpleNamespace(stop_reason="end_turn"),
+            usage=_usage(output_tokens=3),
+        ),
+        _event("message_stop"),
+    ]
+
+    chunks = list(
+        llm._handle_chat_generate_stream_response(
+            model="minimax-m3",
+            prompt_messages=[UserPromptMessage(content="hi")],
+            credentials={},
+            response=events,
+            exclude_reasoning_tokens=True,
+        )
+    )
+
+    contents = [chunk.delta.message.content for chunk in chunks]
+    assert contents == ["Visible answer", ""]
+    assert chunks[-1].delta.message.opaque_body == {
+        "minimax_anthropic_content": [
+            {"type": "thinking", "thinking": "hidden reason", "signature": "sig"},
+            {"type": "text", "text": "Visible answer"},
+        ]
+    }
+
+
 def test_non_stream_tool_call_replays_opaque_content_without_duplicate_thinking_text() -> None:
     llm = _llm()
     response = SimpleNamespace(
@@ -379,6 +476,33 @@ def test_non_stream_tool_call_replays_opaque_content_without_duplicate_thinking_
             {"type": "text", "text": "I will call a tool."},
             {"type": "tool_use", "id": "call_1", "name": "search", "input": {"query": "m3"}},
         ],
+    }
+
+
+def test_non_stream_can_hide_thinking_without_dropping_opaque_content() -> None:
+    llm = _llm()
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="hidden reason", signature="sig"),
+            SimpleNamespace(type="text", text="Visible answer"),
+        ],
+        usage=_usage(output_tokens=3),
+    )
+
+    result = llm._handle_chat_generate_response(
+        model="minimax-m3",
+        prompt_messages=[UserPromptMessage(content="hi")],
+        credentials={},
+        response=response,
+        exclude_reasoning_tokens=True,
+    )
+
+    assert result.message.content == "Visible answer"
+    assert result.message.opaque_body == {
+        "minimax_anthropic_content": [
+            {"type": "thinking", "thinking": "hidden reason", "signature": "sig"},
+            {"type": "text", "text": "Visible answer"},
+        ]
     }
 
 


### PR DESCRIPTION
## Summary

Adds document upload support and a configurable hidden-thought display mode for MiniMax-M3, then refactors the adapter around a functional core.

- Advertises the `document` capability and converts URL/base64 document inputs to Anthropic-compatible document blocks.
- Adds a “Hide the thought process” boolean parameter, enabled by default.
- Suppresses visible `<think>` output in both streaming and non-streaming responses while retaining opaque thinking blocks for tool-call replay.
- Moves deterministic policy and data transformations into a pure `_functional.py` module.
- Uses immutable option records and lookup tables for models, media kinds, and finish reasons.
- Avoids mutation of caller-owned parameters/messages and completed stream tool calls.
- Collapses duplicated stream finalization into one path.
- Bumps the MiniMax plugin version to `0.0.24`.

This fixes the missing document-input capability and lack of a user-facing reasoning visibility control. The functional-core refactor makes those policies independently testable without an API client and leaves network/stream side effects at the adapter boundary.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable; the new boolean parameter uses Dify's standard model-parameter control.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Message flow (system messages, user ↔ assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (the plugin already uses the repository's current `dify_plugin>=0.9.0` dependency)

## Testing

- `uv run --frozen pytest -q` — 23 passed, 10 skipped because `MINIMAX_API_KEY` is not set
- Black check passed for the refactored core, adapter, and functional tests
- Focused Ruff correctness checks passed
- YAML parsing and `git diff --check` passed
