### PR TITLE
feat(outlook): sort order for list_events (latest first, 0.4.0)

### DIFF
--- a/tools/outlook/manifest.yaml
+++ b/tools/outlook/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.3.0
+version: 0.4.0
 type: plugin
 author: langgenius
 name: outlook

--- a/tools/outlook/tools/list_events.py
+++ b/tools/outlook/tools/list_events.py
@@ -14,6 +14,9 @@ class ListEventsTool(Tool):
         try:
             top = tool_parameters.get("top") or 25
             calendar_id = tool_parameters.get("calendar_id")
+            order = (tool_parameters.get("order") or "desc").lower()
+            if order not in ("asc", "desc"):
+                order = "desc"
 
             access_token = self.runtime.credentials.get("access_token")
             if not access_token:
@@ -32,7 +35,7 @@ class ListEventsTool(Tool):
 
             params = {
                 "$top": int(top),
-                "$orderby": "start/dateTime",
+                "$orderby": f"start/dateTime {order}",
                 "$select": "id,subject,start,end,organizer,webLink"
             }
 

--- a/tools/outlook/tools/list_events.yaml
+++ b/tools/outlook/tools/list_events.yaml
@@ -35,6 +35,39 @@ parameters:
       zh_Hant: 要返回的最大事件數
     llm_description: Maximum number of events to return, default is 25
     form: llm
+  - name: order
+    type: select
+    required: false
+    default: desc
+    options:
+      - value: desc
+        label:
+          en_US: Descending (latest first)
+          zh_Hans: 降序（最新在前）
+          pt_BR: Decrescente (mais recentes primeiro)
+          ja_JP: 降順（最新が先頭）
+          zh_Hant: 降序（最新在前）
+      - value: asc
+        label:
+          en_US: Ascending (oldest first)
+          zh_Hans: 升序（最早在前）
+          pt_BR: Crescente (mais antigos primeiro)
+          ja_JP: 昇順（古い順）
+          zh_Hant: 升序（最早在前）
+    label:
+      en_US: Sort Order
+      zh_Hans: 排序
+      pt_BR: Ordem de classificação
+      ja_JP: 並び順
+      zh_Hant: 排序
+    human_description:
+      en_US: Sort events by start time - descending (latest first) or ascending (oldest first)
+      zh_Hans: 按开始时间排序 - 降序（最新在前）或升序（最早在前）
+      pt_BR: Ordenar eventos por horário de início - decrescente (mais recentes primeiro) ou crescente (mais antigos primeiro)
+      ja_JP: 開始時刻でイベントを並べ替え - 降順（最新が先頭）または昇順（古い順）
+      zh_Hant: 按開始時間排序 - 降序（最新在前）或升序（最早在前）
+    llm_description: Sort order by event start time. Use 'desc' for latest first (default) or 'asc' for oldest first.
+    form: llm
   - name: calendar_id
     type: string
     required: false


### PR DESCRIPTION
## Summary

Adds a **Sort Order** option to the Outlook `list_events` tool and bumps to **0.4.0**.

Previously `list_events` ordered by `start/dateTime` ascending, so old events (e.g. 2021) came first and the latest were buried. New `order` select — **descending (latest first)** is the default, or ascending (oldest first) — mapped to `$orderby=start/dateTime {order}`.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (0.3.0 → 0.4.0)
- [x] `dify_plugin>=0.9.0` declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [x] Local deployment — Dify version: <!-- fill in -->
- [ ] SaaS (cloud.dify.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
