### PR TITLE
fix(tools): ComfyUI img2vid error "Node 6 is not CLIPTextEncode" 

### DIFF
--- a/tools/comfyui/manifest.yaml
+++ b/tools/comfyui/manifest.yaml
@@ -31,4 +31,4 @@ resource:
 tags:
   - image
 type: plugin
-version: 0.3.10
+version: 0.3.11

--- a/tools/comfyui/tools/img2vid.py
+++ b/tools/comfyui/tools/img2vid.py
@@ -321,10 +321,10 @@ class ComfyuiImg2Vid(Tool):
             workflow = ComfyUiWorkflow(file.read(), object_info=self.comfyui.get_object_info())
             self.model_manager.download_from_json(workflow.json_original_str())
 
-        workflow.set_prompt("6", config.prompt)
-        workflow.set_prompt("7", config.negative_prompt)
+        workflow.set_prompt("93", config.prompt)
+        workflow.set_prompt("89", config.negative_prompt)
 
-        wan2_2 = workflow.identify_node_by_class_type("Wan22ImageToVideoLatent")
+        wan2_2 = workflow.identify_node_by_class_type("WanImageToVideo")
         workflow.set_property(wan2_2, "inputs/width", config.width)
         workflow.set_property(wan2_2, "inputs/height", config.height)
         workflow.set_property(wan2_2, "inputs/length", config.frameN)

--- a/tools/comfyui/tools/img2vid.yaml
+++ b/tools/comfyui/tools/img2vid.yaml
@@ -53,6 +53,9 @@ parameters:
           en_US: WAN 2.1
         value: wan2_1
       - label:
+          en_US: WAN 2.2 14B
+        value: wan2_2_14B
+      - label:
           en_US: LTXV
         value: ltxv
       - label:


### PR DESCRIPTION

## Summary


The text-to-video node of ComfyUI tool reported this error message when model type was set to wan2_2_14B.
`An error occurred in the langgenius/comfyui/comfyui, please contact the author of langgenius/comfyui/comfyui for help, error type: Exception, error details: Node 6 is not CLIPTextEncode`


## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos


| Before | After |
| ------ | ----- |
|  <img width="362" height="128" alt="image" src="https://github.com/user-attachments/assets/610722d0-5566-49f5-b83f-92f74ab73329" />      |   <img width="364" height="146" alt="image" src="https://github.com/user-attachments/assets/9623e519-b3dc-416e-9aec-f20ee23e1faf" />    |




## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)


## Testing


- [x] Local deployment — Dify version: 1.5.0
- [ ] SaaS (cloud.dify.ai)
