### PR TITLE
feat(openrouter): expose reasoning and vision controls

### DIFF
--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -26,5 +26,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.1.1
+version: 0.1.2
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/openrouter/models/llm/llm.py
+++ b/models/openrouter/models/llm/llm.py
@@ -206,7 +206,8 @@ class OpenRouterLargeLanguageModel(OAICompatLargeLanguageModel):
 
         # Only convert file content to text descriptions for models that don't support vision
         model_schema = self.get_model_schema(model, credentials)
-        if not (model_schema and ModelFeature.VISION in (model_schema.features or [])):
+        model_features = getattr(model_schema, "features", None) or []
+        if ModelFeature.VISION not in model_features:
             prompt_messages = self._convert_files_to_text(prompt_messages)
 
         if model in IMAGE_GENERATION_MODELS:
@@ -219,13 +220,9 @@ class OpenRouterLargeLanguageModel(OAICompatLargeLanguageModel):
         # Allow data collection by default so that all available providers can serve requests.
         # Without this, models whose only providers require data collection would return a 404
         # ("No endpoints available matching your guardrail restrictions and data policy").
-        if "provider" not in model_parameters:
-            model_parameters["provider"] = {"data_collection": "allow"}
-        elif (
-            isinstance(model_parameters["provider"], dict)
-            and "data_collection" not in model_parameters["provider"]
-        ):
-            model_parameters["provider"]["data_collection"] = "allow"
+        provider_parameters = model_parameters.setdefault("provider", {})
+        if isinstance(provider_parameters, dict):
+            provider_parameters.setdefault("data_collection", "allow")
 
         return self._generate(
             model,
@@ -333,43 +330,42 @@ class OpenRouterLargeLanguageModel(OAICompatLargeLanguageModel):
     ) -> AIModelEntity:
         entity = super().get_customizable_model_schema(model, credentials)
 
-        if credentials.get("reasoning_support", "no_support") == "support":
-            features = list(entity.features or [])
-            if ModelFeature.AGENT_THOUGHT not in features:
-                features.append(ModelFeature.AGENT_THOUGHT)
-            entity.features = features
+        if credentials.get("reasoning_support") != "support":
+            return entity
 
-            entity.parameter_rules.extend(
-                [
-                    ParameterRule(
-                        name="reasoning_effort",
-                        label=I18nObject(en_us="Reasoning Effort", zh_hans="推理程度"),
-                        help=I18nObject(
-                            en_us="Controls how much effort the model spends on reasoning.",
-                            zh_hans="控制模型用于推理的工作量。",
-                        ),
-                        type=ParameterType.STRING,
-                        options=["low", "medium", "high"],
-                        required=False,
+        features = [*(entity.features or []), ModelFeature.AGENT_THOUGHT]
+        entity.features = list(dict.fromkeys(features))
+        entity.parameter_rules.extend(
+            [
+                ParameterRule(
+                    name="reasoning_effort",
+                    label=I18nObject(en_us="Reasoning Effort", zh_hans="推理程度"),
+                    help=I18nObject(
+                        en_us="Controls how much effort the model spends on reasoning.",
+                        zh_hans="控制模型用于推理的工作量。",
                     ),
-                    ParameterRule(
-                        name="exclude_reasoning_tokens",
-                        label=I18nObject(
-                            en_us="Hide the thought process", zh_hans="隐藏思考过程"
-                        ),
-                        help=I18nObject(
-                            en_us=(
-                                "Lets the model reason internally without returning "
-                                "reasoning tokens in its response."
-                            ),
-                            zh_hans="允许模型在内部推理，但不在响应中返回推理 token。",
-                        ),
-                        type=ParameterType.BOOLEAN,
-                        default=True,
-                        required=False,
+                    type=ParameterType.STRING,
+                    options=["low", "medium", "high"],
+                    required=False,
+                ),
+                ParameterRule(
+                    name="exclude_reasoning_tokens",
+                    label=I18nObject(
+                        en_us="Hide the thought process", zh_hans="隐藏思考过程"
                     ),
-                ]
-            )
+                    help=I18nObject(
+                        en_us=(
+                            "Lets the model reason internally without returning "
+                            "reasoning tokens in its response."
+                        ),
+                        zh_hans="允许模型在内部推理，但不在响应中返回推理 token。",
+                    ),
+                    type=ParameterType.BOOLEAN,
+                    default=True,
+                    required=False,
+                ),
+            ]
+        )
 
         return entity
 

--- a/models/openrouter/models/llm/llm.py
+++ b/models/openrouter/models/llm/llm.py
@@ -6,7 +6,13 @@ from typing import Optional, Union, Any
 
 import requests
 from dify_plugin import OAICompatLargeLanguageModel
-from dify_plugin.entities.model import AIModelEntity, ModelFeature
+from dify_plugin.entities.model import (
+    AIModelEntity,
+    I18nObject,
+    ModelFeature,
+    ParameterRule,
+    ParameterType,
+)
 from dify_plugin.entities.model.llm import (
     LLMResult,
     LLMResultChunk,
@@ -215,7 +221,10 @@ class OpenRouterLargeLanguageModel(OAICompatLargeLanguageModel):
         # ("No endpoints available matching your guardrail restrictions and data policy").
         if "provider" not in model_parameters:
             model_parameters["provider"] = {"data_collection": "allow"}
-        elif isinstance(model_parameters["provider"], dict) and "data_collection" not in model_parameters["provider"]:
+        elif (
+            isinstance(model_parameters["provider"], dict)
+            and "data_collection" not in model_parameters["provider"]
+        ):
             model_parameters["provider"]["data_collection"] = "allow"
 
         return self._generate(
@@ -322,7 +331,47 @@ class OpenRouterLargeLanguageModel(OAICompatLargeLanguageModel):
     def get_customizable_model_schema(
         self, model: str, credentials: dict
     ) -> AIModelEntity:
-        return super().get_customizable_model_schema(model, credentials)
+        entity = super().get_customizable_model_schema(model, credentials)
+
+        if credentials.get("reasoning_support", "no_support") == "support":
+            features = list(entity.features or [])
+            if ModelFeature.AGENT_THOUGHT not in features:
+                features.append(ModelFeature.AGENT_THOUGHT)
+            entity.features = features
+
+            entity.parameter_rules.extend(
+                [
+                    ParameterRule(
+                        name="reasoning_effort",
+                        label=I18nObject(en_us="Reasoning Effort", zh_hans="推理程度"),
+                        help=I18nObject(
+                            en_us="Controls how much effort the model spends on reasoning.",
+                            zh_hans="控制模型用于推理的工作量。",
+                        ),
+                        type=ParameterType.STRING,
+                        options=["low", "medium", "high"],
+                        required=False,
+                    ),
+                    ParameterRule(
+                        name="exclude_reasoning_tokens",
+                        label=I18nObject(
+                            en_us="Hide the thought process", zh_hans="隐藏思考过程"
+                        ),
+                        help=I18nObject(
+                            en_us=(
+                                "Lets the model reason internally without returning "
+                                "reasoning tokens in its response."
+                            ),
+                            zh_hans="允许模型在内部推理，但不在响应中返回推理 token。",
+                        ),
+                        type=ParameterType.BOOLEAN,
+                        default=True,
+                        required=False,
+                    ),
+                ]
+            )
+
+        return entity
 
     def get_num_tokens(
         self,

--- a/models/openrouter/provider/openrouter.yaml
+++ b/models/openrouter/provider/openrouter.yaml
@@ -98,6 +98,25 @@ model_credential_schema:
       variable: __model_type
     type: radio
     variable: vision_support
+  - default: no_support
+    label:
+      en_US: Reasoning Support
+      zh_Hans: 是否支持推理
+    options:
+    - label:
+        en_US: 'Yes'
+        zh_Hans: 是
+      value: support
+    - label:
+        en_US: 'No'
+        zh_Hans: 否
+      value: no_support
+    required: false
+    show_on:
+    - value: llm
+      variable: __model_type
+    type: radio
+    variable: reasoning_support
   - default: no_call
     label:
       en_US: Function calling

--- a/models/openrouter/tests/test_llm_features.py
+++ b/models/openrouter/tests/test_llm_features.py
@@ -1,0 +1,102 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dify_plugin.entities.model import ModelFeature
+from dify_plugin.entities.model.message import (
+    ImagePromptMessageContent,
+    TextPromptMessageContent,
+    UserPromptMessage,
+)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from models.llm.llm import OpenRouterLargeLanguageModel
+
+
+@pytest.fixture
+def llm() -> OpenRouterLargeLanguageModel:
+    return OpenRouterLargeLanguageModel(model_schemas=[])
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high"])
+def test_set_reasoning_params_supports_requested_effort_levels(effort: str) -> None:
+    model_parameters = {
+        "reasoning_effort": effort,
+        "exclude_reasoning_tokens": True,
+        "temperature": 0.2,
+    }
+
+    OpenRouterLargeLanguageModel._set_reasoning_params(model_parameters)
+
+    assert model_parameters == {
+        "reasoning": {"effort": effort, "exclude": True},
+        "temperature": 0.2,
+    }
+
+
+def test_custom_reasoning_model_exposes_effort_and_hide_controls(
+    llm: OpenRouterLargeLanguageModel,
+) -> None:
+    schema = llm.get_customizable_model_schema(
+        "custom/reasoning-model",
+        {
+            "mode": "chat",
+            "context_size": "128000",
+            "max_tokens_to_sample": "8192",
+            "reasoning_support": "support",
+        },
+    )
+
+    rules = {rule.name: rule for rule in schema.parameter_rules}
+    assert ModelFeature.AGENT_THOUGHT in (schema.features or [])
+    assert rules["reasoning_effort"].options == ["low", "medium", "high"]
+    assert rules["exclude_reasoning_tokens"].default is True
+
+
+def test_custom_vision_model_keeps_uploaded_images(
+    llm: OpenRouterLargeLanguageModel,
+) -> None:
+    credentials = {
+        "mode": "chat",
+        "context_size": "128000",
+        "max_tokens_to_sample": "8192",
+        "vision_support": "support",
+    }
+    vision_schema = llm.get_customizable_model_schema(
+        "custom/vision-model", credentials
+    )
+    assert ModelFeature.VISION in (vision_schema.features or [])
+
+    prompt_messages = [
+        UserPromptMessage(
+            content=[
+                TextPromptMessageContent(data="What is in this image?"),
+                ImagePromptMessageContent(
+                    format="png",
+                    mime_type="image/png",
+                    base64_data="aW1hZ2U=",
+                ),
+            ]
+        )
+    ]
+
+    with (
+        patch.object(llm, "_update_credential"),
+        patch.object(llm, "get_model_schema", return_value=vision_schema),
+        patch.object(llm, "_generate", return_value="result") as generate,
+    ):
+        result = llm._invoke(
+            model="custom/vision-model",
+            credentials=credentials,
+            prompt_messages=prompt_messages,
+            model_parameters={},
+        )
+
+    assert result == "result"
+    assert generate.call_args.args[2] is prompt_messages
+    sent_content = generate.call_args.args[2][0].content
+    assert isinstance(sent_content, list)
+    assert any(isinstance(part, ImagePromptMessageContent) for part in sent_content)


### PR DESCRIPTION
## What changed

- add a custom-model `Reasoning Support` capability toggle
- expose `low`, `medium`, and `high` reasoning effort levels for reasoning-capable custom models
- add a `Hide the thought process` control, enabled by default, which maps to OpenRouter's `reasoning.exclude`
- preserve native image content for custom models configured with Vision Support
- add focused tests for reasoning payloads, schema controls, and uploaded image handling
- bump the OpenRouter plugin version to `0.1.2`

## Why

OpenRouter's request layer already supported reasoning effort, reasoning exclusion, and multimodal messages, but custom model schemas did not expose the reasoning controls consistently. This made those capabilities unavailable from the Dify model configuration UI even when the selected OpenRouter model supported them.

## User impact

Users configuring a custom OpenRouter model can now opt into reasoning support, select LOW/MEDIUM/HIGH effort, hide returned reasoning tokens, and enable Vision Support for uploaded image inputs.

## Validation

- `uv run ruff check models/llm/llm.py tests/test_llm_features.py`
- `uv run pyrefly check models/llm/llm.py tests/test_llm_features.py`
- `uv run pytest -q` — 17 passed, 65 skipped
- YAML schema/manifest validation
- Python bytecode compilation
- `git diff --check`