### PR TITLE
feat(volcengine): add deepseek-v4-flash-ga-260731 model

### DIFF
--- a/models/volcengine/manifest.yaml
+++ b/models/volcengine/manifest.yaml
@@ -33,4 +33,4 @@ resource:
       text_embedding: false
       tts: false
 type: plugin
-version: 0.0.13
+version: 0.0.14

--- a/models/volcengine/models/llm/_position.yaml
+++ b/models/volcengine/models/llm/_position.yaml
@@ -24,5 +24,6 @@
 - doubao-1-5-pro-32k-character-250228
 - doubao-1-5-lite-32k-250115
 - deepseek-v4-pro-260425
+- deepseek-v4-flash-ga-260731
 - deepseek-v4-flash-260425
 - deepseek-v3-2-251201

--- a/models/volcengine/models/llm/deepseek-v4-flash-ga-260731.yaml
+++ b/models/volcengine/models/llm/deepseek-v4-flash-ga-260731.yaml
@@ -1,0 +1,35 @@
+model: deepseek-v4-flash-ga-260731
+label:
+  en_US: deepseek-v4-flash-ga-260731
+  zh_Hans: deepseek-v4-flash-ga-260731
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: medium
+    options:
+      - minimal
+      - low
+      - medium
+      - high
+      - max
+    help:
+      zh_Hans: 控制思维链长度，平衡效果、时延与成本。minimal 关闭思考直接回答；low 轻量思考侧重快速响应；medium 均衡模式；high 深度分析处理复杂问题；max 最高程度思考适配高难度推理任务。
+      en_US: Controls chain-of-thought length to balance quality, latency, and cost. minimal answers directly without thinking; low favors fast response; medium is balanced; high enables deep analysis; max maximizes reasoning for hardest tasks.
+pricing:
+  input: "1"
+  output: "2"
+  unit: "0.000001"
+  currency: RMB


### PR DESCRIPTION
## Summary

Add the new Volcengine Ark model **`deepseek-v4-flash-ga-260731`** (DeepSeek V4 Flash GA, generally available) to the Volcengine plugin.

- New model definition `models/volcengine/models/llm/deepseek-v4-flash-ga-260731.yaml` with chat mode, 1M context, agent-thought/tool-call/stream-tool-call/multi-tool-call features, `reasoning_effort` parameter (minimal/low/medium/high/max), and pricing.
- Register the model in `models/volcengine/models/llm/_position.yaml` (positioned above the preview `deepseek-v4-flash-260425`).
- Bump plugin `version` `0.0.13` → `0.0.14` in `manifest.yaml`.

This is the GA release of the DeepSeek V4 Flash line currently represented by the `deepseek-v4-flash-260425` preview model.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

N/A — additive model registration, no UI/config surface changes.

| Before | After |
| ------ | ----- |
| Volcengine plugin exposes `deepseek-v4-flash-260425` (preview) | Also exposes `deepseek-v4-flash-ga-260731` (GA) |

<img width="930" height="670" alt="image" src="https://github.com/user-attachments/assets/7a7322ba-b59e-495c-9450-32e110303583" />


## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (`0.0.13` → `0.0.14`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` — this plugin pins `dify-plugin>=0.9.1` (already satisfied; unchanged by this PR)

## Testing

- [x] Local deployment — Dify version: 1.16.1
- [ ] SaaS (cloud.dify.ai)

> Model config validated against the existing `deepseek-v4-flash-260425` definition (identical schema). Runtime validation against the live Volcengine Ark endpoint pending.