### PR TITLE
ci: run the marketplace uploader as a package

### DIFF
--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -170,7 +170,7 @@ jobs:
             exit 0
           fi
 
-          uv run --with requests --with dify_plugin python .scripts/uploader/upload-package.py -d "${{ matrix.plugin_path }}" -t "$MARKETPLACE_TOKEN" --plugin-daemon-path .scripts/dify -u "$MARKETPLACE_BASE_URL" -f --test
+          uv run --with requests --with dify_plugin python .scripts/uploader -d "${{ matrix.plugin_path }}" -t "$MARKETPLACE_TOKEN" --plugin-daemon-path .scripts/dify -u "$MARKETPLACE_BASE_URL" -f --test
 
       - name: Package plugin
         run: |

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -159,4 +159,4 @@ jobs:
 
       - name: Upload Plugin
         run: |
-          uv run --with requests --with dify_plugin python .scripts/uploader/upload-package.py -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f
+          uv run --with requests --with dify_plugin python .scripts/uploader -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f


### PR DESCRIPTION
Switches the marketplace uploader to its package invocation: `python .scripts/uploader`. Two lines change; arguments, secrets and triggers stay the same.

```mermaid
sequenceDiagram
    participant W as upload-merged workflow
    participant U as python .scripts/uploader
    participant M as Marketplace

    W->>U: -d plugin_path -t token -u base_url
    U->>M: POST /plugins/inner-upload
    M-->>U: version.checksum
    U->>U: security scan
    U->>M: PUT /plugin-artifacts/{checksum}/scan-report
```

The scan-and-report step lives entirely inside the uploader — workflows carry no scan logic, a report failure warns without failing a publish, and the pre-check's `--test` run scans without any network call.

Merge after langgenius/dify-marketplace-toolkit#4, which ships the package entry point (the old `upload-package.py` path keeps working there as an alias until both plugin repositories migrate).