### PR TITLE
Fix Volcengine vision embedding batching

### DIFF
--- a/models/volcengine_maas/manifest.yaml
+++ b/models/volcengine_maas/manifest.yaml
@@ -35,4 +35,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.52
+version: 0.0.53

--- a/models/volcengine_maas/models/text_embedding/text_embedding.py
+++ b/models/volcengine_maas/models/text_embedding/text_embedding.py
@@ -1,6 +1,8 @@
 import base64
 import binascii
+import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 from decimal import Decimal
 from typing import Optional
 from dify_plugin import TextEmbeddingModel
@@ -50,6 +52,10 @@ from legacy.errors import (
     ServerUnavailableErrors,
 )
 from models.text_embedding.models import get_model_config
+
+
+DEFAULT_MULTIMODAL_TEXT_EMBEDDING_CONCURRENCY = 4
+MAX_MULTIMODAL_TEXT_EMBEDDING_CONCURRENCY = 16
 
 
 class VolcengineMaaSTextEmbeddingModel(TextEmbeddingModel):
@@ -110,14 +116,8 @@ class VolcengineMaaSTextEmbeddingModel(TextEmbeddingModel):
         client = ArkClientV3.from_credentials(credentials)
 
         if self._is_multimodal_model(model, credentials):
-            resp = client.multimodal_embeddings(input=self._transform_input_text(texts))
-            usage = self._calc_response_usage(
-                model=model,
-                credentials=credentials,
-                tokens=getattr(resp.usage, "total_tokens", 0),
-            )
-            result = TextEmbeddingResult(
-                model=model, embeddings=[resp.data.embedding], usage=usage
+            return self._generate_multimodal_text_embeddings(
+                model=model, credentials=credentials, client=client, texts=texts
             )
         else:
             resp = client.embeddings(texts)
@@ -128,6 +128,58 @@ class VolcengineMaaSTextEmbeddingModel(TextEmbeddingModel):
                 model=model, embeddings=[v.embedding for v in resp.data], usage=usage
             )
         return result
+
+    def _generate_multimodal_text_embeddings(
+        self,
+        model: str,
+        credentials: dict,
+        client: ArkClientV3,
+        texts: list[str],
+    ) -> TextEmbeddingResult:
+        if not texts:
+            usage = self._calc_response_usage(
+                model=model, credentials=credentials, tokens=0
+            )
+            return TextEmbeddingResult(model=model, embeddings=[], usage=usage)
+
+        concurrency = self._get_multimodal_text_embedding_concurrency(len(texts))
+
+        def invoke_one(text: str):
+            resp = client.multimodal_embeddings(input=self._transform_input_text([text]))
+            return resp.data.embedding, getattr(resp.usage, "total_tokens", 0)
+
+        if concurrency == 1 or len(texts) == 1:
+            results = [invoke_one(text) for text in texts]
+        else:
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                results = list(executor.map(invoke_one, texts))
+
+        embeddings = [embedding for embedding, _tokens in results]
+        if len(embeddings) != len(texts):
+            raise InvokeBadRequestError(
+                f"Multimodal embedding count mismatch: expected {len(texts)}, "
+                f"got {len(embeddings)}"
+            )
+
+        total_tokens = sum(tokens for _embedding, tokens in results)
+        usage = self._calc_response_usage(
+            model=model, credentials=credentials, tokens=total_tokens
+        )
+        return TextEmbeddingResult(model=model, embeddings=embeddings, usage=usage)
+
+    def _get_multimodal_text_embedding_concurrency(self, text_count: int) -> int:
+        raw_value = os.getenv(
+            "VOLCENGINE_MAAS_MULTIMODAL_TEXT_EMBEDDING_CONCURRENCY",
+            str(DEFAULT_MULTIMODAL_TEXT_EMBEDDING_CONCURRENCY),
+        )
+        try:
+            configured = int(raw_value)
+        except ValueError:
+            configured = DEFAULT_MULTIMODAL_TEXT_EMBEDDING_CONCURRENCY
+
+        concurrency = max(1, configured)
+        concurrency = min(concurrency, MAX_MULTIMODAL_TEXT_EMBEDDING_CONCURRENCY)
+        return min(concurrency, text_count)
 
     def get_num_tokens(
         self, model: str, credentials: dict, texts: list[str]

--- a/models/volcengine_maas/tests/test_text_embedding_multimodal_batch.py
+++ b/models/volcengine_maas/tests/test_text_embedding_multimodal_batch.py
@@ -1,0 +1,61 @@
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from dify_plugin.entities.model.text_embedding import EmbeddingUsage
+
+from models.text_embedding.text_embedding import VolcengineMaaSTextEmbeddingModel
+
+
+class FakeArkClient:
+    def __init__(self):
+        self.calls = []
+
+    def multimodal_embeddings(self, input):
+        self.calls.append(input)
+        index = len(self.calls)
+        return SimpleNamespace(
+            data=SimpleNamespace(embedding=[float(index)]),
+            usage=SimpleNamespace(total_tokens=index),
+        )
+
+
+def make_usage(tokens: int) -> EmbeddingUsage:
+    return EmbeddingUsage(
+        tokens=tokens,
+        total_tokens=tokens,
+        unit_price=Decimal("0"),
+        price_unit=Decimal("0"),
+        total_price=Decimal("0"),
+        currency="USD",
+        latency=0,
+    )
+
+
+def test_multimodal_text_batch_invokes_one_request_per_text(monkeypatch):
+    monkeypatch.setenv("VOLCENGINE_MAAS_MULTIMODAL_TEXT_EMBEDDING_CONCURRENCY", "1")
+    fake_client = FakeArkClient()
+    model = VolcengineMaaSTextEmbeddingModel([])
+
+    with (
+        patch.object(model, "_is_multimodal_model", return_value=True),
+        patch.object(model, "_calc_response_usage", return_value=make_usage(6)),
+        patch(
+            "models.text_embedding.text_embedding.ArkClientV3.from_credentials",
+            return_value=fake_client,
+        ),
+    ):
+        result = model._generate_v3(
+            model="Doubao-embedding-vision",
+            credentials={},
+            texts=["first", "second", "third"],
+        )
+
+    assert result.embeddings == [[1.0], [2.0], [3.0]]
+    assert len(fake_client.calls) == 3
+    assert [len(call) for call in fake_client.calls] == [1, 1, 1]
+    assert [call[0]["text"] for call in fake_client.calls] == [
+        "first",
+        "second",
+        "third",
+    ]


### PR DESCRIPTION
## Summary

Fix `Doubao-embedding-vision` batch embedding in the Volcengine MaaS plugin.

When Dify sends multiple text chunks to the vision embedding model, the plugin previously sent the whole text batch as one multimodal embedding request. The Volcengine multimodal embedding API returns one fused embedding for that request, which can break Dify's one-input-to-one-vector contract and cause retrieval misses for indexed chunks.

This change keeps `max_chunks=32`, but internally invokes the multimodal endpoint once per text chunk, preserves input order, and returns one embedding per input text. It also adds bounded internal concurrency and a regression test.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| Batched vision text embedding could return one fused vector for multiple Dify chunks. | Batched vision text embedding returns one vector per Dify chunk, preserving order. |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [x] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — existing plugin uses `dify_plugin>=0.9.0` in `pyproject.toml`

## Testing

- [x] Local deployment — Dify version: 1.16.0
- [ ] SaaS (cloud.dify.ai)

Additional checks:

- `PYTHONPYCACHEPREFIX=/tmp/project-ai-pr-pycache python3 -m py_compile models/volcengine_maas/models/text_embedding/text_embedding.py models/volcengine_maas/tests/test_text_embedding_multimodal_batch.py`
- `cd models/volcengine_maas && /tmp/project-ai-volcengine-maas-test-venv/bin/python -m pytest tests/test_text_embedding_multimodal_batch.py -q`
