### PR TITLE
chore(llama_parse): upgrade dify-plugin to 0.10.1

### DIFF
--- a/tools/llama_parse/manifest.yaml
+++ b/tools/llama_parse/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 tags:
   - utilities

--- a/tools/llama_parse/pyproject.toml
+++ b/tools/llama_parse/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llama_parse"
-version = "0.1.0"
+version = "0.0.9"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tools/llama_parse/tests/test_smoke.py
+++ b/tools/llama_parse/tests/test_smoke.py
@@ -1,0 +1,33 @@
+"""Smoke-test provider registration against its declared tool manifests."""
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from provider.llama import LlamaParseProvider
+
+
+class LlamaParseProviderSmokeTest(unittest.TestCase):
+    def test_provider_declares_manifest_tools(self) -> None:
+        plugin_root = Path(__file__).resolve().parents[1]
+        provider_manifest = yaml.safe_load(
+            (plugin_root / "provider" / "llama.yaml").read_text()
+        )
+        provider = LlamaParseProvider()
+
+        declared_tools = provider_manifest["tools"]
+        self.assertIsInstance(provider, LlamaParseProvider)
+        self.assertEqual(
+            ["llama_parse", "llama_parse_advanced"],
+            [
+                yaml.safe_load((plugin_root / tool).read_text())["identity"]["name"]
+                for tool in declared_tools
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/llama_parse/uv.lock
+++ b/tools/llama_parse/uv.lock
@@ -352,12 +352,12 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dpkt" },
     { name = "flask" },
     { name = "gevent" },
+    { name = "h11" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -369,9 +369,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/bc/a8dd795c7dd33947a90a2832a7d32c6b7f5a771554cb3890369244d72331/dify_plugin-0.10.1.tar.gz", hash = "sha256:875fe38d7a97d05fabb3b4f1ab467f2dc50ad2458a1eac68e6e212e29e7e1d29", size = 320686, upload-time = "2026-08-05T16:52:22.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d1/21ef487ef4bbb38ea1e19489a2c7a81f4a91865ba91fedd921226ede862c/dify_plugin-0.10.1-py3-none-any.whl", hash = "sha256:b36161c72d4235af4241b8e417edea78689f3d6e4598cf2368b2a1523bf96809", size = 379287, upload-time = "2026-08-05T16:52:21.112Z" },
 ]
 
 [[package]]
@@ -381,15 +381,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/04/d24f6e645ad82ba0ef092fa17d9ef7a21953781663648a01c9371d9e8e98/dirtyjson-1.0.8.tar.gz", hash = "sha256:90ca4a18f3ff30ce849d100dcf4a003953c79d3a2348ef056f1d9c22231a25fd", size = 30782, upload-time = "2022-11-28T23:32:33.319Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/69/1bcf70f81de1b4a9f21b3a62ec0c83bdff991c88d6cc2267d02408457e88/dirtyjson-1.0.8-py3-none-any.whl", hash = "sha256:125e27248435a58acace26d5c2c4c11a1c0de0a9c5124c5a94ba78e517d74f53", size = 25197, upload-time = "2022-11-28T23:32:31.219Z" },
-]
-
-[[package]]
-name = "dpkt"
-version = "1.9.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/7d/52f17a794db52a66e46ebb0c7549bf2f035ed61d5a920ba4aaa127dd038e/dpkt-1.9.8.tar.gz", hash = "sha256:43f8686e455da5052835fd1eda2689d51de3670aac9799b1b00cfd203927ee45", size = 180073, upload-time = "2022-08-18T05:54:13.582Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/79/479e2194c9096b92aecdf33634ae948d2be306c6011673e98ee1917f32c2/dpkt-1.9.8-py3-none-any.whl", hash = "sha256:4da4d111d7bf67575b571f5c678c71bddd2d8a01a3d57d489faf0a92c748fbfd", size = 194973, upload-time = "2022-08-18T05:54:10.793Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade the locked `dify-plugin` SDK from 0.9.0 to 0.10.1
- align the package and marketplace plugin versions at 0.0.9
- add provider tool-manifest smoke coverage

## Verification
- `python -c "import main"`
- `python tests/test_smoke.py`
- `ruff check tests/test_smoke.py`

The SDK release notes add polling and tool-parameter capabilities plus fixes to HTTP handling, model streaming, file parameters, and related plugin types. This plugin uses the SDK plugin entrypoint, tool provider, tool/message, and file imports; none of the changed APIs are used, and no source changes were required.