### PR TITLE
feat(aihubmix-image): add Qwen Image 3 models

### DIFF
--- a/tools/aihubmix_image/README.md
+++ b/tools/aihubmix_image/README.md
@@ -2,7 +2,7 @@
 
 **Author:** AIHubMix
 
-**Version:** 0.1.4
+**Version:** 0.1.5
 
 **Type:** Dify Plugin
 
@@ -20,7 +20,7 @@ The AIHubMix Image Generation Plugin provides access to a variety of advanced im
 * **Gemini Nano Banana** (`gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`, plus preview IDs)
 * **Google Imagen** (Imagen 4.0 series)
 * **Flux** (`FLUX.1-Kontext-pro`, `FLUX-1.1-pro`)
-* **Qwen Image** (`qwen-image`, `qwen-image-2.0`, `qwen-image-2.0-pro`, Max, and Plus)
+* **Qwen Image** (`qwen-image`, `qwen-image-2.0`, `qwen-image-2.0-pro`, `qwen-image-3.0`, `qwen-image-3.0-pro`, Max, and Plus)
 * **Wan** (`wan2.7-image`, `wan2.7-image-pro`)
 * **Doubao Seedream** (`doubao-seedream-5.0-pro`, `doubao-seedream-5.0-lite`, `doubao-seedream-4-5`)
 * **GLM Image**, **Ideogram V3**, and **ERNIE iRAG**

--- a/tools/aihubmix_image/manifest.yaml
+++ b/tools/aihubmix_image/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.1.4
+version: 0.1.5
 type: plugin
 author: langgenius
 name: aihubmix-image

--- a/tools/aihubmix_image/tests/test_model_catalog.py
+++ b/tools/aihubmix_image/tests/test_model_catalog.py
@@ -62,6 +62,12 @@ class ImageModelCatalogTests(unittest.TestCase):
         data = read_yaml("tools/doubao.yaml")
         self.assertNotIn("doubao-seedream-5.0-pro", option_values(parameter(data, "model")))
 
+    def test_qwen_tool_contains_image_3_models(self) -> None:
+        data = read_yaml("tools/qwen-image.yaml")
+        models = option_values(parameter(data, "model"))
+        self.assertIn("qwen-image-3.0", models)
+        self.assertIn("qwen-image-3.0-pro", models)
+
     def test_doubao_pro_tool_exposes_only_verified_parameters(self) -> None:
         relative = "tools/doubao-seedream-5-pro.yaml"
         self.assertTrue((PLUGIN_ROOT / relative).is_file())

--- a/tools/aihubmix_image/tests/test_qwen_image_payload.py
+++ b/tools/aihubmix_image/tests/test_qwen_image_payload.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "qwen-image.py"
+SPEC = importlib.util.spec_from_file_location("qwen_image", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {MODULE_PATH}")
+qwen_image = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(qwen_image)
+
+build_payload = qwen_image.build_payload
+endpoint_path = qwen_image.endpoint_path
+extract_images = qwen_image.extract_images
+download_protected_image = qwen_image.download_protected_image
+
+
+class QwenImagePayloadTests(unittest.TestCase):
+    def test_image_3_models_use_unified_image_endpoint(self) -> None:
+        for model in ("qwen-image-3.0", "qwen-image-3.0-pro"):
+            with self.subTest(model=model):
+                self.assertEqual(endpoint_path(model), "/ai/v1/images/generations")
+
+    def test_image_3_payload_uses_top_level_openai_shape(self) -> None:
+        payload = build_payload(
+            model="qwen-image-3.0",
+            prompt="draw a circle",
+            resolution="1024x1024",
+            num_images=1,
+            refer_image="",
+            guidance=7.5,
+            watermark=False,
+            image_format="png",
+        )
+
+        self.assertNotIn("input", payload)
+        self.assertEqual(payload["model"], "qwen-image-3.0")
+        self.assertEqual(payload["prompt"], "draw a circle")
+        self.assertEqual(payload["size"], "1024x1024")
+        self.assertEqual(payload["output_format"], "png")
+        self.assertNotIn("watermark", payload)
+        self.assertNotIn("extra", payload)
+
+    def test_image_3_watermark_uses_vendor_extra(self) -> None:
+        payload = build_payload(
+            model="qwen-image-3.0-pro",
+            prompt="draw a circle",
+            resolution="1024x1024",
+            num_images=1,
+            refer_image="",
+            guidance=7.5,
+            watermark=True,
+            image_format="png",
+        )
+
+        self.assertNotIn("watermark", payload)
+        self.assertEqual(payload["extra"], {"watermark": True})
+
+    def test_existing_models_keep_predictions_shape(self) -> None:
+        payload = build_payload(
+            model="qwen-image-2.0-pro",
+            prompt="draw a circle",
+            resolution="1024x1024",
+            num_images=1,
+            refer_image="",
+            guidance=7.5,
+            watermark=False,
+            image_format="png",
+        )
+
+        self.assertEqual(
+            endpoint_path("qwen-image-2.0-pro"),
+            "/v1/models/bailian/qwen-image-2.0-pro/predictions",
+        )
+        self.assertEqual(payload["input"]["prompt"], "draw a circle")
+        self.assertNotIn("model", payload)
+
+    def test_extract_images_supports_unified_and_legacy_responses(self) -> None:
+        self.assertEqual(
+            extract_images({"data": [{"url": "https://example.com/image.png"}]}),
+            [{"url": "https://example.com/image.png"}],
+        )
+        self.assertEqual(
+            extract_images({"output": [{"bytesBase64": "encoded-image"}]}),
+            [{"b64_json": "encoded-image"}],
+        )
+        self.assertEqual(
+            extract_images(
+                {
+                    "output": [
+                        {
+                            "content_url": "https://example.com/ai/v1/images/task/content/result"
+                        }
+                    ]
+                }
+            ),
+            [
+                {
+                    "content_url": "https://example.com/ai/v1/images/task/content/result"
+                }
+            ],
+        )
+
+    def test_protected_result_download_reuses_api_key(self) -> None:
+        response = Mock(status_code=200, content=b"image-bytes")
+        with patch.object(qwen_image.requests, "get", return_value=response) as get:
+            self.assertEqual(
+                download_protected_image("https://example.com/result", "test-key"),
+                b"image-bytes",
+            )
+
+        get.assert_called_once_with(
+            "https://example.com/result",
+            headers={"Authorization": "Bearer test-key"},
+            timeout=120,
+        )
+
+    def test_protected_result_download_rejects_http_error(self) -> None:
+        response = Mock(status_code=401, content=b"")
+        with patch.object(qwen_image.requests, "get", return_value=response):
+            with self.assertRaisesRegex(
+                qwen_image.InvokeError,
+                "result download failed with status 401",
+            ):
+                download_protected_image("https://example.com/result", "test-key")
+
+    def test_image_3_invoke_downloads_protected_output_as_blob(self) -> None:
+        post_response = Mock(status_code=200)
+        post_response.json.return_value = {
+            "id": "task-123",
+            "status": "completed",
+            "output": [
+                {
+                    "content_url": "https://example.com/ai/v1/images/task/content/result"
+                }
+            ],
+        }
+        get_response = Mock(status_code=200, content=b"\x89PNG\r\n\x1a\nimage")
+        tool = qwen_image.QwenImageTool(
+            runtime=Mock(
+                credentials={
+                    "api_key": "test-key",
+                    "base_url": "https://example.com",
+                }
+            ),
+            session=Mock(),
+        )
+
+        with (
+            patch.object(qwen_image.requests, "post", return_value=post_response) as post,
+            patch.object(qwen_image.requests, "get", return_value=get_response) as get,
+        ):
+            messages = list(
+                tool._invoke(
+                    {
+                        "model": "qwen-image-3.0-pro",
+                        "prompt": "red dot",
+                        "resolution": "1024x1024",
+                        "num_images": 1,
+                        "image_format": "png",
+                    }
+                )
+            )
+
+        post.assert_called_once()
+        self.assertEqual(
+            post.call_args.args[0],
+            "https://example.com/ai/v1/images/generations",
+        )
+        get.assert_called_once_with(
+            "https://example.com/ai/v1/images/task/content/result",
+            headers={"Authorization": "Bearer test-key"},
+            timeout=120,
+        )
+        self.assertEqual(messages[1].message.blob, get_response.content)
+        self.assertEqual(messages[2].message.json_object["task_id"], "task-123")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/aihubmix_image/tools/qwen-image.py
+++ b/tools/aihubmix_image/tools/qwen-image.py
@@ -1,142 +1,226 @@
-import json
-import requests
 import base64
 from collections.abc import Generator
-from typing import Any, Dict, List
+from typing import Any
 
+import requests
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.errors.model import InvokeError
 
 
+QWEN_IMAGE_3_MODELS = {"qwen-image-3.0", "qwen-image-3.0-pro"}
+
+
+def endpoint_path(model: str) -> str:
+    if model in QWEN_IMAGE_3_MODELS:
+        return "/ai/v1/images/generations"
+    vendor = "qianfan" if model == "qwen-image" else "bailian"
+    return f"/v1/models/{vendor}/{model}/predictions"
+
+
+def build_payload(
+    *,
+    model: str,
+    prompt: str,
+    resolution: str,
+    num_images: int,
+    refer_image: str,
+    guidance: float,
+    watermark: bool,
+    image_format: str,
+) -> dict[str, Any]:
+    if model in QWEN_IMAGE_3_MODELS:
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "n": num_images,
+            "size": resolution,
+        }
+        if image_format:
+            payload["output_format"] = image_format
+        if refer_image:
+            payload["image"] = refer_image
+        if watermark:
+            payload["extra"] = {"watermark": True}
+        return payload
+
+    return {
+        "input": {
+            "prompt": prompt,
+            "refer_image": refer_image,
+            "n": num_images,
+            "size": resolution,
+            "guidance": guidance,
+            "watermark": watermark,
+        }
+    }
+
+
+def extract_images(data: dict[str, Any]) -> list[dict[str, str]]:
+    items: Any = data.get("data")
+    if not isinstance(items, list):
+        items = data.get("output")
+
+    if isinstance(items, dict):
+        items = items.get("b64_json") or items.get("images") or []
+    if not isinstance(items, list):
+        return []
+
+    images: list[dict[str, str]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if isinstance(item.get("content_url"), str):
+            images.append({"content_url": item["content_url"]})
+            continue
+        if isinstance(item.get("url"), str):
+            images.append({"url": item["url"]})
+            continue
+        for key in ("b64_json", "bytesBase64", "bytesBase64Encoded"):
+            value = item.get(key)
+            if isinstance(value, str):
+                images.append({"b64_json": value})
+                break
+    return images
+
+
+def detect_image_format(image_bytes: bytes) -> tuple[str, str]:
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg", "jpg"
+    if image_bytes.startswith(b"RIFF") and image_bytes[8:12] == b"WEBP":
+        return "image/webp", "webp"
+    return "image/png", "png"
+
+
+def download_protected_image(content_url: str, api_key: str) -> bytes:
+    response = requests.get(
+        content_url,
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=120,
+    )
+    if response.status_code != 200:
+        raise InvokeError(
+            f"Qwen Image result download failed with status {response.status_code}"
+        )
+    return response.content
+
+
 class QwenImageTool(Tool):
-    """
-    Qwen Image Generation Tool
-    Uses qianfan/qwen-image model optimized for Chinese prompts
-    """
-    
+    """Generate images with the Qwen Image family."""
+
     DEFAULT_BASE_URL = "https://api.inferera.com"
 
     def get_base_url(self) -> str:
         return (self.runtime.credentials.get("base_url") or self.DEFAULT_BASE_URL).rstrip("/")
 
     def get_endpoint(self, model: str) -> str:
-        vendor = "qianfan" if model == "qwen-image" else "bailian"
-        return f"{self.get_base_url()}/v1/models/{vendor}/{model}/predictions"
-    
-    def create_image_info(self, base64_data: str, resolution: str) -> dict:
-        mime_type = "image/png"
-        return {
-            "url": f"data:{mime_type};base64,{base64_data}",
-            "resolution": resolution
-        }
-    
+        return f"{self.get_base_url()}{endpoint_path(model)}"
+
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
-        """
-        Main invoke method for Qwen Image generation
-        """
         try:
-            # Extract and validate parameters
             prompt = tool_parameters.get("prompt", "").strip()
             if not prompt:
                 raise InvokeError("Prompt is required")
-            
+
             model = tool_parameters.get("model", "qwen-image")
             resolution = tool_parameters.get("resolution", "1024x1024")
             num_images = int(tool_parameters.get("num_images", 1))
             refer_image = tool_parameters.get("refer_image", "")
             guidance = float(tool_parameters.get("guidance", 7.5))
             watermark = tool_parameters.get("watermark", False)
-            
-            # Validate parameters
+            image_format = tool_parameters.get("image_format", "png")
+
             if num_images < 1 or num_images > 4:
                 raise InvokeError("Number of images must be between 1 and 4")
-            
-            # Get API key from credentials
+
             api_key = self.runtime.credentials.get("api_key")
             if not api_key:
                 raise InvokeError("API Key is required")
-            
-            # Prepare headers
+
             headers = {
                 "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             }
-            
-            # Prepare request payload for Qwen Image according to API documentation
-            payload = {
-                "input": {
-                    "prompt": prompt,
-                    "refer_image": refer_image,
-                    "n": num_images,
-                    "size": resolution,
-                    "guidance": guidance,
-                    "watermark": watermark
-                }
-            }
-            
+            payload = build_payload(
+                model=model,
+                prompt=prompt,
+                resolution=resolution,
+                num_images=num_images,
+                refer_image=refer_image,
+                guidance=guidance,
+                watermark=watermark,
+                image_format=image_format,
+            )
+
             yield self.create_text_message(f"Generating {num_images} image(s) with {model}...")
 
             response = requests.post(
                 self.get_endpoint(model),
                 headers=headers,
                 json=payload,
-                timeout=120,
+                timeout=300,
             )
-            
             if response.status_code != 200:
                 error_msg = f"Qwen Image API request failed with status {response.status_code}"
                 try:
-                    error_data = response.json()
-                    if "error" in error_data:
-                        error_msg += f": {error_data['error'].get('message', 'Unknown error')}"
-                except:
+                    error = response.json().get("error")
+                    if isinstance(error, dict):
+                        error_msg += f": {error.get('message', 'Unknown error')}"
+                    elif error:
+                        error_msg += f": {error}"
+                except ValueError:
                     pass
                 raise InvokeError(error_msg)
-            
-            data = response.json()
-            
-            # Extract image data from response
-            images = []
-            if "output" in data and isinstance(data["output"], list):
-                for item in data["output"]:
-                    if "b64_json" in item:
-                        images.append({"b64_json": item["b64_json"]})
-                    elif "url" in item:
-                        images.append({"url": item["url"]})
-            
+
+            response_data = response.json()
+            images = extract_images(response_data)
             if not images:
                 raise InvokeError("No images were generated")
-            
-            # Process images - return as blobs for base64 data, or display URLs
-            for idx, img in enumerate(images):
-                if "b64_json" in img:
-                    # Decode base64 and return as blob
-                    base64_data = img["b64_json"]
-                    image_bytes = base64.b64decode(base64_data)
-                    filename = f"qwen_image_{idx + 1}.png"
-                    mime_type = "image/png"
-                    yield self.create_blob_message(blob=image_bytes, meta={"mime_type": mime_type, "filename": filename})
-                elif "url" in img:
-                    # For URL responses, create image message
-                    yield self.create_image_message(img["url"])
-            
-            # Return results as JSON
-            yield self.create_json_message({
-                "success": True,
-                "model": model,
-                "prompt": prompt,
-                "resolution": resolution,
-                "num_images": len(images),
-                "images": images,
-                "refer_image": refer_image,
-                "guidance": guidance,
-                "watermark": watermark
-            })
-            
-            # Also create text message with image URLs
-            image_urls = "\n".join([img['url'] for img in images])
-            yield self.create_text_message(image_urls)
-                
-        except Exception as e:
-            raise InvokeError(f"Qwen Image generation failed: {str(e)}")
+
+            for idx, image in enumerate(images):
+                if "b64_json" in image:
+                    image_bytes = base64.b64decode(image["b64_json"])
+                    mime_type, extension = detect_image_format(image_bytes)
+                    yield self.create_blob_message(
+                        blob=image_bytes,
+                        meta={
+                            "mime_type": mime_type,
+                            "filename": f"qwen_image_{idx + 1}.{extension}",
+                        },
+                    )
+                elif "url" in image:
+                    yield self.create_image_message(image["url"])
+                elif "content_url" in image:
+                    image_bytes = download_protected_image(image["content_url"], api_key)
+                    mime_type, extension = detect_image_format(image_bytes)
+                    yield self.create_blob_message(
+                        blob=image_bytes,
+                        meta={
+                            "mime_type": mime_type,
+                            "filename": f"qwen_image_{idx + 1}.{extension}",
+                        },
+                    )
+
+            yield self.create_json_message(
+                {
+                    "success": True,
+                    "model": model,
+                    "prompt": prompt,
+                    "resolution": resolution,
+                    "num_images": len(images),
+                    "images": images,
+                    "refer_image": refer_image,
+                    "guidance": guidance,
+                    "watermark": watermark,
+                    "image_format": image_format,
+                    "task_id": response_data.get("id"),
+                }
+            )
+
+            image_urls = "\n".join(image["url"] for image in images if "url" in image)
+            if image_urls:
+                yield self.create_text_message(image_urls)
+        except InvokeError:
+            raise
+        except Exception as exc:
+            raise InvokeError(f"Qwen Image generation failed: {exc}") from exc

--- a/tools/aihubmix_image/tools/qwen-image.yaml
+++ b/tools/aihubmix_image/tools/qwen-image.yaml
@@ -8,11 +8,11 @@ identity:
     ja_JP: "Qwen Image"
 description:
   human:
-    en_US: "Alibaba Qwen-Image text-to-image. 2.0-pro has the strongest text rendering and semantics, max excels at industrial design and geometric reasoning, plus supports custom resolution, the base qwen-image is the entry option."
+    en_US: "Alibaba Qwen-Image text-to-image, including Qwen Image 3.0 and 3.0 Pro alongside the existing model variants."
     zh_Hans: "阿里 Qwen-Image 文生图。2.0-pro 文字渲染与语义理解最强，max 擅长工业设计与几何推理，plus 支持自定义分辨率，基础版 qwen-image 适合入门。"
     pt_BR: "Texto-para-imagem Qwen-Image da Alibaba. 2.0-pro tem a melhor renderização de texto e semântica; max se destaca em design industrial e raciocínio geométrico; plus suporta resolução personalizada; qwen-image base é a opção de entrada."
     ja_JP: "Alibaba Qwen-Image のテキストから画像生成。2.0-pro はテキスト描画と意味理解が最強、max は工業デザインと幾何推論に優れる、plus はカスタム解像度対応、qwen-image はベース版。"
-  llm: "Generate images with Alibaba Qwen-Image (qwen-image / 2.0 / 2.0-pro / max / plus). Particularly strong on Chinese prompts and rendering legible text inside images."
+  llm: "Generate images with Alibaba Qwen-Image, including qwen-image-3.0 and qwen-image-3.0-pro."
 parameters:
   - name: prompt
     type: string
@@ -43,7 +43,7 @@ parameters:
       zh_Hans: "Qwen Image 模型变体"
       pt_BR: "Variante do modelo Qwen Image"
       ja_JP: "Qwen Image モデルバリアント"
-    llm_description: "Qwen Image model selection. qwen-image-2.0-pro is strongest, qwen-image-max excels at industrial design, qwen-image-plus supports custom resolution."
+    llm_description: "Qwen Image model selection, including Qwen Image 3.0 and Qwen Image 3.0 Pro."
     form: form
     default: "qwen-image"
     options:
@@ -53,6 +53,18 @@ parameters:
           zh_Hans: "qwen-image（基础版）"
           pt_BR: "qwen-image (base)"
           ja_JP: "qwen-image（ベース）"
+      - value: "qwen-image-3.0"
+        label:
+          en_US: "qwen-image-3.0"
+          zh_Hans: "qwen-image-3.0"
+          pt_BR: "qwen-image-3.0"
+          ja_JP: "qwen-image-3.0"
+      - value: "qwen-image-3.0-pro"
+        label:
+          en_US: "qwen-image-3.0-pro"
+          zh_Hans: "qwen-image-3.0-pro"
+          pt_BR: "qwen-image-3.0-pro"
+          ja_JP: "qwen-image-3.0-pro"
       - value: "qwen-image-2.0-pro"
         label:
           en_US: "qwen-image-2.0-pro"


### PR DESCRIPTION
## Summary

Adds Qwen Image 3.0 and Qwen Image 3.0 Pro to the AIHubMix Image tool.

- Registers `qwen-image-3.0` and `qwen-image-3.0-pro` in the model selector.
- Uses the unified `/ai/v1/images/generations` media endpoint for both models while preserving the existing Predictions routes for earlier Qwen Image variants.
- Supports `output[].content_url` results by downloading protected image content with the configured AIHubMix credential and returning Dify BLOB outputs.
- Maps enabled watermarking to `extra.watermark`, preserves image format selection, and includes the media task ID in the JSON output.
- Adds focused coverage for endpoint selection, payload construction, response parsing, protected image downloads, and existing-model routing.
- Bumps the plugin version from `0.1.4` to `0.1.5`.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

Not included. The change updates the existing Qwen Image model selector and response handling.

## LLM Plugin Checklist

Not applicable; this is a tool plugin.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.9.0` is declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [ ] Local deployment - Dify version: 1.14.2
- [ ] SaaS (cloud.dify.ai)
- `python -m unittest discover -s tests -v`: 21 tests passed.
- Python compilation completed for `main.py`, `provider`, and `tools`.
- Plugin packaging completed successfully with `dify-plugin` v0.6.2.
- A minimal 1K `qwen-image-3.0-pro` request through `/ai/v1/images/generations` returned HTTP 200 and one completed image task.
- The protected image content download returned HTTP 200 as `image/png`.
- AIHubMix Logs recorded `$0.035720`, matching the published 1K image price.
