### PR TITLE
fix(minimax_tts): add endpoint selector and reject invalid credentials

### DIFF
--- a/tools/minimax_tts/manifest.yaml
+++ b/tools/minimax_tts/manifest.yaml
@@ -29,4 +29,4 @@ resource:
 tags:
   - utilities
 type: plugin
-version: 0.0.6
+version: 0.0.7

--- a/tools/minimax_tts/provider/minimax_tts.yaml
+++ b/tools/minimax_tts/provider/minimax_tts.yaml
@@ -38,6 +38,29 @@ credentials_for_provider:
       en_US: Get your api key from Minimax
       zh_Hans: 获取您的 Minimax api key
     url: https://api.minimax.chat/user-center/basic-information/interface-key
+  api_endpoint:
+    type: select
+    required: false
+    default: legacy
+    label:
+      en_US: API Endpoint
+      zh_Hans: API 端点
+    help:
+      en_US: MiniMax runs separate account systems; pick the platform your key was created on.
+      zh_Hans: MiniMax 国内与国际平台账号体系相互独立，请选择创建密钥的平台。
+    options:
+      - value: legacy
+        label:
+          en_US: api.minimax.chat (legacy, current default)
+          zh_Hans: api.minimax.chat（旧域名，当前默认）
+      - value: china
+        label:
+          en_US: api.minimaxi.com (China)
+          zh_Hans: api.minimaxi.com（中国大陆）
+      - value: international
+        label:
+          en_US: api.minimax.io (International)
+          zh_Hans: api.minimax.io（国际站）
 tools:
   - tools/tts.yaml
 extra:

--- a/tools/minimax_tts/tests/test_endpoint.py
+++ b/tools/minimax_tts/tests/test_endpoint.py
@@ -1,0 +1,46 @@
+"""In-process tests for MiniMax TTS endpoint selection (pytest-shaped).
+
+Fails before this change: both t2a_v2 call sites hardcoded the legacy
+api.minimax.chat host; keys from MiniMax's current china (api.minimaxi.com)
+and international (api.minimax.io) platforms had no way in."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from utils.endpoint import get_base_url  # noqa: E402
+
+
+def test_default_is_byte_identical_legacy():
+    # absent / empty / unknown values all resolve to the exact host every
+    # existing installation used before this change
+    for creds in ({}, {"api_endpoint": ""}, {"api_endpoint": "bogus"}):
+        assert get_base_url(creds) == "https://api.minimax.chat"
+
+
+def test_documented_current_hosts():
+    assert get_base_url({"api_endpoint": "china"}) == "https://api.minimaxi.com"
+    assert get_base_url({"api_endpoint": "international"}) == "https://api.minimax.io"
+
+
+def test_no_hardcoded_host_left_in_api_calls():
+    for sub in ("provider", "tools"):
+        for py in (_PLUGIN_ROOT / sub).glob("*.py"):
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                    assert not node.value.startswith("https://api.minimax"), (
+                        f"hardcoded API host in {py.name}:{node.lineno}"
+                    )
+                if isinstance(node, ast.JoinedStr):
+                    for part in node.values:
+                        if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                            assert "api.minimax.chat" not in part.value, (
+                                f"hardcoded host in f-string {py.name}:{node.lineno}"
+                            )

--- a/tools/minimax_tts/tests/test_endpoint.py
+++ b/tools/minimax_tts/tests/test_endpoint.py
@@ -44,3 +44,29 @@ def test_no_hardcoded_host_left_in_api_calls():
                             assert "api.minimax.chat" not in part.value, (
                                 f"hardcoded host in f-string {py.name}:{node.lineno}"
                             )
+
+
+def test_validation_rejects_junk_key_and_names_the_endpoint():
+    """Unmocked, real-network: every MiniMax host answers HTTP 200 with a
+    base_resp error for a bad key, so before this change credential validation
+    PASSED with any junk key on any endpoint. Asserts the invoke path the
+    provider validates through now raises, naming the configured host."""
+    import dify_plugin  # noqa: F401  (gevent-patches ssl; must precede requests)
+    import pytest
+
+    from tools.tts import MinimaxTTS
+
+    for choice, host in (
+        ("legacy", "api.minimax.chat"),
+        ("china", "api.minimaxi.com"),
+        ("international", "api.minimax.io"),
+    ):
+        credentials = {
+            "group_id": "1234567890",
+            "api_key": "junk-invalid-on-purpose",
+            "api_endpoint": choice,
+        }
+        tool = MinimaxTTS.from_credentials(credentials)
+        with pytest.raises(Exception, match=host):
+            for _ in tool.invoke(tool_parameters={"text": "test"}):
+                pass

--- a/tools/minimax_tts/tools/tts.py
+++ b/tools/minimax_tts/tools/tts.py
@@ -61,6 +61,7 @@ class MinimaxTTS(Tool):
             response = requests.post(url, headers=headers, json=payload, timeout=(10, 30))
             response.raise_for_status()
             parsed_json = response.json()
+            self._raise_on_base_resp_error(parsed_json, url)
             audio_hex = parsed_json.get("data", {}).get("audio")
             if not audio_hex:
                 yield self.create_text_message("API 未返回音频数据")
@@ -81,6 +82,21 @@ class MinimaxTTS(Tool):
                 pass
             yield self.create_text_message(f"{error_msg}: {str(e)}")
 
+    @staticmethod
+    def _raise_on_base_resp_error(parsed_json: dict, url: str) -> None:
+        """MiniMax returns HTTP 200 with a base_resp error (e.g. status_code
+        1004 for a bad key) on ALL its hosts, so without this check a wrong or
+        wrong-platform key sails through credential validation."""
+        base_resp = parsed_json.get("base_resp") or {}
+        if base_resp.get("status_code", 0) != 0:
+            endpoint = url.split("?")[0]
+            raise Exception(
+                f"MiniMax API error {base_resp.get('status_code')} from {endpoint}: "
+                f"{base_resp.get('status_msg')} (MiniMax keys only work on the "
+                f"platform where they were minted; check the 'API Endpoint' "
+                f"credential setting)"
+            )
+
     def tts(self, text: str, group_id: str, api_key: str) -> bytes:
         """调用 MiniMax TTS API 进行文本转语音"""
         url = f"{get_base_url(self.runtime.credentials)}/v1/t2a_v2?GroupId={group_id}"
@@ -99,6 +115,11 @@ class MinimaxTTS(Tool):
         try:
             response = requests.post(url, headers=headers, data=payload, timeout=(10, 30))
             response.raise_for_status()
+            try:
+                parsed_json = response.json()
+            except ValueError:
+                return response.content
+            self._raise_on_base_resp_error(parsed_json, url)
             return response.content
         except requests.exceptions.ReadTimeout:
             raise Exception("请求超时，请稍后重试")

--- a/tools/minimax_tts/tools/tts.py
+++ b/tools/minimax_tts/tools/tts.py
@@ -7,6 +7,8 @@ import requests
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
+from utils.endpoint import get_base_url
+
 logger = logging.getLogger(__name__)
 
 class MinimaxTTS(Tool):
@@ -41,7 +43,7 @@ class MinimaxTTS(Tool):
         if emotion:
             voice_setting["emotion"] = emotion
 
-        url = f"https://api.minimax.chat/v1/t2a_v2?GroupId={group_id}"
+        url = f"{get_base_url(self.runtime.credentials)}/v1/t2a_v2?GroupId={group_id}"
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json"
@@ -81,7 +83,7 @@ class MinimaxTTS(Tool):
 
     def tts(self, text: str, group_id: str, api_key: str) -> bytes:
         """调用 MiniMax TTS API 进行文本转语音"""
-        url = f"https://api.minimax.chat/v1/t2a_v2?GroupId={group_id}"
+        url = f"{get_base_url(self.runtime.credentials)}/v1/t2a_v2?GroupId={group_id}"
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json"

--- a/tools/minimax_tts/utils/endpoint.py
+++ b/tools/minimax_tts/utils/endpoint.py
@@ -1,0 +1,15 @@
+MINIMAX_ENDPOINTS = {
+    # Byte-identical default: the host this plugin has always called. It still
+    # serves /v1/t2a_v2 but no longer appears in MiniMax's current docs, which
+    # list only the china and international hosts below.
+    "legacy": "https://api.minimax.chat",
+    "china": "https://api.minimaxi.com",
+    "international": "https://api.minimax.io",
+}
+
+
+def get_base_url(credentials: dict) -> str:
+    """API base for the configured MiniMax endpoint. MiniMax runs separate
+    account systems: keys work only on the platform where they were minted."""
+    choice = credentials.get("api_endpoint") or "legacy"
+    return MINIMAX_ENDPOINTS.get(choice, MINIMAX_ENDPOINTS["legacy"])


### PR DESCRIPTION
## Summary

Fixes #3600

The MiniMax TTS tools plugin has two credential-handling defects, both fixed here.

**1. Hardcoded legacy endpoint.** Both `t2a_v2` call sites in `tools/tts.py` hardcode `https://api.minimax.chat` — MiniMax's legacy domain. MiniMax's current docs list `api.minimax.io` (International) and `api.minimaxi.com` (China) as separate account systems with region-locked keys; `api.minimax.chat` is no longer documented. Keys from either current platform cannot authorize. This adds an optional **`api_endpoint`** select (legacy / china / international) routed through one helper covering both call sites. **The default stays the legacy host — byte-identical for existing users** (verified: it still serves `t2a_v2` with the same response envelope as the current hosts).

**2. Validation silently accepts any credential.** MiniMax returns HTTP 200 with `base_resp.status_code 1004` for a bad key rather than an HTTP error, and the plugin's validation only failed on a raised exception — so it passed for invalid keys, wrong-region keys, and wrong `group_id`s. Validation now inspects `base_resp` and rejects a non-zero status, surfacing MiniMax's own message and the selected endpoint.

**Open question for maintainers (not decided here):** whether the default should migrate off the undocumented legacy host. Keeping it legacy is byte-identical-safe today; migrating to `china`/`international` would be a behavior change for existing users. Left as the maintainers' call.

## Change Type
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)

## Screenshots / Videos

**Before (marketplace 0.0.6)**

Bogus key + group_id → "Action succeeded" (validation accepts invalid credentials)

https://github.com/user-attachments/assets/bc531b4c-199f-4ddb-8395-3bec24bb444c

---

**After (this fix)**

Rejects bogus api key
<img width="1280" height="1203" alt="minimax-after-1-bogus-api-key" src="https://github.com/user-attachments/assets/c1976098-9fef-42f7-b153-6b23fc03432f" />

Rejects valid api key + bogus group_id
<img width="1280" height="1203" alt="minimimax-after-2-bogus-group_id" src="https://github.com/user-attachments/assets/ff531826-f700-4ebb-b92e-2f041e09f00b" />

## Version
- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.6 → 0.0.7
- [x] `dify_plugin` declared in `pyproject.toml` / locked in `uv.lock` (unchanged)

## Testing
- [x] Local deployment — Dify 1.16.1 (self-hosted, Docker). Installed the packaged 0.0.7 build. Validation now **rejects** invalid credentials that marketplace 0.0.6 accepted: a malformed key returns `login fail` (1004) and a real key with a mismatched `group_id` returns `token not match group` (1004) — both naming `https://api.minimax.io/v1/t2a_v2` and pointing at the API Endpoint setting. The endpoint selector routes to the chosen host (confirmed in the request URL). A successful TTS generation was not exercised (requires a real matching group_id on the selected platform); the fix's routing and the corrected validation are demonstrated above.
- [ ] SaaS — not tested

In-process tests: default byte-identity (absent/empty/unknown → legacy), current-host mapping, AST no-hardcoded-host check covering f-string parts (the original hardcodes were f-strings). 3/3 pass.