### PR TITLE
feat(openrouter): add MiniMax M3 reasoning and vision controls

### DIFF
--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -26,5 +26,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.1.2
+version: 0.1.3
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/openrouter/models/llm/minimax-m3.yaml
+++ b/models/openrouter/models/llm/minimax-m3.yaml
@@ -8,6 +8,7 @@ features:
   - tool-call
   - multi-tool-call
   - stream-tool-call
+  - vision
 model_properties:
   mode: chat
   context_size: 1048576
@@ -36,6 +37,29 @@ parameter_rules:
     options:
       - text
       - json_object
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理程度
+      en_US: Reasoning Effort
+    type: string
+    help:
+      zh_Hans: 指定模型推理的难度
+      en_US: specifying the difficulty of the model's reasoning
+    required: false
+    options:
+      - low
+      - medium
+      - high
+  - name: exclude_reasoning_tokens
+    label:
+      zh_Hans: 隐藏思考过程
+      en_US: Hide the thought process
+    type: boolean
+    default: true
+    help:
+      zh_Hans: 是否隐藏思考过程。
+      en_US: Whether to hide the thought process.
+    required: false
 pricing:
   input: '0.3'
   output: '1.2'

--- a/models/openrouter/tests/test_llm_features.py
+++ b/models/openrouter/tests/test_llm_features.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from dify_plugin.entities.model import ModelFeature
 from dify_plugin.entities.model.message import (
@@ -35,6 +36,18 @@ def test_set_reasoning_params_supports_requested_effort_levels(effort: str) -> N
         "reasoning": {"effort": effort, "exclude": True},
         "temperature": 0.2,
     }
+
+
+def test_minimax_m3_exposes_reasoning_and_vision_controls() -> None:
+    schema_path = (
+        Path(__file__).resolve().parent.parent / "models" / "llm" / "minimax-m3.yaml"
+    )
+    schema = yaml.safe_load(schema_path.read_text(encoding="utf-8"))
+    rules = {rule["name"]: rule for rule in schema["parameter_rules"]}
+
+    assert "vision" in schema["features"]
+    assert rules["reasoning_effort"]["options"] == ["low", "medium", "high"]
+    assert rules["exclude_reasoning_tokens"]["default"] is True
 
 
 def test_custom_reasoning_model_exposes_effort_and_hide_controls(


### PR DESCRIPTION
## Summary

Expose MiniMax M3 capabilities already supported by OpenRouter and the provider implementation:

- add `low`, `medium`, and `high` reasoning-effort options
- enable image uploads by declaring vision support
- add a **Hide the thought process** toggle, enabled by default, which maps to OpenRouter's `reasoning.exclude`
- add regression coverage for the MiniMax M3 model schema
- bump the OpenRouter plugin version from `0.1.2` to `0.1.3`

OpenRouter's live model metadata advertises `text+image+video->text` modalities and support for the unified `reasoning` parameter:
https://openrouter.ai/api/v1/models/minimax/minimax-m3/endpoints

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| MiniMax M3 did not expose reasoning effort, thought-process visibility, or image upload controls. | MiniMax M3 exposes reasoning effort, thought-process visibility, and vision input. |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (the existing OpenRouter plugin currently uses `dify_plugin>=0.9.0`)

## Testing

- [x] `uv run pytest` — 18 passed, 65 live tests skipped without credentials
- [x] `uv run ruff check tests/test_llm_features.py`
- [x] `uv run black --check tests/test_llm_features.py`
- [x] `uv run pyrefly check` — 0 errors
- [ ] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

A repository-wide Ruff run also reports two pre-existing unused imports in `models/text_embedding/__init__.py` and `tests/test_llm_call.py`; neither file is changed by this PR.