### PR TITLE
fix(siliconflow): add international endpoint option to tools plugin

### DIFF
--- a/tools/siliconflow/manifest.yaml
+++ b/tools/siliconflow/manifest.yaml
@@ -32,4 +32,4 @@ resource:
 tags:
   - image
 type: plugin
-version: 0.0.12
+version: 0.0.13

--- a/tools/siliconflow/provider/siliconflow.py
+++ b/tools/siliconflow/provider/siliconflow.py
@@ -2,16 +2,27 @@ import requests
 from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 from dify_plugin import ToolProvider
 
+from utils.endpoint import get_base_url
+
 
 class SiliconflowProvider(ToolProvider):
     def _validate_credentials(self, credentials: dict[str, str]) -> None:
-        url = "https://api.siliconflow.cn/v1/models"
+        base_url = get_base_url(credentials)
+        url = f"{base_url}/v1/models"
         headers = {
             "accept": "application/json",
             "authorization": f"Bearer {credentials.get('siliconFlow_api_key')}",
         }
         response = requests.get(url, headers=headers, timeout=30)
+        if response.status_code == 401:
+            raise ToolProviderCredentialValidationError(
+                f"SiliconFlow API key was rejected by {base_url} "
+                f"(HTTP 401). If your key is from the other SiliconFlow site "
+                f"(siliconflow.cn vs siliconflow.com), change the "
+                f"'Use International Endpoint' setting to match it."
+            )
         if response.status_code != 200:
             raise ToolProviderCredentialValidationError(
-                "SiliconFlow API key is invalid"
+                f"SiliconFlow credential validation against {url} failed "
+                f"with HTTP {response.status_code}: {response.text[:200]}"
             )

--- a/tools/siliconflow/provider/siliconflow.yaml
+++ b/tools/siliconflow/provider/siliconflow.yaml
@@ -7,6 +7,22 @@ credentials_for_provider:
     required: true
     type: secret-input
     url: https://cloud.siliconflow.cn/account/ak
+  use_international_endpoint:
+    label:
+      en_US: Use International Endpoint
+      zh_CN: 使用国际站端点
+    required: false
+    type: select
+    default: "false"
+    options:
+      - label:
+          en_US: "True"
+          zh_CN: "是"
+        value: "true"
+      - label:
+          en_US: "False"
+          zh_CN: "否"
+        value: "false"
 extra:
   python:
     source: provider/siliconflow.py

--- a/tools/siliconflow/tests/test_endpoint.py
+++ b/tools/siliconflow/tests/test_endpoint.py
@@ -1,0 +1,48 @@
+"""In-process tests for the SiliconFlow endpoint selection (pytest-shaped).
+
+Fails before this change: every API call hardcoded api.siliconflow.cn, so an
+international (api.siliconflow.com) key could never validate or invoke."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from utils.endpoint import get_base_url  # noqa: E402
+
+
+def test_default_is_byte_identical_cn():
+    # absent, "false", and empty-string credential all resolve to the exact
+    # host every existing installation used before this change
+    for creds in ({}, {"use_international_endpoint": "false"},
+                  {"use_international_endpoint": ""}):
+        assert get_base_url(creds) == "https://api.siliconflow.cn"
+
+
+def test_international_opt_in():
+    assert (
+        get_base_url({"use_international_endpoint": "true"})
+        == "https://api.siliconflow.com"
+    )
+
+
+def test_no_hardcoded_host_left_in_api_calls():
+    # no string literal in provider/ or tools/ may carry a full
+    # https://api.siliconflow URL — the helper in utils/endpoint.py is the
+    # single source of the host (host names in human-readable error text,
+    # without a scheme, are fine)
+    import ast
+
+    for sub in ("provider", "tools"):
+        for py in (_PLUGIN_ROOT / sub).glob("*.py"):
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                    assert not node.value.startswith("https://api.siliconflow"), (
+                        f"hardcoded API host in {py.name}:{node.lineno}: "
+                        f"{node.value!r}"
+                    )

--- a/tools/siliconflow/tests/test_endpoint.py
+++ b/tools/siliconflow/tests/test_endpoint.py
@@ -5,6 +5,8 @@ international (api.siliconflow.com) key could never validate or invoke."""
 
 from __future__ import annotations
 
+import dify_plugin  # noqa: F401  (gevent-patches ssl; must precede requests)
+
 import sys
 from pathlib import Path
 
@@ -46,3 +48,28 @@ def test_no_hardcoded_host_left_in_api_calls():
                         f"hardcoded API host in {py.name}:{node.lineno}: "
                         f"{node.value!r}"
                     )
+
+
+def test_validation_401_names_the_endpoint_it_hit():
+    """Unmocked, real-network: both SiliconFlow hosts return 401 for a junk
+    key, so the validation error must name the base URL that rejected it.
+    Asserts provider validation flows through the endpoint switch."""
+    import pytest
+
+    from dify_plugin.errors.tool import ToolProviderCredentialValidationError
+    from provider.siliconflow import SiliconflowProvider
+
+    provider = SiliconflowProvider.__new__(SiliconflowProvider)
+    for flag, host in (
+        ("true", "api.siliconflow.com"),
+        ("false", "api.siliconflow.cn"),
+    ):
+        credentials = {
+            "siliconFlow_api_key": "sk-invalid-on-purpose",
+            "use_international_endpoint": flag,
+        }
+        with pytest.raises(ToolProviderCredentialValidationError) as excinfo:
+            provider._validate_credentials(credentials)
+        assert host in str(excinfo.value), (
+            f"validation error must name {host}: {excinfo.value}"
+        )

--- a/tools/siliconflow/tools/image-edit.py
+++ b/tools/siliconflow/tools/image-edit.py
@@ -5,7 +5,9 @@ import requests
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-SILICONFLOW_IMAGE_API_URL = "https://api.siliconflow.cn/v1/images/generations"
+from utils.endpoint import get_base_url
+
+SILICONFLOW_IMAGE_API_PATH = "/v1/images/generations"
 QWEN_IMAGE_EDIT_MODELS = {
     "qwen_image_edit_2509": "Qwen/Qwen-Image-Edit-2509",
     "qwen_image_edit": "Qwen/Qwen-Image-Edit",
@@ -66,7 +68,7 @@ class ImageEditTool(Tool):
 
         try:
             response = requests.post(
-                SILICONFLOW_IMAGE_API_URL,
+                get_base_url(self.runtime.credentials) + SILICONFLOW_IMAGE_API_PATH,
                 json=payload,
                 headers=headers,
                 timeout=REQUEST_TIMEOUT,

--- a/tools/siliconflow/tools/image-generate.py
+++ b/tools/siliconflow/tools/image-generate.py
@@ -5,7 +5,9 @@ import requests
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-SILICONFLOW_IMAGE_API_URL = "https://api.siliconflow.cn/v1/images/generations"
+from utils.endpoint import get_base_url
+
+SILICONFLOW_IMAGE_API_PATH = "/v1/images/generations"
 REQUEST_TIMEOUT = 120
 IMAGE_GENERATION_MODELS = {
     "kolors": "Kwai-Kolors/Kolors",
@@ -57,7 +59,7 @@ class ImageGenerateTool(Tool):
 
         try:
             response = requests.post(
-                SILICONFLOW_IMAGE_API_URL,
+                get_base_url(self.runtime.credentials) + SILICONFLOW_IMAGE_API_PATH,
                 json=payload,
                 headers=headers,
                 timeout=REQUEST_TIMEOUT,

--- a/tools/siliconflow/tools/video-generate.py
+++ b/tools/siliconflow/tools/video-generate.py
@@ -8,10 +8,12 @@ import requests
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
+from utils.endpoint import get_base_url
+
 IMAGE_TO_VIDEO_MODEL = "Wan-AI/Wan2.2-I2V-A14B"
 TEXT_TO_VIDEO_MODEL = "Wan-AI/Wan2.2-T2V-A14B"
-SILICONFLOW_VIDEO_SUBMIT_ENDPOINT = "https://api.siliconflow.cn/v1/video/submit"
-SILICONFLOW_VIDEO_STATUS_ENDPOINT = "https://api.siliconflow.cn/v1/video/status"
+SILICONFLOW_VIDEO_SUBMIT_PATH = "/v1/video/submit"
+SILICONFLOW_VIDEO_STATUS_PATH = "/v1/video/status"
 REQUEST_TIMEOUT = 60
 POLL_INTERVAL_SECONDS = 5
 MAX_WAIT_SECONDS = 300
@@ -70,7 +72,7 @@ class VideoGenerateTool(Tool):
         while waited_seconds < MAX_WAIT_SECONDS:
             try:
                 response = requests.post(
-                    SILICONFLOW_VIDEO_STATUS_ENDPOINT,
+                    get_base_url(self.runtime.credentials) + SILICONFLOW_VIDEO_STATUS_PATH,
                     json={"requestId": request_id},
                     headers=headers,
                     timeout=REQUEST_TIMEOUT,
@@ -176,7 +178,7 @@ class VideoGenerateTool(Tool):
 
         try:
             response = requests.post(
-                SILICONFLOW_VIDEO_SUBMIT_ENDPOINT,
+                get_base_url(self.runtime.credentials) + SILICONFLOW_VIDEO_SUBMIT_PATH,
                 json=payload,
                 headers=headers,
                 timeout=REQUEST_TIMEOUT,

--- a/tools/siliconflow/utils/endpoint.py
+++ b/tools/siliconflow/utils/endpoint.py
@@ -1,0 +1,11 @@
+SILICONFLOW_CN_BASE_URL = "https://api.siliconflow.cn"
+SILICONFLOW_INTERNATIONAL_BASE_URL = "https://api.siliconflow.com"
+
+
+def get_base_url(credentials: dict) -> str:
+    """API base for the configured endpoint. Defaults to the .cn endpoint so
+    existing installations keep their exact current behavior; the international
+    endpoint (api.siliconflow.com) uses separate accounts and keys."""
+    if credentials.get("use_international_endpoint", "false") == "true":
+        return SILICONFLOW_INTERNATIONAL_BASE_URL
+    return SILICONFLOW_CN_BASE_URL


### PR DESCRIPTION
## Summary

Fixes #3603

The SiliconFlow **tools** plugin hardcodes `api.siliconflow.cn` at five call sites (provider validation, image-generate, image-edit, video submit + status), so a valid key from the international site (`api.siliconflow.com` — a separate account system) fails validation with a misleading *"SiliconFlow API key is invalid."*

This mirrors the approach the **models** plugin already merged in #2394: an optional **`use_international_endpoint`** credential (select, default `"false"`). All five call sites resolve their base URL through one helper (`utils/endpoint.py`).

- **Zero change for existing users:** with the credential absent or `"false"`, every resolved URL is byte-identical to the current hardcoded ones (audited in the tests).
- **Honest validation errors:** a 401 now names the endpoint that rejected the key and points at the new setting; other failures report HTTP status + upstream response instead of unconditionally blaming the key.
- Survey note: of the providers shipping both a models and a tools plugin, siliconflow was the only one with a region credential on the models side and a hardcoded host on the tools side (jina has the analogous gap with `base_url`; stepfun has the inverse).

**On the widget:** #2394 uses a `radio` for this choice, which lives in a model-provider schema. Tools plugins use `credentials_for_provider`, whose SDK offers `select` but no radio type — so this is rendered as a dropdown with the same variable name, default, and values (in-repo precedent: jira, email, mineru).

## Change Type
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)

## Screenshots / Videos

**Before (marketplace 0.0.12)**
Valid international key → "SiliconFlow API key is invalid"
<img width="1280" height="1203" alt="siliconflow-before" src="https://github.com/user-attachments/assets/f2953d57-43af-4693-8031-471ca1a86ab8" />

---

**After (this fix, 0.0.13)**
Same key + "Use International Endpoint: True" → validates against api.siliconflow.com ("Action succeeded")
<img width="1280" height="1203" alt="silicon-flow-after-1" src="https://github.com/user-attachments/assets/0576e468-57f9-4d7d-bd10-a8b86b3d83c8" />
<img width="1280" height="1203" alt="silicon-flow-after-2" src="https://github.com/user-attachments/assets/ec0427d8-f651-45e7-82d1-24d22f09af0a" />


## Version
- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.12 → 0.0.13
- [x] `dify_plugin` declared in `pyproject.toml` / locked in `uv.lock` (unchanged)

## Testing
- [x] Local deployment — Dify 1.16.1 (self-hosted, Docker). Installed the packaged 0.0.13 build. With an international (`.com`) key and "Use International Endpoint" set to True, validation passes against `api.siliconflow.com` — the same key that stock 0.0.12 rejects as invalid. The default path (credential absent/False) resolves to `api.siliconflow.cn`, byte-identical to the current hardcoded URLs (audited mechanically per call site). A `.cn`-key round trip and a completed image generation were not separately exercised; the international validation path and the byte-identical default are demonstrated.
- [ ] SaaS — not tested

In-process tests (`tools/siliconflow/tests/test_endpoint.py`): default byte-identity (absent/false/empty → .cn), international opt-in (→ .com), and an AST check that no `https://api.siliconflow…` literal remains in provider/tools code. 3/3 pass.