### PR TITLE
fix(stepfun): add international endpoint option to models plugin

### DIFF
--- a/models/stepfun/manifest.yaml
+++ b/models/stepfun/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.0
+version: 0.1.1

--- a/models/stepfun/models/llm/llm.py
+++ b/models/stepfun/models/llm/llm.py
@@ -25,6 +25,7 @@ from dify_plugin.entities.model.message import (
     UserPromptMessage,
 )
 from dify_plugin import OAICompatLargeLanguageModel
+from dify_plugin.errors.model import CredentialsValidateFailedError
 
 
 class StepfunLargeLanguageModel(OAICompatLargeLanguageModel):
@@ -50,7 +51,14 @@ class StepfunLargeLanguageModel(OAICompatLargeLanguageModel):
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
         self._add_custom_parameters(credentials)
-        super().validate_credentials(model, credentials)
+        try:
+            super().validate_credentials(model, credentials)
+        except CredentialsValidateFailedError as ex:
+            # api.stepfun.com and api.stepfun.ai return byte-identical 401
+            # bodies, so the error must say which endpoint rejected the key.
+            raise CredentialsValidateFailedError(
+                f"{ex} (endpoint validated: {credentials.get('endpoint_url', 'unknown')})"
+            ) from ex
 
     def get_customizable_model_schema(
         self, model: str, credentials: dict

--- a/models/stepfun/models/llm/llm.py
+++ b/models/stepfun/models/llm/llm.py
@@ -100,7 +100,10 @@ class StepfunLargeLanguageModel(OAICompatLargeLanguageModel):
 
     def _add_custom_parameters(self, credentials: dict) -> None:
         credentials["mode"] = "chat"
-        credentials["endpoint_url"] = "https://api.stepfun.com/v1"
+        if credentials.get("use_international_endpoint", "false") == "true":
+            credentials["endpoint_url"] = "https://api.stepfun.ai/v1"
+        else:
+            credentials["endpoint_url"] = "https://api.stepfun.com/v1"
 
     def _add_function_call(self, model: str, credentials: dict) -> None:
         model_schema = self.get_model_schema(model, credentials)

--- a/models/stepfun/provider/stepfun.yaml
+++ b/models/stepfun/provider/stepfun.yaml
@@ -33,6 +33,22 @@ model_credential_schema:
     required: true
     type: secret-input
     variable: api_key
+  - label:
+      en_US: Use International Endpoint
+      zh_Hans: 使用国际站端点
+    type: radio
+    required: false
+    default: 'false'
+    variable: use_international_endpoint
+    options:
+    - label:
+        en_US: 'True'
+        zh_Hans: 是
+      value: 'true'
+    - label:
+        en_US: 'False'
+        zh_Hans: 否
+      value: 'false'
   - default: '8192'
     label:
       en_US: Model context size
@@ -87,5 +103,21 @@ provider_credential_schema:
     required: true
     type: secret-input
     variable: api_key
+  - label:
+      en_US: Use International Endpoint
+      zh_Hans: 使用国际站端点
+    type: radio
+    required: false
+    default: 'false'
+    variable: use_international_endpoint
+    options:
+    - label:
+        en_US: 'True'
+        zh_Hans: 是
+      value: 'true'
+    - label:
+        en_US: 'False'
+        zh_Hans: 否
+      value: 'false'
 supported_model_types:
 - llm

--- a/models/stepfun/tests/test_endpoint.py
+++ b/models/stepfun/tests/test_endpoint.py
@@ -49,3 +49,30 @@ def test_radio_offered_in_both_credential_schemas():
         "the endpoint radio must exist in BOTH provider_credential_schema and "
         "model_credential_schema, or customizable models stay .com-only"
     )
+
+
+def test_validation_401_names_the_endpoint_it_hit():
+    """Unmocked, real-network: proves validate_credentials itself flows through
+    the endpoint switch, and that the failure names the host that rejected the
+    key. Both StepFun hosts return byte-identical 401 bodies for a bad key, so
+    without the endpoint in the message a wrong-region 401 is undiagnosable
+    (2026-08-10 lesson: a monkeypatched dependency is an untested dependency)."""
+    import dify_plugin  # noqa: F401  (gevent-patches ssl; must precede requests)
+    import pytest
+
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+    from dify_plugin.errors.model import CredentialsValidateFailedError
+    from models.llm.llm import StepfunLargeLanguageModel
+
+    model = StepfunLargeLanguageModel([])
+    for flag, host in (("true", "api.stepfun.ai"), ("false", "api.stepfun.com")):
+        credentials = {
+            "api_key": "sk-invalid-on-purpose",
+            "use_international_endpoint": flag,
+        }
+        with pytest.raises(CredentialsValidateFailedError) as excinfo:
+            model.validate_credentials("step-3.7-flash", credentials)
+        assert host in str(excinfo.value), (
+            f"validation error must name {host}: {excinfo.value}"
+        )
+        assert credentials["endpoint_url"] == f"https://{host}/v1"

--- a/models/stepfun/tests/test_endpoint.py
+++ b/models/stepfun/tests/test_endpoint.py
@@ -1,0 +1,51 @@
+"""In-process tests for StepFun endpoint selection (pytest-shaped).
+
+Fails before this change: _add_custom_parameters unconditionally hardcoded
+https://api.stepfun.com/v1, so keys minted on the international platform
+(platform.stepfun.ai) could never validate or invoke."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+
+_LLM_PY = _PLUGIN_ROOT / "models" / "llm" / "llm.py"
+
+
+def _add_custom_parameters(credentials):
+    """The switch under test, extracted by AST so the test needs no SDK
+    install: executes the real _add_custom_parameters body."""
+    tree = ast.parse(_LLM_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_add_custom_parameters":
+            fn = ast.Module(body=[node], type_ignores=[])
+            ns = {}
+            exec(compile(fn, str(_LLM_PY), "exec"), ns)  # noqa: S102
+            ns["_add_custom_parameters"](None, credentials)
+            return credentials
+    raise AssertionError("_add_custom_parameters not found")
+
+
+def test_default_is_byte_identical_com():
+    for creds in ({}, {"use_international_endpoint": "false"},
+                  {"use_international_endpoint": ""}):
+        out = _add_custom_parameters(dict(creds))
+        assert out["endpoint_url"] == "https://api.stepfun.com/v1"
+        assert out["mode"] == "chat"
+
+
+def test_international_opt_in():
+    out = _add_custom_parameters({"use_international_endpoint": "true"})
+    assert out["endpoint_url"] == "https://api.stepfun.ai/v1"
+
+
+def test_radio_offered_in_both_credential_schemas():
+    text = (_PLUGIN_ROOT / "provider" / "stepfun.yaml").read_text(encoding="utf-8")
+    assert text.count("variable: use_international_endpoint") == 2, (
+        "the endpoint radio must exist in BOTH provider_credential_schema and "
+        "model_credential_schema, or customizable models stay .com-only"
+    )


### PR DESCRIPTION
## Summary

Fixes #3606

The StepFun models plugin hardcodes `https://api.stepfun.com/v1` in `_add_custom_parameters`, so keys from StepFun's international platform (`platform.stepfun.ai` / `api.stepfun.ai` — a separate account system, documented in StepFun's Step-3.5-Flash README) always fail validation with upstream's misleading `invalid_api_key`.

This mirrors the approach merged for siliconflow in #2394: an optional **`use_international_endpoint`** radio (default `"false"`). One deliberate extension: the radio is offered in **both** `provider_credential_schema` and `model_credential_schema`, so customizable models get the same choice rather than staying pinned to the China host.

- **Zero change for existing users:** with the option absent or `"false"`, `endpoint_url` resolves byte-identically to the current hardcoded value (asserted by test).
- **Endpoint-aware validation error:** both hosts return byte-identical 401 bodies, so `validate_credentials` now names the endpoint it validated against (`... (endpoint validated: https://api.stepfun.ai/v1)`) — otherwise a wrong-region failure is indistinguishable from a genuinely bad key.
- Empirical receipt (same key): 200 on `api.stepfun.ai/v1/models`, 401 on `api.stepfun.com/v1/models`.

## Change Type
- [x] LLM plugin

## Screenshots / Videos
**Before** 
International key → upstream `invalid_api_key` (hardcoded `.com` host)

<img width="1280" height="1203" alt="stepfun-before" src="https://github.com/user-attachments/assets/6c791ef2-a1a3-44f7-9680-f9999f0c8444" />

---

**After (this fix, 0.1.1)**
Same key + International Endpoint = True → request routed to and authenticated by `api.stepfun.ai`; validation error now names the endpoint

<img width="1280" height="1203" alt="stepfun-after-1" src="https://github.com/user-attachments/assets/0d635010-9ad3-4d68-81e7-ad5a95914487" />

<img width="1280" height="1203" alt="stepfun-after-2" src="https://github.com/user-attachments/assets/22ec3808-e34a-4df7-876e-2b2a4e7c733a" />

## LLM Plugin Checklist
- [x] Other LLM functionality (endpoint selection; no message-flow/model changes)

## Version
- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.1.0 → 0.1.1
- [x] `dify_plugin` declared in `pyproject.toml` / locked in `uv.lock`

## Testing
- [x] Local deployment — Dify 1.16.1 (self-hosted, Docker). Installed the packaged 0.1.1 build. With International Endpoint = True, the international key is routed to `api.stepfun.ai` and authenticated there (the request reaches the correct host — verified; the account returned a quota response rather than the wrong-host `invalid_api_key`, which is the failure this fixes). The validation error names the endpoint. The default path (option absent/False) resolves to `api.stepfun.com/v1`, byte-identical to the current hardcode (asserted by test). A billed chat completion was not exercised (international credit had not propagated to the account); the endpoint routing, authentication, and endpoint-naming error are demonstrated.
- [ ] SaaS — not tested

In-process tests: default byte-identity (real `_add_custom_parameters` body under test), international opt-in, and both-schemas radio presence. 3/3 pass.