### PR TITLE
fix(bailian_memory): add international endpoint option to tools plugin

### DIFF
--- a/tools/bailian_memory/manifest.yaml
+++ b/tools/bailian_memory/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.7
+version: 0.0.8
 type: plugin
 author: "langgenius"
 name: bailian_memory

--- a/tools/bailian_memory/provider/bailian_memory.py
+++ b/tools/bailian_memory/provider/bailian_memory.py
@@ -3,6 +3,7 @@ from typing import Any
 from dify_plugin import ToolProvider
 from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 
+from tools.base import DASHSCOPE_CN_BASE_URL, DASHSCOPE_INTL_BASE_URL
 from tools.search_memory import SearchMemoryTool
 
 
@@ -25,5 +26,14 @@ class BailianMemoryProvider(ToolProvider):
         except Exception as e:
             error_msg = str(e)
             if "InvalidApiKey" in error_msg or "401" in error_msg:
-                raise ToolProviderCredentialValidationError("Invalid DashScope API Key")
+                # Both regions reject foreign keys with identical bodies, so
+                # name the host that was actually hit.
+                intl = credentials.get("use_international_endpoint", "false") == "true"
+                endpoint = (DASHSCOPE_INTL_BASE_URL if intl else DASHSCOPE_CN_BASE_URL).removeprefix("https://")
+                raise ToolProviderCredentialValidationError(
+                    f"DashScope rejected the API key at {endpoint} (InvalidApiKey). "
+                    f"Model Studio keys are region-specific: if this key is from the "
+                    f"{'China (Beijing)' if intl else 'International (Singapore)'} console, "
+                    f"flip the 'Use International Endpoint' setting to match it."
+                )
             # Other errors (like empty results) are fine - the key is valid

--- a/tools/bailian_memory/provider/bailian_memory.yaml
+++ b/tools/bailian_memory/provider/bailian_memory.yaml
@@ -29,6 +29,29 @@ credentials_for_provider:
       zh_Hans: 从阿里云百炼控制台获取 API Key
       ja_Jp: Alibaba Cloud百炼コンソールからAPIキーを取得してください
     url: https://bailian.console.aliyun.com/
+  use_international_endpoint:
+    type: select
+    required: false
+    default: "false"
+    label:
+      en_US: Use International Endpoint
+      zh_Hans: 使用国际端点
+      ja_Jp: 国際エンドポイントを使用
+    help:
+      en_US: Model Studio API keys are region-specific; select "True" for keys from the International (Singapore) console.
+      zh_Hans: 百炼 API Key 区分地域，国际站（新加坡）创建的 Key 请选择“是”。
+      ja_Jp: Model StudioのAPIキーはリージョン固有です。国際版（シンガポール）のキーは「True」を選択してください。
+    options:
+      - value: "true"
+        label:
+          en_US: "True"
+          zh_Hans: "是"
+          ja_Jp: "True"
+      - value: "false"
+        label:
+          en_US: "False"
+          zh_Hans: "否"
+          ja_Jp: "False"
 extra:
   python:
     source: provider/bailian_memory.py

--- a/tools/bailian_memory/tests/test_endpoint.py
+++ b/tools/bailian_memory/tests/test_endpoint.py
@@ -1,0 +1,51 @@
+"""In-process tests for Bailian Memory endpoint selection (pytest-shaped).
+
+Fails before this change: every request went through a module-level BASE_URL
+hardcoding dashscope.aliyuncs.com, so region-locked keys from the
+International (Singapore) Model Studio console could never authorize."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from tools.base import BailianMemoryBaseTool  # noqa: E402
+
+
+def _tool_with(credentials):
+    t = BailianMemoryBaseTool()
+    t.runtime = SimpleNamespace(credentials=credentials)
+    return t
+
+
+def test_default_is_byte_identical_cn():
+    for creds in ({"dashscope_api_key": "x"},
+                  {"dashscope_api_key": "x", "use_international_endpoint": "false"},
+                  {"dashscope_api_key": "x", "use_international_endpoint": ""}):
+        assert (_tool_with(creds)._get_base_url()
+                == "https://dashscope.aliyuncs.com/api/v2/apps/memory")
+
+
+def test_international_opt_in():
+    t = _tool_with({"dashscope_api_key": "x", "use_international_endpoint": "true"})
+    assert t._get_base_url() == "https://dashscope-intl.aliyuncs.com/api/v2/apps/memory"
+
+
+def test_no_hardcoded_full_url_left():
+    # the only allowed dashscope literals are the two bases + path constant in
+    # base.py; no other file may carry a full dashscope URL
+    for py in _PLUGIN_ROOT.rglob("*.py"):
+        if "tests" in py.parts:
+            continue
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str) \
+                    and "dashscope" in node.value and "aliyuncs.com" in node.value:
+                assert py.name == "base.py", (
+                    f"dashscope URL outside base.py: {py.name}:{node.lineno}")

--- a/tools/bailian_memory/tests/test_endpoint.py
+++ b/tools/bailian_memory/tests/test_endpoint.py
@@ -6,6 +6,8 @@ International (Singapore) Model Studio console could never authorize."""
 
 from __future__ import annotations
 
+import dify_plugin  # noqa: F401  (gevent-patches ssl; must precede requests)
+
 import ast
 import sys
 from pathlib import Path
@@ -49,3 +51,29 @@ def test_no_hardcoded_full_url_left():
                     and "dashscope" in node.value and "aliyuncs.com" in node.value:
                 assert py.name == "base.py", (
                     f"dashscope URL outside base.py: {py.name}:{node.lineno}")
+
+
+def test_validation_401_names_the_endpoint_it_hit():
+    """Unmocked, real-network: both DashScope regions return byte-identical
+    InvalidApiKey bodies for a foreign or junk key, so the validation error
+    must name the host that rejected it. Asserts the provider's validation
+    path flows through the endpoint switch for both settings."""
+    import pytest
+
+    from dify_plugin.errors.tool import ToolProviderCredentialValidationError
+    from provider.bailian_memory import BailianMemoryProvider
+
+    provider = BailianMemoryProvider.__new__(BailianMemoryProvider)
+    for flag, host in (
+        ("true", "dashscope-intl.aliyuncs.com"),
+        ("false", "dashscope.aliyuncs.com"),
+    ):
+        credentials = {
+            "dashscope_api_key": "sk-invalid-on-purpose",
+            "use_international_endpoint": flag,
+        }
+        with pytest.raises(ToolProviderCredentialValidationError) as excinfo:
+            provider._validate_credentials(credentials)
+        assert host in str(excinfo.value), (
+            f"validation error must name {host}: {excinfo.value}"
+        )

--- a/tools/bailian_memory/tools/base.py
+++ b/tools/bailian_memory/tools/base.py
@@ -3,11 +3,23 @@ from typing import Any
 
 import requests
 
-BASE_URL = "https://dashscope.aliyuncs.com/api/v2/apps/memory"
+MEMORY_API_PATH = "/api/v2/apps/memory"
+DASHSCOPE_CN_BASE_URL = "https://dashscope.aliyuncs.com"
+DASHSCOPE_INTL_BASE_URL = "https://dashscope-intl.aliyuncs.com"
 
 
 class BailianMemoryBaseTool:
     """Base mixin for Bailian Memory API tools."""
+
+    def _get_base_url(self) -> str:
+        """Memory API base for the configured endpoint. Defaults to the China
+        (Beijing) endpoint so existing installations keep their exact current
+        behavior; Model Studio API keys are region-specific, so international
+        (Singapore) keys need dashscope-intl."""
+        creds = self.runtime.credentials
+        if creds.get("use_international_endpoint", "false") == "true":
+            return DASHSCOPE_INTL_BASE_URL + MEMORY_API_PATH
+        return DASHSCOPE_CN_BASE_URL + MEMORY_API_PATH
 
     def _get_headers(self) -> dict[str, str]:
         api_key = self.runtime.credentials["dashscope_api_key"]
@@ -24,7 +36,8 @@ class BailianMemoryBaseTool:
         json_body: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        url = f"{BASE_URL}/{path}" if path else BASE_URL
+        base_url = self._get_base_url()
+        url = f"{base_url}/{path}" if path else base_url
         response = requests.request(
             method,
             url,

--- a/tools/bailian_memory/tools/base.py
+++ b/tools/bailian_memory/tools/base.py
@@ -51,8 +51,10 @@ class BailianMemoryBaseTool:
                 error_detail = response.json()
             except Exception:
                 error_detail = response.text
+            # Both DashScope hosts return byte-identical InvalidApiKey bodies,
+            # so the URL is the only way to tell which region rejected the key.
             raise Exception(
-                f"API request failed ({response.status_code}): "
+                f"API request failed ({response.status_code}) at {url}: "
                 f"{json.dumps(error_detail, ensure_ascii=False) if isinstance(error_detail, dict) else error_detail}"
             )
         return response.json()


### PR DESCRIPTION
## Summary

Fixes #3608

`tools/bailian_memory` hardcodes `dashscope.aliyuncs.com` in its shared request base (`tools/base.py`). Model Studio API keys are region-specific (per Alibaba's Region-and-endpoints doc), so keys from the International (Singapore) console — which map to `dashscope-intl.aliyuncs.com` — can never authorize this plugin.

This adds an optional **`use_international_endpoint`** select (default `"false"`), mirroring the mechanism and variable name the **tongyi** models plugin already uses for this provider family. All ten tools inherit the choice through the shared `_request` path, and provider validation follows automatically.

- **Zero change for existing users:** the default resolves the byte-identical China URL (asserted by test against the real `_get_base_url`).
- The International host serves the same memory API with an identical response envelope (verified unauthenticated).
- The same region-locked key that this plugin rejects is accepted by the Tongyi models provider with its international-endpoint option — demonstrating the key is valid and the failure is purely the missing endpoint choice.

**On the widget:** tongyi uses a `radio` (model-provider schema). This is a tools plugin (`credentials_for_provider`), whose SDK offers `select` but no radio type — same variable name, default, and values, rendered as a dropdown (in-repo precedent: jira, email, mineru).

## Change Type
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)

## Screenshots / Videos

**Before**
International (Singapore) key → "Invalid DashScope API Key"

<img width="1280" height="1203" alt="bailian-before" src="https://github.com/user-attachments/assets/1372a11f-c7d6-4fc6-be74-6f18e5b33af5" />

---

**After**
Same key + Use International Endpoint = True → Action succeeded

<img width="1280" height="1203" alt="bailian-after-1" src="https://github.com/user-attachments/assets/d4e00f5c-a203-458c-8195-1f6bd739adc2" />

<img width="1280" height="1203" alt="bailian-after-2" src="https://github.com/user-attachments/assets/17f65df2-951b-46bd-b65c-08a594342aaf" />


## Version
- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.7 → 0.0.8
- [x] `dify_plugin` declared in `pyproject.toml` / locked in `uv.lock` (unchanged)

## Testing
- [x] Local deployment — Dify 1.16.1 (self-hosted, Docker). The region-locked International (Singapore) Model Studio key that this plugin rejects as "Invalid DashScope API Key" is accepted by the Tongyi models provider using its `use_international_endpoint` option, in the same workspace. Direct check with the same key: 200 on `dashscope-intl.aliyuncs.com/compatible-mode/v1/models`, 401 on `dashscope.aliyuncs.com/...`. The default path (option absent/False) resolves to the byte-identical China host (asserted by test).
- [ ] SaaS — not tested

In-process tests: default byte-identity (real `_get_base_url` under test), international opt-in, and an AST check that no dashscope URL exists outside `base.py`. 3/3 pass.

Confirmed directly: the same key with 'Use International Endpoint' = True validates against the fixed plugin ('Action succeeded')