### PR TITLE
ci: publish merged plugins to staging in a separate step

### DIFF
--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -166,30 +166,15 @@ jobs:
         run: |
           uv run --with requests --with dify_plugin python .scripts/uploader -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f
 
-      # Staging exists to exercise the publish pipeline -- several backend
-      # scheduler tasks (sync_latest_plugins and the rest of the
-      # upload-signal-driven set) only run when an upload signals them, so a
-      # staging deployment that never receives one cannot be tested at all.
-      #
-      # It must never decide whether a plugin reaches production, so this step
-      # is allowed to fail and reports itself through a commit comment instead
-      # of a red workflow. It also runs after production, so a package
-      # production rejects never lands on staging either.
-      #
-      # -f keeps a re-run idempotent: staging is not the record of truth, and a
-      # 409 from a version some backfill already put there would hide whether
-      # the pipeline reached it.
-      #
-      # Packaging repeats here (the uploader packages what -d points at). The
-      # requirements.txt export above is not redone, and a full security scan
-      # measures 16s, so the second leg costs seconds -- not worth passing the
-      # package between steps for.
+      # Staging cannot be tested without receiving uploads: the backend's
+      # latest/recommended rebuilds only run when an upload signals them.
+      # It must never block a release though -- a red merge workflow invites a
+      # re-run, which uploads the package again. -f keeps that re-run idempotent.
       - name: Upload Plugin (staging)
         id: upload-staging
         continue-on-error: true
         env:
-          # matrix.plugin_path, unlike the community repository's PLUGIN_PATH,
-          # is not in $GITHUB_ENV -- it has to be passed in explicitly.
+          # The matrix value is not in $GITHUB_ENV; pass it in explicitly.
           PLUGIN_PATH: ${{ matrix.plugin_path }}
           STAGING_BASE_URL: ${{ secrets.MARKETPLACE_STAGING_BASE_URL }}
           STAGING_TOKEN: ${{ secrets.MARKETPLACE_STAGING_TOKEN }}

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -62,6 +62,11 @@ jobs:
         run: .github/scripts/detect-changed-plugins.sh
 
   upload-merged-plugin:
+    permissions:
+      # contents: write is only what lets the failure report post a commit
+      # comment. The toolkit and the CLI are cloned with
+      # ORG_SCOPE_GITHUB_TOKEN, not with this token.
+      contents: write
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: depot-ubuntu-24.04-4
@@ -157,6 +162,55 @@ jobs:
         run: |
           bash .github/scripts/export-legacy-requirements.sh "${{ matrix.plugin_path }}"
 
-      - name: Upload Plugin
+      - name: Upload Plugin (production)
         run: |
           uv run --with requests --with dify_plugin python .scripts/uploader -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f
+
+      # Staging exists to exercise the publish pipeline -- several backend
+      # scheduler tasks (sync_latest_plugins and the rest of the
+      # upload-signal-driven set) only run when an upload signals them, so a
+      # staging deployment that never receives one cannot be tested at all.
+      #
+      # It must never decide whether a plugin reaches production, so this step
+      # is allowed to fail and reports itself through a commit comment instead
+      # of a red workflow. It also runs after production, so a package
+      # production rejects never lands on staging either.
+      #
+      # -f keeps a re-run idempotent: staging is not the record of truth, and a
+      # 409 from a version some backfill already put there would hide whether
+      # the pipeline reached it.
+      #
+      # Packaging repeats here (the uploader packages what -d points at). The
+      # requirements.txt export above is not redone, and a full security scan
+      # measures 16s, so the second leg costs seconds -- not worth passing the
+      # package between steps for.
+      - name: Upload Plugin (staging)
+        id: upload-staging
+        continue-on-error: true
+        env:
+          STAGING_BASE_URL: ${{ secrets.MARKETPLACE_STAGING_BASE_URL }}
+          STAGING_TOKEN: ${{ secrets.MARKETPLACE_STAGING_TOKEN }}
+        run: |
+          if [ -z "$STAGING_BASE_URL" ] || [ -z "$STAGING_TOKEN" ]; then
+            echo "MARKETPLACE_STAGING_BASE_URL / _TOKEN are not set; skipping the staging upload"
+            exit 0
+          fi
+          uv run --with requests --with dify_plugin python .scripts/uploader -d "$PLUGIN_PATH" -t "$STAGING_TOKEN" \
+            --plugin-daemon-path .scripts/dify -u "$STAGING_BASE_URL" -f
+
+      - name: Report a failed staging upload
+        if: steps.upload-staging.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PLUGIN: ${{ matrix.plugin_path }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/comments" \
+            -f body="$(printf '%s\n' \
+              "**Staging upload failed** for \`$PLUGIN\`." \
+              "" \
+              "The plugin **is** published to production -- only <https://marketplace-staging.dify.dev> is missing it, so nothing needs re-merging or re-reviewing." \
+              "" \
+              "Reason: [workflow run]($RUN_URL). The next push of this plugin, or a backfill run, will bring staging back in line." \
+              "" \
+              "_This comment exists because the staging leg is deliberately non-blocking._")"

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -166,15 +166,13 @@ jobs:
         run: |
           uv run --with requests --with dify_plugin python .scripts/uploader -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f
 
-      # Staging cannot be tested without receiving uploads: the backend's
-      # latest/recommended rebuilds only run when an upload signals them.
-      # It must never block a release though -- a red merge workflow invites a
-      # re-run, which uploads the package again. -f keeps that re-run idempotent.
+      # Staging only becomes testable once uploads reach it: the backend rebuilds
+      # latest/recommended on an upload signal. Never blocking, though -- a red run
+      # invites a re-run, which re-uploads; -f keeps that idempotent.
       - name: Upload Plugin (staging)
         id: upload-staging
         continue-on-error: true
         env:
-          # The matrix value is not in $GITHUB_ENV; pass it in explicitly.
           PLUGIN_PATH: ${{ matrix.plugin_path }}
           STAGING_BASE_URL: ${{ secrets.MARKETPLACE_STAGING_BASE_URL }}
           STAGING_TOKEN: ${{ secrets.MARKETPLACE_STAGING_TOKEN }}
@@ -188,10 +186,8 @@ jobs:
 
       - name: Report a failed staging upload
         if: steps.upload-staging.outcome == 'failure'
-        # Reporting must not do what it reports about. A 403 from the comment
-        # API or a rate limit would otherwise redden a production publish that
-        # succeeded, which is exactly the re-run this step exists to avoid. The
-        # job summary needs no token, so it is written first and unconditionally.
+        # Summary needs no token; the comment is best-effort. Neither may redden
+        # a production publish that already succeeded.
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -188,17 +188,21 @@ jobs:
 
       - name: Report a failed staging upload
         if: steps.upload-staging.outcome == 'failure'
+        # Reporting must not do what it reports about. A 403 from the comment
+        # API or a rate limit would otherwise redden a production publish that
+        # succeeded, which is exactly the re-run this step exists to avoid. The
+        # job summary needs no token, so it is written first and unconditionally.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PLUGIN: ${{ matrix.plugin_path }}
         run: |
-          gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/comments" \
-            -f body="$(printf '%s\n' \
-              "**Staging upload failed** for \`$PLUGIN\`." \
-              "" \
-              "The plugin **is** published to production -- only <https://marketplace-staging.dify.dev> is missing it, so nothing needs re-merging or re-reviewing." \
-              "" \
-              "Reason: [workflow run]($RUN_URL). The next push of this plugin, or a backfill run, will bring staging back in line." \
-              "" \
-              "_This comment exists because the staging leg is deliberately non-blocking._")"
+          report=$(printf '%s\n' \
+            "**Staging upload failed** for \`$PLUGIN\`." \
+            "" \
+            "The plugin **is** published to production -- only <https://marketplace-staging.dify.dev> is missing it, so nothing needs re-merging or re-reviewing." \
+            "" \
+            "Reason: [workflow run]($RUN_URL). The next push of this plugin, or a backfill run, will bring staging back in line.")
+          printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
+          gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/comments" -f body="$report"

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -188,6 +188,9 @@ jobs:
         id: upload-staging
         continue-on-error: true
         env:
+          # matrix.plugin_path, unlike the community repository's PLUGIN_PATH,
+          # is not in $GITHUB_ENV -- it has to be passed in explicitly.
+          PLUGIN_PATH: ${{ matrix.plugin_path }}
           STAGING_BASE_URL: ${{ secrets.MARKETPLACE_STAGING_BASE_URL }}
           STAGING_TOKEN: ${{ secrets.MARKETPLACE_STAGING_TOKEN }}
         run: |


### PR DESCRIPTION
## Problem

Staging has received no plugin since it was seeded: **531** plugins against production's **918**, and the newest entry in the `latest` collection is from **2026-01-20**.

It is not only a stale catalog. The backend's `latest` / `latest-tools` rebuild is upload-signal driven — `runSyncLatest` does `GETDEL(signalKey)` and returns immediately when nothing signalled it — so those scheduler tasks have never run on staging, and cannot be tested there until real uploads arrive.

## Change

A second upload step after production, with its own `-u`, split into two steps per @crazywoola's review:

- `continue-on-error`, and it runs after production, so it can neither fail this workflow nor publish something production rejected;
- on failure it writes the reason to the job summary and posts a commit comment — a red merge workflow would invite a re-run, and a re-run uploads the package again;
- `-f`, so that re-run is idempotent;
- both secrets are read into `env` and checked for emptiness, so this is a **no-op until `MARKETPLACE_STAGING_BASE_URL` / `MARKETPLACE_STAGING_TOKEN` exist** — merge order against the secrets does not matter.

Retry is per job, not per step: a failed staging upload heals on the next push of that plugin, or on a backfill run.

Historical plugins are not backfilled by this — it forwards publishes from now on and never reconciles.
