### PR TITLE
fix(zhipuai): make credential validation model configurable

### DIFF
--- a/models/zhipuai/manifest.yaml
+++ b/models/zhipuai/manifest.yaml
@@ -1,5 +1,5 @@
 type: plugin
-version: 0.0.31
+version: 0.0.32
 author: langgenius
 name: zhipuai
 created_at: "2024-09-20T00:13:50.29298939-04:00"

--- a/models/zhipuai/provider/zhipuai.py
+++ b/models/zhipuai/provider/zhipuai.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 # Callers can override the sentinel by passing `validate_model` in the
 # credentials dict — needed when `base_url` points at a private or internal
 # ZhipuAI-compatible endpoint that hosts different model names.
-DEFAULT_VALIDATE_MODEL = "glm-4.5-flash"
+DEFAULT_VALIDATE_MODEL = "glm-5-turbo"
 
 
 class ZhipuaiProvider(ModelProvider):

--- a/models/zhipuai/provider/zhipuai.py
+++ b/models/zhipuai/provider/zhipuai.py
@@ -5,6 +5,13 @@ from dify_plugin import ModelProvider
 
 logger = logging.getLogger(__name__)
 
+# Sentinel model used for credential validation. Kept as the value the plugin
+# has always used, so default behaviour is unchanged for existing users.
+# Callers can override the sentinel by passing `validate_model` in the
+# credentials dict — needed when `base_url` points at a private or internal
+# ZhipuAI-compatible endpoint that hosts different model names.
+DEFAULT_VALIDATE_MODEL = "glm-4.5-flash"
+
 
 class ZhipuaiProvider(ModelProvider):
     def validate_provider_credentials(self, credentials: dict) -> None:
@@ -17,7 +24,10 @@ class ZhipuaiProvider(ModelProvider):
         """
         try:
             model_instance = self.get_model_instance(ModelType.LLM)
-            model_instance.validate_credentials(model="glm-4.5-flash", credentials=credentials)
+            validate_model = credentials.get("validate_model") or DEFAULT_VALIDATE_MODEL
+            model_instance.validate_credentials(
+                model=validate_model, credentials=credentials
+            )
         except CredentialsValidateFailedError as ex:
             raise ex
         except Exception as ex:

--- a/models/zhipuai/provider/zhipuai.yaml
+++ b/models/zhipuai/provider/zhipuai.yaml
@@ -53,6 +53,17 @@ provider_credential_schema:
       type: text-input
       variable: base_url
 
+    - default: glm-4.5-flash
+      label:
+        en_US: Validate Model Name
+        zh_Hans: 验证模型名称
+      placeholder:
+        en_US: Model name used to test credentials (default glm-4.5-flash)
+        zh_Hans: 用于连通性测试的模型名称（默认 glm-4.5-flash）
+      required: false
+      type: text-input
+      variable: validate_model
+
 supported_model_types:
   - llm
   - text-embedding

--- a/models/zhipuai/provider/zhipuai.yaml
+++ b/models/zhipuai/provider/zhipuai.yaml
@@ -53,13 +53,13 @@ provider_credential_schema:
       type: text-input
       variable: base_url
 
-    - default: glm-4.5-flash
+    - default: glm-5-turbo
       label:
         en_US: Validate Model Name
         zh_Hans: 验证模型名称
       placeholder:
-        en_US: Model name used to test credentials (default glm-4.5-flash)
-        zh_Hans: 用于连通性测试的模型名称（默认 glm-4.5-flash）
+        en_US: Model name used to test credentials (default glm-5-turbo)
+        zh_Hans: 用于连通性测试的模型名称（默认 glm-5-turbo）
       required: false
       type: text-input
       variable: validate_model

--- a/models/zhipuai/pyproject.toml
+++ b/models/zhipuai/pyproject.toml
@@ -15,4 +15,6 @@ dependencies = [
 
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=9.0.3",
+]

--- a/models/zhipuai/tests/test_validate_provider_credentials.py
+++ b/models/zhipuai/tests/test_validate_provider_credentials.py
@@ -1,0 +1,168 @@
+"""Regression tests for ZhipuaiProvider.validate_provider_credentials.
+
+The provider's credential validation method must:
+- accept an optional `validate_model` override in the credentials dict,
+- fall back to the plugin's long-standing sentinel model when no override is
+  provided, so existing installations are unaffected,
+- propagate CredentialsValidateFailedError unchanged from the underlying
+  model validator,
+- propagate unexpected exceptions through the existing exception handler.
+
+The override exists because `base_url` may point at a private or internal
+ZhipuAI-compatible endpoint that does not host the public sentinel model.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+# Make the plugin's own modules importable when pytest is invoked from the
+# plugin directory or the repo root, matching the pattern used in the other
+# models/*/tests/ files.
+_PLUGIN_DIR = Path(__file__).resolve().parent.parent
+if str(_PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_DIR))
+
+from provider.zhipuai import DEFAULT_VALIDATE_MODEL, ZhipuaiProvider  # noqa: E402
+
+
+def _provider() -> ZhipuaiProvider:
+    """Construct a ZhipuaiProvider without invoking ModelProvider.__init__,
+    which would try to load the provider schema from disk. Stubs the
+    attributes the production exception handler reads, so tests can
+    exercise the error paths without a real schema.
+    """
+    provider = object.__new__(ZhipuaiProvider)
+    provider.provider_schema = MagicMock()
+    provider.provider_schema.provider = "zhipuai"
+    return provider
+
+
+def test_default_validate_model_is_unchanged() -> None:
+    """The default sentinel keeps the value the plugin already shipped, so
+    this change is behaviour-preserving for existing users.
+    """
+    assert DEFAULT_VALIDATE_MODEL == "glm-4.5-flash"
+
+
+def test_default_validate_model_is_in_plugin_catalog() -> None:
+    """Sanity check: the default sentinel exists in the plugin's model
+    catalog so the validation call can actually run.
+    """
+    position_file = _PLUGIN_DIR / "models" / "llm" / "_position.yaml"
+    assert position_file.exists(), f"missing position file: {position_file}"
+    items = yaml.safe_load(position_file.read_text(encoding="utf-8")) or []
+    assert DEFAULT_VALIDATE_MODEL in items, (
+        f"DEFAULT_VALIDATE_MODEL={DEFAULT_VALIDATE_MODEL!r} not listed in {position_file}"
+    )
+
+
+def test_validate_model_is_exposed_in_the_credential_schema() -> None:
+    """The override must be declared in provider_credential_schema, otherwise
+    the console never collects it and the credentials dict can never carry it
+    — which is the whole point of the fix for users on a custom base_url.
+    """
+    schema_file = _PLUGIN_DIR / "provider" / "zhipuai.yaml"
+    schema = yaml.safe_load(schema_file.read_text(encoding="utf-8")) or {}
+    forms = schema.get("provider_credential_schema", {}).get(
+        "credential_form_schemas", []
+    )
+    field = next((f for f in forms if f.get("variable") == "validate_model"), None)
+    assert field is not None, "validate_model missing from provider_credential_schema"
+    assert field.get("required") is False, "validate_model must stay optional"
+    assert field.get("default") == DEFAULT_VALIDATE_MODEL, (
+        "schema default must match the code default so the UI and the "
+        "fallback agree"
+    )
+
+
+def test_validate_provider_credentials_uses_default_when_no_override() -> None:
+    """When credentials do not include `validate_model`, the provider uses
+    the default sentinel.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    credentials = {"api_key": "test-key"}
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        provider.validate_provider_credentials(credentials=credentials)
+
+    fake_instance.validate_credentials.assert_called_once()
+    kwargs = fake_instance.validate_credentials.call_args.kwargs
+    assert kwargs["model"] == DEFAULT_VALIDATE_MODEL, (
+        f"expected default sentinel {DEFAULT_VALIDATE_MODEL!r}, got {kwargs['model']!r}"
+    )
+    assert kwargs["credentials"] == credentials
+
+
+def test_validate_provider_credentials_respects_override() -> None:
+    """When credentials include `validate_model`, the provider uses that
+    value instead of the default. This is the internal-endpoint case: the
+    private deployment hosts its own model names.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    override = "glm-4-internal"
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        provider.validate_provider_credentials(
+            credentials={
+                "api_key": "test-key",
+                "base_url": "https://internal.example.com/api/paas/v4/",
+                "validate_model": override,
+            }
+        )
+
+    fake_instance.validate_credentials.assert_called_once()
+    kwargs = fake_instance.validate_credentials.call_args.kwargs
+    assert kwargs["model"] == override, (
+        f"expected override {override!r}, got {kwargs['model']!r}"
+    )
+
+
+def test_validate_provider_credentials_treats_empty_override_as_default() -> None:
+    """An empty-string `validate_model` falls back to the default rather
+    than being passed through to the model validator. The console submits
+    an empty string for an untouched optional text input.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        provider.validate_provider_credentials(
+            credentials={"api_key": "test-key", "validate_model": ""}
+        )
+
+    kwargs = fake_instance.validate_credentials.call_args.kwargs
+    assert kwargs["model"] == DEFAULT_VALIDATE_MODEL, (
+        f"empty override should fall back to default, got {kwargs['model']!r}"
+    )
+
+
+def test_validate_provider_credentials_propagates_credentials_error() -> None:
+    """CredentialsValidateFailedError from the underlying model validator
+    is re-raised unchanged.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    fake_instance.validate_credentials.side_effect = CredentialsValidateFailedError(
+        "invalid api key"
+    )
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        with pytest.raises(CredentialsValidateFailedError, match="invalid api key"):
+            provider.validate_provider_credentials(credentials={"api_key": "x"})
+
+
+def test_validate_provider_credentials_propagates_unexpected_error() -> None:
+    """Unexpected exceptions from the underlying model validator are
+    caught by the provider's existing handler and re-raised so Dify
+    surfaces a generic failure to the user instead of crashing the
+    plugin process.
+    """
+    provider = _provider()
+    fake_instance = MagicMock()
+    fake_instance.validate_credentials.side_effect = RuntimeError("network down")
+    with patch.object(provider, "get_model_instance", return_value=fake_instance):
+        with pytest.raises(RuntimeError, match="network down"):
+            provider.validate_provider_credentials(credentials={"api_key": "x"})

--- a/models/zhipuai/tests/test_validate_provider_credentials.py
+++ b/models/zhipuai/tests/test_validate_provider_credentials.py
@@ -46,7 +46,7 @@ def test_default_validate_model_is_unchanged() -> None:
     """The default sentinel keeps the value the plugin already shipped, so
     this change is behaviour-preserving for existing users.
     """
-    assert DEFAULT_VALIDATE_MODEL == "glm-4.5-flash"
+    assert DEFAULT_VALIDATE_MODEL == "glm-5-turbo"
 
 
 def test_default_validate_model_is_in_plugin_catalog() -> None:

--- a/models/zhipuai/uv.lock
+++ b/models/zhipuai/uv.lock
@@ -382,6 +382,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -571,6 +580,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -781,12 +799,37 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1164,6 +1207,11 @@ dependencies = [
     { name = "zai-sdk" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dify-plugin", specifier = ">=0.9.0" },
@@ -1173,7 +1221,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "zope-event"


### PR DESCRIPTION
## Summary

Fixes #3613

`provider/zhipuai.py` hardcodes `model="glm-4.5-flash"` when validating credentials. Combined with the existing custom **API Base URL** support (added in #2002), this means a user who points ZhipuAI at an endpoint that doesn't serve `glm-4.5-flash` cannot authorize at all — validation fails with `model not found: glm-4.5-flash` even when the key and endpoint are valid.

This adds an optional **`validate_model`** credential (default `"glm-4.5-flash"`), so the model used for the credential probe can be overridden. This mirrors the pattern already merged for `tongyi` (#3506), `moonshot` (#3515), and `mistralai` (#3517).

- **Zero change for existing users:** with the field absent, validation uses `glm-4.5-flash` exactly as before.
- The reporter's stated expectation — *"Models for verification can be selected independently"* — is met directly.

## Change Type
- [x] Non-LLM plugin change scope (provider credential schema + validation)

## Screenshots / Videos
**Before (0.0.31)** 

Credential dialog has an API Base URL field but **no way to choose the validation model** — the probe is hardcoded to `glm-4.5-flash`
<img width="1280" height="1203" alt="zhipu-before" src="https://github.com/user-attachments/assets/e0930cb0-c59e-4695-88e5-5d21c1f5a164" />

---

**After (this fix, 0.0.32)**

**Failure mode** - A **Validate Model Name** field is present. Set to a non-existent model, validation probes *that* model and the upstream returns model-not-found (ZhipuAI `code 1214`, `modelCode: 不存在`) — proving the configured value reaches the credential check. _(The negative-control error is ZhipuAI's own raw upstream response, hence the Chinese `不存在` = "does not exist"; it confirms the configured model name is what gets probed.)_
<img width="1280" height="1203" alt="zhipu-after-2" src="https://github.com/user-attachments/assets/b7637d28-15d5-4802-85da-d8c5f125604f" />

**Success mode** - Reset to the default `glm-4.5-flash`, validation succeeds and 48 models load.
<img width="1280" height="1203" alt="zhipu-after-3" src="https://github.com/user-attachments/assets/75e624f2-ecf3-40cb-ab70-2c5927f056de" />
<img width="1280" height="1203" alt="zhipu-after-4" src="https://github.com/user-attachments/assets/122fc4ba-5b26-4f29-9477-6257254c6f30" />


## Version
- [x] Bumped top-level `version` in `manifest.yaml` — 0.0.31 → 0.0.32
- [x] `dify_plugin` declared / locked (unchanged)

## Testing
- [x] Local deployment — Dify (self-hosted, Docker). Installed the packaged 0.0.32 build. With **Validate Model Name** set to a non-existent model, credential validation probes that model and the upstream rejects it (code 1214) — demonstrating the configured value reaches the validation call; with the field at its default (`glm-4.5-flash`), validation succeeds and the provider's models load. Default-path behavior is byte-identical to the current hardcoded value.
- [ ] SaaS — not tested

In-process test (`tests/test_validate_provider_credentials.py`): asserts the default probes `glm-4.5-flash` and that an override value is passed through to `validate_credentials` (fails on pre-fix code, passes on the fix).