### PR TITLE
fix(tongyi): add stable deepseek-v4-flash-0731 to the predefined model list

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.2.9
+version: 0.2.10
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/models/llm/_position.yaml
+++ b/models/tongyi/models/llm/_position.yaml
@@ -19,6 +19,7 @@
 - deepseek-r1-distill-qwen-14b
 - deepseek-r1-distill-qwen-32b
 - deepseek-v4-pro
+- deepseek-v4-flash-0731
 - deepseek-v4-flash
 - deepseek-v3.2-exp
 - deepseek-v3.1

--- a/models/tongyi/models/llm/deepseek-v4-flash-0731.yaml
+++ b/models/tongyi/models/llm/deepseek-v4-flash-0731.yaml
@@ -1,0 +1,86 @@
+# this model corresponds to the stable release of deepseek-v4-flash, for more details
+# please refer to (https://help.aliyun.com/zh/model-studio/deepseek-v4-flash)
+model: deepseek-v4-flash-0731
+label:
+  zh_Hans: DeepSeek-V4-Flash-0731
+  en_US: DeepSeek-V4-Flash-0731
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    default: 1.0
+  - name: max_tokens
+    use_template: max_tokens
+    type: int
+    default: 4096
+    min: 1
+    max: 393216
+    help:
+      zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
+      en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
+  - name: top_p
+    use_template: top_p
+    default: 1.0
+  - name: top_k
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    type: int
+    help:
+      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
+      en_US: Only sample from the top K options for each subsequent token.
+    required: false
+  - name: frequency_penalty
+    use_template: frequency_penalty
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+  - name: enable_search
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    help:
+      zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑"自行判断"是否使用互联网搜索结果。
+      en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: true
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking mode
+    help:
+      zh_Hans: 是否开启思考模式。
+      en_US: Whether to enable thinking mode.
+  - name: extra_headers
+    required: false
+    type: string
+    label:
+      zh_Hans: 额外请求头，Json字符串格式
+      en_US: Extra Headers
+    help:
+      zh_Hans: 以 JSON 字符串格式输入额外的 HTTP 请求头，这些请求头将包含在 API 请求中。
+      en_US: Enter extra HTTP headers in JSON string format, which will be included in the API request.
+pricing:
+  input: "0.001"
+  output: "0.002"
+  unit: "0.001"
+  currency: RMB

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -310,7 +310,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         ) or model == "kimi-k2-thinking"
 
         thinking_deepseek_v4 = (
-            model in ("deepseek-v4-pro", "deepseek-v4-flash")
+            model in ("deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v4-flash-0731")
             and model_parameters.get("enable_thinking", True)
         )
 

--- a/models/tongyi/tests/test_deepseek_v4_flash_registry.py
+++ b/models/tongyi/tests/test_deepseek_v4_flash_registry.py
@@ -1,0 +1,70 @@
+"""
+Registry/metadata tests for deepseek-v4-flash-0731 (stable release of DeepSeek-V4-Flash).
+
+Regression tests for https://github.com/langgenius/dify-official-plugins/issues/3612:
+the plugin exposed only the preview ID `deepseek-v4-flash`, so Dify rejected the
+documented stable ID `deepseek-v4-flash-0731` with
+"ValueError: model.name must be in the specified model list" even though the
+Tongyi API serves it. Reference: https://help.aliyun.com/zh/model-studio/deepseek-v4-flash
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+MODELS_DIR = Path(__file__).parent.parent / "models" / "llm"
+DATED_MODEL = "deepseek-v4-flash-0731"
+PREVIEW_MODEL = "deepseek-v4-flash"
+
+
+def _load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_dated_model_listed_in_position():
+    position = _load_yaml(MODELS_DIR / "_position.yaml")
+    assert DATED_MODEL in position, f"{DATED_MODEL} missing from _position.yaml"
+    # The preview ID must remain for backward compatibility.
+    assert PREVIEW_MODEL in position, f"{PREVIEW_MODEL} removed from _position.yaml"
+
+
+def test_dated_model_yaml_exists_with_correct_id():
+    schema_path = MODELS_DIR / f"{DATED_MODEL}.yaml"
+    assert schema_path.exists(), f"missing model schema file {schema_path.name}"
+    schema = _load_yaml(schema_path)
+    assert schema["model"] == DATED_MODEL
+    assert schema["model_type"] == "llm"
+
+
+def test_dated_model_inherits_flash_capabilities():
+    dated = _load_yaml(MODELS_DIR / f"{DATED_MODEL}.yaml")
+    preview = _load_yaml(MODELS_DIR / f"{PREVIEW_MODEL}.yaml")
+
+    assert dated["features"] == preview["features"]
+    assert set(dated["features"]) >= {
+        "agent-thought",
+        "tool-call",
+        "multi-tool-call",
+        "stream-tool-call",
+    }
+    assert dated["model_properties"] == preview["model_properties"]
+    assert dated["parameter_rules"] == preview["parameter_rules"]
+    assert dated["pricing"] == preview["pricing"]
+
+    rule_names = {rule["name"] for rule in dated["parameter_rules"]}
+    assert "enable_thinking" in rule_names
+    assert "enable_search" in rule_names
+
+
+def test_llm_thinking_branch_recognizes_dated_model():
+    source = (MODELS_DIR / "llm.py").read_text(encoding="utf-8")
+    match = re.search(
+        r"thinking_deepseek_v4 = \((?P<expr>.*?)\)\n", source, flags=re.DOTALL
+    )
+    assert match, "thinking_deepseek_v4 branch not found in llm.py"
+    expr = match.group("expr")
+    assert f'"{DATED_MODEL}"' in expr, (
+        f"{DATED_MODEL} not handled by the DeepSeek V4 thinking/streaming "
+        "condition in llm.py"
+    )


### PR DESCRIPTION
## Summary

Fixes #3612

Tongyi 0.2.9 exposes only the preview model ID `deepseek-v4-flash`, so Dify rejects the Alibaba-documented stable snapshot `deepseek-v4-flash-0731` with `ValueError: model.name must be in the specified model list`, even though the Tongyi API serves it. Per the [official docs](https://help.aliyun.com/zh/model-studio/deepseek-v4-flash), `deepseek-v4-flash-0731` is the currently recommended stable version, and Alibaba treats the generic and dated IDs as separate models with independent free-tier quotas — so hiding the stable ID also causes confusing quota behavior.

This PR follows the plugin's existing dated-snapshot pattern (e.g. `qwen-flash-2025-07-28` beside `qwen-flash`):

- Add `models/llm/deepseek-v4-flash-0731.yaml`, mirroring the DeepSeek-V4-Flash metadata (agent-thought, tool-call, multi-tool-call, stream-tool-call, thinking mode, web search, 1M context / 393,216 max output, same pricing — the docs state identical specs for both IDs).
- List `deepseek-v4-flash-0731` in `_position.yaml`, directly above the preview ID (dated-before-generic, matching `qwen-flash`).
- Include the dated ID in the `thinking_deepseek_v4` condition in `llm.py` so thinking mode correctly forces streaming/incremental output.
- Add registry/metadata regression tests (`tests/test_deepseek_v4_flash_registry.py`); they fail without the fix and pass with it. Full suite: 60 passed, 80 skipped (integration tests require an API key).
- Bump plugin version 0.2.9 → 0.2.10.

The preview ID `deepseek-v4-flash` is retained unchanged for backward compatibility.

Verified against the live provider: a direct call to `deepseek-v4-flash-0731` on the international DashScope endpoint returns a normal completion, including reasoning output with thinking enabled — confirming the model is served and the thinking branch is exercised.

AI disclosure: this change was prepared with the assistance of Claude Code; all changes were human-reviewed and tested before submission.

## Change Type

- [x] LLM plugin

## Screenshots / Videos

**Before (0.2.9)**
Tongyi model picker lists `DeepSeek-V4-Flash` but not the stable `DeepSeek-V4-Flash-0731`

<img width="1280" height="1203" alt="tongyi-before" src="https://github.com/user-attachments/assets/17b1ba9d-aa2a-4c30-93d1-bba78a38f9e6" />

---

**After (0.2.10)**
 `DeepSeek-V4-Flash-0731` now appears (directly above `DeepSeek-V4-Flash`) 

<img width="1280" height="1203" alt="tongyi-after" src="https://github.com/user-attachments/assets/01d710e2-e856-4b66-b01a-18c879ad01d7" />


## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)

Note: the Tongyi plugin declares `dify_plugin>=0.9.0` in `pyproject.toml`/`uv.lock` (unchanged by this PR), so the `>=0.3.0,<0.6.0` box is intentionally left unchecked.

## Testing

- [x] Local deployment — Dify (self-hosted, Docker). Installed the packaged 0.2.10 build; `DeepSeek-V4-Flash-0731` appears in the Tongyi predefined model list (absent in 0.2.9). The model was independently confirmed served via a direct API call to the international DashScope endpoint, with reasoning output present when thinking is enabled.
- [ ] SaaS (cloud.dify.ai)