### PR TITLE
fix(tongyi): InvokeError: [models] Error: 'required' 

### DIFF
--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -922,7 +922,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         tool_definitions = []
         for tool in tools:
             properties = tool.parameters["properties"]
-            required_properties = tool.parameters["required"]
+            required_properties = tool.parameters.get("required", [])
             properties_definitions = {}
             for p_key, p_val in properties.items():
                 desc = p_val.get("description") or ""


### PR DESCRIPTION
## Summary
fix [#39937](https://github.com/langgenius/dify/issues/39937)

Root cause: When an Agent node runs inside a Chatflow/workflow, the model selector only stores provider, model, and mode — it does not include completion_params (temperature, max_tokens, etc.). The plugin daemon receives an empty parameters dict, and model providers that declare required parameter rules (e.g. Tongyi Qwen) fail with KeyError('required') during validation. The standalone Agent app doesn't hit this because it populates model settings from a different path 

## Change Type

- [ ] LLM plugin

## Screenshots / Videos
Before (0.2.9)

<img width="1054" height="226" alt="image" src="https://github.com/user-attachments/assets/e719b129-1fd8-4bcc-ab09-f9c82367d4cf" />



## LLM Plugin Checklist


<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] New models / model parameter fixes

</details>

## Version

- [ ] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)

Note: the Tongyi plugin declares dify_plugin>=0.9.0 in pyproject.toml/uv.lock (unchanged by this PR), so the >=0.3.0,<0.6.0 box is intentionally left unchecked.


## Testing

- [ ] Local deployment — Dify version: 1.16.0