### PR TITLE
fix(tongyi): retry transient connection errors in text embedding

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.2.10
+version: 0.2.11
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/models/_common.py
+++ b/models/tongyi/models/_common.py
@@ -1,5 +1,7 @@
 from typing import Mapping
 
+import requests
+
 from dashscope.common.error import (
     AuthenticationError,
     InvalidParameter,
@@ -58,6 +60,9 @@ class _CommonTongyi:
         return {
             InvokeConnectionError: [
                 RequestFailure,
+                # The DashScope SDK lets transport-level failures propagate unwrapped.
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
             ],
             InvokeServerUnavailableError: [
                 ServiceUnavailableError,

--- a/models/tongyi/models/text_embedding/text_embedding.py
+++ b/models/tongyi/models/text_embedding/text_embedding.py
@@ -1,10 +1,12 @@
 import base64
+import logging
 import time
 import os
 import yaml
 from typing import Optional
 import dashscope
 import numpy as np
+import requests
 from dify_plugin.entities.model import EmbeddingInputType, PriceType
 from dify_plugin.entities.model.text_embedding import EmbeddingUsage, MultiModalContent, MultiModalContentType, MultiModalEmbeddingResult, TextEmbeddingResult
 from dify_plugin.errors.model import CredentialsValidateFailedError
@@ -13,6 +15,40 @@ from models._common import _CommonTongyi, get_http_base_address
 from ..constant import BURY_POINT_HEADER
 
 vision_models = dict()
+
+logger = logging.getLogger(__name__)
+
+# Connection-level failures the DashScope SDK raises straight through (it does not
+# wrap them): the remote end closing the connection surfaces as a requests
+# ConnectionError, a stalled request as a requests Timeout. Both are transient.
+_RETRYABLE_EXCEPTIONS = (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+# Backoff before each retry; its length is the number of retries.
+_RETRY_BACKOFFS = (1, 3)
+
+
+def _call_with_retry(call, payload):
+    """Call the embedding endpoint, retrying transient connection failures.
+
+    Once the retries are exhausted the original exception is re-raised unchanged so
+    the provider error mapping can classify it as a connection error.
+    """
+    attempts = len(_RETRY_BACKOFFS) + 1
+    for attempt, backoff in enumerate((*_RETRY_BACKOFFS, None), start=1):
+        try:
+            return call(payload)
+        except _RETRYABLE_EXCEPTIONS as e:
+            if backoff is None:
+                raise
+            logger.warning(
+                "Connection error calling Tongyi embedding endpoint (attempt %d/%d), "
+                "retrying in %ds: %s",
+                attempt,
+                attempts,
+                backoff,
+                e,
+            )
+            time.sleep(backoff)
+
 
 class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
     """
@@ -135,38 +171,32 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         embedding_used_tokens = 0
         
         def call_embedding_api(text):
+            if model in ["multimodal-embedding-v1"]:
+                return dashscope.MultiModalEmbedding.call(
+                    api_key=credentials_kwargs["dashscope_api_key"],
+                    model=model,
+                    input=[{"text": text}],
+                    base_address=base_address,
+                )
+            else:
+                return dashscope.TextEmbedding.call(
+                    api_key=credentials_kwargs["dashscope_api_key"],
+                    model=model,
+                    input=text,
+                    headers=BURY_POINT_HEADER,
+                    text_type="document",
+                    base_address=base_address,
+                )
 
-            try:
-                if model in ["multimodal-embedding-v1"]:
-                    return dashscope.MultiModalEmbedding.call(
-                        api_key=credentials_kwargs["dashscope_api_key"],
-                        model=model,
-                        input=[{"text": text}],
-                        base_address=base_address,
-                    )
-                else:
-                    return dashscope.TextEmbedding.call(
-                        api_key=credentials_kwargs["dashscope_api_key"],
-                        model=model,
-                        input=text,
-                        headers=BURY_POINT_HEADER,
-                        text_type="document",
-                        base_address=base_address,
-                    )
-            except Exception as e:
-                # Return the exception to be handled by the caller
-                return e
-            
         for text in texts:
             # First attempt
-            response = call_embedding_api(text)
-            # Handle rate limit error (429)
-            # Check if response is an exception with rate limit info
+            response = _call_with_retry(call_embedding_api, text)
+            # Handle rate limit error (429), which arrives as a response object
             if hasattr(response, 'status_code') and response.status_code == 429:
-                print(f"Rate limit exceeded (429). Response: {response}")
+                logger.warning("Rate limit exceeded (429). Response: %s", response)
                 time.sleep(10)
                 # Retry once after sleeping
-                response = call_embedding_api(text)
+                response = _call_with_retry(call_embedding_api, text)
             
             # Process response
             if hasattr(response, 'output') and response.output and "embeddings" in response.output and response.output["embeddings"]:
@@ -315,17 +345,13 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         embedding_used_tokens = 0
         
         def call_embedding_api(input):
-            try:
-                return dashscope.MultiModalEmbedding.call(
-                    api_key=credentials_kwargs["dashscope_api_key"], 
-                    model=model, 
-                    input=[input],
-                    base_address=base_address,
-                )
-            except Exception as e:
-                # Return the exception to be handled by the caller
-                return e
-            
+            return dashscope.MultiModalEmbedding.call(
+                api_key=credentials_kwargs["dashscope_api_key"],
+                model=model,
+                input=[input],
+                base_address=base_address,
+            )
+
         for document in documents:
             # First attempt
             if document.content_type == MultiModalContentType.TEXT:
@@ -341,15 +367,14 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                 }
             else:
                 raise ValueError(f"Unsupported content type: {document.content_type}")
-            response = call_embedding_api(input)
-            
-            # Handle rate limit error (429)
-            # Check if response is an exception with rate limit info
+            response = _call_with_retry(call_embedding_api, input)
+
+            # Handle rate limit error (429), which arrives as a response object
             if hasattr(response, 'status_code') and response.status_code == 429:
-                print(f"Rate limit exceeded (429). Response: {response}")
+                logger.warning("Rate limit exceeded (429). Response: %s", response)
                 time.sleep(10)
                 # Retry once after sleeping
-                response = call_embedding_api(input)
+                response = _call_with_retry(call_embedding_api, input)
             
             # Process response
             if hasattr(response, 'output') and response.output and "embeddings" in response.output and response.output["embeddings"]:

--- a/models/tongyi/tests/test_text_embedding_retry.py
+++ b/models/tongyi/tests/test_text_embedding_retry.py
@@ -1,0 +1,286 @@
+"""Regression tests for connection handling in the Tongyi text embedding model.
+
+`call_embedding_api` used to catch every exception and return the exception object
+as if it were a response. A connection-level failure carries no `status_code` and no
+`output`, so it fell through to the "Response output is missing or does not contain
+embeddings" ValueError with the exception repr embedded, and only HTTP 429 was ever
+retried. That misclassified transient network faults as malformed responses, which
+also meant `_transform_invoke_error` could never map them to a connection error.
+
+These tests pin the corrected behaviour:
+- transient connection failures are retried with a bounded backoff and then succeed,
+- persistent failures re-raise the ORIGINAL exception rather than a ValueError,
+- the malformed-response ValueError still fires for genuinely malformed but
+  successful responses,
+- the pre-existing 429 retry path is unchanged,
+- a connection error maps to InvokeConnectionError through the tongyi mapping.
+
+Everything here is offline by construction: the dashscope call boundary is
+monkeypatched, so no credentials and no network I/O are required. Sleeps are captured
+rather than performed, so the module runs in well under a second.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from dify_plugin.entities.model.text_embedding import (
+    MultiModalContent,
+    MultiModalContentType,
+)
+from dify_plugin.errors.model import InvokeConnectionError
+
+# Make the plugin's own modules importable when pytest is invoked from the
+# plugin directory or the repo root, matching the pattern in the other
+# models/tongyi/tests/ files.
+_PLUGIN_DIR = Path(__file__).resolve().parent.parent
+if str(_PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_DIR))
+
+from models.text_embedding import text_embedding as te  # noqa: E402
+
+TongyiTextEmbeddingModel = te.TongyiTextEmbeddingModel
+
+CREDENTIALS = {"dashscope_api_key": "test-key"}
+BASE_ADDRESS = "https://dashscope.aliyuncs.com/api/v1"
+TEXT_MODEL = "text-embedding-v3"
+MULTIMODAL_MODEL = "multimodal-embedding-v1"
+
+# The exact error the DashScope SDK lets propagate when the remote end closes the
+# connection: requests raises ConnectionError wrapping http.client.RemoteDisconnected.
+# Reproduced verbatim from the report in dify-official-plugins issue 3622.
+CONNECTION_ABORTED_MESSAGE = (
+    "('Connection aborted.', "
+    "RemoteDisconnected('Remote end closed connection without response'))"
+)
+
+
+def _connection_error() -> requests.exceptions.ConnectionError:
+    return requests.exceptions.ConnectionError(CONNECTION_ABORTED_MESSAGE)
+
+
+class _TextResponse:
+    """A realistic successful DashScope text-embedding response."""
+
+    def __init__(self) -> None:
+        self.status_code = 200
+        self.output = {"embeddings": [{"embedding": [0.1, 0.2, 0.3], "type": "text"}]}
+        self.usage = {"total_tokens": 7}
+
+
+class _MultiModalResponse:
+    """A realistic successful DashScope multimodal-embedding response."""
+
+    def __init__(self) -> None:
+        self.status_code = 200
+        self.output = {"embeddings": [{"embedding": [0.4, 0.5], "type": "text"}]}
+        self.usage = {"input_tokens": 5, "image_tokens": 0}
+
+
+class _MalformedResponse:
+    """A SUCCESSFUL response whose payload carries no embeddings."""
+
+    def __init__(self) -> None:
+        self.status_code = 200
+        self.output = {"embeddings": []}
+        self.usage = {"total_tokens": 1}
+
+
+class _RateLimitedResponse:
+    """DashScope surfaces HTTP 429 as a response object, not as an exception."""
+
+    def __init__(self) -> None:
+        self.status_code = 429
+        self.output = None
+        self.usage = None
+
+
+class _Caller:
+    """Stands in for the dashscope call, counting invocations.
+
+    Raises `error` for the first `failures` calls (or forever when `failures` is
+    None), then returns `response`.
+    """
+
+    def __init__(self, response=None, error=None, failures=0):
+        self.response = response
+        self.error = error
+        self.failures = failures
+        self.calls = 0
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        if self.error is not None and (self.failures is None or self.calls <= self.failures):
+            raise self.error
+        return self.response
+
+
+class _Sequence:
+    """Returns queued responses in order, counting invocations."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = 0
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        return self.responses.pop(0)
+
+
+@pytest.fixture
+def sleeps(monkeypatch) -> list:
+    """Capture backoff durations instead of waiting them out.
+
+    Returns the list of seconds passed to time.sleep, so tests can assert the
+    retry schedule as well as the retry count.
+    """
+    recorded: list = []
+    monkeypatch.setattr(te.time, "sleep", recorded.append)
+    return recorded
+
+
+def _embed_documents():
+    return TongyiTextEmbeddingModel.embed_documents(
+        credentials_kwargs=CREDENTIALS,
+        model=TEXT_MODEL,
+        texts=["hello"],
+        base_address=BASE_ADDRESS,
+    )
+
+
+def _embed_multimodal_documents():
+    documents = [MultiModalContent(content_type=MultiModalContentType.TEXT, content="hello")]
+    return TongyiTextEmbeddingModel.embed_multimodal_documents(
+        credentials_kwargs=CREDENTIALS,
+        model=MULTIMODAL_MODEL,
+        documents=documents,
+        base_address=BASE_ADDRESS,
+    )
+
+
+def test_successful_call_is_not_retried(monkeypatch, sleeps) -> None:
+    """A response that arrives first time must cost exactly one API call."""
+    caller = _Caller(response=_TextResponse())
+    monkeypatch.setattr(te.dashscope.TextEmbedding, "call", caller)
+
+    assert _embed_documents() == ([[0.1, 0.2, 0.3]], 7)
+    assert caller.calls == 1
+    assert sleeps == []
+
+
+def test_transient_connection_error_is_retried_then_succeeds(monkeypatch, sleeps) -> None:
+    """One transient blip -- the reporter's scenario -- must no longer be fatal."""
+    caller = _Caller(response=_TextResponse(), error=_connection_error(), failures=1)
+    monkeypatch.setattr(te.dashscope.TextEmbedding, "call", caller)
+
+    assert _embed_documents() == ([[0.1, 0.2, 0.3]], 7)
+    assert caller.calls == 2
+    assert sleeps == [1]
+
+
+def test_transient_connection_error_is_retried_for_multimodal(monkeypatch, sleeps) -> None:
+    """embed_multimodal_documents duplicated the pattern and must behave identically."""
+    caller = _Caller(response=_MultiModalResponse(), error=_connection_error(), failures=1)
+    monkeypatch.setattr(te.dashscope.MultiModalEmbedding, "call", caller)
+
+    assert _embed_multimodal_documents() == ([[0.4, 0.5]], 5)
+    assert caller.calls == 2
+    assert sleeps == [1]
+
+
+def test_transient_timeout_is_retried_then_succeeds(monkeypatch, sleeps) -> None:
+    """Timeouts are the same class of transient transport fault as a dropped
+    connection, and the SDK raises them equally unwrapped.
+    """
+    caller = _Caller(
+        response=_TextResponse(),
+        error=requests.exceptions.Timeout("timed out"),
+        failures=1,
+    )
+    monkeypatch.setattr(te.dashscope.TextEmbedding, "call", caller)
+
+    assert _embed_documents() == ([[0.1, 0.2, 0.3]], 7)
+    assert caller.calls == 2
+
+
+def test_persistent_connection_error_reraises_original_exception(monkeypatch, sleeps) -> None:
+    """Once retries are exhausted the ORIGINAL exception must propagate.
+
+    This is the core of the bug: it previously surfaced as a ValueError about a
+    malformed response, which hid the real cause and defeated the SDK's error
+    taxonomy. Asserting the type (not just the message) is the point.
+    """
+    error = _connection_error()
+    caller = _Caller(error=error, failures=None)
+    monkeypatch.setattr(te.dashscope.TextEmbedding, "call", caller)
+
+    with pytest.raises(requests.exceptions.ConnectionError) as excinfo:
+        _embed_documents()
+
+    assert excinfo.value is error
+    assert not isinstance(excinfo.value, ValueError)
+    # One initial attempt plus two retries, with the 1s/3s backoff schedule.
+    assert caller.calls == 3
+    assert sleeps == [1, 3]
+
+
+def test_persistent_connection_error_reraises_for_multimodal(monkeypatch, sleeps) -> None:
+    """Same guarantee for the multimodal path."""
+    error = _connection_error()
+    caller = _Caller(error=error, failures=None)
+    monkeypatch.setattr(te.dashscope.MultiModalEmbedding, "call", caller)
+
+    with pytest.raises(requests.exceptions.ConnectionError) as excinfo:
+        _embed_multimodal_documents()
+
+    assert excinfo.value is error
+    assert caller.calls == 3
+    assert sleeps == [1, 3]
+
+
+def test_malformed_successful_response_still_raises_value_error(monkeypatch, sleeps) -> None:
+    """The ValueError was narrowed, not removed: a successful response carrying no
+    embeddings is still a malformed response and must still be reported as one.
+    """
+    caller = _Caller(response=_MalformedResponse())
+    monkeypatch.setattr(te.dashscope.TextEmbedding, "call", caller)
+
+    with pytest.raises(ValueError, match="Response output is missing"):
+        _embed_documents()
+
+    # A malformed payload is not a transport fault, so it must not be retried.
+    assert caller.calls == 1
+
+
+def test_rate_limit_429_retry_path_is_unchanged(monkeypatch, sleeps) -> None:
+    """429 arrives as a response object, so it must keep using the pre-existing
+    single retry after a 10s sleep rather than the connection-error retry.
+    """
+    caller = _Sequence([_RateLimitedResponse(), _TextResponse()])
+    monkeypatch.setattr(te.dashscope.TextEmbedding, "call", caller)
+
+    assert _embed_documents() == ([[0.1, 0.2, 0.3]], 7)
+    assert caller.calls == 2
+    assert sleeps == [10]
+
+
+def test_connection_error_maps_to_invoke_connection_error() -> None:
+    """The re-raised exception must land in the connection bucket of the provider
+    error mapping; without it the SDK falls back to a generic InvokeError.
+    """
+    model = TongyiTextEmbeddingModel(model_schemas=MagicMock())
+
+    mapped = model._transform_invoke_error(_connection_error())
+
+    assert isinstance(mapped, InvokeConnectionError)
+
+
+def test_timeout_maps_to_invoke_connection_error() -> None:
+    """Timeouts must be classified as connection errors too."""
+    model = TongyiTextEmbeddingModel(model_schemas=MagicMock())
+
+    mapped = model._transform_invoke_error(requests.exceptions.Timeout("timed out"))
+
+    assert isinstance(mapped, InvokeConnectionError)


### PR DESCRIPTION
## Summary

Fixes #3622

Thanks @Nikarhub for the report — the error string in your log is reproduced character-for-character by the defect below, and both the failure and the fix are shown live on a self-hosted 1.16.1 in the screenshots.

**Mechanism.** In `models/text_embedding/text_embedding.py`, `call_embedding_api` catches every exception and *returns the exception object as the response*; only `status_code == 429` then gets a retry. A transient connection failure (dashscope 1.26.6 propagates it as an unwrapped `requests.exceptions.ConnectionError` — verified by fault injection against a real local socket, not a mock) has no `status_code` and no `output`, so it falls through to `raise ValueError(f"Response output is missing or does not contain embeddings: {response}")` — a single network blip becomes a hard failure mislabeled as a malformed response, and one the provider error mapping can never classify as a connection error. The same pattern existed in `embed_multimodal_documents`.

**Change.**
- Removed the exception-as-response pattern in both functions; the API call bodies are otherwise unchanged.
- Added `_call_with_retry`: retries `requests.exceptions.ConnectionError` / `Timeout` up to 2 times (1s, then 3s backoff), then re-raises the original exception unmodified.
- The pre-existing 429 handling is untouched and deliberately not routed through the new helper — a real HTTP 429 arrives from this SDK as a *response object*, not an exception (verified against a real 429), so its existing response-based branch is correct as written.
- Extended `_invoke_error_mapping` in `models/_common.py` with `requests.exceptions.ConnectionError` / `Timeout` under `InvokeConnectionError` — previously only dashscope's own `RequestFailure` was listed, so even a correctly re-raised connection error would have been classified as a generic `InvokeError`. Note this mapping is shared by all tongyi model types, so connection-error classification improves plugin-wide; an unwrapped requests `ConnectionError` is a connection error in every one of those contexts.
- `print(...)` on the 429 retry → module logger, matching the plugin's own convention (`provider/tongyi.py`, `models/llm/llm.py`, etc.).
- Added `tests/test_text_embedding_retry.py` — 10 offline regression tests (no credentials, no network I/O; verified by running with outbound sockets blocked). Against the unfixed code, 7 of 10 fail — reproducing the reporter's exact ValueError — and the 3 that pass in both states are guard rails pinning *preserved* behavior (no retry on success, malformed-successful-response still ValueError, 429 path unchanged with its 10s backoff). The retry schedule (`[1, 3]`, `[10]`) and exception identity (re-raised *unmodified*, not just same type) are asserted.

**Trade-off worth knowing:** retries are per-text, matching the existing 429 behavior and avoiding re-embedding already-successful texts — but the worst case for a batch of N texts against a fully-down endpoint is N × 4s before the error surfaces. Happy to change the budget or scope if you'd prefer a different balance.

**One phrasing note:** the "Max retries exceeded" text visible inside both error messages is urllib3's standard wording for a single failed connect at the transport layer — it is not evidence of pre-existing application-level retries (before this change there were none for connection errors, as the tests demonstrate).

**Unrelated observation (not changed here):** `pyproject.toml` declares `dashscope>=1.25.18,<1.26.0` while `uv.lock` pins 1.26.6, which `uv sync --frozen` installs; all verification here is against 1.26.6, the version CI actually uses. A future `uv lock` would silently downgrade the SDK. Flagging in case you want it reconciled separately.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Both captured on self-hosted Dify 1.16.1 (Docker) with a connection fault injected in the plugin_daemon container (dashscope hosts → 127.0.0.1). The injected fault is connection-refused at connect; the reporter's was connection-aborted mid-request — same `requests.exceptions.ConnectionError` class, same code path.

**Before (stock 0.2.10)**
Retrieval test → `[models] Error: Response output is missing or does not contain embeddings: (...)` with the ValueError traceback — a connection failure mislabeled as a malformed response 

<img width="1280" height="1203" alt="tongyi-before" src="https://github.com/user-attachments/assets/4e266f63-1d6c-4799-a85b-10c66ec2248c" />

---

**After (this PR, 0.2.11)**
Same fault, retrieval test → visible retry delay, then `[models] Connection Error, ...` — correctly classified, no mislabel, no leaked traceback |

<img width="1280" height="1203" alt="tongyi-after" src="https://github.com/user-attachments/assets/d3f24d95-6eaf-49b5-b97d-b35d2f2363aa" />


## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

None of the listed areas apply: this change is transport-level error handling and retry inside the text-embedding model type. Message flow, tool use, multimodal behavior, structured output, and token accounting are untouched (token usage is asserted unchanged by the tests).

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.2.10 → 0.2.11
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

Left unchecked because this plugin's existing `dify_plugin` requirement (locked at 0.10.1) is outside the range named in the checkbox; it is unchanged by this PR.

## Testing

- [x] Local deployment — Dify version: 1.16.1 (self-hosted, Docker)
- [ ] SaaS (cloud.dify.ai)

**In-product before/after on 1.16.1:** with a connection fault injected in the plugin daemon, stock 0.2.10 fails a KB retrieval test with the mislabeled "missing embeddings" ValueError; this PR's 0.2.11 build (installed from a local package) retries with the intended schedule and surfaces `[models] Connection Error` — screenshots above. With the fault removed, credential validation on 0.2.11 against the live endpoint succeeds (validation runs a real `embed_documents("ping")`, so this exercises the changed path end-to-end on a healthy connection).

**Offline:** fault injection against the real `requests`/`urllib3` stack (dashscope 1.26.6, the locked version CI uses) — before/after captured for transient-failure, persistent-failure, malformed-response, and real-HTTP-429 scenarios, on both `embed_documents` and `embed_multimodal_documents`. Full plugin suite: 70 passed / 80 skipped under both `pytest tests/` and CI's bare-`pytest` invocation (the 80 skips are the pre-existing live-API tests that self-skip without keys). The 10 new tests run fully offline (verified with outbound sockets blocked).