### PR TITLE
feat(openrouter): add rerank model support

### DIFF
--- a/models/openrouter/README.md
+++ b/models/openrouter/README.md
@@ -1,6 +1,8 @@
 # Overview
 OpenRouter is a powerful platform that provides access to a diverse set of language models, including both commercial and open-source options. It enables developers to integrate various AI capabilities such as text generation, image generation, audio processing, and more through a unified API. OpenRouter supports models like GPT-4, Anthropic's Claude, Google's Gemini, and many others, allowing users to leverage advanced AI functionalities in their applications.
 
+This plugin supports language, text embedding, and text rerank models exposed by OpenRouter. Multimodal rerank models are not currently supported.
+
 # Configuration
 After installation, you need to get API keys from [OpenRouter](https://openrouter.ai/keys) and setup in Settings -> Model Provider.
 

--- a/models/openrouter/manifest.yaml
+++ b/models/openrouter/manifest.yaml
@@ -26,5 +26,5 @@ type: plugin
 plugins:
   models:
     - provider/openrouter.yaml
-version: 0.1.3
+version: 0.1.4
 created_at: 2024-09-20T00:13:50.29298939-04:00

--- a/models/openrouter/models/rerank/__init__.py
+++ b/models/openrouter/models/rerank/__init__.py
@@ -1,0 +1,3 @@
+from .rerank import OpenRouterRerankModel
+
+__all__ = ["OpenRouterRerankModel"]

--- a/models/openrouter/models/rerank/_position.yaml
+++ b/models/openrouter/models/rerank/_position.yaml
@@ -1,0 +1,6 @@
+- cohere/rerank-4-pro
+- cohere/rerank-4-fast
+- cohere/rerank-v3.5
+- voyageai/rerank-2.5
+- voyageai/rerank-2.5-lite
+- qwen/qwen3-reranker-8b

--- a/models/openrouter/models/rerank/cohere-rerank-4-fast.yaml
+++ b/models/openrouter/models/rerank/cohere-rerank-4-fast.yaml
@@ -1,0 +1,6 @@
+model: cohere/rerank-4-fast
+label:
+  en_US: Cohere Rerank 4 Fast
+model_type: rerank
+model_properties:
+  context_size: 32768

--- a/models/openrouter/models/rerank/cohere-rerank-4-pro.yaml
+++ b/models/openrouter/models/rerank/cohere-rerank-4-pro.yaml
@@ -1,0 +1,6 @@
+model: cohere/rerank-4-pro
+label:
+  en_US: Cohere Rerank 4 Pro
+model_type: rerank
+model_properties:
+  context_size: 32768

--- a/models/openrouter/models/rerank/cohere-rerank-v3.5.yaml
+++ b/models/openrouter/models/rerank/cohere-rerank-v3.5.yaml
@@ -1,0 +1,6 @@
+model: cohere/rerank-v3.5
+label:
+  en_US: Cohere Rerank v3.5
+model_type: rerank
+model_properties:
+  context_size: 4096

--- a/models/openrouter/models/rerank/qwen-qwen3-reranker-8b.yaml
+++ b/models/openrouter/models/rerank/qwen-qwen3-reranker-8b.yaml
@@ -1,0 +1,6 @@
+model: qwen/qwen3-reranker-8b
+label:
+  en_US: Qwen3 Reranker 8B
+model_type: rerank
+model_properties:
+  context_size: 40960

--- a/models/openrouter/models/rerank/rerank.py
+++ b/models/openrouter/models/rerank/rerank.py
@@ -1,0 +1,140 @@
+from collections.abc import Mapping
+from typing import NoReturn, Optional
+
+import requests
+
+from dify_plugin import RerankModel
+from dify_plugin.entities import I18nObject
+from dify_plugin.entities.model import AIModelEntity, FetchFrom, ModelPropertyKey, ModelType
+from dify_plugin.entities.model.rerank import RerankDocument, RerankResult
+from dify_plugin.errors.model import (
+    CredentialsValidateFailedError,
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
+
+from models._endpoint_utils import normalize_endpoint_url
+
+
+class OpenRouterRerankModel(RerankModel):
+    """Text rerank models served through OpenRouter's rerank API."""
+
+    def _invoke(
+        self,
+        model: str,
+        credentials: dict,
+        query: str,
+        docs: list[str],
+        score_threshold: Optional[float] = None,
+        top_n: Optional[int] = None,
+        user: Optional[str] = None,
+    ) -> RerankResult:
+        del user
+
+        if not docs:
+            return RerankResult(model=model, docs=[])
+
+        api_key = credentials.get("api_key")
+        if not api_key:
+            raise InvokeAuthorizationError("API key is required.")
+
+        payload: dict = {"model": model, "query": query, "documents": docs}
+        if top_n is not None:
+            payload["top_n"] = top_n
+
+        endpoint_url = normalize_endpoint_url(credentials)
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://dify.ai/",
+            "X-Title": "Dify",
+        }
+
+        try:
+            response = requests.post(
+                f"{endpoint_url}/rerank", headers=headers, json=payload, timeout=(10, 300)
+            )
+            response.raise_for_status()
+            response_data = response.json()
+        except requests.exceptions.HTTPError as ex:
+            self._raise_http_error(ex)
+        except requests.exceptions.Timeout as ex:
+            raise InvokeConnectionError("OpenRouter rerank request timed out.") from ex
+        except requests.exceptions.ConnectionError as ex:
+            raise InvokeConnectionError("Unable to connect to OpenRouter.") from ex
+        except requests.exceptions.JSONDecodeError as ex:
+            raise InvokeServerUnavailableError(
+                "OpenRouter returned an invalid JSON response."
+            ) from ex
+        except requests.exceptions.RequestException as ex:
+            raise InvokeServerUnavailableError(str(ex)) from ex
+
+        try:
+            results = response_data["results"]
+            reranked_docs = []
+            for result in results:
+                index = result["index"]
+                score = result["relevance_score"]
+                if not isinstance(index, int) or index < 0 or index >= len(docs):
+                    raise ValueError(f"Invalid document index returned: {index!r}")
+                if score_threshold is None or score >= score_threshold:
+                    reranked_docs.append(RerankDocument(index=index, text=docs[index], score=score))
+        except (KeyError, TypeError, ValueError) as ex:
+            raise InvokeServerUnavailableError(
+                f"OpenRouter returned an invalid rerank response: {ex}"
+            ) from ex
+
+        return RerankResult(model=model, docs=reranked_docs)
+
+    def validate_credentials(self, model: str, credentials: dict) -> None:
+        try:
+            self._invoke(
+                model=model,
+                credentials=credentials,
+                query="What is the capital of the United States?",
+                docs=[
+                    "Carson City is the capital of Nevada.",
+                    "Washington, D.C. is the capital of the United States.",
+                ],
+                top_n=1,
+            )
+        except Exception as ex:
+            raise CredentialsValidateFailedError(str(ex)) from ex
+
+    def get_customizable_model_schema(self, model: str, credentials: Mapping) -> AIModelEntity:
+        return AIModelEntity(
+            model=model,
+            label=I18nObject(en_us=model, zh_hans=model),
+            model_type=ModelType.RERANK,
+            fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
+            model_properties={
+                ModelPropertyKey.CONTEXT_SIZE: int(credentials.get("context_size") or 0)
+            },
+        )
+
+    @staticmethod
+    def _raise_http_error(error: requests.exceptions.HTTPError) -> NoReturn:
+        response = error.response
+        status_code = response.status_code if response is not None else None
+        message = f"OpenRouter rerank request failed with status {status_code}."
+
+        if status_code in (401, 403):
+            raise InvokeAuthorizationError(message) from error
+        if status_code == 429:
+            raise InvokeRateLimitError(message) from error
+        if status_code is not None and status_code >= 500:
+            raise InvokeServerUnavailableError(message) from error
+        raise InvokeBadRequestError(message) from error
+
+    def _transform_invoke_error(self, error: Exception) -> InvokeError:
+        if isinstance(error, InvokeError):
+            return error
+        return super()._transform_invoke_error(error)
+
+    @property
+    def _invoke_error_mapping(self) -> dict[type[InvokeError], list[type[Exception]]]:
+        return {}

--- a/models/openrouter/models/rerank/voyageai-rerank-2.5-lite.yaml
+++ b/models/openrouter/models/rerank/voyageai-rerank-2.5-lite.yaml
@@ -1,0 +1,6 @@
+model: voyageai/rerank-2.5-lite
+label:
+  en_US: VoyageAI Rerank 2.5 Lite
+model_type: rerank
+model_properties:
+  context_size: 32000

--- a/models/openrouter/models/rerank/voyageai-rerank-2.5.yaml
+++ b/models/openrouter/models/rerank/voyageai-rerank-2.5.yaml
@@ -1,0 +1,6 @@
+model: voyageai/rerank-2.5
+label:
+  en_US: VoyageAI Rerank 2.5
+model_type: rerank
+model_properties:
+  context_size: 32000

--- a/models/openrouter/provider/openrouter.yaml
+++ b/models/openrouter/provider/openrouter.yaml
@@ -6,6 +6,7 @@ extra:
   python:
     model_sources:
     - models/llm/llm.py
+    - models/rerank/rerank.py
     - models/text_embedding/text_embedding.py
     provider_source: provider/openrouter.py
 help:
@@ -147,6 +148,10 @@ models:
     position: models/llm/_position.yaml
     predefined:
     - models/llm/*.yaml
+  rerank:
+    position: models/rerank/_position.yaml
+    predefined:
+    - models/rerank/*.yaml
   text_embedding:
     position: models/text_embedding/_position.yaml
     predefined:
@@ -173,4 +178,5 @@ provider_credential_schema:
     variable: endpoint_url
 supported_model_types:
 - llm
+- rerank
 - text-embedding

--- a/models/openrouter/tests/test_rerank_call.py
+++ b/models/openrouter/tests/test_rerank_call.py
@@ -1,0 +1,70 @@
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dify_plugin.config.integration_config import IntegrationConfig
+from dify_plugin.core.entities.plugin.request import (
+    ModelActions,
+    ModelInvokeRerankRequest,
+    PluginInvokeType,
+)
+from dify_plugin.entities.model import ModelType
+from dify_plugin.entities.model.rerank import RerankResult
+from dify_plugin.integration.run import PluginRunner
+
+
+def get_all_rerank_models() -> list[str]:
+    position_file = Path(__file__).parent.parent / "models" / "rerank" / "_position.yaml"
+    try:
+        data = yaml.safe_load(position_file.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in {position_file}") from exc
+
+    if not isinstance(data, list):
+        raise ValueError(f"Expected a YAML list in {position_file}")
+    return [item.strip() for item in data if isinstance(item, str) and item.strip()]
+
+
+@pytest.mark.parametrize("model_name", get_all_rerank_models())
+def test_rerank_invoke(model_name: str) -> None:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        pytest.skip("OPENROUTER_API_KEY is not set")
+
+    plugin_path = os.getenv("PLUGIN_FILE_PATH")
+    if not plugin_path:
+        if os.getenv("CI"):
+            raise ValueError(
+                "PLUGIN_FILE_PATH environment variable is required in CI when provider API key is set"
+            )
+        plugin_path = str(Path(__file__).parent.parent)
+
+    payload = ModelInvokeRerankRequest(
+        user_id="test_user",
+        provider="openrouter",
+        model_type=ModelType.RERANK,
+        model=model_name,
+        credentials={"api_key": api_key},
+        query="What is the capital of France?",
+        docs=["Berlin is the capital of Germany.", "Paris is the capital of France."],
+        score_threshold=None,
+        top_n=1,
+    )
+
+    with PluginRunner(config=IntegrationConfig(), plugin_package_path=plugin_path) as runner:
+        results = list(
+            runner.invoke(
+                access_type=PluginInvokeType.Model,
+                access_action=ModelActions.InvokeRerank,
+                payload=payload,
+                response_type=RerankResult,
+            )
+        )
+
+    assert len(results) == 1
+    result = results[0]
+    assert isinstance(result, RerankResult)
+    assert len(result.docs) == 1
+    assert result.docs[0].index == 1

--- a/models/openrouter/tests/test_rerank_model.py
+++ b/models/openrouter/tests/test_rerank_model.py
@@ -1,0 +1,169 @@
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+
+from dify_plugin.entities.model import FetchFrom, ModelPropertyKey, ModelType
+from dify_plugin.errors.model import (
+    CredentialsValidateFailedError,
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from models.rerank.rerank import OpenRouterRerankModel
+
+
+class TestOpenRouterRerankModel(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rerank = OpenRouterRerankModel(model_schemas=[])
+
+    @patch("models.rerank.rerank.requests.post")
+    def test_invoke_calls_openrouter_and_filters_by_score(self, mock_post: Mock) -> None:
+        response = Mock()
+        response.json.return_value = {
+            "model": "cohere/rerank-v3.5",
+            "results": [
+                {"index": 1, "relevance_score": 0.95},
+                {"index": 0, "relevance_score": 0.25},
+            ],
+        }
+        mock_post.return_value = response
+
+        result = self.rerank._invoke(
+            model="cohere/rerank-v3.5",
+            credentials={"api_key": "test-key"},
+            query="capital",
+            docs=["Carson City", "Washington, D.C."],
+            score_threshold=0.5,
+            top_n=2,
+        )
+
+        mock_post.assert_called_once_with(
+            "https://openrouter.ai/api/v1/rerank",
+            headers={
+                "Authorization": "Bearer test-key",
+                "Content-Type": "application/json",
+                "HTTP-Referer": "https://dify.ai/",
+                "X-Title": "Dify",
+            },
+            json={
+                "model": "cohere/rerank-v3.5",
+                "query": "capital",
+                "documents": ["Carson City", "Washington, D.C."],
+                "top_n": 2,
+            },
+            timeout=(10, 300),
+        )
+        self.assertEqual(result.model, "cohere/rerank-v3.5")
+        self.assertEqual(len(result.docs), 1)
+        self.assertEqual(result.docs[0].index, 1)
+        self.assertEqual(result.docs[0].text, "Washington, D.C.")
+        self.assertEqual(result.docs[0].score, 0.95)
+
+    @patch("models.rerank.rerank.requests.post")
+    def test_invoke_normalizes_custom_endpoint_and_omits_top_n(self, mock_post: Mock) -> None:
+        response = Mock()
+        response.json.return_value = {"results": []}
+        mock_post.return_value = response
+
+        self.rerank._invoke(
+            model="custom/reranker",
+            credentials={
+                "api_key": "test-key",
+                "endpoint_url": " https://openrouter.example.com/api/v1/ ",
+            },
+            query="query",
+            docs=["document"],
+        )
+
+        call = mock_post.call_args
+        self.assertEqual(call.args[0], "https://openrouter.example.com/api/v1/rerank")
+        self.assertNotIn("top_n", call.kwargs["json"])
+
+    @patch("models.rerank.rerank.requests.post")
+    def test_empty_documents_do_not_call_api(self, mock_post: Mock) -> None:
+        result = self.rerank._invoke(
+            model="cohere/rerank-v3.5", credentials={}, query="query", docs=[]
+        )
+
+        self.assertEqual(result.docs, [])
+        mock_post.assert_not_called()
+
+    @patch("models.rerank.rerank.requests.post")
+    def test_invalid_result_index_is_server_error(self, mock_post: Mock) -> None:
+        response = Mock()
+        response.json.return_value = {"results": [{"index": 2, "relevance_score": 0.9}]}
+        mock_post.return_value = response
+
+        with self.assertRaises(InvokeServerUnavailableError):
+            self.rerank._invoke(
+                model="cohere/rerank-v3.5",
+                credentials={"api_key": "test-key"},
+                query="query",
+                docs=["only document"],
+            )
+
+    @patch("models.rerank.rerank.requests.post")
+    def test_http_status_errors_are_mapped(self, mock_post: Mock) -> None:
+        cases = [
+            (400, InvokeBadRequestError),
+            (401, InvokeAuthorizationError),
+            (403, InvokeAuthorizationError),
+            (429, InvokeRateLimitError),
+            (500, InvokeServerUnavailableError),
+        ]
+
+        for status_code, expected_error in cases:
+            with self.subTest(status_code=status_code):
+                response = requests.Response()
+                response.status_code = status_code
+                response.url = "https://openrouter.ai/api/v1/rerank"
+                mock_post.return_value = response
+
+                with self.assertRaises(expected_error):
+                    self.rerank._invoke(
+                        model="cohere/rerank-v3.5",
+                        credentials={"api_key": "test-key"},
+                        query="query",
+                        docs=["document"],
+                    )
+
+    @patch("models.rerank.rerank.requests.post")
+    def test_timeout_is_connection_error(self, mock_post: Mock) -> None:
+        mock_post.side_effect = requests.exceptions.Timeout("timed out")
+
+        with self.assertRaises(InvokeConnectionError):
+            self.rerank.invoke(
+                model="cohere/rerank-v3.5",
+                credentials={"api_key": "test-key"},
+                query="query",
+                docs=["document"],
+            )
+
+    @patch.object(OpenRouterRerankModel, "_invoke")
+    def test_validate_credentials_wraps_errors(self, mock_invoke: Mock) -> None:
+        mock_invoke.side_effect = InvokeAuthorizationError("bad key")
+
+        with self.assertRaises(CredentialsValidateFailedError):
+            self.rerank.validate_credentials("cohere/rerank-v3.5", {"api_key": "bad-key"})
+
+    def test_customizable_model_schema(self) -> None:
+        schema = self.rerank.get_customizable_model_schema(
+            "custom/reranker", {"context_size": "8192"}
+        )
+
+        self.assertEqual(schema.model, "custom/reranker")
+        self.assertEqual(schema.model_type, ModelType.RERANK)
+        self.assertEqual(schema.fetch_from, FetchFrom.CUSTOMIZABLE_MODEL)
+        self.assertEqual(schema.model_properties[ModelPropertyKey.CONTEXT_SIZE], 8192)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add text rerank support to the OpenRouter model provider.

- Call the OpenRouter `/api/v1/rerank` endpoint with custom base URL support, Dify attribution headers, score-threshold filtering, and typed error handling.
- Register rerank as a supported model type and add six text rerank presets from Cohere, VoyageAI, and Qwen.
- Add unit and integration coverage, document the supported capability, and bump the plugin version to `0.1.4`.
- Multimodal rerank is intentionally out of scope for this change.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable; this change adds a model-provider capability without UI changes.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reranking)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (the existing plugin uses `dify_plugin>=0.9.0`; dependencies are unchanged)

## Testing

- [ ] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

Completed repository-level verification:

- `uv run pytest -q tests/test_rerank_call.py` — 6 passed against the live OpenRouter API, covering every preset text rerank model
- `uv run pytest -q` — 26 passed, 71 skipped when provider API keys were not configured
- Black, Ruff, and Pyrefly checks passed for the new rerank implementation and tests
- Dify CLI `0.6.10` packaged the plugin successfully
- PluginRunner end-to-end rerank invocation passed against a local OpenRouter-compatible test endpoint
