### PR TITLE
feat(outlook): send_message attachments + Korean localization (0.5.0)

### DIFF
--- a/tools/outlook/README.md
+++ b/tools/outlook/README.md
@@ -7,7 +7,7 @@ Dify's integration with Microsoft Outlook (via Microsoft Graph) for **email and 
 ### Email
 - **List Messages** — list messages from your Outlook inbox.
 - **Get Message** — detailed info about a specific email by its ID.
-- **Send Message** — send an email through Outlook.
+- **Send Message** — send an email through Outlook, with optional file attachments.
 - **Send Draft** — send a draft email (needs a draft ID from Draft Email).
 - **Draft Email** — create a draft email.
 - **List Draft Emails** — list your draft emails.

--- a/tools/outlook/manifest.yaml
+++ b/tools/outlook/manifest.yaml
@@ -4,11 +4,13 @@ author: langgenius
 name: outlook
 label:
   en_US: outlook
+  ko_KR: outlook
   ja_JP: outlook
   zh_Hans: outlook
   pt_BR: outlook
 description:
   en_US: Integrate Microsoft Outlook with Dify - read, send and organize email, and manage calendar events.
+  ko_KR: Microsoft Outlook을 Dify와 연동 - 이메일 읽기, 보내기, 정리 및 캘린더 일정 관리를 할 수 있습니다.
   ja_JP: Microsoft Outlook を Dify と連携 - メールの読み取り・送信・整理、カレンダーの予定管理ができます。
   zh_Hans: 将 Microsoft Outlook 集成到 Dify - 读取、发送和整理邮件，并管理日历事件。
   pt_BR: Integre o Microsoft Outlook ao Dify - leia, envie e organize e-mails e gerencie eventos de calendário.

--- a/tools/outlook/manifest.yaml
+++ b/tools/outlook/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.4.0
+version: 0.5.0
 type: plugin
 author: langgenius
 name: outlook

--- a/tools/outlook/provider/outlook.yaml
+++ b/tools/outlook/provider/outlook.yaml
@@ -2,12 +2,14 @@ identity:
   author: langgenius
   name: outlook
   label:
-    en_US: Outlook 
-    zh_Hans: Outlook 
+    en_US: Outlook
+    ko_KR: Outlook
+    zh_Hans: Outlook
     pt_BR: Outlook 
     zh_Hant: Outlook
   description:
     en_US: Interact with Outlook emails
+    ko_KR: Outlook 이메일과 상호작용
     zh_Hans: 与 Outlook 邮件交互
     pt_BR: Interagir com e-mails do Outlook
     ja_JP: Outlook メールと連携する
@@ -20,18 +22,21 @@ oauth_schema:
       required: true
       label:
         en_US: "Client ID"
+        ko_KR: "클라이언트 ID"
         zh_Hans: "客户端 ID"
         pt_BR: "ID do Cliente"
         ja_JP: "クライアント ID"
         zh_Hant: "客戶端 ID"
       placeholder:
         en_US: "Please input your Azure AD application client ID"
+        ko_KR: "Azure AD 애플리케이션 클라이언트 ID를 입력하세요"
         zh_Hans: "请输入您的 Azure AD 应用程序客户端 ID"
         pt_BR: "Por favor, insira o ID do cliente do seu aplicativo Azure AD"
         ja_JP: "Azure AD アプリケーションのクライアント ID を入力してください"
         zh_Hant: "請輸入您的 Azure AD 應用程式客戶端 ID"
       help:
         en_US: "Get your client ID from Azure Portal > App Registrations"
+        ko_KR: "Azure Portal > 앱 등록에서 클라이언트 ID를 가져오세요"
         zh_Hans: "从 Azure 门户 > 应用注册获取您的客户端 ID"
         pt_BR: "Obtenha seu ID de cliente no Portal do Azure > Registros de Aplicativos"
         ja_JP: "Azure ポータル > アプリの登録からクライアント ID を取得してください"
@@ -42,18 +47,21 @@ oauth_schema:
       required: true
       label:
         en_US: "Client Secret"
+        ko_KR: "클라이언트 시크릿"
         zh_Hans: "客户端密钥"
         pt_BR: "Segredo do Cliente"
         ja_JP: "クライアントシークレット"
         zh_Hant: "客戶端密鑰"
       placeholder:
         en_US: "Please input your Azure AD application client secret"
+        ko_KR: "Azure AD 애플리케이션 클라이언트 시크릿을 입력하세요"
         zh_Hans: "请输入您的 Azure AD 应用程序客户端密钥"
         pt_BR: "Por favor, insira o segredo do cliente do seu aplicativo Azure AD"
         ja_JP: "Azure AD アプリケーションのクライアントシークレットを入力してください"
         zh_Hant: "請輸入您的 Azure AD 應用程式客戶端密鑰"
       help:
         en_US: "Get your client secret from Azure Portal > App Registrations > Your App > Certificates & secrets"
+        ko_KR: "Azure Portal > 앱 등록 > 내 앱 > 인증서 및 비밀에서 클라이언트 시크릿을 가져오세요"
         zh_Hans: "从 Azure 门户 > 应用注册 > 您的应用 > 证书和密码获取您的客户端密钥"
         pt_BR: "Obtenha seu segredo de cliente no Portal do Azure > Registros de Aplicativos > Seu Aplicativo > Certificados e segredos"
         ja_JP: "Azure ポータル > アプリの登録 > あなたのアプリ > 証明書とシークレットからクライアントシークレットを取得してください"
@@ -65,18 +73,21 @@ oauth_schema:
       default: common
       label:
         en_US: "Tenant ID"
+        ko_KR: "테넌트 ID"
         zh_Hans: "租户 ID"
         pt_BR: "ID do Locatário"
         ja_JP: "テナント ID"
         zh_Hant: "租戶 ID"
       placeholder:
         en_US: "Please input your Azure AD tenant ID; If you are not an enterprise user, leave it blank"
+        ko_KR: "Azure AD 테넌트 ID를 입력하세요; 기업 사용자가 아닌 경우 비워 두세요"
         zh_Hans: "请输入您的 Azure AD 租户 ID；如果您不是企业版用户，请留空"
         pt_BR: "Por favor, insira o ID do locatário do seu Azure AD; Se você não for um usuário corporativo, deixe em branco"
         ja_JP: "Azure AD テナント ID を入力してください; 企業ユーザーでない場合は空白のままにしてください"
         zh_Hant: "請輸入您的 Azure AD 租戶 ID；如果您不是企業用戶，請留空"
       help:
         en_US: "Get your tenant ID from Azure Portal > Azure Active Directory > Properties"
+        ko_KR: "Azure Portal > Azure Active Directory > 속성에서 테넌트 ID를 가져오세요"
         zh_Hans: "从 Azure 门户 > Azure Active Directory > 属性获取您的租户 ID"
         pt_BR: "Obtenha seu ID de locatário no Portal do Azure > Azure Active Directory > Propriedades"
         ja_JP: "Azure ポータル > Azure Active Directory > プロパティからテナント ID を取得してください"
@@ -87,18 +98,21 @@ oauth_schema:
       type: "secret-input"
       label:
         en_US: "Access Token"
+        ko_KR: "액세스 토큰"
         zh_Hans: "访问令牌"
         pt_BR: "Token de Acesso"
         ja_JP: "アクセストークン"
         zh_Hant: "存取權杖"
       placeholder:
         en_US: "Please input your Microsoft Graph access token"
+        ko_KR: "Microsoft Graph 액세스 토큰을 입력하세요"
         zh_Hans: "请输入您的 Microsoft Graph 访问令牌"
         pt_BR: "Por favor, insira seu token de acesso do Microsoft Graph"
         ja_JP: "Microsoft Graph アクセストークンを入力してください"
         zh_Hant: "請輸入您的 Microsoft Graph 存取權杖"
       help:
         en_US: "Get your access token from Microsoft Graph API"
+        ko_KR: "Microsoft Graph API에서 액세스 토큰을 가져오세요"
         zh_Hans: "从 Microsoft Graph API 获取您的访问令牌"
         pt_BR: "Obtenha seu token de acesso da API do Microsoft Graph"
         ja_JP: "Microsoft Graph API からアクセストークンを取得してください"

--- a/tools/outlook/tools/add_attachment_to_draft.yaml
+++ b/tools/outlook/tools/add_attachment_to_draft.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Add Attachment to Draft
+    ko_KR: 초안에 첨부 파일 추가
     zh_Hans: 向草稿添加附件
     pt_BR: Adicionar Anexo ao Rascunho
     ja_JP: 下書きに添付ファイルを追加
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Add a file attachment to a draft email
+    ko_KR: 초안 이메일에 파일 첨부 추가
     zh_Hans: 向草稿邮件添加文件附件
     pt_BR: Adicionar um anexo a um rascunho de e-mail
     ja_JP: 下書きメールにファイルを添付
@@ -23,12 +25,14 @@ parameters:
     required: true
     label:
       en_US: Draft ID
+      ko_KR: 초안 ID
       zh_Hans: 草稿ID
       pt_BR: ID do Rascunho
       ja_JP: 下書きID
       zh_Hant: 草稿ID
     human_description:
       en_US: The unique identifier of the draft email
+      ko_KR: 초안 이메일의 고유 식별자
       zh_Hans: 草稿邮件的唯一标识符
       pt_BR: O identificador único do rascunho de e-mail
       ja_JP: 下書きメールの一意の識別子
@@ -41,12 +45,14 @@ parameters:
     required: true
     label:
       en_US: Files to Attach
+      ko_KR: 첨부할 파일
       zh_Hans: 要附加的文件
       pt_BR: Arquivos para Anexar
       ja_JP: 添付するファイル
       zh_Hant: 要附加的檔案
     human_description:
       en_US: The files to attach to the draft email
+      ko_KR: 초안 이메일에 첨부할 파일
       zh_Hans: 要附加到草稿邮件的文件
       pt_BR: Os arquivos para anexar ao rascunho de e-mail
       ja_JP: 下書きメールに添付するファイル
@@ -59,12 +65,14 @@ parameters:
     required: false
     label:
       en_US: Attachment Name
+      ko_KR: 첨부 파일 이름
       zh_Hans: 附件名称
       pt_BR: Nome do Anexo
       ja_JP: 添付ファイル名
       zh_Hant: 附件名稱
     human_description:
       en_US: Optional name for the attachment
+      ko_KR: 첨부 파일의 선택적 이름
       zh_Hans: 可选的附件名称
       pt_BR: Nome opcional para o anexo
       ja_JP: 添付ファイルのオプション名

--- a/tools/outlook/tools/create_event.yaml
+++ b/tools/outlook/tools/create_event.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Create Event
+    ko_KR: 이벤트 생성
     zh_Hans: 创建事件
     pt_BR: Criar Evento
     ja_JP: イベント作成
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Create a calendar event in your Outlook account
+    ko_KR: Outlook 계정에 캘린더 이벤트를 생성합니다
     zh_Hans: 在您的 Outlook 账户中创建日历事件
     pt_BR: Criar um evento de calendário na sua conta do Outlook
     ja_JP: Outlook アカウントにカレンダーイベントを作成
@@ -22,12 +24,14 @@ parameters:
     required: true
     label:
       en_US: Subject
+      ko_KR: 제목
       zh_Hans: 主题
       pt_BR: Assunto
       ja_JP: 件名
       zh_Hant: 主題
     human_description:
       en_US: The subject or title of the event
+      ko_KR: 이벤트의 제목 또는 표제
       zh_Hans: 事件的主题或标题
       pt_BR: O assunto ou título do evento
       ja_JP: イベントの件名またはタイトル
@@ -39,12 +43,14 @@ parameters:
     required: true
     label:
       en_US: Start Datetime
+      ko_KR: 시작 일시
       zh_Hans: 开始时间
       pt_BR: Data e Hora de Início
       ja_JP: 開始日時
       zh_Hant: 開始時間
     human_description:
       en_US: The start date and time in ISO 8601 format, e.g. 2026-08-10T14:00:00
+      ko_KR: ISO 8601 형식의 시작 날짜 및 시간, 예 2026-08-10T14:00:00
       zh_Hans: ISO 8601 格式的开始日期和时间，例如 2026-08-10T14:00:00
       pt_BR: A data e hora de início no formato ISO 8601, por exemplo 2026-08-10T14:00:00
       ja_JP: ISO 8601 形式の開始日時、例 2026-08-10T14:00:00
@@ -56,12 +62,14 @@ parameters:
     required: true
     label:
       en_US: End Datetime
+      ko_KR: 종료 일시
       zh_Hans: 结束时间
       pt_BR: Data e Hora de Término
       ja_JP: 終了日時
       zh_Hant: 結束時間
     human_description:
       en_US: The end date and time in ISO 8601 format, e.g. 2026-08-10T15:00:00
+      ko_KR: ISO 8601 형식의 종료 날짜 및 시간, 예 2026-08-10T15:00:00
       zh_Hans: ISO 8601 格式的结束日期和时间，例如 2026-08-10T15:00:00
       pt_BR: A data e hora de término no formato ISO 8601, por exemplo 2026-08-10T15:00:00
       ja_JP: ISO 8601 形式の終了日時、例 2026-08-10T15:00:00
@@ -74,12 +82,14 @@ parameters:
     default: UTC
     label:
       en_US: Time Zone
+      ko_KR: 시간대
       zh_Hans: 时区
       pt_BR: Fuso Horário
       ja_JP: タイムゾーン
       zh_Hant: 時區
     human_description:
       en_US: The time zone for the start and end times, e.g. UTC or Asia/Tokyo
+      ko_KR: 시작 및 종료 시간의 시간대, 예 UTC 또는 Asia/Tokyo
       zh_Hans: 开始和结束时间的时区，例如 UTC 或 Asia/Tokyo
       pt_BR: O fuso horário para os horários de início e término, por exemplo UTC ou Asia/Tokyo
       ja_JP: 開始と終了時刻のタイムゾーン、例 UTC または Asia/Tokyo
@@ -91,12 +101,14 @@ parameters:
     required: false
     label:
       en_US: Body
+      ko_KR: 본문
       zh_Hans: 正文
       pt_BR: Corpo
       ja_JP: 本文
       zh_Hant: 內文
     human_description:
       en_US: The description or body content of the event
+      ko_KR: 이벤트의 설명 또는 본문 내용
       zh_Hans: 事件的描述或正文内容
       pt_BR: A descrição ou conteúdo do corpo do evento
       ja_JP: イベントの説明または本文内容
@@ -108,12 +120,14 @@ parameters:
     required: false
     label:
       en_US: Attendees
+      ko_KR: 참석자
       zh_Hans: 参与者
       pt_BR: Participantes
       ja_JP: 出席者
       zh_Hant: 與會者
     human_description:
       en_US: Comma-separated list of attendee email addresses
+      ko_KR: 쉼표로 구분된 참석자 이메일 주소 목록
       zh_Hans: 以逗号分隔的参与者电子邮件地址列表
       pt_BR: Lista de endereços de e-mail dos participantes separados por vírgula
       ja_JP: カンマ区切りの出席者メールアドレスのリスト
@@ -125,12 +139,14 @@ parameters:
     required: false
     label:
       en_US: Location
+      ko_KR: 장소
       zh_Hans: 地点
       pt_BR: Local
       ja_JP: 場所
       zh_Hant: 地點
     human_description:
       en_US: The location of the event
+      ko_KR: 이벤트의 장소
       zh_Hans: 事件的地点
       pt_BR: O local do evento
       ja_JP: イベントの場所
@@ -143,12 +159,14 @@ parameters:
     default: false
     label:
       en_US: Is Online Meeting
+      ko_KR: 온라인 회의 여부
       zh_Hans: 是否为在线会议
       pt_BR: É Reunião Online
       ja_JP: オンライン会議
       zh_Hant: 是否為線上會議
     human_description:
       en_US: Whether to create a Teams online meeting for the event
+      ko_KR: 이벤트에 Teams 온라인 회의를 생성할지 여부
       zh_Hans: 是否为该事件创建 Teams 在线会议
       pt_BR: Se deve criar uma reunião online do Teams para o evento
       ja_JP: イベントに Teams オンライン会議を作成するかどうか

--- a/tools/outlook/tools/delete_event.yaml
+++ b/tools/outlook/tools/delete_event.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Delete Event
+    ko_KR: 이벤트 삭제
     zh_Hans: 删除事件
     pt_BR: Excluir Evento
     ja_JP: イベント削除
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Delete a calendar event from your Outlook account
+    ko_KR: Outlook 계정에서 캘린더 이벤트를 삭제합니다
     zh_Hans: 从您的 Outlook 账户中删除日历事件
     pt_BR: Excluir um evento de calendário da sua conta do Outlook
     ja_JP: Outlook アカウントからカレンダーイベントを削除
@@ -22,12 +24,14 @@ parameters:
     required: true
     label:
       en_US: Event ID
+      ko_KR: 이벤트 ID
       zh_Hans: 事件 ID
       pt_BR: ID do Evento
       ja_JP: イベント ID
       zh_Hant: 事件 ID
     human_description:
       en_US: The ID of the event to delete
+      ko_KR: 삭제할 이벤트의 ID
       zh_Hans: 要删除的事件的 ID
       pt_BR: O ID do evento a excluir
       ja_JP: 削除するイベントの ID

--- a/tools/outlook/tools/draft_message.yaml
+++ b/tools/outlook/tools/draft_message.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Draft Email
+    ko_KR: 이메일 초안 작성
     zh_Hans: 创建草稿邮件
     pt_BR: Rascunhar E-mail
     ja_JP: メールの下書き作成
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Create a draft email in Outlook
+    ko_KR: Outlook에서 이메일 초안을 작성합니다
     zh_Hans: 在 Outlook 中创建草稿邮件
     pt_BR: Criar um rascunho de e-mail no Outlook
     ja_JP: Outlook でメールの下書きを作成
@@ -23,12 +25,14 @@ parameters:
     required: true
     label:
       en_US: To Recipients
+      ko_KR: 받는 사람
       zh_Hans: 收件人
       pt_BR: Destinatários
       ja_JP: 宛先
       zh_Hant: 收件人
     human_description:
       en_US: Email addresses of the recipients
+      ko_KR: 받는 사람의 이메일 주소
       zh_Hans: 收件人的电子邮件地址
       pt_BR: Endereços de e-mail dos destinatários
       ja_JP: 受信者のメールアドレス
@@ -41,12 +45,14 @@ parameters:
     required: false
     label:
       en_US: CC Recipients
+      ko_KR: 참조 수신자
       zh_Hans: 抄送收件人
       pt_BR: Destinatários em Cópia
       ja_JP: CC 宛先
       zh_Hant: 副本收件人
     human_description:
       en_US: Email addresses of CC recipients
+      ko_KR: 참조 수신자의 이메일 주소
       zh_Hans: 抄送收件人的电子邮件地址
       pt_BR: Endereços de e-mail dos destinatários em cópia
       ja_JP: CC 受信者のメールアドレス
@@ -59,12 +65,14 @@ parameters:
     required: false
     label:
       en_US: BCC Recipients
+      ko_KR: 숨은 참조 수신자
       zh_Hans: 密送收件人
       pt_BR: Destinatários em Cópia Oculta
       ja_JP: BCC 宛先
       zh_Hant: 密件副本收件人
     human_description:
       en_US: Email addresses of BCC recipients
+      ko_KR: 숨은 참조 수신자의 이메일 주소
       zh_Hans: 密送收件人的电子邮件地址
       pt_BR: Endereços de e-mail dos destinatários em cópia oculta
       ja_JP: BCC 受信者のメールアドレス
@@ -77,12 +85,14 @@ parameters:
     required: true
     label:
       en_US: Subject
+      ko_KR: 제목
       zh_Hans: 主题
       pt_BR: Assunto
       ja_JP: 件名
       zh_Hant: 主旨
     human_description:
       en_US: Subject line of the email
+      ko_KR: 이메일의 제목 줄
       zh_Hans: 邮件的主题行
       pt_BR: Linha de assunto do e-mail
       ja_JP: メールの件名
@@ -95,12 +105,14 @@ parameters:
     required: true
     label:
       en_US: Body
+      ko_KR: 본문
       zh_Hans: 正文
       pt_BR: Corpo
       ja_JP: 本文
       zh_Hant: 內文
     human_description:
       en_US: Content of the email message
+      ko_KR: 이메일 메시지의 내용
       zh_Hans: 邮件的内容
       pt_BR: Conteúdo da mensagem de e-mail
       ja_JP: メールの本文
@@ -114,12 +126,14 @@ parameters:
     default: text
     label:
       en_US: Body Type
+      ko_KR: 본문 유형
       zh_Hans: 正文类型
       pt_BR: Tipo de Corpo
       ja_JP: 本文タイプ
       zh_Hant: 內文類型
     human_description:
       en_US: Type of the email body content
+      ko_KR: 이메일 본문 내용의 유형
       zh_Hans: 邮件正文内容的类型
       pt_BR: Tipo do conteúdo do corpo do e-mail
       ja_JP: メール本文のタイプ
@@ -133,12 +147,14 @@ parameters:
     default: normal
     label:
       en_US: Importance
+      ko_KR: 중요도
       zh_Hans: 重要性
       pt_BR: Importância
       ja_JP: 重要度
       zh_Hant: 重要性
     human_description:
       en_US: Importance level of the email
+      ko_KR: 이메일의 중요도 수준
       zh_Hans: 邮件的重要性级别
       pt_BR: Nível de importância do e-mail
       ja_JP: メールの重要度

--- a/tools/outlook/tools/flag_message.yaml
+++ b/tools/outlook/tools/flag_message.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Flag Email
+    ko_KR: 이메일 플래그 지정
     zh_Hans: 标记邮件
     pt_BR: Marcar E-mail
     ja_JP: メールにフラグ
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Flag an email message for follow-up
+    ko_KR: 후속 조치를 위해 이메일 메시지에 플래그 지정
     zh_Hans: 标记邮件以便跟进
     pt_BR: Marcar um e-mail para acompanhamento
     ja_JP: メールにフォローアップ用のフラグを設定
@@ -23,12 +25,14 @@ parameters:
     required: true
     label:
       en_US: Email ID
+      ko_KR: 이메일 ID
       zh_Hans: 邮件ID
       pt_BR: ID do E-mail
       ja_JP: メールID
       zh_Hant: 郵件ID
     human_description:
       en_US: The unique identifier of the email to flag
+      ko_KR: 플래그를 지정할 이메일의 고유 식별자
       zh_Hans: 要标记的邮件的唯一标识符
       pt_BR: O identificador único do e-mail para marcar
       ja_JP: フラグを付けるメールの一意の識別子
@@ -41,12 +45,14 @@ parameters:
     default: flagged
     label:
       en_US: Flag Status
+      ko_KR: 플래그 상태
       zh_Hans: 标记状态
       pt_BR: Status da Marcação
       ja_JP: フラグ状態
       zh_Hant: 標記狀態
     human_description:
       en_US: The status of the flag
+      ko_KR: 플래그의 상태
       zh_Hans: 标记的状态
       pt_BR: O status da marcação
       ja_JP: フラグの状態
@@ -59,12 +65,14 @@ parameters:
     min: 0
     label:
       en_US: Due Date Days
+      ko_KR: 기한 일수
       zh_Hans: 到期天数
       pt_BR: Dias para Vencimento
       ja_JP: 期限日数
       zh_Hant: 到期天數
     human_description:
       en_US: Number of days from now until the flag is due
+      ko_KR: 지금부터 플래그 기한까지의 일수
       zh_Hans: 从现在到标记到期的天数
       pt_BR: Número de dias a partir de agora até o vencimento da marcação
       ja_JP: フラグの期限までの日数
@@ -76,12 +84,14 @@ parameters:
     required: false
     label:
       en_US: Flag Message
+      ko_KR: 플래그 메시지
       zh_Hans: 标记消息
       pt_BR: Mensagem da Marcação
       ja_JP: フラグメッセージ
       zh_Hant: 標記訊息
     human_description:
       en_US: Optional message to include with the flag
+      ko_KR: 플래그에 포함할 선택적 메시지
       zh_Hans: 可选的标记消息
       pt_BR: Mensagem opcional para incluir com a marcação
       ja_JP: フラグに含めるオプションのメッセージ

--- a/tools/outlook/tools/get_event.yaml
+++ b/tools/outlook/tools/get_event.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Get Event
+    ko_KR: 이벤트 가져오기
     zh_Hans: 获取事件
     pt_BR: Obter Evento
     ja_JP: イベント取得
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Get the details of a calendar event from your Outlook account
+    ko_KR: Outlook 계정에서 캘린더 이벤트의 세부 정보를 가져옵니다
     zh_Hans: 获取您的 Outlook 账户中日历事件的详细信息
     pt_BR: Obter os detalhes de um evento de calendário da sua conta do Outlook
     ja_JP: Outlook アカウントのカレンダーイベントの詳細を取得
@@ -22,12 +24,14 @@ parameters:
     required: true
     label:
       en_US: Event ID
+      ko_KR: 이벤트 ID
       zh_Hans: 事件 ID
       pt_BR: ID do Evento
       ja_JP: イベント ID
       zh_Hant: 事件 ID
     human_description:
       en_US: The ID of the event to retrieve
+      ko_KR: 가져올 이벤트의 ID
       zh_Hans: 要检索的事件的 ID
       pt_BR: O ID do evento a recuperar
       ja_JP: 取得するイベントの ID

--- a/tools/outlook/tools/get_message.yaml
+++ b/tools/outlook/tools/get_message.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Get Message
+    ko_KR: 메시지 가져오기
     zh_Hans: 获取消息
     pt_BR: Obter Mensagem
     ja_JP: メッセージを取得
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Get detailed information about a specific email message by its ID
+    ko_KR: ID로 특정 이메일 메시지의 상세 정보를 가져옵니다
     zh_Hans: 通过ID获取特定电子邮件的详细信息
     pt_BR: Obter informações detalhadas sobre uma mensagem de e-mail específica pelo seu ID
     ja_JP: IDで特定のメールの詳細情報を取得
@@ -23,12 +25,14 @@ parameters:
     required: true
     label:
       en_US: Message ID
+      ko_KR: 메시지 ID
       zh_Hans: 消息ID
       pt_BR: ID da Mensagem
       ja_JP: メッセージID
       zh_Hant: 訊息ID
     human_description:
       en_US: The unique identifier of the message to retrieve (obtained from list_messages tool)
+      ko_KR: 가져올 메시지의 고유 식별자 (list_messages 도구에서 획득)
       zh_Hans: 要检索的消息的唯一标识符（从list_messages工具获得）
       pt_BR: O identificador único da mensagem para recuperar (obtido da ferramenta list_messages)
       ja_JP: 取得するメッセージの一意の識別子（list_messagesツールから取得）

--- a/tools/outlook/tools/list_calendars.yaml
+++ b/tools/outlook/tools/list_calendars.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: List Calendars
+    ko_KR: 캘린더 목록
     zh_Hans: 列出日历
     pt_BR: Listar Calendários
     ja_JP: カレンダー一覧
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: List the calendars in your Outlook account
+    ko_KR: Outlook 계정의 캘린더를 나열합니다
     zh_Hans: 列出您的 Outlook 账户中的日历
     pt_BR: Listar os calendários da sua conta do Outlook
     ja_JP: Outlook アカウントのカレンダーを一覧表示
@@ -23,12 +25,14 @@ parameters:
     default: 50
     label:
       en_US: Top
+      ko_KR: 개수
       zh_Hans: 数量
       pt_BR: Quantidade
       ja_JP: 件数
       zh_Hant: 數量
     human_description:
       en_US: Maximum number of calendars to return
+      ko_KR: 반환할 최대 캘린더 수
       zh_Hans: 要返回的最大日历数
       pt_BR: Número máximo de calendários a retornar
       ja_JP: 返すカレンダーの最大数

--- a/tools/outlook/tools/list_draft.yaml
+++ b/tools/outlook/tools/list_draft.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: List Draft Emails
+    ko_KR: 초안 이메일 목록
     zh_Hans: 列出草稿邮件
     pt_BR: Listar Rascunhos
     ja_JP: 下書きメール一覧
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: List your draft emails
+    ko_KR: 초안 이메일 목록을 표시합니다
     zh_Hans: 列出您的草稿邮件
     pt_BR: Listar seus rascunhos de e-mail
     ja_JP: 下書きメールを一覧表示
@@ -26,12 +28,14 @@ parameters:
     max: 100
     label:
       en_US: Limit
+      ko_KR: 제한
       zh_Hans: 限制
       pt_BR: Limite
       ja_JP: 制限
       zh_Hant: 限制
     human_description:
       en_US: Maximum number of draft emails to return
+      ko_KR: 반환할 초안 이메일의 최대 개수
       zh_Hans: 要返回的最大草稿邮件数
       pt_BR: Número máximo de rascunhos a retornar
       ja_JP: 返す下書きメールの最大数
@@ -43,12 +47,14 @@ parameters:
     required: false
     label:
       en_US: Search
+      ko_KR: 검색
       zh_Hans: 搜索
       pt_BR: Pesquisar
       ja_JP: 検索
       zh_Hant: 搜尋
     human_description:
       en_US: Search query to filter draft emails
+      ko_KR: 초안 이메일을 필터링하는 검색 쿼리
       zh_Hans: 用于过滤草稿邮件的搜索查询
       pt_BR: Consulta de pesquisa para filtrar rascunhos
       ja_JP: 下書きメールをフィルタリングする検索クエリ
@@ -61,12 +67,14 @@ parameters:
     default: true
     label:
       en_US: Include Attachments Info
+      ko_KR: 첨부 파일 정보 포함
       zh_Hans: 包含附件信息
       pt_BR: Incluir Informações de Anexos
       ja_JP: 添付ファイル情報を含める
       zh_Hant: 包含附件資訊
     human_description:
       en_US: Whether to include attachment information in the response
+      ko_KR: 응답에 첨부 파일 정보를 포함할지 여부
       zh_Hans: 是否在响应中包含附件信息
       pt_BR: Se deve incluir informações de anexos na resposta
       ja_JP: レスポンスに添付ファイル情報を含めるかどうか

--- a/tools/outlook/tools/list_events.yaml
+++ b/tools/outlook/tools/list_events.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: List Events
+    ko_KR: 이벤트 목록
     zh_Hans: 列出事件
     pt_BR: Listar Eventos
     ja_JP: イベント一覧
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: List calendar events from your Outlook account
+    ko_KR: Outlook 계정의 캘린더 이벤트를 나열합니다
     zh_Hans: 列出您的 Outlook 账户中的日历事件
     pt_BR: Listar eventos de calendário da sua conta do Outlook
     ja_JP: Outlook アカウントのカレンダーイベントを一覧表示
@@ -23,12 +25,14 @@ parameters:
     default: 25
     label:
       en_US: Top
+      ko_KR: 개수
       zh_Hans: 数量
       pt_BR: Quantidade
       ja_JP: 件数
       zh_Hant: 數量
     human_description:
       en_US: Maximum number of events to return
+      ko_KR: 반환할 최대 이벤트 수
       zh_Hans: 要返回的最大事件数
       pt_BR: Número máximo de eventos a retornar
       ja_JP: 返すイベントの最大数
@@ -43,6 +47,7 @@ parameters:
       - value: desc
         label:
           en_US: Descending (latest first)
+          ko_KR: 내림차순(최신순)
           zh_Hans: 降序（最新在前）
           pt_BR: Decrescente (mais recentes primeiro)
           ja_JP: 降順（最新が先頭）
@@ -50,18 +55,21 @@ parameters:
       - value: asc
         label:
           en_US: Ascending (oldest first)
+          ko_KR: 오름차순(오래된순)
           zh_Hans: 升序（最早在前）
           pt_BR: Crescente (mais antigos primeiro)
           ja_JP: 昇順（古い順）
           zh_Hant: 升序（最早在前）
     label:
       en_US: Sort Order
+      ko_KR: 정렬 순서
       zh_Hans: 排序
       pt_BR: Ordem de classificação
       ja_JP: 並び順
       zh_Hant: 排序
     human_description:
       en_US: Sort events by start time - descending (latest first) or ascending (oldest first)
+      ko_KR: 시작 시간을 기준으로 이벤트 정렬 - 내림차순(최신순) 또는 오름차순(오래된순)
       zh_Hans: 按开始时间排序 - 降序（最新在前）或升序（最早在前）
       pt_BR: Ordenar eventos por horário de início - decrescente (mais recentes primeiro) ou crescente (mais antigos primeiro)
       ja_JP: 開始時刻でイベントを並べ替え - 降順（最新が先頭）または昇順（古い順）
@@ -73,12 +81,14 @@ parameters:
     required: false
     label:
       en_US: Calendar ID
+      ko_KR: 캘린더 ID
       zh_Hans: 日历 ID
       pt_BR: ID do Calendário
       ja_JP: カレンダー ID
       zh_Hant: 行事曆 ID
     human_description:
       en_US: The ID of the calendar to list events from; defaults to the primary calendar
+      ko_KR: 이벤트를 나열할 캘린더의 ID이며, 기본값은 기본 캘린더입니다
       zh_Hans: 要列出事件的日历 ID；默认为主日历
       pt_BR: O ID do calendário para listar eventos; o padrão é o calendário principal
       ja_JP: イベントを一覧表示するカレンダーの ID。デフォルトはプライマリカレンダー

--- a/tools/outlook/tools/list_messages.yaml
+++ b/tools/outlook/tools/list_messages.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: List Messages
+    ko_KR: 메시지 목록
     zh_Hans: 列出消息
     pt_BR: Listar Mensagens
     ja_JP: メッセージ一覧
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: List messages from your Outlook inbox
+    ko_KR: Outlook 받은 편지함의 메시지 목록을 표시합니다
     zh_Hans: 列出您的 Outlook 收件箱中的消息
     pt_BR: Listar mensagens da sua caixa de entrada do Outlook
     ja_JP: Outlook の受信トレイからメッセージを一覧表示
@@ -24,12 +26,14 @@ parameters:
     default: inbox
     label:
       en_US: Folder
+      ko_KR: 폴더
       zh_Hans: 文件夹
       pt_BR: Pasta
       ja_JP: フォルダ
       zh_Hant: 資料夾
     human_description:
       en_US: The folder to list messages from
+      ko_KR: 메시지 목록을 표시할 폴더
       zh_Hans: 要列出消息的文件夹
       pt_BR: A pasta para listar mensagens
       ja_JP: メッセージを一覧表示するフォルダ
@@ -41,12 +45,14 @@ parameters:
     required: false
     label:
       en_US: Search
+      ko_KR: 검색
       zh_Hans: 搜索
       pt_BR: Pesquisar
       ja_JP: 検索
       zh_Hant: 搜尋
     human_description:
       en_US: Search query to filter messages
+      ko_KR: 메시지를 필터링하기 위한 검색 쿼리
       zh_Hans: 用于过滤消息的搜索查询
       pt_BR: Consulta de pesquisa para filtrar mensagens
       ja_JP: メッセージをフィルタリングする検索クエリ
@@ -61,12 +67,14 @@ parameters:
     max: 100
     label:
       en_US: Limit
+      ko_KR: 제한
       zh_Hans: 限制
       pt_BR: Limite
       ja_JP: 制限
       zh_Hant: 限制
     human_description:
       en_US: Maximum number of messages to return
+      ko_KR: 반환할 최대 메시지 수
       zh_Hans: 要返回的最大消息数
       pt_BR: Número máximo de mensagens a retornar
       ja_JP: 返すメッセージの最大数
@@ -79,12 +87,14 @@ parameters:
     default: false
     label:
       en_US: Include Body
+      ko_KR: 본문 포함
       zh_Hans: 包含正文
       pt_BR: Incluir Corpo
       ja_JP: 本文を含める
       zh_Hant: 包含內文
     human_description:
       en_US: Whether to include the full message body in the response
+      ko_KR: 응답에 전체 메시지 본문을 포함할지 여부
       zh_Hans: 是否在响应中包含完整的消息正文
       pt_BR: Se deve incluir o corpo completo da mensagem na resposta
       ja_JP: レスポンスにメッセージの本文全体を含めるかどうか

--- a/tools/outlook/tools/prioritize_message_tool.yaml
+++ b/tools/outlook/tools/prioritize_message_tool.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Prioritize Email
+    ko_KR: 이메일 우선순위 설정
     zh_Hans: 设置邮件优先级
     pt_BR: Priorizar E-mail
     ja_JP: メールの優先度設定
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Set the priority level of an email message
+    ko_KR: 이메일 메시지의 우선순위 수준 설정
     zh_Hans: 设置邮件的优先级级别
     pt_BR: Definir o nível de prioridade de um e-mail
     ja_JP: メールの優先度を設定
@@ -23,12 +25,14 @@ parameters:
     required: true
     label:
       en_US: Email ID
+      ko_KR: 이메일 ID
       zh_Hans: 邮件ID
       pt_BR: ID do E-mail
       ja_JP: メールID
       zh_Hant: 郵件ID
     human_description:
       en_US: The unique identifier of the email to prioritize
+      ko_KR: 우선순위를 설정할 이메일의 고유 식별자
       zh_Hans: 要设置优先级的邮件的唯一标识符
       pt_BR: O identificador único do e-mail para priorizar
       ja_JP: 優先度を設定するメールの一意の識別子
@@ -42,12 +46,14 @@ parameters:
     default: high
     label:
       en_US: Priority Level
+      ko_KR: 우선순위 수준
       zh_Hans: 优先级
       pt_BR: Nível de Prioridade
       ja_JP: 優先度
       zh_Hant: 優先級
     human_description:
       en_US: The priority level to set for the email
+      ko_KR: 이메일에 설정할 우선순위 수준
       zh_Hans: 要为邮件设置的优先级
       pt_BR: O nível de prioridade a ser definido para o e-mail
       ja_JP: メールに設定する優先度

--- a/tools/outlook/tools/send_draft.yaml
+++ b/tools/outlook/tools/send_draft.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Send Draft
+    ko_KR: 초안 보내기
     zh_Hans: 发送草稿
     pt_BR: Enviar Rascunho
     ja_JP: 下書きを送信
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Send a draft email message through Outlook using Microsoft Graph API, requires a draft ID from the draft_message tool
+    ko_KR: Microsoft Graph API를 사용하여 Outlook을 통해 초안 이메일을 보냅니다. draft_message 도구에서 얻은 초안 ID가 필요합니다
     zh_Hans: 通过Outlook使用Microsoft Graph API发送草稿电子邮件，需要从draft_message工具中获取草稿ID
     pt_BR: Envia uma mensagem de e-mail rascunho através do Outlook usando a API do Microsoft Graph, requer um ID de rascunho do tool draft_message
     ja_JP: Outlookを使用してMicrosoft Graph API経由で下書きメールを送信する。draft_messageツールから下書きIDが必要です。
@@ -23,12 +25,14 @@ parameters:
     required: true
     label:
       en_US: Draft ID
+      ko_KR: 초안 ID
       zh_Hans: 草稿ID
       pt_BR: ID do Rascunho
       ja_JP: 下書きID
       zh_Hant: 草稿ID
     human_description:
       en_US: The unique identifier of the draft message to send
+      ko_KR: 보낼 초안 메시지의 고유 식별자
       zh_Hans: 要发送的草稿消息的唯一标识符
       pt_BR: O identificador único do rascunho para enviar
       ja_JP: 送信する下書きの一意の識別子

--- a/tools/outlook/tools/send_message.py
+++ b/tools/outlook/tools/send_message.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
 from typing import Any
+import base64
 import requests
-import json
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
@@ -17,91 +17,116 @@ class SendMessageTool(Tool):
             to_recipients = tool_parameters.get("to", "")
             subject = tool_parameters.get("subject", "")
             message = tool_parameters.get("message", "")
-            
+            attachments = tool_parameters.get("attachments")  # optional list of files
+
             # Validate required parameters
             if not to_recipients:
                 yield self.create_text_message("To recipients are required.")
                 return
-            
+
             if not subject:
                 yield self.create_text_message("Subject is required.")
                 return
-                
+
             if not message:
                 yield self.create_text_message("Message content is required.")
                 return
-                
+
             # Get access token from OAuth credentials
             access_token = self.runtime.credentials.get("access_token")
             if not access_token:
                 yield self.create_text_message("Access token is required in credentials.")
                 return
-            
+
             try:
                 # Send the email directly
-                result = self._send_message(access_token, to_recipients, subject, message)
-                
+                result = self._send_message(access_token, to_recipients, subject, message, attachments)
+
                 if isinstance(result, str):  # Error message
                     yield self.create_text_message(result)
                     return
-                
+
                 # Success
-                yield self.create_text_message(f"Message sent successfully: {subject}")
+                attach_note = f" with {result.get('attachment_count', 0)} attachment(s)" if result.get("attachment_count") else ""
+                yield self.create_text_message(f"Message sent successfully: {subject}{attach_note}")
                 yield self.create_json_message({
                     "status": "sent",
-                    "message_id": result.get("id"),
                     "subject": subject,
                     "to_recipients": self._parse_recipients(to_recipients),
-                    "sent_datetime": result.get("sentDateTime")
+                    "attachment_count": result.get("attachment_count", 0),
                 })
-                
+
             except Exception as e:
                 yield self.create_text_message(f"Error sending message: {str(e)}")
                 return
-                
+
         except Exception as e:
             yield self.create_text_message(f"Error: {str(e)}")
             return
-    
-    def _send_message(self, access_token: str, to_recipients: str, subject: str, message: str):
+
+    def _build_attachments(self, attachments) -> list:
+        """
+        Convert Dify file objects into Microsoft Graph fileAttachment entries.
+
+        Note: sendMail carries attachments inline (base64) in the request, so the
+        total size should stay small (a few MB). For larger files, use the draft
+        flow (draft_message -> add_attachment_to_draft -> send_draft).
+        """
+        graph_attachments = []
+        for file_obj in (attachments or []):
+            content = file_obj.blob
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            name = file_obj.filename or "attachment"
+            extension = getattr(file_obj, "extension", None)
+            if extension and not name.endswith(extension):
+                name += extension
+            graph_attachments.append({
+                "@odata.type": "#microsoft.graph.fileAttachment",
+                "name": name,
+                "contentBytes": base64.b64encode(content).decode("utf-8"),
+            })
+        return graph_attachments
+
+    def _send_message(self, access_token: str, to_recipients: str, subject: str, message: str, attachments=None):
         """
         Send an email message using Microsoft Graph API
         """
         try:
             # Parse recipients
             recipient_list = self._parse_recipients(to_recipients)
-            
+
             # Prepare message body
-            message_body = {
-                "message": {
-                    "subject": subject,
-                    "body": {
-                        "contentType": "text",
-                        "content": message
-                    },
-                    "toRecipients": [
-                        {
-                            "emailAddress": {
-                                "address": email.strip()
-                            }
-                        }
-                        for email in recipient_list
-                    ]
-                }
+            graph_message: dict[str, Any] = {
+                "subject": subject,
+                "body": {
+                    "contentType": "text",
+                    "content": message
+                },
+                "toRecipients": [
+                    {"emailAddress": {"address": email.strip()}}
+                    for email in recipient_list
+                ]
             }
-            
+
+            graph_attachments = self._build_attachments(attachments)
+            if graph_attachments:
+                graph_message["attachments"] = graph_attachments
+
+            message_body = {"message": graph_message}
+
             # API endpoint
             url = "https://graph.microsoft.com/v1.0/me/sendMail"
-            
+
             # Headers
             headers = {
                 "Authorization": f"Bearer {access_token}",
                 "Content-Type": "application/json"
             }
-            
+
             # Make API request
-            response = requests.post(url, headers=headers, json=message_body, timeout=30)
-            
+            response = requests.post(url, headers=headers, json=message_body, timeout=60)
+
             # Handle response
             if response.status_code == 401:
                 return "Authentication failed. Token may be expired."
@@ -111,30 +136,28 @@ class SendMessageTool(Tool):
                 return f"Bad request: {response.text}"
             elif response.status_code != 202:
                 return f"API error {response.status_code}: {response.text}"
-            
+
             # For sendMail endpoint, successful response is 202 with empty body
-            # Return a success indicator with basic info
             return {
-                "id": None,  # sendMail doesn't return message ID
-                "sentDateTime": None,  # Not available from sendMail response
-                "status": "sent"
+                "status": "sent",
+                "attachment_count": len(graph_attachments),
             }
-            
+
         except requests.exceptions.RequestException as e:
             return f"Network error: {str(e)}"
         except Exception as e:
             return f"Error sending message: {str(e)}"
-    
+
     def _parse_recipients(self, recipients_str: str) -> list:
         """
         Parse comma-separated email addresses
         """
         if not recipients_str:
             return []
-        
+
         # Split by comma and clean up whitespace
         recipients = [email.strip() for email in recipients_str.split(",")]
         # Filter out empty strings
         recipients = [email for email in recipients if email]
-        
+
         return recipients

--- a/tools/outlook/tools/send_message.yaml
+++ b/tools/outlook/tools/send_message.yaml
@@ -69,6 +69,23 @@ parameters:
       zh_Hant: 訊息的內容
     llm_description: The content of the message
     form: llm
+  - name: attachments
+    type: files
+    required: false
+    label:
+      en_US: Attachments
+      zh_Hans: 附件
+      pt_BR: Anexos
+      ja_JP: 添付ファイル
+      zh_Hant: 附件
+    human_description:
+      en_US: Optional files to attach to the email (kept small; a few MB total)
+      zh_Hans: 可选，要附加到邮件的文件（保持较小，总计几 MB）
+      pt_BR: Arquivos opcionais para anexar ao e-mail (mantenha pequenos, alguns MB no total)
+      ja_JP: メールに添付する任意のファイル（合計数 MB 程度に抑えてください）
+      zh_Hant: 可選，要附加到郵件的檔案（保持較小，總計幾 MB）
+    llm_description: Optional files to attach to the email. Sent inline via sendMail, so keep the total size small (a few MB); for larger files use the draft flow.
+    form: llm
 extra:
   python:
-    source: tools/send_message.py 
+    source: tools/send_message.py

--- a/tools/outlook/tools/send_message.yaml
+++ b/tools/outlook/tools/send_message.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Send Message
+    ko_KR: 메시지 보내기
     zh_Hans: 发送消息
     pt_BR: Enviar Mensagem
     ja_JP: メッセージを送信
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Send a message through Outlook using Microsoft Graph API
+    ko_KR: Microsoft Graph API를 사용하여 Outlook을 통해 메시지를 보냅니다
     zh_Hans: 通过Outlook使用Microsoft Graph API发送消息
     pt_BR: Envia uma mensagem através do Outlook usando a API do Microsoft Graph
     ja_JP: Outlookを使用してMicrosoft Graph API経由でメッセージを送信する
@@ -23,12 +25,14 @@ parameters:
     required: true
     label:
       en_US: To
+      ko_KR: 받는 사람
       zh_Hans: 收件人
       pt_BR: Para
       ja_JP: 宛先
       zh_Hant: 收件人
     human_description:
       en_US: The email address of the recipient
+      ko_KR: 받는 사람의 이메일 주소
       zh_Hans: 收件人的电子邮件地址
       pt_BR: O endereço de e-mail do destinatário
       ja_JP: 宛先の電子メールアドレス
@@ -40,12 +44,14 @@ parameters:
     required: true
     label:
       en_US: Subject
+      ko_KR: 제목
       zh_Hans: 主题
       pt_BR: Assunto
       ja_JP: 件名
       zh_Hant: 主題
     human_description:
       en_US: The subject of the message
+      ko_KR: 메시지의 제목
       zh_Hans: 消息的主题
       pt_BR: O assunto da mensagem
       ja_JP: 件名
@@ -57,12 +63,14 @@ parameters:
     required: true
     label:
       en_US: Message
+      ko_KR: 메시지
       zh_Hans: 消息
       pt_BR: Mensagem
       ja_JP: メッセージ
       zh_Hant: 訊息
     human_description:
       en_US: The content of the message
+      ko_KR: 메시지의 내용
       zh_Hans: 消息的内容
       pt_BR: O conteúdo da mensagem
       ja_JP: メッセージの内容
@@ -74,12 +82,14 @@ parameters:
     required: false
     label:
       en_US: Attachments
+      ko_KR: 첨부 파일
       zh_Hans: 附件
       pt_BR: Anexos
       ja_JP: 添付ファイル
       zh_Hant: 附件
     human_description:
       en_US: Optional files to attach to the email (kept small; a few MB total)
+      ko_KR: 이메일에 첨부할 파일(선택 사항, 총 몇 MB 이내로 유지)
       zh_Hans: 可选，要附加到邮件的文件（保持较小，总计几 MB）
       pt_BR: Arquivos opcionais para anexar ao e-mail (mantenha pequenos, alguns MB no total)
       ja_JP: メールに添付する任意のファイル（合計数 MB 程度に抑えてください）
@@ -88,4 +98,4 @@ parameters:
     form: llm
 extra:
   python:
-    source: tools/send_message.py
+    source: tools/send_message.py 

--- a/tools/outlook/tools/update_event.yaml
+++ b/tools/outlook/tools/update_event.yaml
@@ -4,6 +4,7 @@ identity:
   author: Dify
   label:
     en_US: Update Event
+    ko_KR: 이벤트 업데이트
     zh_Hans: 更新事件
     pt_BR: Atualizar Evento
     ja_JP: イベント更新
@@ -11,6 +12,7 @@ identity:
 description:
   human:
     en_US: Update an existing calendar event in your Outlook account
+    ko_KR: Outlook 계정의 기존 캘린더 이벤트를 업데이트합니다
     zh_Hans: 更新您的 Outlook 账户中现有的日历事件
     pt_BR: Atualizar um evento de calendário existente na sua conta do Outlook
     ja_JP: Outlook アカウントの既存のカレンダーイベントを更新
@@ -22,12 +24,14 @@ parameters:
     required: true
     label:
       en_US: Event ID
+      ko_KR: 이벤트 ID
       zh_Hans: 事件 ID
       pt_BR: ID do Evento
       ja_JP: イベント ID
       zh_Hant: 事件 ID
     human_description:
       en_US: The ID of the event to update
+      ko_KR: 업데이트할 이벤트의 ID
       zh_Hans: 要更新的事件的 ID
       pt_BR: O ID do evento a atualizar
       ja_JP: 更新するイベントの ID
@@ -39,12 +43,14 @@ parameters:
     required: false
     label:
       en_US: Subject
+      ko_KR: 제목
       zh_Hans: 主题
       pt_BR: Assunto
       ja_JP: 件名
       zh_Hant: 主題
     human_description:
       en_US: The new subject or title of the event
+      ko_KR: 이벤트의 새 제목 또는 표제
       zh_Hans: 事件的新主题或标题
       pt_BR: O novo assunto ou título do evento
       ja_JP: イベントの新しい件名またはタイトル
@@ -56,12 +62,14 @@ parameters:
     required: false
     label:
       en_US: Start Datetime
+      ko_KR: 시작 일시
       zh_Hans: 开始时间
       pt_BR: Data e Hora de Início
       ja_JP: 開始日時
       zh_Hant: 開始時間
     human_description:
       en_US: The new start date and time in ISO 8601 format, e.g. 2026-08-10T14:00:00
+      ko_KR: ISO 8601 형식의 새 시작 날짜 및 시간, 예 2026-08-10T14:00:00
       zh_Hans: ISO 8601 格式的新开始日期和时间，例如 2026-08-10T14:00:00
       pt_BR: A nova data e hora de início no formato ISO 8601, por exemplo 2026-08-10T14:00:00
       ja_JP: ISO 8601 形式の新しい開始日時、例 2026-08-10T14:00:00
@@ -73,12 +81,14 @@ parameters:
     required: false
     label:
       en_US: End Datetime
+      ko_KR: 종료 일시
       zh_Hans: 结束时间
       pt_BR: Data e Hora de Término
       ja_JP: 終了日時
       zh_Hant: 結束時間
     human_description:
       en_US: The new end date and time in ISO 8601 format, e.g. 2026-08-10T15:00:00
+      ko_KR: ISO 8601 형식의 새 종료 날짜 및 시간, 예 2026-08-10T15:00:00
       zh_Hans: ISO 8601 格式的新结束日期和时间，例如 2026-08-10T15:00:00
       pt_BR: A nova data e hora de término no formato ISO 8601, por exemplo 2026-08-10T15:00:00
       ja_JP: ISO 8601 形式の新しい終了日時、例 2026-08-10T15:00:00
@@ -91,12 +101,14 @@ parameters:
     default: UTC
     label:
       en_US: Time Zone
+      ko_KR: 시간대
       zh_Hans: 时区
       pt_BR: Fuso Horário
       ja_JP: タイムゾーン
       zh_Hant: 時區
     human_description:
       en_US: The time zone for the updated start and end times, e.g. UTC or Asia/Tokyo
+      ko_KR: 업데이트된 시작 및 종료 시간의 시간대, 예 UTC 또는 Asia/Tokyo
       zh_Hans: 更新后的开始和结束时间的时区，例如 UTC 或 Asia/Tokyo
       pt_BR: O fuso horário para os horários de início e término atualizados, por exemplo UTC ou Asia/Tokyo
       ja_JP: 更新後の開始と終了時刻のタイムゾーン、例 UTC または Asia/Tokyo
@@ -108,12 +120,14 @@ parameters:
     required: false
     label:
       en_US: Body
+      ko_KR: 본문
       zh_Hans: 正文
       pt_BR: Corpo
       ja_JP: 本文
       zh_Hant: 內文
     human_description:
       en_US: The new description or body content of the event
+      ko_KR: 이벤트의 새 설명 또는 본문 내용
       zh_Hans: 事件的新描述或正文内容
       pt_BR: A nova descrição ou conteúdo do corpo do evento
       ja_JP: イベントの新しい説明または本文内容
@@ -125,12 +139,14 @@ parameters:
     required: false
     label:
       en_US: Location
+      ko_KR: 장소
       zh_Hans: 地点
       pt_BR: Local
       ja_JP: 場所
       zh_Hant: 地點
     human_description:
       en_US: The new location of the event
+      ko_KR: 이벤트의 새 장소
       zh_Hans: 事件的新地点
       pt_BR: O novo local do evento
       ja_JP: イベントの新しい場所


### PR DESCRIPTION
## Summary

Two additions to the Outlook plugin (0.4.0 → **0.5.0**):

1. **Send Message file attachments.** A new optional **Attachments** (files) parameter on the Send Message tool — send an email with files in one step (previously attachments required the draft flow: draft → add attachment → send). Files are sent inline via Microsoft Graph `sendMail` as `#microsoft.graph.fileAttachment` (base64); keep the total small (a few MB) — larger files should still use the draft flow. Backward compatible (the parameter is optional).

2. **Korean (`ko_KR`) localization.** Added Korean to every user-facing i18n string across the manifest, provider and all 15 tools, alongside the existing languages.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (0.4.0 → 0.5.0)
- [x] `dify_plugin>=0.9.0` declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [x] Local deployment — Dify version: <!-- fill in -->
- [ ] SaaS (cloud.dify.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
