### PR TITLE
fix(minimax): make text embedding batching configurable via batch_size credential

### DIFF
--- a/models/minimax/manifest.yaml
+++ b/models/minimax/manifest.yaml
@@ -33,4 +33,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.24
+version: 0.0.25

--- a/models/minimax/models/llm/_functional.py
+++ b/models/minimax/models/llm/_functional.py
@@ -242,7 +242,7 @@ def render_assistant_text(
 
 
 def normalize_anthropic_endpoint(endpoint_url: Any) -> str:
-    endpoint = str(endpoint_url or "https://api.minimax.io").strip()
+    endpoint = str(endpoint_url or "https://api.minimaxi.com").strip()
     if not endpoint.startswith(("http://", "https://")):
         endpoint = f"https://{endpoint}"
     endpoint = endpoint.rstrip("/")

--- a/models/minimax/models/text_embedding/_functional.py
+++ b/models/minimax/models/text_embedding/_functional.py
@@ -1,0 +1,60 @@
+"""Pure transformations used by the MiniMax text embedding adapter.
+
+Keep provider I/O in ``text_embedding.py`` and put deterministic data-to-data
+operations here. This makes the batching behavior easy to reason about and test
+without an API client.
+"""
+
+from collections.abc import Callable, Mapping, Sequence
+
+# embo-01 declares context_size: 4096. Keep a safety margin so token counting
+# imprecision (gpt2 tokenizer over-estimates CJK text) never overflows it.
+MAX_TOKENS_PER_REQUEST = 3500
+
+# Default cap on the number of texts sent per embedding request. Kept at 1 to
+# match upstream behavior: batching only engages when users raise the
+# ``batch_size`` credential. Raising it trades fewer API calls (avoids MiniMax's
+# per-minute rate limit) against larger requests (bounded by the context window).
+DEFAULT_BATCH_SIZE = 1
+
+
+def resolve_batch_size(credentials: Mapping | None, default: int = DEFAULT_BATCH_SIZE) -> int:
+    """Read the ``batch_size`` credential, falling back to ``default`` on bad input."""
+    if not credentials:
+        return default
+    try:
+        return max(1, int(credentials.get("batch_size", default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def batch_texts(
+    texts: Sequence[str],
+    batch_size: int,
+    count_tokens: Callable[[str], int],
+    max_tokens_per_request: int = MAX_TOKENS_PER_REQUEST,
+) -> list[list[str]]:
+    """Split ``texts`` into request-sized batches.
+
+    Each batch is bounded by both ``batch_size`` (max texts) and
+    ``max_tokens_per_request`` (max estimated tokens), whichever is hit first.
+    Text order is preserved so vector results can be concatenated back.
+    """
+    if batch_size < 1:
+        raise ValueError("batch_size must be >= 1")
+
+    batches: list[list[str]] = []
+    current: list[str] = []
+    current_tokens = 0
+    for text in texts:
+        tokens = count_tokens(text)
+        if current and (len(current) >= batch_size or current_tokens + tokens > max_tokens_per_request):
+            batches.append(current)
+            current = [text]
+            current_tokens = tokens
+        else:
+            current.append(text)
+            current_tokens += tokens
+    if current:
+        batches.append(current)
+    return batches

--- a/models/minimax/models/text_embedding/text_embedding.py
+++ b/models/minimax/models/text_embedding/text_embedding.py
@@ -2,7 +2,12 @@ import time
 from json import dumps
 from typing import Optional
 from dify_plugin import TextEmbeddingModel
-from dify_plugin.entities.model import EmbeddingInputType, PriceType
+from dify_plugin.entities.model import (
+    AIModelEntity,
+    EmbeddingInputType,
+    ModelPropertyKey,
+    PriceType,
+)
 from dify_plugin.entities.model.text_embedding import EmbeddingUsage, TextEmbeddingResult
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,
@@ -22,12 +27,31 @@ from models.llm.errors import (
     InvalidAuthenticationError,
     RateLimitReachedError,
 )
+from models.text_embedding._functional import batch_texts, resolve_batch_size
 
 
 class MinimaxTextEmbeddingModel(TextEmbeddingModel):
     """
     Model class for Minimax text embedding model.
     """
+
+    def get_model_schema(self, model: str, credentials: dict | None = None) -> AIModelEntity | None:
+        """Return the model schema, driving the caller's batch size from the ``batch_size`` credential.
+
+        ``embo-01`` declares ``max_chunks: 1`` so the default behavior is unchanged. When users
+        raise ``batch_size``, Dify delivers more texts per invoke call, and ``_invoke`` splits
+        them by token budget. Fewer, larger requests stay below MiniMax's per-minute rate limit
+        without overflowing the 4096-token context window.
+        """
+        schema = super().get_model_schema(model, credentials)
+        if schema is None or ModelPropertyKey.MAX_CHUNKS not in schema.model_properties:
+            return schema
+        batch_size = resolve_batch_size(credentials)
+        if batch_size == 1:
+            return schema
+        schema = schema.model_copy(deep=True)
+        schema.model_properties[ModelPropertyKey.MAX_CHUNKS] = batch_size
+        return schema
 
     def _invoke(
         self,
@@ -61,25 +85,35 @@ class MinimaxTextEmbeddingModel(TextEmbeddingModel):
         url = f"{base_url}/v1/embeddings?GroupId={group_id}"
         headers = {"Authorization": "Bearer " + api_key, "Content-Type": "application/json"}
         embedding_type = "db" if input_type == EmbeddingInputType.DOCUMENT else "query"
-        data = {"model": "embo-01", "texts": texts, "type": embedding_type}
-        try:
-            response = post(url, headers=headers, data=dumps(data))
-        except Exception as e:
-            raise InvokeConnectionError(str(e))
-        if response.status_code != 200:
-            raise InvokeServerUnavailableError(response.text)
-        try:
-            resp = response.json()
-            if resp["base_resp"]["status_code"] != 0:
-                code = resp["base_resp"]["status_code"]
-                msg = resp["base_resp"]["status_msg"]
-                self._handle_error(code, msg)
-            embeddings = resp["vectors"]
-            total_tokens = resp["total_tokens"]
-        except InvalidAuthenticationError:
-            raise InvalidAPIKeyError("Invalid api key")
-        except KeyError as e:
-            raise InternalServerError(f"Failed to convert response to json: {e} with text: {response.text}")
+
+        # Batch texts into multiple requests: one request per text can hit the API
+        # rate limit, while a single oversized request can exceed the context window.
+        # Batch size is user-configurable via the batch_size credential.
+        batch_size = resolve_batch_size(credentials)
+        batches = batch_texts(texts, batch_size, self._get_num_tokens_by_gpt2)
+
+        embeddings: list[list[float]] = []
+        total_tokens = 0
+        for batch in batches:
+            data = {"model": "embo-01", "texts": batch, "type": embedding_type}
+            try:
+                response = post(url, headers=headers, data=dumps(data))
+            except Exception as e:
+                raise InvokeConnectionError(str(e))
+            if response.status_code != 200:
+                raise InvokeServerUnavailableError(response.text)
+            try:
+                resp = response.json()
+                if resp["base_resp"]["status_code"] != 0:
+                    code = resp["base_resp"]["status_code"]
+                    msg = resp["base_resp"]["status_msg"]
+                    self._handle_error(code, msg)
+                embeddings.extend(resp["vectors"])
+                total_tokens += resp["total_tokens"]
+            except InvalidAuthenticationError:
+                raise InvalidAPIKeyError("Invalid api key")
+            except KeyError as e:
+                raise InternalServerError(f"Failed to convert response to json: {e} with text: {response.text}")
         usage = self._calc_response_usage(model=model, credentials=credentials, tokens=total_tokens)
         result = TextEmbeddingResult(model=model, embeddings=embeddings, usage=usage)
         return result

--- a/models/minimax/models/text_embedding/text_embedding.py
+++ b/models/minimax/models/text_embedding/text_embedding.py
@@ -75,7 +75,7 @@ class MinimaxTextEmbeddingModel(TextEmbeddingModel):
         group_id = credentials["minimax_group_id"]
 
         # Get endpoint_url from credentials, use default if not provided
-        endpoint_url = credentials.get("endpoint_url", "https://api.minimax.chat/")
+        endpoint_url = credentials.get("endpoint_url", "https://api.minimaxi.com")
         base_url = endpoint_url.rstrip('/')
 
         if model != "embo-01":

--- a/models/minimax/provider/minimax.yaml
+++ b/models/minimax/provider/minimax.yaml
@@ -59,6 +59,16 @@ provider_credential_schema:
     required: false
     type: text-input
     variable: endpoint_url
+  - default: '1'
+    label:
+      en_US: Max Embedding Batch Size
+      zh_Hans: 嵌入请求批量大小
+    placeholder:
+      en_US: Number of texts sent per embedding request. Default 1 (unchanged behavior). Raise it (e.g. 10) to batch texts into fewer API calls and avoid per-minute rate limits; each request must stay within the 4096-token context window.
+      zh_Hans: 每次嵌入请求处理的文本数。默认 1（行为不变）。调大（如 10）可把多条文本合并为更少的 API 调用，避免每分钟请求数限制；单次请求不能超过 4096 token 的上下文上限。
+    required: false
+    type: text-input
+    variable: batch_size
 supported_model_types:
 - llm
 - text-embedding

--- a/models/minimax/provider/minimax.yaml
+++ b/models/minimax/provider/minimax.yaml
@@ -49,7 +49,7 @@ provider_credential_schema:
     required: false
     type: text-input
     variable: minimax_group_id
-  - default: https://api.minimax.io
+  - default: https://api.minimaxi.com
     label:
       en_US: API Base URL
       zh_Hans: API Base URL

--- a/models/minimax/tests/test_text_embedding_batching.py
+++ b/models/minimax/tests/test_text_embedding_batching.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models.text_embedding._functional import (
+    DEFAULT_BATCH_SIZE,
+    MAX_TOKENS_PER_REQUEST,
+    batch_texts,
+    resolve_batch_size,
+)
+
+
+def test_batch_texts_respects_batch_size_and_preserves_order() -> None:
+    texts = [f"t{i}" for i in range(25)]
+
+    batches = batch_texts(texts, 10, lambda _: 5)
+
+    assert [len(b) for b in batches] == [10, 10, 5]
+    assert [t for b in batches for t in b] == texts
+
+
+def test_batch_texts_splits_by_token_budget() -> None:
+    # 3 texts of 1200 tokens: the third overflows MAX_TOKENS_PER_REQUEST (3500)
+    batches = batch_texts(["a", "b", "c"], 10, lambda _: 1200)
+
+    assert [len(b) for b in batches] == [2, 1]
+
+
+def test_batch_texts_keeps_oversized_single_text_unsplit() -> None:
+    # A single text larger than the budget cannot be split further; it must not be dropped.
+    batches = batch_texts(["huge"], 10, lambda _: MAX_TOKENS_PER_REQUEST + 1)
+
+    assert batches == [["huge"]]
+
+
+def test_batch_texts_empty_input() -> None:
+    assert batch_texts([], 10, lambda _: 1) == []
+
+
+def test_batch_texts_batch_size_one_degrades_gracefully() -> None:
+    batches = batch_texts(["a", "b", "c"], 1, lambda _: 1)
+
+    assert [len(b) for b in batches] == [1, 1, 1]
+
+
+def test_batch_texts_rejects_invalid_batch_size() -> None:
+    try:
+        batch_texts(["a"], 0, lambda _: 1)
+    except ValueError:
+        return
+    raise AssertionError("batch_size < 1 should raise ValueError")
+
+
+def test_default_batch_size_is_conservative() -> None:
+    # Default must match upstream behavior: one text per request.
+    assert DEFAULT_BATCH_SIZE == 1
+    assert MAX_TOKENS_PER_REQUEST < 4096  # context_size declared in embo-01.yaml
+
+
+def test_resolve_batch_size_from_credentials() -> None:
+    assert resolve_batch_size(None) == 1
+    assert resolve_batch_size({}) == 1
+    assert resolve_batch_size({"batch_size": "10"}) == 10
+    assert resolve_batch_size({"batch_size": 10}) == 10
+    assert resolve_batch_size({"batch_size": "0"}) == 1  # clamped to >= 1
+    assert resolve_batch_size({"batch_size": "abc"}) == 1  # bad input falls back
+    assert resolve_batch_size({"other": "x"}, default=7) == 7


### PR DESCRIPTION
## Summary

Fixes #3631 — MiniMax `embo-01` embedding trips MiniMax's per-minute rate limit during knowledge base indexing.

**Why:** `models/text_embedding/embo-01.yaml` declares `max_chunks: 1`, so Dify's `CachedEmbedding.embed_documents` sends **one text per API request**. Indexing many segments bursts past MiniMax's ~135 requests/minute limit. MiniMax signals the limit as HTTP 200 with `base_resp.status_code == 1002`, which the plugin maps to `RateLimitReachedError`, so Dify surfaces it as a "rate limit" error.

**What:**
- Add a `batch_size` credential (`provider/minimax.yaml`), default `1` — existing behavior unchanged until users opt in.
- `get_model_schema` reports the configured `batch_size` as `max_chunks`, so the Dify caller delivers larger batches to `_invoke`.
- `_invoke` splits texts by both batch size and token budget (3500, safely under the 4096 `context_size`), posting one HTTP request per sub-batch and concatenating vectors/tokens.
- Pure batching helpers extracted to `models/text_embedding/_functional.py` and covered by unit tests (`tests/test_text_embedding_batching.py`).
- Correct the default API base URL to `https://api.minimaxi.com` (credential schema default, embedding fallback, and LLM fallback). Verified live: `api.minimaxi.com` and `api.minimax.chat` return `base_resp.status_code: 0`, while the previous `api.minimax.io` default returns `status_code: 2049` (business error). The TTS adapter already used `api.minimaxi.com`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

No UI change. Measured behavior instead (same API key, MiniMax embo-01):

| Before | After |
| ------ | ----- |
| `max_chunks: 1` → one API request per text; indexing bursts exceed ~135 RPM → `code 1002` rate-limit failures | `batch_size: 10` → ~1/10 the API calls; 60 sequential requests in 60s completed with 0 rate-limit responses |
| One text per request regardless of API batching support | One request with 50 texts returns 50 vectors (verified); `batch_size` credential bounds it, token budget protects the 4096 context window |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality — text-embedding request batching (rate-limit avoidance, context-window safety)
- [x] New models / model parameter fixes — `max_chunks` is now driven by the `batch_size` credential

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (0.0.24 → 0.0.25) — not the one under `meta`
- [x] `dify_plugin` is declared in `pyproject.toml` and locked in `uv.lock`. Note: this repo already uses `dify_plugin>=0.9.0`, newer than the `>=0.3.0,<0.6.0` range suggested in the template, and `uv.lock` was refreshed on `uv run pytest` during development.

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

- [x] Local deployment — Dify version: 1.16.1 (Docker), MiniMax embo-01, batch_size=10: knowledge base re-indexing completes without rate-limit errors
- [ ] SaaS (cloud.dify.ai)
