### PR TITLE
fix(aws_tools): refresh boto3 credentials per-call across 16 tool files (closes #3544)

### DIFF
--- a/tools/aws/manifest.yaml
+++ b/tools/aws/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.30
+version: 0.0.31
 type: plugin
 author: langgenius
 name: aws_tools

--- a/tools/aws/tools/agentcore_code_interpreter.py
+++ b/tools/aws/tools/agentcore_code_interpreter.py
@@ -6,113 +6,142 @@ import boto3
 import json
 import time
 
+
 class AgentcoreCodeInterpreterTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         result = self.execute(**tool_parameters)
         yield self.create_json_message(result)
 
-
-    def execute(self, language=None, code=None, command=None, session_id=None, code_interpreter_id=None, aws_ak=None, aws_sk=None, aws_region=None, **kwargs):
+    def execute(
+        self,
+        language=None,
+        code=None,
+        command=None,
+        session_id=None,
+        code_interpreter_id=None,
+        aws_ak=None,
+        aws_sk=None,
+        aws_region=None,
+        **kwargs,
+    ):
         error_msg = ""
-        
+
         try:
             # 1. Create clients based on provided AWS credentials
-            data_client = self.create_client(aws_ak, aws_sk, aws_region, 'bedrock-agentcore')
-            
+            data_client = self.create_client(
+                aws_ak, aws_sk, aws_region, "bedrock-agentcore"
+            )
+
             # 2. Get or create code interpreter
             if not code_interpreter_id:
-                control_client = self.create_client(aws_ak, aws_sk, aws_region, 'bedrock-agentcore-control')
+                control_client = self.create_client(
+                    aws_ak, aws_sk, aws_region, "bedrock-agentcore-control"
+                )
                 code_interpreter_id = self.create_code_interpreter(control_client)
-            
+
             # 3. Get or create session
             if not session_id:
                 session_id = self.init_session(data_client, code_interpreter_id)
-            
+
             # 4. Execute command first if provided, then code
             results = []
-            
+
             if command:
-                command_result = self.exec_command_internal(data_client, code_interpreter_id, session_id, command)
+                command_result = self.exec_command_internal(
+                    data_client, code_interpreter_id, session_id, command
+                )
                 results.append({"type": "command", "result": command_result})
-            
+
             if code and language:
-                code_result = self.exec_code_internal(data_client, code_interpreter_id, session_id, language, code)
+                code_result = self.exec_code_internal(
+                    data_client, code_interpreter_id, session_id, language, code
+                )
                 results.append({"type": "code", "result": code_result})
-            
+
             if not command and not code:
                 raise ValueError("Either command or code must be provided")
-                
+
         except Exception as e:
             error_msg = str(e)
-        
+
         if error_msg:
             result = {"status": "error", "reason": str(error_msg)}
         else:
             result = {
-                "status": "success", 
-                "session_id": session_id, 
+                "status": "success",
+                "session_id": session_id,
                 "code_interpreter_id": code_interpreter_id,
-                "results": results
+                "results": results,
             }
-        
+
         return result
 
-    def create_client(self, aws_ak=None, aws_sk=None, aws_region=None, service_name='bedrock-agentcore'):
-        """Create AWS client with or without provided credentials"""
+    def create_client(
+        self,
+        aws_ak=None,
+        aws_sk=None,
+        aws_region=None,
+        service_name="bedrock-agentcore",
+    ):
+        """Create AWS client with or without provided credentials.
+
+        Uses a fresh boto3.Session per call so disk-refreshed credentials
+        (saml2aws login, aws sso login, IMDS) are picked up without a
+        plugin restart. Same fix as #3535 / #3545.
+        """
         if aws_ak and aws_sk and aws_region:
-            return boto3.client(service_name, 
-                              aws_access_key_id=aws_ak, 
-                              aws_secret_access_key=aws_sk, 
-                              region_name=aws_region)
+            return boto3.Session().client(
+                service_name,
+                aws_access_key_id=aws_ak,
+                aws_secret_access_key=aws_sk,
+                region_name=aws_region,
+            )
         else:
-            return boto3.client(service_name)
+            return boto3.Session().client(service_name)
 
     def create_code_interpreter(self, client):
         """Create a new code interpreter"""
         timestamp = int(time.time())
         response = client.create_code_interpreter(
-            name=f'code_interpreter_{timestamp}',
-            description='code-interpreter with network access',
-            networkConfiguration={'networkMode': 'PUBLIC'}
+            name=f"code_interpreter_{timestamp}",
+            description="code-interpreter with network access",
+            networkConfiguration={"networkMode": "PUBLIC"},
         )
-        return response.get('codeInterpreterId')
+        return response.get("codeInterpreterId")
 
-    def exec_code_internal(self, client, code_interpreter_id, session_id, language, code):
+    def exec_code_internal(
+        self, client, code_interpreter_id, session_id, language, code
+    ):
         """Execute code in the code interpreter"""
-        arguments = {
-            "language": language,
-            "code": code
-        }
+        arguments = {"language": language, "code": code}
         response = client.invoke_code_interpreter(
             codeInterpreterIdentifier=code_interpreter_id,
             name="executeCode",
             sessionId=session_id,
-            arguments=arguments
+            arguments=arguments,
         )
         return self.get_tool_result(response)
 
     def exec_command_internal(self, client, code_interpreter_id, session_id, command):
         """Execute command in the code interpreter"""
-        arguments = {
-            "command": command
-        }
+        arguments = {"command": command}
         response = client.invoke_code_interpreter(
             codeInterpreterIdentifier=code_interpreter_id,
             name="executeCommand",
             sessionId=session_id,
-            arguments=arguments
+            arguments=arguments,
         )
         return self.get_tool_result(response)
 
-
     def init_session(self, data_client, ci_id):
         try:
-            response = data_client.start_code_interpreter_session(codeInterpreterIdentifier=ci_id, sessionTimeoutSeconds=900)
-            session_id = response['sessionId']
+            response = data_client.start_code_interpreter_session(
+                codeInterpreterIdentifier=ci_id, sessionTimeoutSeconds=900
+            )
+            session_id = response["sessionId"]
         except Exception as e:
             raise
         return session_id
-
 
     def get_tool_result(self, response):
         try:

--- a/tools/aws/tools/dynamodb_manager.py
+++ b/tools/aws/tools/dynamodb_manager.py
@@ -8,10 +8,22 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 
-class DynamoDBManager(Tool):
-    dynamodb_resource: Any = None
-    dynamodb_client: Any = None
+def _build_dynamodb_resource(credentials: dict) -> Any:
+    """Build a fresh DynamoDB resource from a new ``boto3.Session``.
 
+    Mirrors the per-call ``boto3.Session()`` pattern from
+    ``tools/aws`` PR #3545 (Bedrock family) and the in-progress
+    boto3 batch under issue #3544. boto3's default session caches
+    credentials in-process, so a ``saml2aws login`` /
+    ``aws sso login`` / IMDS refresh after the plugin process
+    started never reaches the cached client. Building a fresh
+    session on every invocation picks up the new credentials.
+    """
+    aws_region = credentials.get("aws_region", "us-east-1")
+    return boto3.Session(region_name=aws_region).resource("dynamodb")
+
+
+class DynamoDBManager(Tool):
     def _invoke(
         self,
         tool_parameters: dict[str, Any],
@@ -20,24 +32,21 @@ class DynamoDBManager(Tool):
         invoke DynamoDB Manager operations
         """
         try:
-            # Initialize DynamoDB client/resource if not already done
-            if not self.dynamodb_resource or not self.dynamodb_client:
-                aws_region = tool_parameters.get("aws_region", "us-east-1")
-                self.dynamodb_resource = boto3.resource("dynamodb", region_name=aws_region)
-                self.dynamodb_client = boto3.client("dynamodb", region_name=aws_region)
-
+            # Build a fresh resource per invocation so disk-refreshed
+            # credentials are picked up on every call. See issue #3544.
+            dynamodb_resource = _build_dynamodb_resource(tool_parameters)
             operation_type = tool_parameters.get("operation_type")
 
             if operation_type == "create_table":
-                result = self._create_table(tool_parameters)
+                result = self._create_table(tool_parameters, dynamodb_resource)
             elif operation_type == "put_item":
-                result = self._put_item(tool_parameters)
+                result = self._put_item(tool_parameters, dynamodb_resource)
             elif operation_type == "get_item":
-                result = self._get_item(tool_parameters)
+                result = self._get_item(tool_parameters, dynamodb_resource)
             elif operation_type == "delete_item":
-                result = self._delete_item(tool_parameters)
+                result = self._delete_item(tool_parameters, dynamodb_resource)
             elif operation_type == "scan":
-                result = self._scan(tool_parameters)
+                result = self._scan(tool_parameters, dynamodb_resource)
             else:
                 result = f"Unsupported operation: {operation_type}"
 
@@ -49,25 +58,29 @@ class DynamoDBManager(Tool):
         except Exception as e:
             yield self.create_text_message(f"Error: {str(e)}")
 
-    def _create_table(self, params: dict) -> str:
+    def _create_table(self, params: dict, dynamodb_resource: Any) -> str:
         """Create DynamoDB table"""
         table_name = params.get("table_name")
         partition_key_name = params.get("partition_key_name", "id")
         sort_key_name = params.get("sort_key_name")
-        
+
         key_schema = [{"AttributeName": partition_key_name, "KeyType": "HASH"}]
-        attribute_definitions = [{"AttributeName": partition_key_name, "AttributeType": "S"}]
-        
+        attribute_definitions = [
+            {"AttributeName": partition_key_name, "AttributeType": "S"}
+        ]
+
         if sort_key_name:
             key_schema.append({"AttributeName": sort_key_name, "KeyType": "RANGE"})
-            attribute_definitions.append({"AttributeName": sort_key_name, "AttributeType": "S"})
+            attribute_definitions.append(
+                {"AttributeName": sort_key_name, "AttributeType": "S"}
+            )
 
         try:
-            table = self.dynamodb_resource.create_table(
+            table = dynamodb_resource.create_table(
                 TableName=table_name,
                 KeySchema=key_schema,
                 AttributeDefinitions=attribute_definitions,
-                BillingMode="PAY_PER_REQUEST"
+                BillingMode="PAY_PER_REQUEST",
             )
             table.wait_until_exists()
             return f"Table {table_name} created successfully"
@@ -77,7 +90,7 @@ class DynamoDBManager(Tool):
             else:
                 raise e
 
-    def _put_item(self, params: dict) -> str:
+    def _put_item(self, params: dict, dynamodb_resource: Any) -> str:
         """Put item into DynamoDB table"""
         table_name = params.get("table_name")
         partition_key_name = params.get("partition_key_name")
@@ -96,62 +109,60 @@ class DynamoDBManager(Tool):
             item_data = json.loads(item_data)
 
         item.update(item_data)
-        
-        table = self.dynamodb_resource.Table(table_name)
+
+        table = dynamodb_resource.Table(table_name)
         table.put_item(Item=item)
         return f"Item added to {table_name} successfully"
 
-    def _get_item(self, params: dict) -> str:
+    def _get_item(self, params: dict, dynamodb_resource: Any) -> str:
         """Get item from DynamoDB table"""
         table_name = params.get("table_name")
         partition_key_name = params.get("partition_key_name")
         partition_key = params.get("partition_key")
         sort_key = params.get("sort_key")
         sort_key_name = params.get("sort_key_name")
-        
+
         # Build key data
         key_data = {}
         key_data[partition_key_name] = partition_key
 
         if sort_key_name and sort_key:
             key_data[sort_key_name] = sort_key
-        
-        table = self.dynamodb_resource.Table(table_name)
 
-        response = table.get_item(
-            Key=key_data
-        )
-        return response.get('Item')
+        table = dynamodb_resource.Table(table_name)
 
-    def _delete_item(self, params: dict) -> str:
+        response = table.get_item(Key=key_data)
+        return response.get("Item")
+
+    def _delete_item(self, params: dict, dynamodb_resource: Any) -> str:
         """Delete item from DynamoDB table"""
         table_name = params.get("table_name")
         partition_key = params.get("partition_key")
         sort_key = params.get("sort_key")
         partition_key_name = params.get("partition_key_name", "id")
         sort_key_name = params.get("sort_key_name")
-        
+
         # Build key data
         key_data = {}
         key_data[partition_key_name] = partition_key
 
         if sort_key_name and sort_key:
             key_data[sort_key_name] = sort_key
-        
-        table = self.dynamodb_resource.Table(table_name)
+
+        table = dynamodb_resource.Table(table_name)
         table.delete_item(Key=key_data)
         return f"Item deleted from {table_name} successfully"
 
-    def _scan(self, params: dict) -> dict:
+    def _scan(self, params: dict, dynamodb_resource: Any) -> dict:
         """Scan DynamoDB table"""
         table_name = params.get("table_name")
         limit = params.get("limit", 100)
-        
-        table = self.dynamodb_resource.Table(table_name)
+
+        table = dynamodb_resource.Table(table_name)
         response = table.scan(Limit=limit)
-        
+
         return {
             "Items": response.get("Items", []),
             "Count": response.get("Count", 0),
-            "ScannedCount": response.get("ScannedCount", 0)
+            "ScannedCount": response.get("ScannedCount", 0),
         }

--- a/tools/aws/tools/lambda_translate_utils.py
+++ b/tools/aws/tools/lambda_translate_utils.py
@@ -7,10 +7,19 @@ import boto3  # type: ignore
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-class LambdaTranslateUtilsTool(Tool):
-    lambda_client: Any = None
 
-    def _invoke_lambda(self, text_content, src_lang, dest_lang, model_id, dictionary_name, request_type, lambda_name):
+class LambdaTranslateUtilsTool(Tool):
+    def _invoke_lambda(
+        self,
+        text_content,
+        src_lang,
+        dest_lang,
+        model_id,
+        dictionary_name,
+        request_type,
+        lambda_name,
+        lambda_client,
+    ):
         msg = {
             "src_contents": [text_content],
             "src_lang": src_lang,
@@ -20,8 +29,10 @@ class LambdaTranslateUtilsTool(Tool):
             "model_id": model_id,
         }
 
-        invoke_response = self.lambda_client.invoke(
-            FunctionName=lambda_name, InvocationType="RequestResponse", Payload=json.dumps(msg)
+        invoke_response = lambda_client.invoke(
+            FunctionName=lambda_name,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(msg),
         )
         response_body = invoke_response["Payload"]
 
@@ -37,13 +48,16 @@ class LambdaTranslateUtilsTool(Tool):
         invoke tools
         """
         line = 0
+        lambda_client = None
         try:
-            if not self.lambda_client:
-                aws_region = tool_parameters.get("aws_region")
-                if aws_region:
-                    self.lambda_client = boto3.client("lambda", region_name=aws_region)
-                else:
-                    self.lambda_client = boto3.client("lambda")
+            # Build a fresh boto3 client per invocation so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked
+            # up without a plugin restart. Same fix as #3535 / #3545.
+            aws_region = tool_parameters.get("aws_region")
+            if aws_region:
+                lambda_client = boto3.Session().client("lambda", region_name=aws_region)
+            else:
+                lambda_client = boto3.Session().client("lambda")
 
             line = 1
             text_content = tool_parameters.get("text_content", "")
@@ -81,7 +95,14 @@ class LambdaTranslateUtilsTool(Tool):
                 yield self.create_text_message("Please input dictionary_name")
 
             result = self._invoke_lambda(
-                text_content, src_lang, dest_lang, model_id, dictionary_name, request_type, lambda_name
+                text_content,
+                src_lang,
+                dest_lang,
+                model_id,
+                dictionary_name,
+                request_type,
+                lambda_name,
+                lambda_client,
             )
 
             yield self.create_text_message(text=result)

--- a/tools/aws/tools/lambda_yaml_to_json.py
+++ b/tools/aws/tools/lambda_yaml_to_json.py
@@ -16,14 +16,14 @@ logger.addHandler(console_handler)
 
 
 class LambdaYamlToJsonTool(Tool):
-    lambda_client: Any = None
-
-    def _invoke_lambda(self, lambda_name: str, yaml_content: str) -> str:
+    def _invoke_lambda(self, lambda_name: str, yaml_content: str, lambda_client) -> str:
         msg = {"body": yaml_content}
         logger.info(json.dumps(msg))
 
-        invoke_response = self.lambda_client.invoke(
-            FunctionName=lambda_name, InvocationType="RequestResponse", Payload=json.dumps(msg)
+        invoke_response = lambda_client.invoke(
+            FunctionName=lambda_name,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(msg),
         )
         response_body = invoke_response["Payload"]
 
@@ -43,13 +43,18 @@ class LambdaYamlToJsonTool(Tool):
         """
         invoke tools
         """
+        lambda_client = None
         try:
-            if not self.lambda_client:
-                aws_region = tool_parameters.get("aws_region")  # todo: move aws_region out, and update client region
-                if aws_region:
-                    self.lambda_client = boto3.client("lambda", region_name=aws_region)
-                else:
-                    self.lambda_client = boto3.client("lambda")
+            # Build a fresh boto3 client per invocation so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked
+            # up without a plugin restart. Same fix as #3535 / #3545.
+            aws_region = tool_parameters.get(
+                "aws_region"
+            )  # todo: move aws_region out, and update client region
+            if aws_region:
+                lambda_client = boto3.Session().client("lambda", region_name=aws_region)
+            else:
+                lambda_client = boto3.Session().client("lambda")
 
             yaml_content = tool_parameters.get("yaml_content", "")
             if not yaml_content:
@@ -60,7 +65,7 @@ class LambdaYamlToJsonTool(Tool):
                 return self.create_text_message("Please input lambda_name")
             logger.debug(f"{json.dumps(tool_parameters, indent=2, ensure_ascii=False)}")
 
-            result = self._invoke_lambda(lambda_name, yaml_content)
+            result = self._invoke_lambda(lambda_name, yaml_content, lambda_client)
             logger.debug(result)
 
             return self.create_text_message(result)

--- a/tools/aws/tools/nova_canvas.py
+++ b/tools/aws/tools/nova_canvas.py
@@ -22,9 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class NovaCanvasTool(Tool):
-    def _invoke(
-        self, tool_parameters: dict[str, Any]
-    ) -> Generator[ToolInvokeMessage]:
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         """
         Invoke AWS Bedrock Nova Canvas model for image generation
         """
@@ -32,9 +30,13 @@ class NovaCanvasTool(Tool):
         prompt = tool_parameters.get("prompt", "")
         image_output_s3uri = tool_parameters.get("image_output_s3uri", "").strip()
         if not prompt:
-            yield self.create_text_message("Please provide a text prompt for image generation.")
+            yield self.create_text_message(
+                "Please provide a text prompt for image generation."
+            )
         if not image_output_s3uri or urlparse(image_output_s3uri).scheme != "s3":
-            yield self.create_text_message("Please provide an valid S3 URI for image output.")
+            yield self.create_text_message(
+                "Please provide an valid S3 URI for image output."
+            )
 
         task_type = tool_parameters.get("task_type", "TEXT_IMAGE")
         aws_region = tool_parameters.get("aws_region", "us-east-1")
@@ -51,15 +53,19 @@ class NovaCanvasTool(Tool):
         image_input_s3uri = tool_parameters.get("image_input_s3uri", "")
         if task_type != "TEXT_IMAGE":
             if not image_input_s3uri or urlparse(image_input_s3uri).scheme != "s3":
-                yield self.create_text_message("Please provide a valid S3 URI for image to image generation.")
+                yield self.create_text_message(
+                    "Please provide a valid S3 URI for image to image generation."
+                )
 
             # Parse S3 URI
             parsed_uri = urlparse(image_input_s3uri)
             bucket = parsed_uri.netloc
             key = parsed_uri.path.lstrip("/")
 
-            # Initialize S3 client and download image
-            s3_client = boto3.client("s3")
+            # Initialize S3 client and download image. Use a fresh
+            # boto3.Session per call so disk-refreshed credentials are
+            # picked up without a plugin restart. Same fix as #3535 / #3545.
+            s3_client = boto3.Session().client("s3")
             response = s3_client.get_object(Bucket=bucket, Key=key)
             image_data = response["Body"].read()
 
@@ -67,8 +73,11 @@ class NovaCanvasTool(Tool):
             input_image = base64.b64encode(image_data).decode("utf-8")
 
         try:
-            # Initialize Bedrock client
-            bedrock = boto3.client(service_name="bedrock-runtime", region_name=aws_region)
+            # Initialize Bedrock client. Fresh boto3.Session per call —
+            # see #3535 / #3545.
+            bedrock = boto3.Session().client(
+                service_name="bedrock-runtime", region_name=aws_region
+            )
 
             # Base image generation config
             image_generation_config = {
@@ -90,9 +99,13 @@ class NovaCanvasTool(Tool):
                     body["textToImageParams"]["negativeText"] = negative_prompt
 
             elif task_type == "COLOR_GUIDED_GENERATION":
-                colors = tool_parameters.get("colors", "#ff8080-#ffb280-#ffe680-#ffe680")
+                colors = tool_parameters.get(
+                    "colors", "#ff8080-#ffb280-#ffe680-#ffe680"
+                )
                 if not self._validate_color_string(colors):
-                    yield self.create_text_message("Please provide valid colors in hexadecimal format.")
+                    yield self.create_text_message(
+                        "Please provide valid colors in hexadecimal format."
+                    )
 
                 body["taskType"] = "COLOR_GUIDED_GENERATION"
                 body["colorGuidedGenerationParams"] = {
@@ -101,7 +114,9 @@ class NovaCanvasTool(Tool):
                     "text": prompt,
                 }
                 if negative_prompt:
-                    body["colorGuidedGenerationParams"]["negativeText"] = negative_prompt
+                    body["colorGuidedGenerationParams"]["negativeText"] = (
+                        negative_prompt
+                    )
 
             elif task_type == "IMAGE_VARIATION":
                 similarity_strength = tool_parameters.get("similarity_strength", 0.5)
@@ -118,17 +133,25 @@ class NovaCanvasTool(Tool):
             elif task_type == "INPAINTING":
                 mask_prompt = tool_parameters.get("mask_prompt")
                 if not mask_prompt:
-                    yield self.create_text_message("Please provide a mask prompt for image inpainting.")
+                    yield self.create_text_message(
+                        "Please provide a mask prompt for image inpainting."
+                    )
 
                 body["taskType"] = "INPAINTING"
-                body["inPaintingParams"] = {"image": input_image, "maskPrompt": mask_prompt, "text": prompt}
+                body["inPaintingParams"] = {
+                    "image": input_image,
+                    "maskPrompt": mask_prompt,
+                    "text": prompt,
+                }
                 if negative_prompt:
                     body["inPaintingParams"]["negativeText"] = negative_prompt
 
             elif task_type == "OUTPAINTING":
                 mask_prompt = tool_parameters.get("mask_prompt")
                 if not mask_prompt:
-                    yield self.create_text_message("Please provide a mask prompt for image outpainting.")
+                    yield self.create_text_message(
+                        "Please provide a mask prompt for image outpainting."
+                    )
                 outpainting_mode = tool_parameters.get("outpainting_mode", "DEFAULT")
 
                 body["taskType"] = "OUTPAINTING"
@@ -159,7 +182,9 @@ class NovaCanvasTool(Tool):
             # Process response
             response_body = json.loads(response.get("body").read())
             if response_body.get("error"):
-                raise Exception(f"Error in model response: {response_body.get('error')}")
+                raise Exception(
+                    f"Error in model response: {response_body.get('error')}"
+                )
             base64_image = response_body.get("images")[0]
 
             # Upload to S3 if image_output_s3uri is provided
@@ -173,19 +198,26 @@ class NovaCanvasTool(Tool):
                 output_key = f"{output_base_path}/canvas-output-{timestamp}.png"
 
                 # Initialize S3 client if not already done
-                s3_client = boto3.client("s3", region_name=aws_region)
+                s3_client = boto3.Session().client("s3", region_name=aws_region)
 
                 # Decode base64 image and upload to S3
                 image_data = base64.b64decode(base64_image)
-                s3_client.put_object(Bucket=output_bucket, Key=output_key, Body=image_data, ContentType="image/png")
+                s3_client.put_object(
+                    Bucket=output_bucket,
+                    Key=output_key,
+                    Body=image_data,
+                    ContentType="image/png",
+                )
                 logger.info(f"Image uploaded to s3://{output_bucket}/{output_key}")
             except Exception as e:
                 logger.exception("Failed to upload image to S3")
             # return image
-            yield self.create_text_message(f"Image is available at: s3://{output_bucket}/{output_key}")
+            yield self.create_text_message(
+                f"Image is available at: s3://{output_bucket}/{output_key}"
+            )
             yield self.create_blob_message(
-                    blob=base64.b64decode(base64_image),
-                    meta={"mime_type": "image/png"},
+                blob=base64.b64decode(base64_image),
+                meta={"mime_type": "image/png"},
             )
 
         except Exception as e:
@@ -214,20 +246,27 @@ class NovaCanvasTool(Tool):
             ),
             ToolParameter(
                 name="image_input_s3uri",
-                label=I18nObject(en_us="Input image s3 uri", zh_hans="输入图片的s3 uri"),
+                label=I18nObject(
+                    en_us="Input image s3 uri", zh_hans="输入图片的s3 uri"
+                ),
                 type=ToolParameter.ToolParameterType.STRING,
                 required=False,
                 form=ToolParameter.ToolParameterForm.LLM,
-                human_description=I18nObject(en_us="Image to be modified", zh_hans="想要修改的图片"),
+                human_description=I18nObject(
+                    en_us="Image to be modified", zh_hans="想要修改的图片"
+                ),
             ),
             ToolParameter(
                 name="image_output_s3uri",
-                label=I18nObject(en_us="Output Image S3 URI", zh_hans="输出图片的S3 URI目录"),
+                label=I18nObject(
+                    en_us="Output Image S3 URI", zh_hans="输出图片的S3 URI目录"
+                ),
                 type=ToolParameter.ToolParameterType.STRING,
                 required=True,
                 form=ToolParameter.ToolParameterForm.FORM,
                 human_description=I18nObject(
-                    en_us="S3 URI where the generated image should be uploaded", zh_hans="生成的图像应该上传到的S3 URI"
+                    en_us="S3 URI where the generated image should be uploaded",
+                    zh_hans="生成的图像应该上传到的S3 URI",
                 ),
             ),
             ToolParameter(
@@ -237,7 +276,9 @@ class NovaCanvasTool(Tool):
                 required=False,
                 default=1024,
                 form=ToolParameter.ToolParameterForm.FORM,
-                human_description=I18nObject(en_us="Width of the generated image", zh_hans="生成图像的宽度"),
+                human_description=I18nObject(
+                    en_us="Width of the generated image", zh_hans="生成图像的宽度"
+                ),
             ),
             ToolParameter(
                 name="height",
@@ -246,7 +287,9 @@ class NovaCanvasTool(Tool):
                 required=False,
                 default=1024,
                 form=ToolParameter.ToolParameterForm.FORM,
-                human_description=I18nObject(en_us="Height of the generated image", zh_hans="生成图像的高度"),
+                human_description=I18nObject(
+                    en_us="Height of the generated image", zh_hans="生成图像的高度"
+                ),
             ),
             ToolParameter(
                 name="cfg_scale",
@@ -256,7 +299,8 @@ class NovaCanvasTool(Tool):
                 default=8.0,
                 form=ToolParameter.ToolParameterForm.FORM,
                 human_description=I18nObject(
-                    en_us="How strongly the image should conform to the prompt", zh_hans="图像应该多大程度上符合提示词"
+                    en_us="How strongly the image should conform to the prompt",
+                    zh_hans="图像应该多大程度上符合提示词",
                 ),
             ),
             ToolParameter(
@@ -267,7 +311,8 @@ class NovaCanvasTool(Tool):
                 default="",
                 form=ToolParameter.ToolParameterForm.LLM,
                 human_description=I18nObject(
-                    en_us="Things you don't want in the generated image", zh_hans="您不想在生成的图像中出现的内容"
+                    en_us="Things you don't want in the generated image",
+                    zh_hans="您不想在生成的图像中出现的内容",
                 ),
             ),
             ToolParameter(
@@ -277,7 +322,10 @@ class NovaCanvasTool(Tool):
                 required=False,
                 default=0,
                 form=ToolParameter.ToolParameterForm.FORM,
-                human_description=I18nObject(en_us="Random seed for image generation", zh_hans="图像生成的随机种子"),
+                human_description=I18nObject(
+                    en_us="Random seed for image generation",
+                    zh_hans="图像生成的随机种子",
+                ),
             ),
             ToolParameter(
                 name="aws_region",
@@ -286,7 +334,10 @@ class NovaCanvasTool(Tool):
                 required=False,
                 default="us-east-1",
                 form=ToolParameter.ToolParameterForm.FORM,
-                human_description=I18nObject(en_us="AWS region for Bedrock service", zh_hans="Bedrock 服务的 AWS 区域"),
+                human_description=I18nObject(
+                    en_us="AWS region for Bedrock service",
+                    zh_hans="Bedrock 服务的 AWS 区域",
+                ),
             ),
             ToolParameter(
                 name="task_type",
@@ -295,7 +346,9 @@ class NovaCanvasTool(Tool):
                 required=False,
                 default="TEXT_IMAGE",
                 form=ToolParameter.ToolParameterForm.LLM,
-                human_description=I18nObject(en_us="Type of image generation task", zh_hans="图像生成任务的类型"),
+                human_description=I18nObject(
+                    en_us="Type of image generation task", zh_hans="图像生成任务的类型"
+                ),
             ),
             ToolParameter(
                 name="quality",
@@ -305,7 +358,8 @@ class NovaCanvasTool(Tool):
                 default="standard",
                 form=ToolParameter.ToolParameterForm.FORM,
                 human_description=I18nObject(
-                    en_us="Quality of the generated image (standard or premium)", zh_hans="生成图像的质量（标准或高级）"
+                    en_us="Quality of the generated image (standard or premium)",
+                    zh_hans="生成图像的质量（标准或高级）",
                 ),
             ),
             ToolParameter(

--- a/tools/aws/tools/nova_reel.py
+++ b/tools/aws/tools/nova_reel.py
@@ -39,9 +39,7 @@ NOVA_REEL_REQUIRED_IMAGE_MODE = "RGB"
 
 
 class NovaReelTool(Tool):
-    def _invoke(
-        self, tool_parameters: dict[str, Any]
-    ) -> Generator[ToolInvokeMessage]:
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         """
         Invoke AWS Bedrock Nova Reel model for video generation.
 
@@ -67,19 +65,27 @@ class NovaReelTool(Tool):
                 yield model_input
 
             # Start video generation
-            invocation = self._start_video_generation(bedrock, model_input, params["video_output_s3uri"])
+            invocation = self._start_video_generation(
+                bedrock, model_input, params["video_output_s3uri"]
+            )
             invocation_arn = invocation["invocationArn"]
 
             # Handle async/sync mode
-            yield self._handle_generation_mode(bedrock, s3_client, invocation_arn, params["async_mode"])
+            yield self._handle_generation_mode(
+                bedrock, s3_client, invocation_arn, params["async_mode"]
+            )
 
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
             error_message = e.response.get("Error", {}).get("Message", str(e))
             logger.exception(f"AWS API error: {error_code} - {error_message}")
-            yield self.create_text_message(f"AWS service error: {error_code} - {error_message}")
+            yield self.create_text_message(
+                f"AWS service error: {error_code} - {error_message}"
+            )
         except Exception as e:
-            logger.error(f"Unexpected error in video generation: {str(e)}", exc_info=True)
+            logger.error(
+                f"Unexpected error in video generation: {str(e)}", exc_info=True
+            )
             yield self.create_text_message(f"Failed to generate video: {str(e)}")
 
     def _validate_and_extract_parameters(
@@ -91,16 +97,26 @@ class NovaReelTool(Tool):
 
         # Validate required parameters
         if not prompt:
-            return self.create_text_message("Please provide a text prompt for video generation.")
+            return self.create_text_message(
+                "Please provide a text prompt for video generation."
+            )
         if not video_output_s3uri:
-            return self.create_text_message("Please provide an S3 URI for video output.")
+            return self.create_text_message(
+                "Please provide an S3 URI for video output."
+            )
 
         # Validate S3 URI format
         if not video_output_s3uri.startswith("s3://"):
-            return self.create_text_message("Invalid S3 URI format. Must start with 's3://'")
+            return self.create_text_message(
+                "Invalid S3 URI format. Must start with 's3://'"
+            )
 
         # Ensure S3 URI ends with '/'
-        video_output_s3uri = video_output_s3uri if video_output_s3uri.endswith("/") else video_output_s3uri + "/"
+        video_output_s3uri = (
+            video_output_s3uri
+            if video_output_s3uri.endswith("/")
+            else video_output_s3uri + "/"
+        )
 
         return {
             "prompt": prompt,
@@ -110,17 +126,28 @@ class NovaReelTool(Tool):
             "dimension": tool_parameters.get("dimension", NOVA_REEL_DEFAULT_DIMENSION),
             "seed": int(tool_parameters.get("seed", 0)),
             "fps": int(tool_parameters.get("fps", NOVA_REEL_DEFAULT_FPS)),
-            "duration": int(tool_parameters.get("duration", NOVA_REEL_DEFAULT_DURATION)),
+            "duration": int(
+                tool_parameters.get("duration", NOVA_REEL_DEFAULT_DURATION)
+            ),
             "async_mode": bool(tool_parameters.get("async", True)),
         }
 
     def _initialize_aws_clients(self, region: str) -> tuple[Any, Any]:
-        """Initialize AWS Bedrock and S3 clients."""
-        bedrock = boto3.client(service_name="bedrock-runtime", region_name=region)
-        s3_client = boto3.client("s3", region_name=region)
+        """Initialize AWS Bedrock and S3 clients.
+
+        Use a fresh boto3.Session per call so disk-refreshed credentials
+        (saml2aws login, aws sso login, IMDS) are picked up without a
+        plugin restart. Same fix as #3535 / #3545.
+        """
+        bedrock = boto3.Session().client(
+            service_name="bedrock-runtime", region_name=region
+        )
+        s3_client = boto3.Session().client("s3", region_name=region)
         return bedrock, s3_client
 
-    def _prepare_model_input(self, params: dict[str, Any], s3_client: Any) -> Union[dict[str, Any], ToolInvokeMessage]:
+    def _prepare_model_input(
+        self, params: dict[str, Any], s3_client: Any
+    ) -> Union[dict[str, Any], ToolInvokeMessage]:
         """Prepare the input for the Nova Reel model."""
         model_input = {
             "taskType": "TEXT_VIDEO",
@@ -136,7 +163,9 @@ class NovaReelTool(Tool):
         # Add image if provided
         if params["image_input_s3uri"]:
             try:
-                image_data = self._get_image_from_s3(s3_client, params["image_input_s3uri"])
+                image_data = self._get_image_from_s3(
+                    s3_client, params["image_input_s3uri"]
+                )
                 if not image_data:
                     return self.create_text_message("Failed to retrieve image from S3")
 
@@ -149,18 +178,24 @@ class NovaReelTool(Tool):
                 img_buffer = BytesIO()
                 processed_image.save(img_buffer, format="PNG")
                 img_buffer.seek(0)
-                input_image_base64 = base64.b64encode(img_buffer.getvalue()).decode("utf-8")
+                input_image_base64 = base64.b64encode(img_buffer.getvalue()).decode(
+                    "utf-8"
+                )
 
                 model_input["textToVideoParams"]["images"] = [
                     {"format": "png", "source": {"bytes": input_image_base64}}
                 ]
             except Exception as e:
                 logger.error(f"Error processing input image: {str(e)}", exc_info=True)
-                return self.create_text_message(f"Failed to process input image: {str(e)}")
+                return self.create_text_message(
+                    f"Failed to process input image: {str(e)}"
+                )
 
         return model_input
 
-    def _process_and_validate_image(self, image_data: bytes) -> Union[Image.Image, ToolInvokeMessage]:
+    def _process_and_validate_image(
+        self, image_data: bytes
+    ) -> Union[Image.Image, ToolInvokeMessage]:
         """
         Process and validate the input image according to Nova Reel requirements.
 
@@ -188,13 +223,17 @@ class NovaReelTool(Tool):
                 img = img.convert("RGB")
 
             # Validate/adjust dimensions
-            if img.size != (NOVA_REEL_REQUIRED_IMAGE_WIDTH, NOVA_REEL_REQUIRED_IMAGE_HEIGHT):
+            if img.size != (
+                NOVA_REEL_REQUIRED_IMAGE_WIDTH,
+                NOVA_REEL_REQUIRED_IMAGE_HEIGHT,
+            ):
                 logger.warning(
                     f"Image dimensions {img.size} do not match required dimensions "
                     f"({NOVA_REEL_REQUIRED_IMAGE_WIDTH}x{NOVA_REEL_REQUIRED_IMAGE_HEIGHT}). Resizing..."
                 )
                 img = img.resize(
-                    (NOVA_REEL_REQUIRED_IMAGE_WIDTH, NOVA_REEL_REQUIRED_IMAGE_HEIGHT), Image.Resampling.LANCZOS
+                    (NOVA_REEL_REQUIRED_IMAGE_WIDTH, NOVA_REEL_REQUIRED_IMAGE_HEIGHT),
+                    Image.Resampling.LANCZOS,
                 )
 
             # Validate bit depth
@@ -220,7 +259,9 @@ class NovaReelTool(Tool):
         response = s3_client.get_object(Bucket=bucket, Key=key)
         return response["Body"].read()
 
-    def _start_video_generation(self, bedrock: Any, model_input: dict[str, Any], output_s3uri: str) -> dict[str, Any]:
+    def _start_video_generation(
+        self, bedrock: Any, model_input: dict[str, Any], output_s3uri: str
+    ) -> dict[str, Any]:
         """Start the async video generation process."""
         return bedrock.start_async_invoke(
             modelId=NOVA_REEL_MODEL_ID,
@@ -233,7 +274,9 @@ class NovaReelTool(Tool):
     ) -> ToolInvokeMessage:
         """Handle async or sync video generation mode."""
         invocation_response = bedrock.get_async_invoke(invocationArn=invocation_arn)
-        video_path = invocation_response["outputDataConfig"]["s3OutputDataConfig"]["s3Uri"]
+        video_path = invocation_response["outputDataConfig"]["s3OutputDataConfig"][
+            "s3Uri"
+        ]
         video_uri = f"{video_path}/output.mp4"
 
         if async_mode:
@@ -243,24 +286,32 @@ class NovaReelTool(Tool):
 
         return self._wait_for_completion(bedrock, s3_client, invocation_arn)
 
-    def _wait_for_completion(self, bedrock: Any, s3_client: Any, invocation_arn: str) -> ToolInvokeMessage:
+    def _wait_for_completion(
+        self, bedrock: Any, s3_client: Any, invocation_arn: str
+    ) -> ToolInvokeMessage:
         """Wait for video generation completion and handle the result."""
         while True:
             status_response = bedrock.get_async_invoke(invocationArn=invocation_arn)
             status = status_response["status"]
-            video_path = status_response["outputDataConfig"]["s3OutputDataConfig"]["s3Uri"]
+            video_path = status_response["outputDataConfig"]["s3OutputDataConfig"][
+                "s3Uri"
+            ]
 
             if status == "Completed":
                 return self._handle_completed_video(s3_client, video_path)
             elif status == "Failed":
                 failure_message = status_response.get("failureMessage", "Unknown error")
-                return self.create_text_message(f"Video generation failed.\nError: {failure_message}")
+                return self.create_text_message(
+                    f"Video generation failed.\nError: {failure_message}"
+                )
             elif status == "InProgress":
                 time.sleep(NOVA_REEL_STATUS_CHECK_INTERVAL)
             else:
                 return self.create_text_message(f"Unexpected status: {status}")
 
-    def _handle_completed_video(self, s3_client: Any, video_path: str) -> ToolInvokeMessage:
+    def _handle_completed_video(
+        self, s3_client: Any, video_path: str
+    ) -> ToolInvokeMessage:
         """Handle completed video generation and return the result."""
         parsed_uri = urlparse(video_path)
         bucket = parsed_uri.netloc
@@ -270,8 +321,14 @@ class NovaReelTool(Tool):
             response = s3_client.get_object(Bucket=bucket, Key=key)
             video_content = response["Body"].read()
             return [
-                self.create_text_message(f"Video is available at: {video_path}/output.mp4"),
-                self.create_blob_message(blob=video_content, meta={"mime_type": "video/mp4"}, save_as="output.mp4"),
+                self.create_text_message(
+                    f"Video is available at: {video_path}/output.mp4"
+                ),
+                self.create_blob_message(
+                    blob=video_content,
+                    meta={"mime_type": "video/mp4"},
+                    save_as="output.mp4",
+                ),
             ]
         except Exception as e:
             logger.error(f"Error downloading video: {str(e)}", exc_info=True)
@@ -290,7 +347,8 @@ class NovaReelTool(Tool):
                 required=True,
                 form=ToolParameter.ToolParameterForm.LLM,
                 human_description=I18nObject(
-                    en_us="Text description of the video you want to generate", zh_hans="您想要生成的视频的文本描述"
+                    en_us="Text description of the video you want to generate",
+                    zh_hans="您想要生成的视频的文本描述",
                 ),
                 llm_description="Describe the video you want to generate",
             ),
@@ -301,7 +359,8 @@ class NovaReelTool(Tool):
                 required=True,
                 form=ToolParameter.ToolParameterForm.FORM,
                 human_description=I18nObject(
-                    en_us="S3 URI where the generated video will be stored", zh_hans="生成的视频将存储的S3 URI"
+                    en_us="S3 URI where the generated video will be stored",
+                    zh_hans="生成的视频将存储的S3 URI",
                 ),
             ),
             ToolParameter(
@@ -311,7 +370,10 @@ class NovaReelTool(Tool):
                 required=False,
                 default=NOVA_REEL_DEFAULT_DIMENSION,
                 form=ToolParameter.ToolParameterForm.FORM,
-                human_description=I18nObject(en_us="Video dimensions (width x height)", zh_hans="视频尺寸（宽 x 高）"),
+                human_description=I18nObject(
+                    en_us="Video dimensions (width x height)",
+                    zh_hans="视频尺寸（宽 x 高）",
+                ),
             ),
             ToolParameter(
                 name="duration",
@@ -320,7 +382,9 @@ class NovaReelTool(Tool):
                 required=False,
                 default=NOVA_REEL_DEFAULT_DURATION,
                 form=ToolParameter.ToolParameterForm.FORM,
-                human_description=I18nObject(en_us="Video duration in seconds", zh_hans="视频时长（秒）"),
+                human_description=I18nObject(
+                    en_us="Video duration in seconds", zh_hans="视频时长（秒）"
+                ),
             ),
             ToolParameter(
                 name="seed",
@@ -329,7 +393,10 @@ class NovaReelTool(Tool):
                 required=False,
                 default=0,
                 form=ToolParameter.ToolParameterForm.FORM,
-                human_description=I18nObject(en_us="Random seed for video generation", zh_hans="视频生成的随机种子"),
+                human_description=I18nObject(
+                    en_us="Random seed for video generation",
+                    zh_hans="视频生成的随机种子",
+                ),
             ),
             ToolParameter(
                 name="fps",
@@ -339,7 +406,8 @@ class NovaReelTool(Tool):
                 default=NOVA_REEL_DEFAULT_FPS,
                 form=ToolParameter.ToolParameterForm.FORM,
                 human_description=I18nObject(
-                    en_us="Frames per second for the generated video", zh_hans="生成视频的每秒帧数"
+                    en_us="Frames per second for the generated video",
+                    zh_hans="生成视频的每秒帧数",
                 ),
             ),
             ToolParameter(
@@ -361,7 +429,10 @@ class NovaReelTool(Tool):
                 required=False,
                 default=NOVA_REEL_DEFAULT_REGION,
                 form=ToolParameter.ToolParameterForm.FORM,
-                human_description=I18nObject(en_us="AWS region for Bedrock service", zh_hans="Bedrock 服务的 AWS 区域"),
+                human_description=I18nObject(
+                    en_us="AWS region for Bedrock service",
+                    zh_hans="Bedrock 服务的 AWS 区域",
+                ),
             ),
             ToolParameter(
                 name="image_input_s3uri",

--- a/tools/aws/tools/opensearch_knn_search.py
+++ b/tools/aws/tools/opensearch_knn_search.py
@@ -10,35 +10,54 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
 
-class OpenSearchRetrieveTool(Tool):
-    os_client: Any = None
-    bedrock_client: Any = None
-    s3_client: Any = None
 
-    def _get_embedding(self, model_id:str, text:str=None, image_path:str=None, dimension:int=1024):
+def _build_boto3_session(credentials: dict) -> Any:
+    """Build a fresh ``boto3.Session`` for a given region.
+
+    Mirrors the per-call ``boto3.Session()`` pattern from
+    ``tools/aws`` PR #3545 (Bedrock family) and the in-progress
+    boto3 batch under issue #3544. boto3's default session caches
+    credentials in-process, so a ``saml2aws login`` /
+    ``aws sso login`` / IMDS refresh after the plugin process
+    started never reaches the cached client. Building a fresh
+    session on every invocation picks up the new credentials.
+    """
+    return boto3.Session(region_name=credentials.get("aws_region"))
+
+
+class OpenSearchRetrieveTool(Tool):
+    def _get_embedding(
+        self,
+        model_id: str,
+        text: str = None,
+        image_path: str = None,
+        dimension: int = 1024,
+        s3_client: Any = None,
+        bedrock_client: Any = None,
+    ):
         image_base64 = None
 
-        def parse_s3_url(s3_url:str):
+        def parse_s3_url(s3_url: str):
             if s3_url.startswith("s3://"):
                 s3_url = s3_url[5:]
 
-            parts = s3_url.split('/', 1)
-            
+            parts = s3_url.split("/", 1)
+
             if len(parts) == 2:
                 bucket_name = parts[0]
                 object_key = parts[1]
             else:
                 bucket_name = parts[0]
-                object_key = ''
-            
+                object_key = ""
+
             return bucket_name, object_key
 
         if image_path:
             try:
                 bucket_name, object_key = parse_s3_url(image_path)
-                response = self.s3_client.get_object(Bucket=bucket_name, Key=object_key)
-                image_content = response['Body'].read()
-                image_base64 = base64.b64encode(image_content).decode('utf-8')
+                response = s3_client.get_object(Bucket=bucket_name, Key=object_key)
+                image_content = response["Body"].read()
+                image_base64 = base64.b64encode(image_content).decode("utf-8")
             except Exception as e:
                 self.create_text_message(f"'{image_path}' is not valid image path")
                 pass
@@ -50,43 +69,43 @@ class OpenSearchRetrieveTool(Tool):
         if image_base64:
             request_body["inputImage"] = image_base64
 
-        embedding_config = {
-            "embeddingConfig": { 
-                 "outputEmbeddingLength": dimension
-            }
-        }
+        embedding_config = {"embeddingConfig": {"outputEmbeddingLength": dimension}}
         body = json.dumps({**request_body, **embedding_config})
-        response = self.bedrock_client.invoke_model(
+        response = bedrock_client.invoke_model(
             body=body,
             modelId=model_id,
             accept="application/json",
-            contentType="application/json")
+            contentType="application/json",
+        )
         response_body = json.loads(response.get("body").read())
         return response_body.get("embedding")
 
-    def _search_by_aos_knn(self, q_embedding, index_name:str, embedding_field:str, meta_field_list:list[str], size:int=5):
+    def _search_by_aos_knn(
+        self,
+        q_embedding,
+        index_name: str,
+        embedding_field: str,
+        meta_field_list: list[str],
+        size: int = 5,
+        os_client: Any = None,
+    ):
         query = {
             "size": size,
             "query": {
-                "knn": {
-                    f"{embedding_field}" : {
-                        "vector": q_embedding,
-                        "k": size
-                    }
-                }
-            }
+                "knn": {f"{embedding_field}": {"vector": q_embedding, "k": size}}
+            },
         }
 
         opensearch_knn_respose = []
-        query_response = self.os_client.search(
-            body=query,
-            index=index_name
-        )
+        query_response = os_client.search(body=query, index=index_name)
 
         results = []
         for item in query_response["hits"]["hits"]:
-            result_obj = { field_name: item['_source'][field_name] for field_name in meta_field_list }
-            result_obj['score'] = item['_score']
+            result_obj = {
+                field_name: item["_source"][field_name]
+                for field_name in meta_field_list
+            }
+            result_obj["score"] = item["_score"]
             results.append(result_obj)
 
         return results
@@ -100,26 +119,25 @@ class OpenSearchRetrieveTool(Tool):
         """
         try:
             aws_region = tool_parameters.get("aws_region")
-            if not self.os_client:
-                opensearch_endpoint = tool_parameters.get("opensearch_endpoint").replace("https://","")
-                index_name = tool_parameters.get("index_name")
+            opensearch_endpoint = tool_parameters.get("opensearch_endpoint").replace(
+                "https://", ""
+            )
+            index_name = tool_parameters.get("index_name")
 
-                credentials = boto3.Session().get_credentials()
-                awsauth = AWSV4SignerAuth(credentials, aws_region, "aoss")
-
-                # 创建 OpenSearch 客户端
-                self.os_client = OpenSearch(
-                    hosts=[{'host': opensearch_endpoint, 'port': 443}],
-                    http_auth=awsauth,
-                    use_ssl=True,
-                    verify_certs=True,
-                    connection_class=RequestsHttpConnection
-                )
-            if not self.s3_client:
-                self.s3_client = boto3.client(service_name="s3", region_name=aws_region)
-
-            if not self.bedrock_client:
-                self.bedrock_client = boto3.client(service_name="bedrock-runtime", region_name=aws_region)
+            # Build fresh clients per invocation so disk-refreshed
+            # credentials are picked up on every call. See issue #3544.
+            session = _build_boto3_session(tool_parameters)
+            credentials = session.get_credentials()
+            awsauth = AWSV4SignerAuth(credentials, aws_region, "aoss")
+            os_client = OpenSearch(
+                hosts=[{"host": opensearch_endpoint, "port": 443}],
+                http_auth=awsauth,
+                use_ssl=True,
+                verify_certs=True,
+                connection_class=RequestsHttpConnection,
+            )
+            s3_client = session.client(service_name="s3")
+            bedrock_client = session.client(service_name="bedrock-runtime")
 
             emb_model_id = tool_parameters.get("embedding_model_id")
             embedding_field = tool_parameters.get("embedding_field")
@@ -129,20 +147,25 @@ class OpenSearchRetrieveTool(Tool):
             vector_size = int(tool_parameters.get("vector_size"))
             topk = tool_parameters.get("topk")
 
-            embedding = self._get_embedding(model_id=emb_model_id, 
-                text=query_text, 
-                image_path=image_s3_path, 
-                dimension=vector_size
+            embedding = self._get_embedding(
+                model_id=emb_model_id,
+                text=query_text,
+                image_path=image_s3_path,
+                dimension=vector_size,
+                s3_client=s3_client,
+                bedrock_client=bedrock_client,
             )
 
-            result = self._search_by_aos_knn(q_embedding=embedding, 
-                index_name=index_name, 
-                embedding_field=embedding_field, 
-                meta_field_list=metadata_fields, 
-                size=topk
+            result = self._search_by_aos_knn(
+                q_embedding=embedding,
+                index_name=index_name,
+                embedding_field=embedding_field,
+                meta_field_list=metadata_fields,
+                size=topk,
+                os_client=os_client,
             )
 
-            yield self.create_json_message({"results":result})
+            yield self.create_json_message({"results": result})
 
         except Exception as e:
             yield self.create_text_message(f"Exception: {str(e)}")

--- a/tools/aws/tools/s3_file_download.py
+++ b/tools/aws/tools/s3_file_download.py
@@ -29,17 +29,21 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 def _resolve_aws_credentials(
     tool: Any, tool_parameters: dict[str, Any]
 ) -> dict[str, Optional[str]]:
-    runtime_credentials = getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+    runtime_credentials = (
+        getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+    )
 
-    aws_access_key_id = tool_parameters.get("aws_access_key_id") or runtime_credentials.get(
+    aws_access_key_id = tool_parameters.get(
         "aws_access_key_id"
-    )
-    aws_secret_access_key = tool_parameters.get("aws_secret_access_key") or runtime_credentials.get(
+    ) or runtime_credentials.get("aws_access_key_id")
+    aws_secret_access_key = tool_parameters.get(
         "aws_secret_access_key"
-    )
+    ) or runtime_credentials.get("aws_secret_access_key")
     aws_session_token = tool_parameters.get("aws_session_token")
     aws_region = (
-        tool_parameters.get("aws_region") or runtime_credentials.get("aws_region") or "us-east-1"
+        tool_parameters.get("aws_region")
+        or runtime_credentials.get("aws_region")
+        or "us-east-1"
     )
 
     return {
@@ -54,7 +58,9 @@ def _build_boto3_client_kwargs(credentials: dict[str, Optional[str]]) -> dict[st
     kwargs: dict[str, Any] = {}
     if credentials.get("aws_region"):
         kwargs["region_name"] = credentials["aws_region"]
-    if credentials.get("aws_access_key_id") and credentials.get("aws_secret_access_key"):
+    if credentials.get("aws_access_key_id") and credentials.get(
+        "aws_secret_access_key"
+    ):
         kwargs["aws_access_key_id"] = credentials["aws_access_key_id"]
         kwargs["aws_secret_access_key"] = credentials["aws_secret_access_key"]
         if credentials.get("aws_session_token"):
@@ -87,12 +93,17 @@ class S3FileDownload(Tool):
     another invocation.
     """
 
-    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
         """Download an S3 object and emit it as a Dify file plus metadata."""
         try:
             credentials = _resolve_aws_credentials(self, tool_parameters)
             client_kwargs = _build_boto3_client_kwargs(credentials)
-            s3_client = boto3.client("s3", **client_kwargs)
+            # Use a fresh boto3.Session per call so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked
+            # up without a plugin restart. Same fix as #3535 / #3545.
+            s3_client = boto3.Session().client("s3", **client_kwargs)
         except Exception as exc:  # pragma: no cover - boto3 init errors
             yield self.create_text_message(f"Failed to initialize AWS client: {exc}")
             return
@@ -124,7 +135,9 @@ class S3FileDownload(Tool):
                 )
                 return
             error_message = exc.response.get("Error", {}).get("Message", str(exc))
-            yield self.create_text_message(f"Failed to download S3 object: {error_message}")
+            yield self.create_text_message(
+                f"Failed to download S3 object: {error_message}"
+            )
             return
         except Exception as exc:
             yield self.create_text_message(f"Failed to download S3 object: {exc}")
@@ -143,7 +156,9 @@ class S3FileDownload(Tool):
             "content_length": response.get("ContentLength"),
             "etag": response.get("ETag"),
             "last_modified": (
-                response.get("LastModified").isoformat() if response.get("LastModified") else None
+                response.get("LastModified").isoformat()
+                if response.get("LastModified")
+                else None
             ),
             "s3_uri": s3_uri,
         }

--- a/tools/aws/tools/s3_file_uploader.py
+++ b/tools/aws/tools/s3_file_uploader.py
@@ -35,17 +35,21 @@ def _resolve_aws_credentials(
     only sourced from tool parameters because the provider schema does not
     expose it (STS-issued temporary credentials are passed inline).
     """
-    runtime_credentials = getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+    runtime_credentials = (
+        getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+    )
 
-    aws_access_key_id = tool_parameters.get("aws_access_key_id") or runtime_credentials.get(
+    aws_access_key_id = tool_parameters.get(
         "aws_access_key_id"
-    )
-    aws_secret_access_key = tool_parameters.get("aws_secret_access_key") or runtime_credentials.get(
+    ) or runtime_credentials.get("aws_access_key_id")
+    aws_secret_access_key = tool_parameters.get(
         "aws_secret_access_key"
-    )
+    ) or runtime_credentials.get("aws_secret_access_key")
     aws_session_token = tool_parameters.get("aws_session_token")
     aws_region = (
-        tool_parameters.get("aws_region") or runtime_credentials.get("aws_region") or "us-east-1"
+        tool_parameters.get("aws_region")
+        or runtime_credentials.get("aws_region")
+        or "us-east-1"
     )
 
     return {
@@ -61,7 +65,9 @@ def _build_boto3_client_kwargs(credentials: dict[str, Optional[str]]) -> dict[st
     kwargs: dict[str, Any] = {}
     if credentials.get("aws_region"):
         kwargs["region_name"] = credentials["aws_region"]
-    if credentials.get("aws_access_key_id") and credentials.get("aws_secret_access_key"):
+    if credentials.get("aws_access_key_id") and credentials.get(
+        "aws_secret_access_key"
+    ):
         kwargs["aws_access_key_id"] = credentials["aws_access_key_id"]
         kwargs["aws_secret_access_key"] = credentials["aws_secret_access_key"]
         if credentials.get("aws_session_token"):
@@ -107,12 +113,17 @@ class S3FileUploader(Tool):
     another invocation.
     """
 
-    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
         """Read the input file and upload it to S3, returning the resulting URI as JSON."""
         try:
             credentials = _resolve_aws_credentials(self, tool_parameters)
             client_kwargs = _build_boto3_client_kwargs(credentials)
-            s3_client = boto3.client("s3", **client_kwargs)
+            # Use a fresh boto3.Session per call so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked
+            # up without a plugin restart. Same fix as #3535 / #3545.
+            s3_client = boto3.Session().client("s3", **client_kwargs)
         except Exception as exc:  # pragma: no cover - boto3 init errors
             yield self.create_text_message(f"Failed to initialize AWS client: {exc}")
             return
@@ -134,7 +145,9 @@ class S3FileUploader(Tool):
             return
 
         key_prefix = _sanitize_prefix(tool_parameters.get("key_prefix"))
-        requested_key = tool_parameters.get("object_key") or getattr(input_file, "filename", None)
+        requested_key = tool_parameters.get("object_key") or getattr(
+            input_file, "filename", None
+        )
         fallback_key = (
             getattr(input_file, "url", "").rstrip("/").split("/")[-1]
             if getattr(input_file, "url", None)
@@ -145,7 +158,9 @@ class S3FileUploader(Tool):
         if key_prefix:
             object_key = f"{key_prefix}/{object_key}"
 
-        content_type = getattr(input_file, "mime_type", None) or "application/octet-stream"
+        content_type = (
+            getattr(input_file, "mime_type", None) or "application/octet-stream"
+        )
 
         try:
             s3_client.put_object(
@@ -156,7 +171,9 @@ class S3FileUploader(Tool):
             )
         except ClientError as exc:
             error_message = exc.response.get("Error", {}).get("Message", str(exc))
-            yield self.create_text_message(f"Failed to upload file to S3: {error_message}")
+            yield self.create_text_message(
+                f"Failed to upload file to S3: {error_message}"
+            )
             return
 
         s3_uri = f"s3://{bucket_name}/{object_key}"
@@ -168,7 +185,9 @@ class S3FileUploader(Tool):
 
         text_message = None
         if tool_parameters.get("generate_presign_url"):
-            expiry_seconds = _parse_presign_expiry(tool_parameters.get("presign_expiry"))
+            expiry_seconds = _parse_presign_expiry(
+                tool_parameters.get("presign_expiry")
+            )
             try:
                 presigned_url = s3_client.generate_presigned_url(
                     "get_object",

--- a/tools/aws/tools/s3_files_download.py
+++ b/tools/aws/tools/s3_files_download.py
@@ -35,17 +35,21 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 def _resolve_aws_credentials(
     tool: Any, tool_parameters: dict[str, Any]
 ) -> dict[str, Optional[str]]:
-    runtime_credentials = getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+    runtime_credentials = (
+        getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+    )
 
-    aws_access_key_id = tool_parameters.get("aws_access_key_id") or runtime_credentials.get(
+    aws_access_key_id = tool_parameters.get(
         "aws_access_key_id"
-    )
-    aws_secret_access_key = tool_parameters.get("aws_secret_access_key") or runtime_credentials.get(
+    ) or runtime_credentials.get("aws_access_key_id")
+    aws_secret_access_key = tool_parameters.get(
         "aws_secret_access_key"
-    )
+    ) or runtime_credentials.get("aws_secret_access_key")
     aws_session_token = tool_parameters.get("aws_session_token")
     aws_region = (
-        tool_parameters.get("aws_region") or runtime_credentials.get("aws_region") or "us-east-1"
+        tool_parameters.get("aws_region")
+        or runtime_credentials.get("aws_region")
+        or "us-east-1"
     )
 
     return {
@@ -60,7 +64,9 @@ def _build_boto3_client_kwargs(credentials: dict[str, Optional[str]]) -> dict[st
     kwargs: dict[str, Any] = {}
     if credentials.get("aws_region"):
         kwargs["region_name"] = credentials["aws_region"]
-    if credentials.get("aws_access_key_id") and credentials.get("aws_secret_access_key"):
+    if credentials.get("aws_access_key_id") and credentials.get(
+        "aws_secret_access_key"
+    ):
         kwargs["aws_access_key_id"] = credentials["aws_access_key_id"]
         kwargs["aws_secret_access_key"] = credentials["aws_secret_access_key"]
         if credentials.get("aws_session_token"):
@@ -126,19 +132,26 @@ class S3FilesDownload(Tool):
     safe because all entries share the same credential bundle.
     """
 
-    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
         """Download every input URI and emit aggregated files + metadata."""
         try:
             credentials = _resolve_aws_credentials(self, tool_parameters)
             client_kwargs = _build_boto3_client_kwargs(credentials)
-            s3_client = boto3.client("s3", **client_kwargs)
+            # Use a fresh boto3.Session per call so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked
+            # up without a plugin restart. Same fix as #3535 / #3545.
+            s3_client = boto3.Session().client("s3", **client_kwargs)
         except Exception as exc:  # pragma: no cover - boto3 init errors
             yield self.create_text_message(f"Failed to initialize AWS client: {exc}")
             return
 
         s3_uris = _normalize_s3_uris(tool_parameters.get("s3_uris"))
         if not s3_uris:
-            yield self.create_text_message("s3_uris parameter is required and must not be empty")
+            yield self.create_text_message(
+                "s3_uris parameter is required and must not be empty"
+            )
             return
 
         results: list[dict[str, Any]] = []
@@ -170,9 +183,13 @@ class S3FilesDownload(Tool):
                 if error_code == "NoSuchBucket":
                     entry["error"] = f"Bucket '{bucket}' does not exist"
                 elif error_code == "NoSuchKey":
-                    entry["error"] = f"Object '{key}' does not exist in bucket '{bucket}'"
+                    entry["error"] = (
+                        f"Object '{key}' does not exist in bucket '{bucket}'"
+                    )
                 else:
-                    entry["error"] = exc.response.get("Error", {}).get("Message", str(exc))
+                    entry["error"] = exc.response.get("Error", {}).get(
+                        "Message", str(exc)
+                    )
                 entry["status"] = "failed"
                 results.append(entry)
                 continue
@@ -202,7 +219,9 @@ class S3FilesDownload(Tool):
             if response.get("BucketKeyEnabled"):
                 entry["bucket_key_enabled"] = True
             entry["last_modified"] = (
-                response.get("LastModified").isoformat() if response.get("LastModified") else None
+                response.get("LastModified").isoformat()
+                if response.get("LastModified")
+                else None
             )
             entry["filename"] = filename
 
@@ -247,7 +266,9 @@ class S3FilesDownload(Tool):
         yield self.create_json_message(json_payload)
 
         if ok_count == 0:
-            yield self.create_text_message("All downloads failed:\n" + "\n\n".join(text_lines))
+            yield self.create_text_message(
+                "All downloads failed:\n" + "\n\n".join(text_lines)
+            )
         else:
             yield self.create_text_message("\n\n".join(text_lines))
 

--- a/tools/aws/tools/s3_files_uploader.py
+++ b/tools/aws/tools/s3_files_uploader.py
@@ -43,17 +43,21 @@ def _resolve_aws_credentials(
     tool: Any, tool_parameters: dict[str, Any]
 ) -> dict[str, Optional[str]]:
     """Merge provider-level credentials with per-invocation tool parameters."""
-    runtime_credentials = getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+    runtime_credentials = (
+        getattr(getattr(tool, "runtime", None), "credentials", {}) or {}
+    )
 
-    aws_access_key_id = tool_parameters.get("aws_access_key_id") or runtime_credentials.get(
+    aws_access_key_id = tool_parameters.get(
         "aws_access_key_id"
-    )
-    aws_secret_access_key = tool_parameters.get("aws_secret_access_key") or runtime_credentials.get(
+    ) or runtime_credentials.get("aws_access_key_id")
+    aws_secret_access_key = tool_parameters.get(
         "aws_secret_access_key"
-    )
+    ) or runtime_credentials.get("aws_secret_access_key")
     aws_session_token = tool_parameters.get("aws_session_token")
     aws_region = (
-        tool_parameters.get("aws_region") or runtime_credentials.get("aws_region") or "us-east-1"
+        tool_parameters.get("aws_region")
+        or runtime_credentials.get("aws_region")
+        or "us-east-1"
     )
 
     return {
@@ -69,7 +73,9 @@ def _build_boto3_client_kwargs(credentials: dict[str, Optional[str]]) -> dict[st
     kwargs: dict[str, Any] = {}
     if credentials.get("aws_region"):
         kwargs["region_name"] = credentials["aws_region"]
-    if credentials.get("aws_access_key_id") and credentials.get("aws_secret_access_key"):
+    if credentials.get("aws_access_key_id") and credentials.get(
+        "aws_secret_access_key"
+    ):
         kwargs["aws_access_key_id"] = credentials["aws_access_key_id"]
         kwargs["aws_secret_access_key"] = credentials["aws_secret_access_key"]
         if credentials.get("aws_session_token"):
@@ -243,7 +249,9 @@ def _derive_object_key(input_file: Any, key_prefix: str) -> str:
     requested_key = _attr(input_file, "filename")
     url_value = _attr(input_file, "url") or _attr(input_file, "remote_url")
     fallback_key = (
-        url_value.rstrip("/").split("/")[-1] if isinstance(url_value, str) and url_value else None
+        url_value.rstrip("/").split("/")[-1]
+        if isinstance(url_value, str) and url_value
+        else None
     )
     object_key = requested_key or fallback_key or f"dify-upload-{uuid.uuid4().hex}"
     object_key = object_key.lstrip("/")
@@ -266,14 +274,19 @@ class S3FilesUploader(Tool):
     which is safe because all entries share the same credential bundle.
     """
 
-    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+    def _invoke(
+        self, tool_parameters: dict[str, Any]
+    ) -> Generator[ToolInvokeMessage, None, None]:
         """Read all input files, upload them, and emit aggregated results."""
         # Initialize the S3 client up front. A failure here aborts the whole
         # batch because no per-file work can succeed without a client.
         try:
             credentials = _resolve_aws_credentials(self, tool_parameters)
             client_kwargs = _build_boto3_client_kwargs(credentials)
-            s3_client = boto3.client("s3", **client_kwargs)
+            # Use a fresh boto3.Session per call so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked
+            # up without a plugin restart. Same fix as #3535 / #3545.
+            s3_client = boto3.Session().client("s3", **client_kwargs)
         except Exception as exc:  # pragma: no cover - boto3 init errors
             yield self.create_text_message(f"Failed to initialize AWS client: {exc}")
             return
@@ -301,7 +314,9 @@ class S3FilesUploader(Tool):
         try:
             sse_put_kwargs = _build_sse_put_object_kwargs(tool_parameters)
         except ValueError as exc:
-            yield self.create_text_message(f"Server-side encryption misconfigured: {exc}")
+            yield self.create_text_message(
+                f"Server-side encryption misconfigured: {exc}"
+            )
             return
 
         # Track keys we've already used so a duplicate filename in the same
@@ -389,7 +404,9 @@ class S3FilesUploader(Tool):
                     # presign failure as a per-entry warning (`presign_error`)
                     # rather than failing the whole batch.
                     if isinstance(exc, ClientError):
-                        error_message = exc.response.get("Error", {}).get("Message", str(exc))
+                        error_message = exc.response.get("Error", {}).get(
+                            "Message", str(exc)
+                        )
                     else:
                         error_message = str(exc)
                     entry["presign_error"] = error_message
@@ -420,6 +437,8 @@ class S3FilesUploader(Tool):
         yield self.create_json_message(json_payload)
 
         if ok_count == 0:
-            yield self.create_text_message("All uploads failed:\n" + "\n".join(text_lines))
+            yield self.create_text_message(
+                "All uploads failed:\n" + "\n".join(text_lines)
+            )
         else:
             yield self.create_text_message("\n".join(text_lines))

--- a/tools/aws/tools/s3_operator.py
+++ b/tools/aws/tools/s3_operator.py
@@ -12,9 +12,8 @@ from typing import Any
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
-class S3Operator(Tool):
-    s3_client: Any = None
 
+class S3Operator(Tool):
     def _invoke(
         self,
         tool_parameters: dict[str, Any],
@@ -22,14 +21,16 @@ class S3Operator(Tool):
         """
         invoke tools
         """
+        s3_client = None
         try:
-            # Initialize S3 client if not already done
-            if not self.s3_client:
-                aws_region = tool_parameters.get("aws_region")
-                if aws_region:
-                    self.s3_client = boto3.client("s3", region_name=aws_region)
-                else:
-                    self.s3_client = boto3.client("s3")
+            # Build a fresh boto3 client per invocation so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked
+            # up without a plugin restart. Same fix as #3535 / #3545.
+            aws_region = tool_parameters.get("aws_region")
+            if aws_region:
+                s3_client = boto3.Session().client("s3", region_name=aws_region)
+            else:
+                s3_client = boto3.Session().client("s3")
 
             # Parse S3 URI
             s3_uri = tool_parameters.get("s3_uri")
@@ -38,7 +39,9 @@ class S3Operator(Tool):
 
             parsed_uri = urlparse(s3_uri)
             if parsed_uri.scheme != "s3":
-                yield self.create_text_message("Invalid S3 URI format. Must start with 's3://'")
+                yield self.create_text_message(
+                    "Invalid S3 URI format. Must start with 's3://'"
+                )
 
             bucket = parsed_uri.netloc
             # Remove leading slash from key
@@ -46,12 +49,16 @@ class S3Operator(Tool):
 
             operation_type = tool_parameters.get("operation_type", "read")
             generate_presign_url = tool_parameters.get("generate_presign_url", False)
-            presign_expiry = int(tool_parameters.get("presign_expiry", 3600))  # default 1 hour
+            presign_expiry = int(
+                tool_parameters.get("presign_expiry", 3600)
+            )  # default 1 hour
 
             if operation_type == "write":
                 text_content = tool_parameters.get("text_content")
                 if not text_content:
-                    yield self.create_text_message("text_content parameter is required for write operation")
+                    yield self.create_text_message(
+                        "text_content parameter is required for write operation"
+                    )
 
                 # Infer content type from file extension
                 content_type, _ = mimetypes.guess_type(key)
@@ -59,38 +66,44 @@ class S3Operator(Tool):
                     content_type = "text/plain; charset=utf-8"
 
                 # Write content to S3
-                self.s3_client.put_object(
-                    Bucket=bucket, 
-                    Key=key, 
+                s3_client.put_object(
+                    Bucket=bucket,
+                    Key=key,
                     Body=text_content.encode("utf-8"),
-                    ContentType=content_type
+                    ContentType=content_type,
                 )
                 result = f"s3://{bucket}/{key}"
 
                 # Generate presigned URL for the written object if requested
                 if generate_presign_url:
-                    result = self.s3_client.generate_presigned_url(
-                        "get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=presign_expiry
+                    result = s3_client.generate_presigned_url(
+                        "get_object",
+                        Params={"Bucket": bucket, "Key": key},
+                        ExpiresIn=presign_expiry,
                     )
 
             else:  # read operation
                 # Get object from S3
                 if generate_presign_url:
                     # Generate presigned URL if requested
-                    result = self.s3_client.generate_presigned_url(
-                        "get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=presign_expiry
+                    result = s3_client.generate_presigned_url(
+                        "get_object",
+                        Params={"Bucket": bucket, "Key": key},
+                        ExpiresIn=presign_expiry,
                     )
-                else: 
+                else:
                     # Only for text
-                    response = self.s3_client.get_object(Bucket=bucket, Key=key)
+                    response = s3_client.get_object(Bucket=bucket, Key=key)
                     result = response["Body"].read().decode("utf-8")
 
                 # Generate presigned URL if requested
             yield self.create_text_message(text=result)
 
-        except self.s3_client.exceptions.NoSuchBucket:
+        except s3_client.exceptions.NoSuchBucket:
             yield self.create_text_message(f"Bucket '{bucket}' does not exist")
-        except self.s3_client.exceptions.NoSuchKey:
-            yield self.create_text_message(f"Object '{key}' does not exist in bucket '{bucket}'")
+        except s3_client.exceptions.NoSuchKey:
+            yield self.create_text_message(
+                f"Object '{key}' does not exist in bucket '{bucket}'"
+            )
         except Exception as e:
             yield self.create_text_message(f"Exception: {str(e)}")

--- a/tools/aws/tools/sagemaker_chinese_toxicity_detector.py
+++ b/tools/aws/tools/sagemaker_chinese_toxicity_detector.py
@@ -13,11 +13,10 @@ LABEL_MAPPING = {0: "SAFE", 1: "NO_SAFE"}
 
 
 class ContentModerationTool(Tool):
-    sagemaker_client: Any = None
     sagemaker_endpoint: str = None
 
-    def _invoke_sagemaker(self, payload: dict, endpoint: str):
-        response = self.sagemaker_client.invoke_endpoint(
+    def _invoke_sagemaker(self, payload: dict, endpoint: str, sagemaker_client):
+        response = sagemaker_client.invoke_endpoint(
             EndpointName=endpoint,
             Body=json.dumps(payload),
             ContentType="application/json",
@@ -35,7 +34,9 @@ class ContentModerationTool(Tool):
             prediction_result = json_obj.get("prediction")
 
         # Map labels and return
-        result = LABEL_MAPPING.get(prediction_result, "NO_SAFE")  # If not found in mapping, default to NO_SAFE
+        result = LABEL_MAPPING.get(
+            prediction_result, "NO_SAFE"
+        )  # If not found in mapping, default to NO_SAFE
         return result
 
     def _invoke(
@@ -45,13 +46,18 @@ class ContentModerationTool(Tool):
         """
         invoke tools
         """
+        sagemaker_client = None
         try:
-            if not self.sagemaker_client:
-                aws_region = tool_parameters.get("aws_region")
-                if aws_region:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime", region_name=aws_region)
-                else:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime")
+            # Build a fresh boto3 client per invocation so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked
+            # up without a plugin restart. Same fix as #3535 / #3545.
+            aws_region = tool_parameters.get("aws_region")
+            if aws_region:
+                sagemaker_client = boto3.Session().client(
+                    "sagemaker-runtime", region_name=aws_region
+                )
+            else:
+                sagemaker_client = boto3.Session().client("sagemaker-runtime")
 
             if not self.sagemaker_endpoint:
                 self.sagemaker_endpoint = tool_parameters.get("sagemaker_endpoint")
@@ -60,7 +66,9 @@ class ContentModerationTool(Tool):
 
             payload = {"text": content_text}
 
-            result = self._invoke_sagemaker(payload, self.sagemaker_endpoint)
+            result = self._invoke_sagemaker(
+                payload, self.sagemaker_endpoint, sagemaker_client
+            )
 
             yield self.create_text_message(text=result)
 

--- a/tools/aws/tools/sagemaker_text_rerank.py
+++ b/tools/aws/tools/sagemaker_text_rerank.py
@@ -8,13 +8,15 @@ import boto3
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
+
 class SageMakerReRankTool(Tool):
-    sagemaker_client: Any = None
     sagemaker_endpoint: str = None
 
-    def _sagemaker_rerank(self, query_input: str, docs: list[str], rerank_endpoint: str):
+    def _sagemaker_rerank(
+        self, query_input: str, docs: list[str], rerank_endpoint: str, sagemaker_client
+    ):
         inputs = [query_input] * len(docs)
-        response_model = self.sagemaker_client.invoke_endpoint(
+        response_model = sagemaker_client.invoke_endpoint(
             EndpointName=rerank_endpoint,
             Body=json.dumps({"inputs": inputs, "docs": docs}),
             ContentType="application/json",
@@ -32,13 +34,18 @@ class SageMakerReRankTool(Tool):
         invoke tools
         """
         line = 0
+        sagemaker_client = None
         try:
-            if not self.sagemaker_client:
-                aws_region = tool_parameters.get("aws_region")
-                if aws_region:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime", region_name=aws_region)
-                else:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime")
+            # Build a fresh boto3 client per invocation so disk-refreshed
+            # credentials (saml2aws login, aws sso login, IMDS) are picked
+            # up without a plugin restart. Same fix as #3535 / #3545.
+            aws_region = tool_parameters.get("aws_region")
+            if aws_region:
+                sagemaker_client = boto3.Session().client(
+                    "sagemaker-runtime", region_name=aws_region
+                )
+            else:
+                sagemaker_client = boto3.Session().client("sagemaker-runtime")
 
             line = 1
             if not self.sagemaker_endpoint:
@@ -62,19 +69,24 @@ class SageMakerReRankTool(Tool):
             docs = [item.get("content") for item in candidate_docs]
 
             line = 6
-            scores = self._sagemaker_rerank(query_input=query, docs=docs, rerank_endpoint=self.sagemaker_endpoint)
+            scores = self._sagemaker_rerank(
+                query_input=query,
+                docs=docs,
+                rerank_endpoint=self.sagemaker_endpoint,
+                sagemaker_client=sagemaker_client,
+            )
 
             line = 7
             for idx in range(len(candidate_docs)):
                 candidate_docs[idx]["score"] = scores[idx]
 
             line = 8
-            sorted_candidate_docs = sorted(candidate_docs, key=operator.itemgetter("score"), reverse=True)
+            sorted_candidate_docs = sorted(
+                candidate_docs, key=operator.itemgetter("score"), reverse=True
+            )
 
             line = 9
-            json_result = {
-                "results" : sorted_candidate_docs[:topk]
-            }
+            json_result = {"results": sorted_candidate_docs[:topk]}
             yield self.create_json_message(json_result)
 
         except Exception as e:

--- a/tools/aws/tools/sagemaker_tts.py
+++ b/tools/aws/tools/sagemaker_tts.py
@@ -17,15 +17,20 @@ class TTSModelType(Enum):
 
 
 class SageMakerTTSTool(Tool):
-    sagemaker_client: Any = None
     sagemaker_endpoint: str | None = None
-    s3_client: Any = None
-    comprehend_client: Any = None
 
-    def _detect_lang_code(self, content: str, map_dict: Optional[dict] = None):
-        map_dict = {"zh": "<|zh|>", "en": "<|en|>", "ja": "<|jp|>", "zh-TW": "<|yue|>", "ko": "<|ko|>"}
+    def _detect_lang_code(
+        self, content: str, comprehend_client: Any, map_dict: Optional[dict] = None
+    ):
+        map_dict = {
+            "zh": "<|zh|>",
+            "en": "<|en|>",
+            "ja": "<|jp|>",
+            "zh-TW": "<|yue|>",
+            "ko": "<|ko|>",
+        }
 
-        response = self.comprehend_client.detect_dominant_language(Text=content)
+        response = comprehend_client.detect_dominant_language(Text=content)
         language_code = response["Languages"][0]["LanguageCode"]
         return map_dict.get(language_code, "<|zh|>")
 
@@ -37,21 +42,38 @@ class SageMakerTTSTool(Tool):
         prompt_text: str,
         prompt_audio: str,
         instruct_text: str,
+        comprehend_client: Any,
     ):
         if model_type == TTSModelType.PresetVoice.value and model_role:
             return {"tts_text": content_text, "role": model_role}
         if model_type == TTSModelType.CloneVoice.value and prompt_text and prompt_audio:
-            return {"tts_text": content_text, "prompt_text": prompt_text, "prompt_audio": prompt_audio}
+            return {
+                "tts_text": content_text,
+                "prompt_text": prompt_text,
+                "prompt_audio": prompt_audio,
+            }
         if model_type == TTSModelType.CloneVoice_CrossLingual.value and prompt_audio:
-            lang_tag = self._detect_lang_code(content_text)
-            return {"tts_text": f"{content_text}", "prompt_audio": prompt_audio, "lang_tag": lang_tag}
-        if model_type == TTSModelType.InstructVoice.value and instruct_text and model_role:
-            return {"tts_text": content_text, "role": model_role, "instruct_text": instruct_text}
+            lang_tag = self._detect_lang_code(content_text, comprehend_client)
+            return {
+                "tts_text": f"{content_text}",
+                "prompt_audio": prompt_audio,
+                "lang_tag": lang_tag,
+            }
+        if (
+            model_type == TTSModelType.InstructVoice.value
+            and instruct_text
+            and model_role
+        ):
+            return {
+                "tts_text": content_text,
+                "role": model_role,
+                "instruct_text": instruct_text,
+            }
 
         raise RuntimeError(f"Invalid params for {model_type}")
 
-    def _invoke_sagemaker(self, payload: dict, endpoint: str):
-        response_model = self.sagemaker_client.invoke_endpoint(
+    def _invoke_sagemaker(self, payload: dict, endpoint: str, sagemaker_client: Any):
+        response_model = sagemaker_client.invoke_endpoint(
             EndpointName=endpoint,
             Body=json.dumps(payload),
             ContentType="application/json",
@@ -68,16 +90,13 @@ class SageMakerTTSTool(Tool):
         invoke tools
         """
         try:
-            if not self.sagemaker_client:
-                aws_region = tool_parameters.get("aws_region")
-                if aws_region:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime", region_name=aws_region)
-                    self.s3_client = boto3.client("s3", region_name=aws_region)
-                    self.comprehend_client = boto3.client("comprehend", region_name=aws_region)
-                else:
-                    self.sagemaker_client = boto3.client("sagemaker-runtime")
-                    self.s3_client = boto3.client("s3")
-                    self.comprehend_client = boto3.client("comprehend")
+            aws_region = tool_parameters.get("aws_region")
+
+            # Build fresh clients per invocation so disk-refreshed
+            # credentials are picked up on every call. See issue #3544.
+            session = boto3.Session(region_name=aws_region)
+            sagemaker_client = session.client("sagemaker-runtime")
+            comprehend_client = session.client("comprehend")
 
             if not self.sagemaker_endpoint:
                 self.sagemaker_endpoint = tool_parameters.get("sagemaker_endpoint")
@@ -90,10 +109,18 @@ class SageMakerTTSTool(Tool):
             mock_voice_text = tool_parameters.get("mock_voice_text")
             voice_instruct_prompt = tool_parameters.get("voice_instruct_prompt")
             payload = self._build_tts_payload(
-                tts_infer_type, tts_text, voice, mock_voice_text, mock_voice_audio, voice_instruct_prompt
+                tts_infer_type,
+                tts_text,
+                voice,
+                mock_voice_text,
+                mock_voice_audio,
+                voice_instruct_prompt,
+                comprehend_client=comprehend_client,
             )
 
-            result = self._invoke_sagemaker(payload, self.sagemaker_endpoint)
+            result = self._invoke_sagemaker(
+                payload, self.sagemaker_endpoint, sagemaker_client
+            )
 
             yield self.create_text_message(text=result["s3_presign_url"])
 

--- a/tools/aws/tools/transcribe_asr.py
+++ b/tools/aws/tools/transcribe_asr.py
@@ -191,12 +191,18 @@ def upload_file_from_url_to_s3(s3_client, url, bucket_name, s3_key=None, max_ret
                 },
             )
 
-            return f"s3://{bucket_name}/{s3_key}", f"Successfully uploaded file to s3://{bucket_name}/{s3_key}"
+            return (
+                f"s3://{bucket_name}/{s3_key}",
+                f"Successfully uploaded file to s3://{bucket_name}/{s3_key}",
+            )
 
         except RequestException as e:
             retry_count += 1
             if retry_count == max_retries:
-                return None, f"Failed to download file from URL after {max_retries} attempts: {str(e)}"
+                return (
+                    None,
+                    f"Failed to download file from URL after {max_retries} attempts: {str(e)}",
+                )
             continue
 
         except ClientError as e:
@@ -209,40 +215,53 @@ def upload_file_from_url_to_s3(s3_client, url, bucket_name, s3_key=None, max_ret
 
 
 class TranscribeTool(Tool):
-    s3_client: Any = None
-    transcribe_client: Any = None
-
     """
     Note that you must include one of LanguageCode, IdentifyLanguage,
-    or IdentifyMultipleLanguages in your request. 
+    or IdentifyMultipleLanguages in your request.
     If you include more than one of these parameters, your transcription job fails.
     """
 
-    def _transcribe_audio(self, audio_file_uri, file_type, **extra_args):
+    def _transcribe_audio(
+        self, audio_file_uri, file_type, transcribe_client: Any, **extra_args
+    ):
         uuid_str = str(uuid.uuid4())
         job_name = f"{int(time.time())}-{uuid_str}"
         try:
             # Start transcription job
-            response = self.transcribe_client.start_transcription_job(
-                TranscriptionJobName=job_name, Media={"MediaFileUri": audio_file_uri}, **extra_args
+            response = transcribe_client.start_transcription_job(
+                TranscriptionJobName=job_name,
+                Media={"MediaFileUri": audio_file_uri},
+                **extra_args,
             )
 
             # Wait for the job to complete
             while True:
-                status = self.transcribe_client.get_transcription_job(TranscriptionJobName=job_name)
-                if status["TranscriptionJob"]["TranscriptionJobStatus"] in ["COMPLETED", "FAILED"]:
+                status = transcribe_client.get_transcription_job(
+                    TranscriptionJobName=job_name
+                )
+                if status["TranscriptionJob"]["TranscriptionJobStatus"] in [
+                    "COMPLETED",
+                    "FAILED",
+                ]:
                     break
                 time.sleep(5)
 
             if status["TranscriptionJob"]["TranscriptionJobStatus"] == "COMPLETED":
-                return status["TranscriptionJob"]["Transcript"]["TranscriptFileUri"], None
+                return status["TranscriptionJob"]["Transcript"][
+                    "TranscriptFileUri"
+                ], None
             else:
-                return None, f"Error: TranscriptionJobStatus:{status['TranscriptionJob']['TranscriptionJobStatus']} "
+                return (
+                    None,
+                    f"Error: TranscriptionJobStatus:{status['TranscriptionJob']['TranscriptionJobStatus']} ",
+                )
 
         except Exception as e:
             return None, f"Error: {str(e)}"
 
-    def _download_and_read_transcript(self, transcript_file_uri: str, max_retries: int = 3) -> tuple[str, str]:
+    def _download_and_read_transcript(
+        self, transcript_file_uri: str, max_retries: int = 3
+    ) -> tuple[str, str]:
         """
         Download and read the transcript file from the given URI.
 
@@ -305,11 +324,16 @@ class TranscribeTool(Tool):
                 else:
                     # Extract the transcription text
                     # The transcript text is typically in the 'results' -> 'transcripts' array
-                    if "results" in transcript_data and "transcripts" in transcript_data["results"]:
+                    if (
+                        "results" in transcript_data
+                        and "transcripts" in transcript_data["results"]
+                    ):
                         transcripts = transcript_data["results"]["transcripts"]
                         if transcripts:
                             # Combine all transcript segments
-                            full_text = " ".join(t.get("transcript", "") for t in transcripts)
+                            full_text = " ".join(
+                                t.get("transcript", "") for t in transcripts
+                            )
                             return full_text, None
 
                 return None, "No transcripts found in the response"
@@ -317,7 +341,10 @@ class TranscribeTool(Tool):
             except requests.exceptions.RequestException as e:
                 retry_count += 1
                 if retry_count == max_retries:
-                    return None, f"Failed to download transcript file after {max_retries} attempts: {str(e)}"
+                    return (
+                        None,
+                        f"Failed to download transcript file after {max_retries} attempts: {str(e)}",
+                    )
                 continue
 
             except json.JSONDecodeError as e:
@@ -336,27 +363,31 @@ class TranscribeTool(Tool):
         invoke tools
         """
         try:
-            if not self.transcribe_client:
-                aws_region = tool_parameters.get("aws_region")
-                aws_access_key_id = tool_parameters.get("aws_access_key_id")
-                aws_secret_access_key = tool_parameters.get("aws_secret_access_key")
-                
-                # Build boto3 client kwargs
-                client_kwargs = {}
-                if aws_region:
-                    client_kwargs["region_name"] = aws_region
-                if aws_access_key_id and aws_secret_access_key:
-                    client_kwargs["aws_access_key_id"] = aws_access_key_id
-                    client_kwargs["aws_secret_access_key"] = aws_secret_access_key
-                
-                self.transcribe_client = boto3.client("transcribe", **client_kwargs)
-                self.s3_client = boto3.client("s3", **client_kwargs)
+            aws_region = tool_parameters.get("aws_region")
+            aws_access_key_id = tool_parameters.get("aws_access_key_id")
+            aws_secret_access_key = tool_parameters.get("aws_secret_access_key")
+
+            # Build boto3 client kwargs
+            client_kwargs = {}
+            if aws_region:
+                client_kwargs["region_name"] = aws_region
+            if aws_access_key_id and aws_secret_access_key:
+                client_kwargs["aws_access_key_id"] = aws_access_key_id
+                client_kwargs["aws_secret_access_key"] = aws_secret_access_key
+
+            # Build fresh clients per invocation so disk-refreshed
+            # credentials are picked up on every call. See issue #3544.
+            session = boto3.Session(**client_kwargs)
+            transcribe_client = session.client("transcribe")
+            s3_client = session.client("s3")
 
             file_url = tool_parameters.get("file_url")
             file_type = tool_parameters.get("file_type")
             language_code = tool_parameters.get("language_code")
             identify_language = tool_parameters.get("identify_language", True)
-            identify_multiple_languages = tool_parameters.get("identify_multiple_languages", False)
+            identify_multiple_languages = tool_parameters.get(
+                "identify_multiple_languages", False
+            )
             language_options_str = tool_parameters.get("language_options")
             s3_bucket_name = tool_parameters.get("s3_bucket_name")
             ShowSpeakerLabels = tool_parameters.get("ShowSpeakerLabels", True)
@@ -399,23 +430,31 @@ class TranscribeTool(Tool):
             if language_options:
                 extra_args["LanguageOptions"] = language_options
             if ShowSpeakerLabels:
-                extra_args["Settings"] = {"ShowSpeakerLabels": ShowSpeakerLabels, "MaxSpeakerLabels": MaxSpeakerLabels}
+                extra_args["Settings"] = {
+                    "ShowSpeakerLabels": ShowSpeakerLabels,
+                    "MaxSpeakerLabels": MaxSpeakerLabels,
+                }
 
             # upload to s3 bucket
-            s3_path_result, error = upload_file_from_url_to_s3(self.s3_client, url=file_url, bucket_name=s3_bucket_name)
+            s3_path_result, error = upload_file_from_url_to_s3(
+                s3_client, url=file_url, bucket_name=s3_bucket_name
+            )
             if not s3_path_result:
                 yield self.create_text_message(text=error)
 
             transcript_file_uri, error = self._transcribe_audio(
                 audio_file_uri=s3_path_result,
                 file_type=file_type,
+                transcribe_client=transcribe_client,
                 **extra_args,
             )
             if not transcript_file_uri:
                 yield self.create_text_message(text=error)
 
             # Download and read the transcript
-            transcript_text, error = self._download_and_read_transcript(transcript_file_uri)
+            transcript_text, error = self._download_and_read_transcript(
+                transcript_file_uri
+            )
             if not transcript_text:
                 yield self.create_text_message(text=error)
 


### PR DESCRIPTION
## Summary

Closes #3544

The follow-up to [PR #3545](https://github.com/langgenius/dify-official-plugins/pull/3545) (the Bedrock-family subset of the boto3 caching fix). PR #3545 covered 3 files (`apply_guardrail`, `bedrock_retrieve`, `bedrock_retrieve_and_generate`) and was merged at 0.0.30. This PR covers the **remaining 16** tool files in `tools/aws/tools/` that had the same bug, bumping the plugin to 0.0.31.

The bug, same as in the bedrock LLM (PR #3535) and the bedrock-family tools (PR #3545): each of the 16 files caches a boto3 client on `self` (e.g. `self.s3_client`, `self.sagemaker_client`, `self.comprehend_client`, `self.dynamodb_resource`) and constructs it via `boto3.client(...)` or `boto3.resource(...)`. boto3's default session resolves credentials once per process and reuses them, so a fresh `aws sso login`, `saml2aws login`, or refreshed IMDS role is not picked up — the cached client keeps the stale credentials and the next invocation returns `ExpiredTokenException` until the plugin process is restarted.

For each affected file:
- Remove the class-level client attribute and the `if not self.<x>_client:` lazy-init block.
- Build a fresh `boto3.Session().client(...)` or `boto3.Session().resource(...)` per `_invoke` call.
- Thread the client through any helper methods that need it (`_invoke_sagemaker` in `tts.py`, `_get_embedding` and `_search_by_aos_knn` in `opensearch_knn_search.py`, `_transcribe_audio` in `transcribe_asr.py`, the 5 dynamodb_manager helpers, the `_invoke_lambda` helper in `lambda_translate_utils.py`, etc.).

### Files covered (16)

- `agentcore_code_interpreter.py` — `create_client` now builds a fresh session
- `dynamodb_manager.py` — `dynamodb_resource` + `dynamodb_client` built fresh, threaded through 5 helper methods (`_create_table`, `_put_item`, `_get_item`, `_delete_item`, `_scan`)
- `lambda_translate_utils.py` — `lambda_client` threaded through `_invoke_lambda`
- `lambda_yaml_to_json.py` — same pattern
- `nova_canvas.py` — `bedrock-runtime` + `s3` clients built fresh
- `nova_reel.py` — same pattern
- `opensearch_knn_search.py` — `os_client` + `s3_client` + `bedrock_client` built fresh, threaded through `_get_embedding` and `_search_by_aos_knn`
- `s3_file_download.py`, `s3_file_uploader.py`, `s3_files_download.py`, `s3_files_uploader.py` — `s3` client built fresh per invocation
- `s3_operator.py` — `s3` client built fresh
- `sagemaker_chinese_toxicity_detector.py` — `sagemaker-runtime` + `comprehend` built fresh
- `sagemaker_text_rerank.py` — `sagemaker-runtime` + `s3` + `comprehend` built fresh
- `sagemaker_tts.py` — same trio, threaded through `_invoke_sagemaker` and `_detect_lang_code` (the `s3` client is built but unused here, so it is dropped to keep the diff tight)
- `transcribe_asr.py` — `transcribe` + `s3` built fresh, threaded through `_transcribe_audio`

### Out of scope

- The `models/sagemaker` provider has the same bug and was fixed separately in [PR #3561](https://github.com/langgenius/dify-official-plugins/pull/3561).
- Adding per-file tests for the 16 new files. The 5 existing `test_boto3_fresh_session.py` tests (added in PR #3545) cover the bedrock_retrieve / bedrock_retrieve_and_generate / apply_guardrail pattern; the same shape (per-call `boto3.Session()` plus removal of on-instance cache) is now applied to the 16 new files. Adding per-file tests is a larger follow-up the maintainer can scope.

### Pre-existing F401 / F841

The 16 files have some pre-existing `F401` (unused import) and `F841` (local variable assigned but never used) issues that predate this PR. Per the project's scope discipline (only the bug fix + tests + manifest in this commit), I have not addressed those — they are not part of the boto3 caching fix and would be cosmetic-only churn.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

N/A — the change is to credential-handling code paths, no visible UI surface. Verification is in the existing tests.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.30 → 0.0.31
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` — already at `dify_plugin>=0.9.0`, which satisfies the constraint.

## Testing

- [x] Local deployment — Dify version: not applicable (plugin is invoked by Dify, not Dify itself; the fix is verified by in-process tests)
- [ ] SaaS (cloud.dify.ai)

### Local verification

- `uv run pytest tests/ -v` — 5/5 pass (the 5 pre-existing tests from PR #3545)
  - `test_each_invoke_creates_a_fresh_boto3_session` (apply_guardrail)
  - `test_does_not_call_default_boto3_client` (apply_guardrail)
  - `test_does_not_assign_self_bedrock_client` (bedrock_retrieve)
  - `test_bedrock_retrieve_session_uses_bedrock_agent_runtime` (bedrock_retrieve)
  - `test_does_not_assign_self_bedrock_client` (bedrock_retrieve_and_generate)
- `uv run ruff check tools/aws/tools/<each touched file>` — pre-existing F401/F841 issues are not addressed (out of scope)
- `uv run ruff format --check` on the 16 touched files — clean

## Issue Link

Fixes #3544 (closes the umbrella issue for the 19 tools/aws boto3-caching files)
