### PR TITLE
feat(openai_api_compatible): discover models from the configured endpoint

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.59
+version: 0.0.60
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -228,6 +228,42 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                 f"An error occurred during credentials validation: {ex!s}"
             ) from ex
 
+    def remote_models(self, credentials: dict) -> list[AIModelEntity]:
+        """Discover models advertised by the configured OpenAI-compatible endpoint.
+
+        Calls ``GET /v1/models`` via the OpenAI SDK and returns an
+        ``AIModelEntity`` for every model ID the endpoint advertises.
+        This mirrors the shape of ``models/openai``'s ``remote_models``
+        but, because this plugin has no predefined model catalog, every
+        remote model is surfaced — the user picks which one to add.
+
+        If the endpoint does not support ``/v1/models`` (some custom
+        gateways don't), the call raises and the empty list is
+        returned so the user can still add models manually.
+        """
+        endpoint_url = credentials.get("endpoint_url")
+        if not endpoint_url:
+            return []
+
+        api_key = credentials.get("api_key")
+        extra_headers = credentials.get("extra_headers") or {}
+
+        try:
+            client = OpenAI(
+                api_key=api_key,
+                base_url=endpoint_url,
+                default_headers=extra_headers,
+            )
+            result: list[AIModelEntity] = []
+            for remote in client.models.list():
+                model_id = getattr(remote, "id", None)
+                if not model_id:
+                    continue
+                result.append(self.get_customizable_model_schema(model_id, credentials))
+            return result
+        except Exception:  # noqa: BLE001 - discovery is best-effort
+            return []
+
     def get_customizable_model_schema(
         self, model: str, credentials: Mapping | dict
     ) -> AIModelEntity:

--- a/models/openai_api_compatible/tests/test_remote_models.py
+++ b/models/openai_api_compatible/tests/test_remote_models.py
@@ -1,0 +1,137 @@
+"""Unit tests for OpenAILargeLanguageModel.remote_models.
+
+Mirrors the shape of the first-party ``models/openai`` plugin's
+``remote_models`` but, because this plugin has no predefined catalog,
+every model the endpoint advertises is returned. The user picks
+which one to add.
+
+The OpenAI SDK's ``models.list()`` returns a paginated iterator
+of objects with an ``.id`` attribute. We mock the SDK at the
+module-import boundary so the unit test does not require network
+access.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from models.llm.llm import OpenAILargeLanguageModel
+
+
+class _RemoteModel:
+    def __init__(self, model_id: str) -> None:
+        self.id = model_id
+
+
+class TestRemoteModels(unittest.TestCase):
+    """``remote_models`` discovers every model the configured endpoint advertises."""
+
+    def setUp(self) -> None:
+        self.model = OpenAILargeLanguageModel(model_schemas=[])
+        self.base_credentials = {
+            "endpoint_url": "https://api.example.com/v1/",
+            "api_key": "test-key",
+            "mode": "chat",
+            "context_size": "4096",
+        }
+
+    def test_remote_models_uses_openai_sdk_models_list(self) -> None:
+        """The discovery call must go through the OpenAI SDK, not raw HTTP."""
+        fake_client = MagicMock()
+        fake_client.models.list.return_value = iter(
+            [_RemoteModel("gpt-4o-mini"), _RemoteModel("custom-finetune-1")]
+        )
+
+        with patch("models.llm.llm.OpenAI", return_value=fake_client) as openai_cls:
+            result = self.model.remote_models(self.base_credentials)
+
+        openai_cls.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://api.example.com/v1/",
+            default_headers={},
+        )
+        fake_client.models.list.assert_called_once_with()
+        self.assertEqual(
+            [entity.model for entity in result], ["gpt-4o-mini", "custom-finetune-1"]
+        )
+
+    def test_remote_models_returns_one_entity_per_id(self) -> None:
+        """Each discovered model ID becomes one ``AIModelEntity``."""
+        fake_client = MagicMock()
+        fake_client.models.list.return_value = iter(
+            [_RemoteModel("a"), _RemoteModel("b"), _RemoteModel("c")]
+        )
+
+        with patch("models.llm.llm.OpenAI", return_value=fake_client):
+            result = self.model.remote_models(self.base_credentials)
+
+        self.assertEqual(len(result), 3)
+        # The model IDs are preserved verbatim on the returned entities.
+        self.assertEqual([entity.model for entity in result], ["a", "b", "c"])
+
+    def test_remote_models_skips_entries_without_id(self) -> None:
+        """An SDK response without ``.id`` (e.g. an empty stub) is dropped."""
+        fake_client = MagicMock()
+        fake_client.models.list.return_value = iter(
+            [_RemoteModel("a"), SimpleNamespace(id=None), _RemoteModel("b")]
+        )
+
+        with patch("models.llm.llm.OpenAI", return_value=fake_client):
+            result = self.model.remote_models(self.base_credentials)
+
+        self.assertEqual([entity.model for entity in result], ["a", "b"])
+
+    def test_remote_models_returns_empty_when_endpoint_url_missing(self) -> None:
+        """Missing endpoint_url short-circuits to an empty list, not an exception."""
+        creds = dict(self.base_credentials)
+        creds.pop("endpoint_url")
+        self.assertEqual(self.model.remote_models(creds), [])
+
+    def test_remote_models_returns_empty_on_sdk_failure(self) -> None:
+        """Discovery is best-effort: a transport or auth failure yields []."""
+        with patch(
+            "models.llm.llm.OpenAI", side_effect=RuntimeError("connection refused")
+        ):
+            self.assertEqual(self.model.remote_models(self.base_credentials), [])
+
+    def test_remote_models_passes_extra_headers(self) -> None:
+        """``extra_headers`` from the credential reach the OpenAI client constructor."""
+        creds = dict(self.base_credentials)
+        creds["extra_headers"] = {"X-Custom": "value"}
+
+        fake_client = MagicMock()
+        fake_client.models.list.return_value = iter([_RemoteModel("a")])
+
+        with patch("models.llm.llm.OpenAI", return_value=fake_client) as openai_cls:
+            self.model.remote_models(creds)
+
+        openai_cls.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://api.example.com/v1/",
+            default_headers={"X-Custom": "value"},
+        )
+
+    def test_remote_models_entity_uses_plugin_customizations(self) -> None:
+        """Each returned entity flows through ``get_customizable_model_schema``.
+
+        The plugin augments the parent class's default schema with
+        ``response_format`` and ``agent_thought`` support. The returned
+        entity must carry the augmentation, which proves the discovery
+        path runs through the same schema builder the user gets when
+        adding a model manually.
+        """
+        creds = dict(self.base_credentials)
+        creds["structured_output_support"] = "supported"
+        creds["agent_thought_support"] = "supported"
+
+        fake_client = MagicMock()
+        fake_client.models.list.return_value = iter([_RemoteModel("gpt-4o-mini")])
+
+        with patch("models.llm.llm.OpenAI", return_value=fake_client):
+            result = self.model.remote_models(creds)
+
+        # Confirm the schema came from the plugin's own builder.
+        self.assertEqual(result[0].model, "gpt-4o-mini")
+        rule_names = {rule.name for rule in result[0].parameter_rules}
+        self.assertIn("response_format", rule_names)
+        self.assertIn("enable_thinking", rule_names)


### PR DESCRIPTION
## Summary

Closes #3616

The OpenAI-API-compatible provider currently has no model catalog: every model must be added by hand, including a context size and feature toggles. The first-party `models/openai` plugin already exposes `remote_models()` that lists the models the configured endpoint advertises, but the `openai_api_compatible` plugin does not.

This commit adds `remote_models()` to `OpenAILargeLanguageModel`. The method calls `GET /v1/models` via the OpenAI SDK and returns one `AIModelEntity` per advertised model ID, built by the plugin's own `get_customizable_model_schema` (so the entity already carries the `response_format` / `enable_thinking` / `agent_thought` augmentations the plugin adds for any model the user configures). The user picks which discovered model to add.

### Differences from the first-party `openai` plugin

- The first-party plugin's `remote_models()` only returns fine-tuned models (those whose id starts with `ft:`) because the base model must be in the predefined catalog. The `openai_api_compatible` plugin has no predefined catalog, so every model the endpoint advertises is surfaced.
- Discovery is best-effort: if the endpoint does not implement `/v1/models` (some custom gateways don't), the SDK call raises and the method returns `[]` so the user can still add models manually.
- Missing `endpoint_url` short-circuits to `[]` instead of raising.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

N/A — the change is to the model-discovery surface, no visible UI change beyond the "Add model" dropdown now being populated from the endpoint.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (model discovery / listing)
- [ ] New models / model parameter fixes

</details>

The "Other LLM functionality" item refers to the new model discovery path. This is an LLM plugin; the LLM Plugin Checklist is required per the PR template.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.59 → 0.0.60
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` — already at `dify_plugin>=0.9.0`, which satisfies the constraint.

## Testing

- [x] Local deployment — Dify version: not applicable (plugin is invoked by Dify, not Dify itself; the fix is verified by in-process tests)
- [ ] SaaS (cloud.dify.ai)

### Local verification

- `uv run pytest tests/` — 41/41 pass (7 new in this PR, 34 pre-existing)
  - `test_remote_models_uses_openai_sdk_models_list` — confirms the OpenAI SDK is called with `api_key`, `base_url`, `default_headers`
  - `test_remote_models_returns_one_entity_per_id` — one entity per discovered model
  - `test_remote_models_skips_entries_without_id` — entries with `id=None` are dropped
  - `test_remote_models_returns_empty_when_endpoint_url_missing` — graceful short-circuit
  - `test_remote_models_returns_empty_on_sdk_failure` — `RuntimeError("connection refused")` returns `[]`
  - `test_remote_models_passes_extra_headers` — `extra_headers` from credentials reach the client
  - `test_remote_models_entity_uses_plugin_customizations` — entity carries `response_format` and `enable_thinking` parameter rules, proving it flows through `get_customizable_model_schema`
- `uv run ruff check models/openai_api_compatible/tests/test_remote_models.py` — clean
- `uv run ruff check models/openai_api_compatible/models/llm/llm.py` — 2 pre-existing F541/F401 issues (unused `import json` line 2; extraneous `f` prefix on `"\n</think>"` line 65) are intentionally not addressed in this PR (out of scope)
- `uv run ruff format --check models/openai_api_compatible/tests/test_remote_models.py` — clean

### Issue Link

Closes #3616
