### PR TITLE
fix(tongyi-tts): enable true streaming for qwen3-tts-flash

### DIFF
--- a/models/tongyi/models/tts/tts.py
+++ b/models/tongyi/models/tts/tts.py
@@ -93,38 +93,39 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
                             self._split_text_into_sentences(org_text=content, max_length=wl)
                         )
                     for sentence in sentences:
-                        response = MultiModalConversation.call(
+                        response_stream = MultiModalConversation.call(
                             model=m,
                             api_key=api_key,
                             text=sentence.strip(),
                             voice=voice,
-                            stream=False,
+                            stream=True,
                             base_address=base_address,
                         )
-                        if response.status_code != 200:
-                            error_msg = response.message or f"API error: {response.status_code}"
-                            error_queue.put(InvokeBadRequestError(error_msg))
-                            audio_queue.put(None)
-                            return
-                        if not response.output or not response.output.audio:
-                            error_queue.put(InvokeBadRequestError("No audio in response"))
-                            audio_queue.put(None)
-                            return
-                        audio_url = response.output.audio.get("url")
-                        if not audio_url:
-                            error_queue.put(InvokeBadRequestError("No audio URL in response"))
-                            audio_queue.put(None)
-                            return
-                        try:
-                            with urlopen(audio_url, timeout=30) as response:
-                                audio_data = response.read()
-                            audio_queue.put(audio_data)
-                        except Exception as e:
-                            error_queue.put(
-                                InvokeBadRequestError(f"Failed to download audio: {str(e)}")
-                            )
-                            audio_queue.put(None)
-                            return
+                        for chunk in response_stream:
+                            if chunk.status_code != 200:
+                                error_msg = chunk.message or f"API error: {chunk.status_code}"
+                                error_queue.put(InvokeBadRequestError(error_msg))
+                                audio_queue.put(None)
+                                return
+                            if not chunk.output or not chunk.output.audio:
+                                error_queue.put(InvokeBadRequestError("No audio in response"))
+                                audio_queue.put(None)
+                                return
+                            audio_url = chunk.output.audio.get("url")
+                            if not audio_url:
+                                error_queue.put(InvokeBadRequestError("No audio URL in response"))
+                                audio_queue.put(None)
+                                return
+                            try:
+                                with urlopen(audio_url, timeout=30) as response:
+                                    audio_data = response.read()
+                                audio_queue.put(audio_data)
+                            except Exception as e:
+                                error_queue.put(
+                                    InvokeBadRequestError(f"Failed to download audio: {str(e)}")
+                                )
+                                audio_queue.put(None)
+                                return
                     audio_queue.put(None)
                 except Exception as e:
                     error_queue.put(self._map_invoke_error(e))


### PR DESCRIPTION
Fixes #3585

## Summary

`TongyiText2SpeechModel._tts_invoke_streaming` called `MultiModalConversation.call(..., stream=False)` even though the method name implied streaming. The plugin then downloaded the complete audio file from the returned URL and yielded one big blob per sentence, adding high first-byte latency for `/text-to-audio` and chat auto-play TTS.

qwen3-tts-flash supports real streaming via `stream=True`. Switched the call to stream mode and iterate over the chunked response, downloading and yielding each audio URL as it arrives so the caller sees the first chunk immediately.

The non-streaming error-status checks (HTTP error, missing audio, missing URL) are preserved per chunk so a single bad chunk still surfaces the same actionable error to the caller.