### PR TITLE
fix(agent): pass current-turn images to FunctionCalling strategy

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.42
+version: 0.0.43
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/strategies/function_calling.py
+++ b/agent-strategies/cot_agent/strategies/function_calling.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import time
 from collections.abc import Generator
@@ -14,20 +15,23 @@ from dify_plugin.entities.model.llm import (
 )
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
+    ImagePromptMessageContent,
     PromptMessage,
     PromptMessageContentType,
     SystemPromptMessage,
+    TextPromptMessageContent,
     ToolPromptMessage,
     UserPromptMessage,
 )
 from dify_plugin.entities.tool import ToolInvokeMessage, ToolProviderType
+from dify_plugin.file.file import File, FileType
 from dify_plugin.interfaces.agent import (
     AgentModelConfig,
     AgentStrategy,
     ToolEntity,
     ToolInvokeMeta,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 THINK_START = "<think>"
 THINK_END = "</think>"
@@ -90,13 +94,22 @@ class FunctionCallingParams(BaseModel):
     instruction: str | None
     model: AgentModelConfig
     tools: list[ToolEntity] | None
+    files: list[File] | None = None
     maximum_iterations: int = 3
     context: list[ContextItem] | None = None
+
+    @field_validator("files", mode="before")
+    @classmethod
+    def discard_empty_file_entries(cls, value: Any) -> Any:
+        if isinstance(value, list):
+            return [item for item in value if item is not None]
+        return value
 
 
 class FunctionCallingAgentStrategy(AgentStrategy):
     query: str = ""
     instruction: str | None = ""
+    files: list[File] | None = None
 
     @staticmethod
     def _format_tool_response(
@@ -145,7 +158,34 @@ class FunctionCallingAgentStrategy(AgentStrategy):
 
     @property
     def _user_prompt_message(self) -> UserPromptMessage:
-        return UserPromptMessage(content=self.query)
+        image_contents = [
+            self._to_image_prompt_content(file)
+            for file in self.files or []
+            if file.type == FileType.IMAGE
+        ]
+        if not image_contents:
+            return UserPromptMessage(content=self.query)
+
+        return UserPromptMessage(
+            content=[*image_contents, TextPromptMessageContent(data=self.query)]
+        )
+
+    @staticmethod
+    def _to_image_prompt_content(file: File) -> ImagePromptMessageContent:
+        image_format = (file.extension or "").lstrip(".").lower()
+        if not image_format and file.mime_type and "/" in file.mime_type:
+            image_format = file.mime_type.split("/", maxsplit=1)[1]
+        if image_format == "jpg":
+            image_format = "jpeg"
+        image_format = image_format or "png"
+
+        return ImagePromptMessageContent(
+            format=image_format,
+            base64_data=base64.b64encode(file.blob).decode("ascii"),
+            mime_type=file.mime_type or f"image/{image_format}",
+            filename=file.filename or "",
+            detail=ImagePromptMessageContent.DETAIL.LOW,
+        )
 
     @property
     def _system_prompt_message(self) -> SystemPromptMessage:
@@ -163,6 +203,7 @@ class FunctionCallingAgentStrategy(AgentStrategy):
         query = fc_params.query
         self.query = query
         self.instruction = fc_params.instruction
+        self.files = fc_params.files or []
         history_prompt_messages = fc_params.model.history_prompt_messages
         history_prompt_messages.insert(0, self._system_prompt_message)
         history_prompt_messages.append(self._user_prompt_message)

--- a/agent-strategies/cot_agent/strategies/function_calling.yaml
+++ b/agent-strategies/cot_agent/strategies/function_calling.yaml
@@ -53,6 +53,14 @@ parameters:
       en_US: Query
       zh_Hans: 查询
       pt_BR: Query
+  - name: files
+    type: any
+    scope: array[file]
+    required: false
+    label:
+      en_US: Current-turn files
+      zh_Hans: 当前轮文件
+      pt_BR: Arquivos da rodada atual
   - name: maximum_iterations
     type: number
     required: true

--- a/agent-strategies/cot_agent/tests/test_function_calling.py
+++ b/agent-strategies/cot_agent/tests/test_function_calling.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import sys
 import unittest
@@ -13,10 +14,18 @@ from dify_plugin.entities.model.llm import (
     LLMResultChunkDelta,
     LLMUsage,
 )
-from dify_plugin.entities.model.message import AssistantPromptMessage
+from dify_plugin.entities.model.message import (
+    AssistantPromptMessage,
+    ImagePromptMessageContent,
+    TextPromptMessageContent,
+)
 from dify_plugin.entities.tool import ToolInvokeMessage, ToolProviderType
+from dify_plugin.file.file import File, FileType
 
-from strategies.function_calling import FunctionCallingAgentStrategy
+from strategies.function_calling import (
+    FunctionCallingAgentStrategy,
+    FunctionCallingParams,
+)
 
 
 def _make_tool_call(
@@ -164,6 +173,90 @@ class TestFunctionCallingToolCallParsing(unittest.TestCase):
             "<think>\nAnalyzing the request.\n</think>",
         )
         self.assertFalse(thinking_started)
+
+
+class TestFunctionCallingMultimodalPrompt(unittest.TestCase):
+    def setUp(self):
+        self.strategy = FunctionCallingAgentStrategy(
+            runtime=Mock(), session=Mock()
+        )
+        self.strategy.query = "Describe the current image"
+
+    @staticmethod
+    def _file(file_type: FileType = FileType.IMAGE) -> File:
+        file = File(
+            url="https://example.invalid/test.png",
+            mime_type="image/png" if file_type == FileType.IMAGE else "application/pdf",
+            filename="test.png" if file_type == FileType.IMAGE else "test.pdf",
+            extension=".png" if file_type == FileType.IMAGE else ".pdf",
+            size=7,
+            type=file_type,
+        )
+        file._blob = b"pngdata"
+        return file
+
+    def test_text_only_query_remains_string(self):
+        self.strategy.files = []
+
+        message = self.strategy._user_prompt_message
+
+        self.assertEqual(message.content, "Describe the current image")
+
+    def test_current_image_is_added_before_query_text(self):
+        self.strategy.files = [self._file()]
+
+        message = self.strategy._user_prompt_message
+
+        self.assertIsInstance(message.content, list)
+        self.assertEqual(len(message.content), 2)
+        self.assertIsInstance(message.content[0], ImagePromptMessageContent)
+        self.assertEqual(
+            message.content[0].base64_data,
+            base64.b64encode(b"pngdata").decode("ascii"),
+        )
+        self.assertEqual(message.content[0].detail, ImagePromptMessageContent.DETAIL.LOW)
+        self.assertIsInstance(message.content[1], TextPromptMessageContent)
+        self.assertEqual(message.content[1].data, "Describe the current image")
+
+    def test_multiple_images_preserve_order(self):
+        first = self._file()
+        first.filename = "first.png"
+        second = self._file()
+        second.filename = "second.png"
+        self.strategy.files = [first, second]
+
+        message = self.strategy._user_prompt_message
+
+        self.assertIsInstance(message.content, list)
+        self.assertEqual(
+            [content.filename for content in message.content[:-1]],
+            ["first.png", "second.png"],
+        )
+
+    def test_non_image_files_are_not_added(self):
+        self.strategy.files = [self._file(FileType.DOCUMENT)]
+
+        message = self.strategy._user_prompt_message
+
+        self.assertEqual(message.content, "Describe the current image")
+
+    def test_empty_file_entries_from_dify_are_discarded(self):
+        image = self._file()
+
+        params = FunctionCallingParams(
+            query="Describe the current image",
+            instruction=None,
+            model={
+                "provider": "test/provider",
+                "model": "test-model",
+                "mode": "chat",
+                "completion_params": {},
+            },
+            tools=None,
+            files=[None, image],
+        )
+
+        self.assertEqual(params.files, [image])
 
 
 class TestFunctionCallingToolResponseFormatting(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes langgenius/dify#40731

Related to #2888

The FunctionCalling Agent strategy did not receive files uploaded in the current turn. As a result, an image sent with the first user message was absent from the LLM prompt, while a follow-up could appear to work after the image entered conversation history.

This change:

- declares the current-turn `files` input for the FunctionCalling strategy
- filters null file entries emitted by Dify before Pydantic validation
- converts current-turn image files to Base64 `ImagePromptMessageContent` entries before the query text
- preserves existing behavior for text-only input and ignores non-image files

The implementation uses the SDK-supported `File.blob` API and the existing Agent default of low image detail.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not included. The regression and prompt construction are covered by automated tests.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Message flow (system messages, user <-> assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) - Not applicable: this plugin already declares and locks `dify_plugin>=0.9.0`.

## Testing

- [ ] Local deployment - Dify version: not recorded
- [ ] SaaS (cloud.dify.ai)

- `uv run --python 3.12 pytest -q`: 16 passed on Python 3.12.13
- Built and inspected a clean `langgenius/agent:0.0.43` package; it contains the manifest, strategy, and tests without virtual environments or cache files.
