### PR TITLE
feat(zhipuai): add glm-5.2 and glm-5.3 model support

### DIFF
--- a/models/zhipuai/manifest.yaml
+++ b/models/zhipuai/manifest.yaml
@@ -1,5 +1,5 @@
 type: plugin
-version: 0.0.32
+version: 0.0.33
 author: langgenius
 name: zhipuai
 created_at: "2024-09-20T00:13:50.29298939-04:00"

--- a/models/zhipuai/models/llm/_position.yaml
+++ b/models/zhipuai/models/llm/_position.yaml
@@ -1,5 +1,5 @@
-- glm-5.3
 - glm-5.2
+- glm-5.3
 - glm-5.1
 - glm-5v-turbo
 - glm-5-turbo

--- a/models/zhipuai/models/llm/_position.yaml
+++ b/models/zhipuai/models/llm/_position.yaml
@@ -1,4 +1,5 @@
 - glm-5.3
+- glm-5.2
 - glm-5.1
 - glm-5v-turbo
 - glm-5-turbo

--- a/models/zhipuai/models/llm/_position.yaml
+++ b/models/zhipuai/models/llm/_position.yaml
@@ -1,3 +1,4 @@
+- glm-5.3
 - glm-5.1
 - glm-5v-turbo
 - glm-5-turbo

--- a/models/zhipuai/models/llm/glm-5.2.yaml
+++ b/models/zhipuai/models/llm/glm-5.2.yaml
@@ -1,0 +1,71 @@
+model: glm-5.2
+label:
+  en_US: glm-5.2
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    default: 65536
+    min: 1
+    max: 131072
+  - name: web_search
+    type: boolean
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+    default: false
+    help:
+      zh_Hans: 控制模型是否在生成文本时参考互联网搜索结果。
+      en_US: Controls whether the model uses Internet search results while generating text.
+  - name: thinking
+    label:
+      zh_Hans: 推理模式
+      en_US: Thinking Mode
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 控制模型的推理能力。GLM-5.2 默认启用动态思考，也允许关闭。
+      en_US: Controls the model's reasoning. GLM-5.2 uses dynamic thinking by default and allows it to be disabled.
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    default: max
+    required: false
+    options:
+      - none
+      - minimal
+      - low
+      - medium
+      - high
+      - xhigh
+      - max
+    help:
+      zh_Hans: 控制思考强度。none/minimal 关闭思考，low/medium 映射为 high，xhigh 映射为 max。
+      en_US: Controls reasoning effort. none/minimal disable thinking, low/medium map to high, and xhigh maps to max.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: Specifies the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0.008"
+  output: "0.028"
+  unit: "0.001"
+  currency: RMB

--- a/models/zhipuai/models/llm/glm-5.3.yaml
+++ b/models/zhipuai/models/llm/glm-5.3.yaml
@@ -1,0 +1,43 @@
+model: glm-5.3
+label:
+  en_US: glm-5.3
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    default: 4096
+    min: 1
+    max: 131072
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    default: max
+    required: false
+    options:
+      - low
+      - high
+      - max
+    help:
+      zh_Hans: 控制模型的思考强度。GLM-5.3 始终启用思考模式。
+      en_US: Controls the model's reasoning effort. GLM-5.3 always uses thinking mode.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: Specifies the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object

--- a/models/zhipuai/models/llm/llm.py
+++ b/models/zhipuai/models/llm/llm.py
@@ -241,7 +241,9 @@ class ZhipuAILargeLanguageModel(_CommonZhipuaiAI, LargeLanguageModel):
         elif "json_schema" in model_parameters:
             del model_parameters["json_schema"]
 
-        if "thinking" in model_parameters:
+        if model == "glm-5.3":
+            model_parameters["thinking"] = {"type": "enabled"}
+        elif "thinking" in model_parameters:
             thinking = model_parameters.pop("thinking")
             if thinking:
                 model_parameters["thinking"] = {"type": "enabled"}

--- a/models/zhipuai/pyproject.toml
+++ b/models/zhipuai/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "dify_plugin>=0.9.0",
     "pydantic>=2.13.4",
     "sniffio>=1.3.1",
-    "zai-sdk>=0.2.2",
+    "zai-sdk>=0.2.3",
 ]
 
 # uv run black . -C -l 100 && uv run ruff check --fix

--- a/models/zhipuai/pyproject.toml
+++ b/models/zhipuai/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.10.2",
     "pydantic>=2.13.4",
     "sniffio>=1.3.1",
     "zai-sdk>=0.2.3",

--- a/models/zhipuai/tests/test_glm_5.py
+++ b/models/zhipuai/tests/test_glm_5.py
@@ -13,6 +13,67 @@ if str(PLUGIN_DIR) not in sys.path:
 from models.llm.llm import ZhipuAILargeLanguageModel
 
 
+def test_glm_5_2_schema_and_request_parameters() -> None:
+    model_file = PLUGIN_DIR / "models" / "llm" / "glm-5.2.yaml"
+    schema = yaml.safe_load(model_file.read_text(encoding="utf-8"))
+    AIModelEntity.model_validate(schema)
+
+    position = yaml.safe_load(
+        (model_file.parent / "_position.yaml").read_text(encoding="utf-8")
+    )
+    assert position[:2] == ["glm-5.3", "glm-5.2"]
+
+    rules = {rule["name"]: rule for rule in schema["parameter_rules"]}
+    assert schema["model_properties"]["context_size"] == 1_000_000
+    assert rules["max_tokens"]["default"] == 65_536
+    assert rules["max_tokens"]["max"] == 131_072
+    assert rules["thinking"]["default"] is True
+    assert rules["reasoning_effort"]["options"] == [
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+    assert rules["reasoning_effort"]["default"] == "max"
+    assert rules["response_format"]["options"] == ["text", "json_object"]
+    assert schema["pricing"] == {
+        "input": "0.008",
+        "output": "0.028",
+        "unit": "0.001",
+        "currency": "RMB",
+    }
+
+    client = MagicMock()
+    result = object()
+    llm = ZhipuAILargeLanguageModel(model_schemas=[])
+    with (
+        patch("models.llm.llm.ZhipuAiClient", return_value=client),
+        patch.object(
+            ZhipuAILargeLanguageModel,
+            "_handle_generate_response",
+            return_value=result,
+        ),
+    ):
+        actual = llm._generate(
+            model="glm-5.2",
+            credentials_kwargs={"api_key": "test-key"},
+            prompt_messages=[UserPromptMessage(content="hello")],
+            model_parameters={"thinking": False, "reasoning_effort": "none"},
+            stream=False,
+        )
+
+    assert actual is result
+    client.chat.completions.create.assert_called_once_with(
+        model="glm-5.2",
+        messages=[{"role": "user", "content": "hello"}],
+        thinking={"type": "disabled"},
+        reasoning_effort="none",
+    )
+
+
 def test_glm_5_3_schema_and_request_parameters() -> None:
     model_file = PLUGIN_DIR / "models" / "llm" / "glm-5.3.yaml"
     schema = yaml.safe_load(model_file.read_text(encoding="utf-8"))

--- a/models/zhipuai/tests/test_glm_5.py
+++ b/models/zhipuai/tests/test_glm_5.py
@@ -21,7 +21,7 @@ def test_glm_5_2_schema_and_request_parameters() -> None:
     position = yaml.safe_load(
         (model_file.parent / "_position.yaml").read_text(encoding="utf-8")
     )
-    assert position[:2] == ["glm-5.3", "glm-5.2"]
+    assert position[:2] == ["glm-5.2", "glm-5.3"]
 
     rules = {rule["name"]: rule for rule in schema["parameter_rules"]}
     assert schema["model_properties"]["context_size"] == 1_000_000
@@ -82,7 +82,7 @@ def test_glm_5_3_schema_and_request_parameters() -> None:
     position = yaml.safe_load(
         (model_file.parent / "_position.yaml").read_text(encoding="utf-8")
     )
-    assert position[0] == "glm-5.3"
+    assert position[1] == "glm-5.3"
 
     rules = {rule["name"]: rule for rule in schema["parameter_rules"]}
     assert schema["model_properties"]["context_size"] == 1_000_000

--- a/models/zhipuai/tests/test_glm_5_3.py
+++ b/models/zhipuai/tests/test_glm_5_3.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+from dify_plugin.entities.model import AIModelEntity
+from dify_plugin.entities.model.message import UserPromptMessage
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+if str(PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_DIR))
+
+from models.llm.llm import ZhipuAILargeLanguageModel
+
+
+def test_glm_5_3_schema_and_request_parameters() -> None:
+    model_file = PLUGIN_DIR / "models" / "llm" / "glm-5.3.yaml"
+    schema = yaml.safe_load(model_file.read_text(encoding="utf-8"))
+    AIModelEntity.model_validate(schema)
+
+    position = yaml.safe_load(
+        (model_file.parent / "_position.yaml").read_text(encoding="utf-8")
+    )
+    assert position[0] == "glm-5.3"
+
+    rules = {rule["name"]: rule for rule in schema["parameter_rules"]}
+    assert schema["model_properties"]["context_size"] == 1_000_000
+    assert rules["max_tokens"]["max"] == 131_072
+    assert rules["reasoning_effort"]["options"] == ["low", "high", "max"]
+    assert rules["reasoning_effort"]["default"] == "max"
+    assert "thinking" not in rules
+    assert "pricing" not in schema
+
+    client = MagicMock()
+    result = object()
+    llm = ZhipuAILargeLanguageModel(model_schemas=[])
+    with (
+        patch("models.llm.llm.ZhipuAiClient", return_value=client),
+        patch.object(
+            ZhipuAILargeLanguageModel,
+            "_handle_generate_response",
+            return_value=result,
+        ),
+    ):
+        actual = llm._generate(
+            model="glm-5.3",
+            credentials_kwargs={"api_key": "test-key"},
+            prompt_messages=[UserPromptMessage(content="hello")],
+            model_parameters={"thinking": False, "reasoning_effort": "low"},
+            stream=False,
+        )
+
+    assert actual is result
+    client.chat.completions.create.assert_called_once_with(
+        model="glm-5.3",
+        messages=[{"role": "user", "content": "hello"}],
+        thinking={"type": "enabled"},
+        reasoning_effort="low",
+    )

--- a/models/zhipuai/uv.lock
+++ b/models/zhipuai/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "zai-sdk"
-version = "0.2.2"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -1191,9 +1191,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/a1/0f392da4afd53977383c03ad5c4cc4079b958fb4acd9f8bdeb8fa1e2e5e5/zai_sdk-0.2.2.tar.gz", hash = "sha256:841af188586c41f0f98abcad17b162dc97461c3ab8b3d09f93b0333ebdfe72c3", size = 76605, upload-time = "2026-02-02T16:10:28.502Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/e6/f4954be9a8c70260a5de7a83035d5fbe7ec74799d7dd58857a82141c9a2f/zai_sdk-0.2.3.tar.gz", hash = "sha256:1481f6db746e64fe9e7e0da9a3727fd083890613f9eb8e1d14139ff76ef68a57", size = 76968, upload-time = "2026-06-16T03:07:25.43Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/02/d586e861e711f8449c567b01b004d7c5f65ee07c75709992a84e3ef9c40e/zai_sdk-0.2.2-py3-none-any.whl", hash = "sha256:675e9ff3fc2a86e38631331469b935589ae60492127f2c2822c7555214f2dd25", size = 125579, upload-time = "2026-02-02T16:10:26.975Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/18/2b2c012421936ed370436d844e250e9dbdefa20e845d6aeea7152c26a403/zai_sdk-0.2.3-py3-none-any.whl", hash = "sha256:f8d6417f8cff58d5b6cba5c27577ee55aa817ae825c6c88fe883f6f6f9265d90", size = 125632, upload-time = "2026-06-16T03:07:24.381Z" },
 ]
 
 [[package]]
@@ -1217,7 +1217,7 @@ requires-dist = [
     { name = "dify-plugin", specifier = ">=0.9.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "sniffio", specifier = ">=1.3.1" },
-    { name = "zai-sdk", specifier = ">=0.2.2" },
+    { name = "zai-sdk", specifier = ">=0.2.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/models/zhipuai/uv.lock
+++ b/models/zhipuai/uv.lock
@@ -170,12 +170,12 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dpkt" },
     { name = "flask" },
     { name = "gevent" },
+    { name = "h11" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -187,18 +187,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5a/885909338df3e32604f45c579457c5dcfe982d35857994805735e5487d4b/dify_plugin-0.10.2.tar.gz", hash = "sha256:e37e707b3903c439cd09924b2125ba794ffdc886bfdbcb8f75db28ba64cb795b", size = 320685, upload-time = "2026-08-10T07:04:08.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
-]
-
-[[package]]
-name = "dpkt"
-version = "1.9.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/7d/52f17a794db52a66e46ebb0c7549bf2f035ed61d5a920ba4aaa127dd038e/dpkt-1.9.8.tar.gz", hash = "sha256:43f8686e455da5052835fd1eda2689d51de3670aac9799b1b00cfd203927ee45", size = 180073, upload-time = "2022-08-18T05:54:13.582Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/79/479e2194c9096b92aecdf33634ae948d2be306c6011673e98ee1917f32c2/dpkt-1.9.8-py3-none-any.whl", hash = "sha256:4da4d111d7bf67575b571f5c678c71bddd2d8a01a3d57d489faf0a92c748fbfd", size = 194973, upload-time = "2022-08-18T05:54:10.793Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/5897c50381eb23a10fd7ab770288d8656f3325d3407e4ee4f6fb7e70f76a/dify_plugin-0.10.2-py3-none-any.whl", hash = "sha256:5a30db98cc4c3f36bdcc70ecd217b6bb37279c39fc0a843a985b05581dc461d3", size = 379282, upload-time = "2026-08-10T07:04:07.068Z" },
 ]
 
 [[package]]
@@ -1214,7 +1205,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.2" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "sniffio", specifier = ">=1.3.1" },
     { name = "zai-sdk", specifier = ">=0.2.3" },


### PR DESCRIPTION
## Summary

Closes #3580.

Closes #3645.

This PR adds the official `glm-5.2` and `glm-5.3` text models to the ZhipuAI provider and updates the SDK versions required by their reasoning APIs.

### Model coverage

| Model | Standard API status | Context | Maximum output | Thinking behavior | Direct API pricing |
| --- | --- | ---: | ---: | --- | --- |
| `glm-5.2` | Available | 1,000,000 tokens | 131,072 tokens | Enabled by default, dynamically used, and may be disabled | ¥8/M input and ¥28/M output |
| `glm-5.3` | Pending official rollout | 1,000,000 tokens | 131,072 tokens | Always enabled | Not announced |

The `glm-5.2` catalog entry exposes its official 65,536-token output default, web search, JSON object output, and all seven accepted `reasoning_effort` compatibility values.

The `glm-5.2` parameter help documents that `none` and `minimal` disable thinking, `low` and `medium` map to `high`, and `xhigh` maps to `max`.

The existing generic thinking conversion is reused so `glm-5.2` can send either `thinking.type: enabled` or `thinking.type: disabled` without a model-specific code path.

The `glm-5.3` request path always sends `thinking.type: enabled` because the model rejects disabled thinking, while its `reasoning_effort` options remain `low`, `high`, and `max`.

Both entries declare the existing ZhipuAI multi-tool, streamed tool-call, agent-thought, and structured-output capabilities.

GLM-5.2 sampling parameters are left to the service defaults instead of adding UI defaults, which preserves the official `temperature=1.0` and `top_p=0.95` behavior without SDK boundary normalization.

GLM-5.2 context caching is automatic and therefore does not require a request parameter.

The catalog records the domestic standard API input and output prices that its pricing schema supports.

The separate ¥2/M cached-input rate cannot be represented by the current schema and is not folded into the regular input price.

GLM-5.3 pricing is deliberately omitted because official standard API pricing has not been published.

### Dependencies and version

- Upgrade `zai-sdk` from 0.2.2 to 0.2.3, the first release whose synchronous chat completion API accepts and serializes `reasoning_effort`.
- Upgrade `dify-plugin` from 0.9.0 to 0.10.2 and refresh the transitive lockfile.
- Bump the ZhipuAI plugin manifest from 0.0.32 to 0.0.33.

The SDK changes used here are additive and do not require a compatibility workaround.

This PR remains a draft because the standard GLM-5.3 API cannot yet be live-tested.

### Official references

- [GLM-5.2 model documentation](https://docs.bigmodel.cn/cn/guide/models/text/glm-5.2)
- [GLM-5.2 migration guide](https://docs.bigmodel.cn/cn/guide/start/migrate-to-glm-new)
- [Core parameter reference](https://docs.bigmodel.cn/cn/guide/start/concept-param)
- [Thinking mode reference](https://docs.bigmodel.cn/cn/guide/capabilities/thinking-mode)
- [Official Python SDK guide](https://docs.bigmodel.cn/cn/guide/develop/python/introduction)
- [Official domestic API pricing](https://bigmodel.cn/pricing)
- [GLM-5.3 launch post](https://z.ai/blog/glm-5.3)
- [GLM-5.3 model documentation](https://docs.bigmodel.cn/cn/guide/models/text/glm-5.3)

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable because this change updates the model catalog and request parameters.

| Before | After |
| --- | --- |
| The ZhipuAI catalog stops at GLM-5.1 | Available GLM-5.2 appears first, followed by pending GLM-5.3 |

## LLM Plugin Checklist

<details open>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

The template's legacy SDK range does not match this repository's current dependencies.

This PR declares and locks `dify-plugin>=0.10.2` instead.

## Testing

- [ ] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

Verified from a clean Python 3.12 environment:

- `uv lock --check --directory models/zhipuai`
- `UV_PROJECT_ENVIRONMENT=<temporary-venv> uv sync --all-groups --frozen --python 3.12 --directory models/zhipuai`
- `UV_PROJECT_ENVIRONMENT=<temporary-venv> uv run --frozen --directory models/zhipuai pytest` — 10 passed
- `ruff check models/zhipuai/tests/test_glm_5.py`
- `ruff format --check models/zhipuai/tests/test_glm_5.py`
- Dify plugin CLI 0.6.10 package build, including both model YAML files — passed

The regression test validates the GLM-5.2 schema, pricing, model ordering, accepted reasoning values, and disabled-thinking request serialization.

The same test module validates that GLM-5.3 still forces enabled thinking.

Live GLM-5.3 inference remains pending the official standard API rollout.
