### PR TITLE
fix(ci): ignore stale version conflicts after merge

### DIFF
--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -123,6 +123,7 @@ jobs:
 
       - name: Check If Version Exists
         env:
+          GH_TOKEN: ${{ github.token }}
           MARKETPLACE_BASE_URL: ${{ secrets.MARKETPLACE_BASE_URL }}
         run: |
           if [ -z "$MARKETPLACE_BASE_URL" ]; then
@@ -140,6 +141,11 @@ jobs:
           if [ "$RESPONSE_CODE" = "200" ]; then
             RESPONSE=$(curl -s "$MARKETPLACE_BASE_URL/api/v1/plugins/$AUTHOR/$NAME/$VERSION")
             if [ "$(echo "$RESPONSE" | jq -r '.code')" = "0" ]; then
+              if [ "$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.merged')" = "true" ]; then
+                echo "Pull request already merged; skipping stale marketplace version check."
+                exit 0
+              fi
+
               echo "!!! Plugin version $VERSION already exists, please update the version number in manifest.yaml"
               exit 1
             fi


### PR DESCRIPTION
## Summary

Fixes #3647.

The approval-triggered plugin check can continue after its pull request has merged and the merged-plugin workflow has published the new version.

In that ordering, `Check If Version Exists` mistakes the pull request's own published version for a pre-existing conflict.

PR #3646 reproduced the race: production published `zhipuai` 0.0.33 at 08:42:05 UTC, and the pre-PR lookup rejected it one second later.

This change keeps the Marketplace uniqueness check strict for open pull requests.

Only after the Marketplace confirms that a version exists, the workflow queries the pull request's live `merged` state.

An already merged pull request skips that stale conflict and continues the remaining package, dependency, installation, and test checks.

An open pull request still receives the existing version-conflict failure.

The live query closes the merge-to-publish race without relying on the review webhook's stale pull request state or non-deterministic concurrency ordering.

This workflow-only fix does not change plugin versions and does not turn the approval workflow into a merge gate.

References:

- [Failing pre-PR job](https://github.com/langgenius/dify-official-plugins/actions/runs/31784886132/job/94718619891)
- [Successful merged-plugin upload](https://github.com/langgenius/dify-official-plugins/actions/runs/31784889119)
- [Reproducing pull request](https://github.com/langgenius/dify-official-plugins/pull/3646)

## Change Type

- [x] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

Not applicable because this is a GitHub Actions control-flow fix.

| Before | After |
| --- | --- |
| A post-merge approval check rejects the version published by its own pull request | Merged pull requests skip the stale conflict, while open pull requests still fail on existing versions |

## LLM Plugin Checklist

Not applicable because no plugin or model behavior changes.

## Version

- [ ] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

Both version items are not applicable because this PR only changes a repository workflow.

## Testing

- [ ] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

No Dify runtime deployment is required for this workflow-only change.

Verified locally:

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -shellcheck= -ignore 'label "depot-ubuntu-24\.04(-4)?" is unknown' .github/workflows/pre-pr-check-per-plugin.yaml`
- `gh api repos/langgenius/dify-official-plugins/pulls/3646 --jq '.merged'` returns `true` for the merged reproducer.
- `gh api repos/langgenius/dify-official-plugins/pulls/3644 --jq '.merged'` returns `false` for an open pull request.

The actionlint exclusions cover existing repository-specific Depot runner labels and unrelated pre-existing inline-shell diagnostics.
