### PR TITLE
fix(bedrock): let non-InvokeError exceptions propagate from _invoke inference-profile branch

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.77
+version: 0.0.78
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -367,9 +367,17 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     )
                 else:
                     raise InvokeError(f"Could not get model information for inference profile {inference_profile_id}")
-            except Exception as e:
-                logger.error(f"Failed to invoke inference profile: {str(e)}")
-                raise InvokeError(f"Failed to invoke inference profile {inference_profile_id}: {str(e)}")
+            except InvokeError:
+                raise
+            except Exception:
+                # Real bug — log the full traceback at ERROR level and let
+                # the original exception type propagate so the caller sees
+                # the root cause instead of a generic InvokeError wrapper.
+                # The previous bare `except Exception as e: raise InvokeError(...)`
+                # hid undefined-name and similar bugs (same anti-pattern that
+                # PR #3565 / issue #3564 fixed in `_generate`).
+                logger.exception(f"Failed to invoke inference profile {inference_profile_id}")
+                raise
         else:
             # Check for bedrock-mantle models (GPT-5.5, GPT-5.4) before attempting Converse API.
             # These models use a different endpoint and the OpenAI Responses API.

--- a/models/bedrock/tests/test_inference_profile_propagation.py
+++ b/models/bedrock/tests/test_inference_profile_propagation.py
@@ -1,0 +1,194 @@
+"""Regression test for the bare ``except Exception`` wrapper in
+``_invoke``'s inference-profile branch (issue #3653).
+
+Pre-fix, ``_invoke`` wrapped the entire inference-profile branch in
+``except Exception as e: raise InvokeError(f"Failed to invoke inference
+profile {id}: {e}")``. A ``NameError`` / ``TypeError`` / ``KeyError`` /
+or any other non-``InvokeError`` exception raised inside the block
+surfaced to the caller as a generic ``InvokeError`` whose message
+contained the original exception string. The root-cause type and
+traceback were lost.
+
+The fix mirrors PR #3565 (issue #3564), which addressed the same
+anti-pattern in ``_generate``:
+- ``except InvokeError: raise`` lets legitimate errors propagate unchanged.
+- ``except Exception: logger.exception(...); raise`` logs the full
+  traceback at ERROR level and re-raises the original exception so the
+  caller sees its real type.
+
+These tests pin:
+1. A non-``InvokeError`` exception (e.g. ``NameError``) propagates
+   unchanged — not wrapped in ``InvokeError``.
+2. The existing ``InvokeError("Could not get model information...")``
+   raise inside the try block still propagates as ``InvokeError``.
+3. A source-level guard: the inference-profile branch in ``llm.py``
+   does not contain ``raise InvokeError(f"Failed to invoke inference
+   profile {str(e)}")`` — the old wrapper that swallowed exceptions.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from dify_plugin.errors.model import InvokeError
+
+llm_mod = importlib.import_module("models.llm.llm")
+BedrockLLM = llm_mod.BedrockLargeLanguageModel
+
+
+def _make_instance() -> BedrockLLM:
+    """Construct a ``BedrockLargeLanguageModel`` without invoking the real
+    plugin-runtime ``__init__``. Method-level tests mock the methods
+    they exercise.
+    """
+    return object.__new__(BedrockLLM)
+
+
+_INFERENCE_PROFILE_CREDENTIALS = {
+    "aws_region": "us-east-1",
+    "inference_profile_id": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123",
+}
+
+
+class TestInferenceProfilePropagatesNonInvokeError:
+    """Pre-fix, any non-``InvokeError`` exception inside the
+    inference-profile branch was wrapped in ``InvokeError``. The fix
+    lets the original exception propagate so the caller sees the
+    real type (and the full traceback, captured by ``logger.exception``).
+    """
+
+    def test_name_error_propagates_unchanged(self) -> None:
+        instance = _make_instance()
+        instance._get_model_info = MagicMock(side_effect=NameError("simulated bug"))
+        with pytest.raises(NameError, match="simulated bug"):
+            instance._invoke(
+                model="anthropic.claude-5-opus",
+                credentials=_INFERENCE_PROFILE_CREDENTIALS,
+                prompt_messages=[],
+                model_parameters={},
+                stop=None,
+                stream=True,
+                user=None,
+            )
+
+    def test_type_error_propagates_unchanged(self) -> None:
+        instance = _make_instance()
+        instance._get_model_info = MagicMock(side_effect=TypeError("bad arg"))
+        with pytest.raises(TypeError, match="bad arg"):
+            instance._invoke(
+                model="anthropic.claude-5-opus",
+                credentials=_INFERENCE_PROFILE_CREDENTIALS,
+                prompt_messages=[],
+                model_parameters={},
+                stop=None,
+                stream=True,
+                user=None,
+            )
+
+    def test_key_error_propagates_unchanged(self) -> None:
+        instance = _make_instance()
+        instance._get_model_info = MagicMock(side_effect=KeyError("missing-key"))
+        with pytest.raises(KeyError):
+            instance._invoke(
+                model="anthropic.claude-5-opus",
+                credentials=_INFERENCE_PROFILE_CREDENTIALS,
+                prompt_messages=[],
+                model_parameters={},
+                stop=None,
+                stream=True,
+                user=None,
+            )
+
+    def test_attribute_error_propagates_unchanged(self) -> None:
+        """Real bug seen in production: a downstream method returns
+        ``None`` and the next line accesses ``.get(...)`` on it.
+        Pre-fix, this would have surfaced as ``InvokeError("Failed to
+        invoke inference profile ...: 'NoneType' object has no
+        attribute 'get'")`` — misleading.
+        """
+        instance = _make_instance()
+        instance._get_model_info = MagicMock(
+            side_effect=AttributeError("'NoneType' object has no attribute 'get'")
+        )
+        with pytest.raises(AttributeError, match="NoneType"):
+            instance._invoke(
+                model="anthropic.claude-5-opus",
+                credentials=_INFERENCE_PROFILE_CREDENTIALS,
+                prompt_messages=[],
+                model_parameters={},
+                stop=None,
+                stream=True,
+                user=None,
+            )
+
+
+class TestInferenceProfileInvokeErrorStillPropagates:
+    """The legitimate ``InvokeError("Could not get model information
+    for inference profile ...")`` raise inside the try block must
+    still propagate as ``InvokeError``. The fix must not swallow the
+    intended error path.
+    """
+
+    def test_known_invoke_error_propagates_unchanged(self) -> None:
+        instance = _make_instance()
+        instance._get_model_info = MagicMock(return_value=None)
+        with pytest.raises(InvokeError, match="Could not get model information"):
+            instance._invoke(
+                model="anthropic.claude-5-opus",
+                credentials=_INFERENCE_PROFILE_CREDENTIALS,
+                prompt_messages=[],
+                model_parameters={},
+                stop=None,
+                stream=True,
+                user=None,
+            )
+
+
+class TestInferenceProfileErrorIsLogged:
+    """When a non-``InvokeError`` exception occurs, the fix uses
+    ``logger.exception`` so the full traceback is captured at ERROR
+    level. The previous code used ``logger.error(str(e))`` which lost
+    the traceback.
+    """
+
+    def test_non_invoke_error_logs_with_traceback(self, caplog) -> None:
+        instance = _make_instance()
+        instance._get_model_info = MagicMock(side_effect=NameError("logged bug"))
+        with caplog.at_level(logging.ERROR, logger="models.llm.llm"):
+            with pytest.raises(NameError):
+                instance._invoke(
+                    model="anthropic.claude-5-opus",
+                    credentials=_INFERENCE_PROFILE_CREDENTIALS,
+                    prompt_messages=[],
+                    model_parameters={},
+                    stop=None,
+                    stream=True,
+                    user=None,
+                )
+        assert any(
+            "inference profile" in record.message.lower() for record in caplog.records
+        ), "logger.exception should fire for non-InvokeError exceptions"
+
+
+class TestNoInvokeErrorWrapperInSource:
+    """Belt-and-braces: the source must not contain the old wrapper
+    pattern that re-raised as ``InvokeError(f"Failed to invoke
+    inference profile {str(e)}")``. A future refactor that re-adds
+    the wrapper would silently re-introduce the bug.
+    """
+
+    def test_no_old_wrapper_in_inference_profile_block(self) -> None:
+        from pathlib import Path
+
+        source_path = Path(llm_mod.__file__).resolve()
+        with open(source_path, encoding="utf-8") as fh:
+            source = fh.read()
+        assert 'raise InvokeError(f"Failed to invoke inference profile' not in source, (
+            f"Old `raise InvokeError(f'Failed to invoke inference profile {{str(e)}}')` "
+            f"wrapper has reappeared in {source_path}; this was the bug fixed in "
+            f"PR fixing issue #3653."
+        )


### PR DESCRIPTION
## Summary

Fixes a bare `except Exception` wrapper in `models/bedrock/models/llm/llm.py` `_invoke` (line 370) that hid real bugs as generic `InvokeError`. Same anti-pattern that PR #3565 (issue #3564) fixed in `_generate`.

A `NameError`, `TypeError`, `KeyError`, or `AttributeError` raised inside the inference-profile branch now propagates with its original type and traceback. Legitimate `InvokeError` raises are unchanged.

3 files, +206/-4, manifest `0.0.77 → 0.0.78`.

## Problem

The `_invoke` method wrapped the entire inference-profile branch in:

```python
except Exception as e:
    logger.error(f"Failed to invoke inference profile: {str(e)}")
    raise InvokeError(f"Failed to invoke inference profile {inference_profile_id}: {str(e)}")
```

If `self._get_model_info`, `get_inference_profile_info`, `self._generate_with_converse`, or any dict accessor raised a `NameError` / `TypeError` / `KeyError` / `AttributeError`, the caller saw:

```
InvokeError: Failed to invoke inference profile arn:aws:bedrock:us-east-1:123:.../abc: name 'foo' is not defined
```

instead of the original `NameError` with its full traceback. Real bugs were indistinguishable from legitimate `InvokeError` raises.

## Fix

Mirrors PR #3565's approach. The single bare `except Exception` is split:

```python
except InvokeError:
    raise
except Exception:
    # Real bug — log the full traceback at ERROR level and let
    # the original exception type propagate so the caller sees
    # the root cause instead of a generic InvokeError wrapper.
    logger.exception(f"Failed to invoke inference profile {inference_profile_id}")
    raise
```

- `except InvokeError: raise` lets legitimate `InvokeError` raises propagate unchanged.
- `except Exception: logger.exception(...); raise` captures the full traceback at ERROR level (was previously lost with `logger.error(str(e))`) and re-raises the original exception.

## Tests

`tests/test_inference_profile_propagation.py` (new, 7 tests):

| Test | What it pins |
|---|---|
| `test_name_error_propagates_unchanged` | `NameError` from `_get_model_info` propagates as `NameError`, not `InvokeError` |
| `test_type_error_propagates_unchanged` | Same for `TypeError` |
| `test_key_error_propagates_unchanged` | Same for `KeyError` |
| `test_attribute_error_propagates_unchanged` | Same for `AttributeError` (real bug seen in production: downstream returns `None`) |
| `test_known_invoke_error_propagates_unchanged` | Legitimate `InvokeError("Could not get model information...")` still propagates as `InvokeError` |
| `test_non_invoke_error_logs_with_traceback` | `logger.exception` fires for non-`InvokeError` exceptions |
| `test_no_old_wrapper_in_inference_profile_block` | Source-level guard: `raise InvokeError(f"Failed to invoke inference profile {str(e)}")` cannot reappear |

## Verification

```bash
cd models/bedrock && uv run pytest tests/
# 86 passed (79 existing + 7 new), no regressions

cd models/bedrock && uv run pytest tests/test_inference_profile_propagation.py -v
# 7 passed in 0.66s

cd models/bedrock && uv run ruff check tests/test_inference_profile_propagation.py
# All checks passed!
```

## Why this matters

A future `NameError` (or similar) inside `_get_model_info` or `_generate_with_converse` (which shares the same complex code path) will now surface with its original type and traceback. The user and any maintainer debugging the issue can see the real root cause instead of a generic `InvokeError` wrapper.

The other three `except Exception as ex: raise InvokeError(str(ex))` patterns in `llm.py` (lines 749, 991, 1404) are similar but have different exception-mapping semantics. They are listed as follow-up work in the issue body and would each be a focused single-method PR.

## Backward compatibility

No behavior change for legitimate `InvokeError` raises. Non-`InvokeError` exceptions now surface with their original type instead of being wrapped. This is a strict improvement: callers that previously logged `InvokeError` will now see more specific exception types.

## Risks

Negligible. A caller that depended on receiving `InvokeError` for ALL inference profile failures (including real bugs) would see a change. The current behavior is wrong (it hides real bugs), so any caller relying on it was already operating on misleading information. No documented caller in the dify plugin ecosystem depends on this.

## Future work

- Apply the same fix to `_generate_with_converse` (line 749), tool-call parsing (line 991), and credentials validation (line 1404). Each is a focused follow-up PR.
- Add a static `ast` check that flags any `except Exception` followed by `raise InvokeError(str(ex))` to prevent future regressions across the codebase.

Fixes #3653.
