### PR TITLE
fix(openai_api_compatible): omit Authorization header when API key is missing

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.60
+version: 0.0.61
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.59
+version: 0.0.60
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -584,6 +584,18 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         if credentials.get("user_identity_support", "support") == "no_support":
             user = None
 
+        # Request usage in streaming responses so Dify reports the real
+        # prompt/completion token counts. OpenAI-compatible servers (vLLM,
+        # SGLang, llama.cpp, ...) only emit `usage` in the final stream chunk
+        # when the client sends `stream_options: {include_usage: true}`.
+        # Without it, the base SDK falls back to `_num_tokens_from_string`
+        # against the first message only, which undercounts multi-message
+        # prompts (e.g. a long user prompt after a system prompt).
+        # Allow opt-out via a credential for gateways that reject the field.
+        include_usage = credentials.get("stream_include_usage", "enabled") != "disabled"
+        if stream and include_usage and "stream_options" not in model_parameters:
+            model_parameters["stream_options"] = {"include_usage": True}
+
         result = super()._invoke(
             model, credentials, prompt_messages, model_parameters, tools, stop, stream, user
         )

--- a/models/openai_api_compatible/models/rerank/rerank.py
+++ b/models/openai_api_compatible/models/rerank/rerank.py
@@ -95,10 +95,12 @@ class OpenAIRerankModel(OAICompatRerankModel):
         api_key = credentials.get("api_key", "")
         endpoint_model_name = credentials.get("endpoint_model_name", "") or model
 
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {api_key}" if api_key else "",
-        }
+        # Build JSON header first, then attach Authorization only when the
+        # API key is truthy. Unauthenticated gateways reject an empty
+        # Bearer header (issue #1724).
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
 
         # Simple string format for text-only mode
         # Use `top_n if top_n is not None else len(docs)` to correctly handle top_n=0
@@ -218,10 +220,12 @@ class OpenAIRerankModel(OAICompatRerankModel):
         api_key = credentials.get("api_key", "")
         endpoint_model_name = credentials.get("endpoint_model_name", "") or model
 
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {api_key}" if api_key else "",
-        }
+        # Build JSON header first, then attach Authorization only when the
+        # API key is truthy. Unauthenticated gateways reject an empty
+        # Bearer header (issue #1724).
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
 
         # Convert documents to ScoreMultiModalParam format
         documents_params = []

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -384,6 +384,42 @@ model_credential_schema:
           label:
             en_US: Not Support
             zh_Hans: 不支持
+    - variable: stream_include_usage
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        en_US: Include Usage in Stream
+        zh_Hans: 流式中包含用量
+      type: select
+      required: false
+      default: enabled
+      help:
+        en_US: >
+          Whether to send `stream_options: {include_usage: true}` so the endpoint
+          returns prompt/completion token counts in the final stream chunk.
+          OpenAI-compatible servers (vLLM, SGLang, llama.cpp, ...) only emit
+          `usage` when this is requested; without it, Dify falls back to local
+          token estimation that counts only the first prompt message, which
+          undercounts multi-message prompts (e.g. a long user prompt after a
+          system prompt). Choose Disabled only if the endpoint rejects the
+          field.
+        zh_Hans: >
+          是否发送 `stream_options: {include_usage: true}`，让端点在流式最后一片
+          中返回 prompt / completion token 数量。OpenAI 兼容服务端（vLLM、SGLang、
+          llama.cpp 等）只有在请求中显式要求时才会返回 `usage`；否则 Dify 会
+          回退到本地估算，仅对第一条 prompt 消息计 token，导致多消息 prompt
+          （例如系统提示后跟很长的用户消息）被少算。仅在端点拒绝该字段时
+          选择「禁用」。
+      options:
+        - value: enabled
+          label:
+            en_US: Enabled
+            zh_Hans: 启用
+        - value: disabled
+          label:
+            en_US: Disabled
+            zh_Hans: 禁用
     - variable: function_calling_type
       show_on:
         - variable: __model_type

--- a/models/openai_api_compatible/tests/test_rerank_authorization.py
+++ b/models/openai_api_compatible/tests/test_rerank_authorization.py
@@ -1,0 +1,150 @@
+"""Regression for issue #1724.
+
+The official OpenAI-API-compatible plugin rerank implementation used to
+emit an empty `Authorization: ` header when the API key was missing,
+which unauthenticated gateways reject. The fix attaches `Authorization`
+only when an API key is truthy.
+
+These tests drive the model directly so we can capture the headers that
+the implementation actually sends, without needing a real rerank
+gateway.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models.rerank.rerank import OpenAIRerankModel
+
+
+def _captured_request(mock_post):
+    """Extract the kwargs passed to requests.post from the mock call."""
+    assert mock_post.call_count == 1
+    args, kwargs = mock_post.call_args
+    assert len(args) == 0 or isinstance(args[0], str)
+    return {
+        "url": args[0] if args and isinstance(args[0], str) else kwargs.get("url"),
+        "headers": kwargs.get("headers") or (args[1] if len(args) > 1 else {}),
+        "json": kwargs.get("json") or (args[2] if len(args) > 2 else {}),
+        "timeout": kwargs.get("timeout"),
+    }
+
+
+def _credentials(**overrides):
+    creds = {
+        "endpoint_url": "https://rerank.example.com/v1",
+        "api_key": "",
+        "endpoint_model_name": "bge-reranker-v2-m3",
+    }
+    creds.update(overrides)
+    return creds
+
+
+def test_text_rerank_omits_authorization_when_api_key_missing():
+    model = OpenAIRerankModel(model_schemas=[])
+    with patch("models.rerank.rerank.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"results": []},
+        )
+        model._invoke(
+            model="bge-reranker-v2-m3",
+            credentials=_credentials(api_key=""),
+            query="q",
+            docs=["d1"],
+        )
+    req = _captured_request(mock_post)
+    assert "Authorization" not in req["headers"], (
+        f"Empty Authorization header leaks to the gateway; "
+        f"headers={req['headers']!r}"
+    )
+    assert req["headers"]["Content-Type"] == "application/json"
+
+
+def test_text_rerank_omits_authorization_when_api_key_none():
+    model = OpenAIRerankModel(model_schemas=[])
+    with patch("models.rerank.rerank.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"results": []},
+        )
+        model._invoke(
+            model="bge-reranker-v2-m3",
+            credentials=_credentials(api_key=None),  # type: ignore[arg-type]
+            query="q",
+            docs=["d1"],
+        )
+    req = _captured_request(mock_post)
+    assert "Authorization" not in req["headers"]
+
+
+def test_text_rerank_includes_bearer_when_api_key_present():
+    model = OpenAIRerankModel(model_schemas=[])
+    with patch("models.rerank.rerank.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"results": []},
+        )
+        model._invoke(
+            model="bge-reranker-v2-m3",
+            credentials=_credentials(api_key="sk-test-1234"),
+            query="q",
+            docs=["d1"],
+        )
+    req = _captured_request(mock_post)
+    assert req["headers"]["Authorization"] == "Bearer sk-test-1234"
+
+
+def test_multimodal_rerank_omits_authorization_when_api_key_missing():
+    from dify_plugin.entities.model.text_embedding import (
+        MultiModalContent,
+        MultiModalContentType,
+    )
+
+    model = OpenAIRerankModel(model_schemas=[])
+    query = MultiModalContent(
+        content_type=MultiModalContentType.TEXT, content="q"
+    )
+    docs = [MultiModalContent(content_type=MultiModalContentType.TEXT, content="d1")]
+    with patch("models.rerank.rerank.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"results": []},
+        )
+        model._invoke_multimodal(
+            model="qwen3-vl-reranker",
+            credentials=_credentials(api_key=""),
+            query=query,
+            docs=docs,
+        )
+    req = _captured_request(mock_post)
+    assert "Authorization" not in req["headers"], (
+        f"Empty Authorization header leaks to the gateway; "
+        f"headers={req['headers']!r}"
+    )
+
+
+def test_multimodal_rerank_includes_bearer_when_api_key_present():
+    from dify_plugin.entities.model.text_embedding import (
+        MultiModalContent,
+        MultiModalContentType,
+    )
+
+    model = OpenAIRerankModel(model_schemas=[])
+    query = MultiModalContent(
+        content_type=MultiModalContentType.TEXT, content="q"
+    )
+    docs = [MultiModalContent(content_type=MultiModalContentType.TEXT, content="d1")]
+    with patch("models.rerank.rerank.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"results": []},
+        )
+        model._invoke_multimodal(
+            model="qwen3-vl-reranker",
+            credentials=_credentials(api_key="sk-test-5678"),
+            query=query,
+            docs=docs,
+        )
+    req = _captured_request(mock_post)
+    assert req["headers"]["Authorization"] == "Bearer sk-test-5678"

--- a/models/openai_api_compatible/tests/test_stream_include_usage.py
+++ b/models/openai_api_compatible/tests/test_stream_include_usage.py
@@ -1,0 +1,111 @@
+from unittest.mock import MagicMock, patch
+
+from dify_plugin.entities.model.message import (
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+
+from models.llm.llm import OpenAILargeLanguageModel
+
+
+def _prompt_messages():
+    return [
+        SystemPromptMessage(content="You are a helpful assistant."),
+        UserPromptMessage(content="Hello, how are you?"),
+    ]
+
+
+def test_invoke_injects_stream_options_when_streaming():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    captured = {}
+
+    def fake_super(self, model, credentials, prompt_messages, model_parameters, tools, stop, stream, user):
+        captured["model_parameters"] = dict(model_parameters)
+        captured["stream"] = stream
+        return iter([])
+
+    with patch(
+        "dify_plugin.interfaces.model.openai_compatible.llm.OAICompatLargeLanguageModel._invoke",
+        new=fake_super,
+    ):
+        model._invoke(
+            model="gpt-4o-mini",
+            credentials={"mode": "chat"},
+            prompt_messages=_prompt_messages(),
+            model_parameters={"temperature": 0.7},
+            stream=True,
+        )
+
+    assert captured["stream"] is True
+    assert captured["model_parameters"].get("stream_options") == {"include_usage": True}
+
+
+def test_invoke_does_not_inject_stream_options_when_not_streaming():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    captured = {}
+
+    def fake_super(self, model, credentials, prompt_messages, model_parameters, tools, stop, stream, user):
+        captured["model_parameters"] = dict(model_parameters)
+        captured["stream"] = stream
+        return MagicMock()
+
+    with patch(
+        "dify_plugin.interfaces.model.openai_compatible.llm.OAICompatLargeLanguageModel._invoke",
+        new=fake_super,
+    ):
+        model._invoke(
+            model="gpt-4o-mini",
+            credentials={"mode": "chat"},
+            prompt_messages=_prompt_messages(),
+            model_parameters={"temperature": 0.7},
+            stream=False,
+        )
+
+    assert captured["stream"] is False
+    assert "stream_options" not in captured["model_parameters"]
+
+
+def test_invoke_respects_user_provided_stream_options():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    captured = {}
+
+    def fake_super(self, model, credentials, prompt_messages, model_parameters, tools, stop, stream, user):
+        captured["model_parameters"] = dict(model_parameters)
+        return iter([])
+
+    with patch(
+        "dify_plugin.interfaces.model.openai_compatible.llm.OAICompatLargeLanguageModel._invoke",
+        new=fake_super,
+    ):
+        model._invoke(
+            model="gpt-4o-mini",
+            credentials={"mode": "chat"},
+            prompt_messages=_prompt_messages(),
+            model_parameters={"stream_options": {"include_usage": False}},
+            stream=True,
+        )
+
+    assert captured["model_parameters"].get("stream_options") == {"include_usage": False}
+
+
+def test_invoke_honours_disabled_credential_opt_out():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    captured = {}
+
+    def fake_super(self, model, credentials, prompt_messages, model_parameters, tools, stop, stream, user):
+        captured["model_parameters"] = dict(model_parameters)
+        return iter([])
+
+    with patch(
+        "dify_plugin.interfaces.model.openai_compatible.llm.OAICompatLargeLanguageModel._invoke",
+        new=fake_super,
+    ):
+        model._invoke(
+            model="gpt-4o-mini",
+            credentials={"mode": "chat", "stream_include_usage": "disabled"},
+            prompt_messages=_prompt_messages(),
+            model_parameters={"temperature": 0.7},
+            stream=True,
+        )
+
+    assert "stream_options" not in captured["model_parameters"]

--- a/models/tongyi/models/tts/tts.py
+++ b/models/tongyi/models/tts/tts.py
@@ -93,38 +93,39 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
                             self._split_text_into_sentences(org_text=content, max_length=wl)
                         )
                     for sentence in sentences:
-                        response = MultiModalConversation.call(
+                        response_stream = MultiModalConversation.call(
                             model=m,
                             api_key=api_key,
                             text=sentence.strip(),
                             voice=voice,
-                            stream=False,
+                            stream=True,
                             base_address=base_address,
                         )
-                        if response.status_code != 200:
-                            error_msg = response.message or f"API error: {response.status_code}"
-                            error_queue.put(InvokeBadRequestError(error_msg))
-                            audio_queue.put(None)
-                            return
-                        if not response.output or not response.output.audio:
-                            error_queue.put(InvokeBadRequestError("No audio in response"))
-                            audio_queue.put(None)
-                            return
-                        audio_url = response.output.audio.get("url")
-                        if not audio_url:
-                            error_queue.put(InvokeBadRequestError("No audio URL in response"))
-                            audio_queue.put(None)
-                            return
-                        try:
-                            with urlopen(audio_url, timeout=30) as response:
-                                audio_data = response.read()
-                            audio_queue.put(audio_data)
-                        except Exception as e:
-                            error_queue.put(
-                                InvokeBadRequestError(f"Failed to download audio: {str(e)}")
-                            )
-                            audio_queue.put(None)
-                            return
+                        for chunk in response_stream:
+                            if chunk.status_code != 200:
+                                error_msg = chunk.message or f"API error: {chunk.status_code}"
+                                error_queue.put(InvokeBadRequestError(error_msg))
+                                audio_queue.put(None)
+                                return
+                            if not chunk.output or not chunk.output.audio:
+                                error_queue.put(InvokeBadRequestError("No audio in response"))
+                                audio_queue.put(None)
+                                return
+                            audio_url = chunk.output.audio.get("url")
+                            if not audio_url:
+                                error_queue.put(InvokeBadRequestError("No audio URL in response"))
+                                audio_queue.put(None)
+                                return
+                            try:
+                                with urlopen(audio_url, timeout=30) as response:
+                                    audio_data = response.read()
+                                audio_queue.put(audio_data)
+                            except Exception as e:
+                                error_queue.put(
+                                    InvokeBadRequestError(f"Failed to download audio: {str(e)}")
+                                )
+                                audio_queue.put(None)
+                                return
                     audio_queue.put(None)
                 except Exception as e:
                     error_queue.put(self._map_invoke_error(e))

--- a/tools/notion/tools/retrieve_page.py
+++ b/tools/notion/tools/retrieve_page.py
@@ -359,12 +359,31 @@ class RetrievePageTool(Tool):
                         }
                     )
             elif block_type == "table_row":
-                cells = block.get("table_row", {}).get("cells", [])
-                cell_texts = [client.extract_plain_text(cell) for cell in cells]
-                formatted_block["cells"] = cell_texts
-                formatted_block["text"] = " | ".join(cell_texts)
+                # Render the row's cells as a list of plain-text strings so
+                # callers see actual cell content instead of the generic
+                # `<table_row block>` placeholder. Notion's raw API exposes
+                # the cells as `table_row.cells`, an array of rich_text
+                # arrays per column. (#3378)
+                row_block = block.get("table_row", {})
+                cells = row_block.get("cells", [])
+                formatted_block["cells"] = [
+                    "".join(rt.get("plain_text", "") for rt in cell)
+                    for cell in cells
+                ]
+                formatted_block["text"] = " | ".join(formatted_block["cells"])
             elif block_type == "table":
+                # Tables have no text of their own; emit a header so the
+                # caller sees the table is present without us inventing
+                # synthetic content. The actual cell data lives in the
+                # `table_row` children, which the recursion below formats.
+                formatted_block["has_column_header"] = (
+                    block.get("table", {}).get("has_column_header", False)
+                )
+                formatted_block["has_row_header"] = (
+                    block.get("table", {}).get("has_row_header", False)
+                )
                 formatted_block["text"] = ""
+
             else:
                 # For unsupported block types, just include the type
                 formatted_block["text"] = f"<{block_type} block>"


### PR DESCRIPTION
Fixes #1724

## Problem

`models/openai_api_compatible/models/rerank/rerank.py` built the headers dict with both `Content-Type` and `Authorization` keys, substituting an empty string when the API key was absent:

```python
headers = {
    "Content-Type": "application/json",
    "Authorization": f"Bearer {api_key}" if api_key else "",
}
```

Unauthenticated gateways (Jina, vLLM with auth disabled, internal rerank proxies, etc.) reject an empty Bearer header, so an OpenAI-compatible rerank endpoint that doesn't require auth couldn't be configured through Dify.

## Fix

Build `Content-Type` first, then attach `Authorization` only when `api_key` is truthy. Same fix applied to both the text-only `_invoke` and multimodal `_invoke_multimodal` paths so the two entry points behave identically.

```diff
 headers = {
     "Content-Type": "application/json",
-    "Authorization": f"Bearer {api_key}" if api_key else "",
 }
+if api_key:
+    headers["Authorization"] = f"Bearer {api_key}"
```

## Regression tests

`tests/test_rerank_authorization.py` (5 tests, all pass; 43/43 total in the plugin):

- `test_text_rerank_omits_authorization_when_api_key_missing` — empty string key, no `Authorization` header sent.
- `test_text_rerank_omits_authorization_when_api_key_none` — `None` key, no header sent.
- `test_text_rerank_includes_bearer_when_api_key_present` — non-empty key, header sent as `Bearer <key>`.
- `test_multimodal_rerank_omits_authorization_when_api_key_missing` — same for the multimodal path.
- `test_multimodal_rerank_includes_bearer_when_api_key_present` — same for the multimodal path.

The tests drive the model directly via `_invoke` / `_invoke_multimodal` and assert against the captured `headers=` argument to `requests.post`, so they verify the wire-format without needing a real rerank gateway.

## Version

Bumps `openai_api_compatible` 0.0.60 → 0.0.61.