### PR TITLE
fix(anthropic): harden image fetch against SSRF, unbounded downloads and format errors

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.26
+version: 0.3.27

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -1,10 +1,14 @@
 import base64
 import io
+import ipaddress
 import json
 import re
 import copy
+import socket
+import time
 from collections.abc import Generator, Sequence
 from typing import Any, Mapping, Optional, Union, cast
+from urllib.parse import urljoin, urlparse
 import logging
 
 import anthropic
@@ -167,6 +171,12 @@ class PromptCachingHandler:
             adjusted += int(cache_read_input_tokens * cls.CACHE_READ_MULTIPLIER)
 
         return adjusted
+
+
+_IMAGE_FETCH_MAX_BYTES = 20 * 1024 * 1024  # cap on downloaded / decoded image bytes
+_IMAGE_FETCH_ENCODED_MAX_BYTES = 28 * 1024 * 1024  # cap on data-URI base64 input (pre-decode)
+_IMAGE_FETCH_DEADLINE_S = 30.0  # total wall-clock budget per image fetch (all hops + download)
+_IMAGE_FETCH_MAX_REDIRECTS = 3
 
 
 class AnthropicLargeLanguageModel(LargeLanguageModel):
@@ -1428,29 +1438,119 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         
         return result
     
-    def _process_image_data(self, data: str) -> tuple[str, str]:
-        """Process image data from URL or data URI."""
-        if data.startswith("data:"):
-            # Extract from data URI
-            header, encoded = data.split(";base64,", 1)
-            mime_type = header.replace("data:", "")
-            return mime_type, encoded
-        
-        # Fetch from URL
+    def _assert_public_http_url(self, url: str) -> None:
+        """Validate that url is http(s) and does not target a private/internal address."""
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("Unsupported image URL scheme")
+        hostname = (parsed.hostname or "").lower()
+        if not hostname:
+            raise ValueError("Invalid image URL")
         try:
-            response = requests.get(data)
-            response.raise_for_status()
-            
-            with Image.open(io.BytesIO(response.content)) as img:
-                img_format = img.format or "jpeg"  # Default to jpeg if format is None
-                mime_type = f"image/{img_format.lower()}"
-            
-            base64_data = base64.b64encode(response.content).decode("utf-8")
-            return mime_type, base64_data
-            
+            addr_infos = socket.getaddrinfo(hostname, None)
+        except socket.gaierror as ex:
+            raise ValueError("Invalid or inaccessible image URL") from ex
+        for ai in addr_infos:
+            # strip IPv6 zone index before parsing
+            addr = ai[4][0].split("%", 1)[0]
+            try:
+                ip = ipaddress.ip_address(addr)
+            except ValueError:
+                continue
+            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                raise ValueError("Invalid or inaccessible image URL")
+
+    def _normalize_image_bytes(self, content: bytes) -> tuple[bytes, str]:
+        """Sniff the real image format and convert unsupported formats to PNG."""
+        try:
+            with Image.open(io.BytesIO(content)) as img:
+                img_format = (img.format or "JPEG").upper()
+                if img_format in ("JPEG", "PNG", "GIF", "WEBP"):
+                    return content, f"image/{img_format.lower()}"
+            # BMP, TIFF, ... are rejected by the Messages API; re-encode as PNG
+            with Image.open(io.BytesIO(content)) as img:
+                buffer = io.BytesIO()
+                img.convert("RGB").save(buffer, format="PNG")
+                return buffer.getvalue(), "image/png"
+        except ValueError:
+            raise
         except Exception as ex:
-            raise ValueError(f"Failed to fetch image from {data}: {ex}") from ex
-    
+            raise ValueError("Unsupported image data") from ex
+
+    def _process_image_data(self, data: str) -> tuple[str, str]:
+        """Process image data from URL or data URI.
+
+        Hardened fetch: SSRF guards (scheme + private/link-local/reserved IP blocking,
+        re-validated on every redirect hop), streaming download with a size cap, a total
+        wall-clock deadline, strict base64 validation for data URIs, format sniffing via
+        Pillow, and error messages that never echo URLs or query strings.
+        """
+        if data.startswith("data:"):
+            # data URI: strict base64, cap input BEFORE decoding, sniff actual format
+            try:
+                header, encoded = data.split(";base64,", 1)
+            except ValueError as ex:
+                raise ValueError("Malformed base64 data URI") from ex
+            if len(encoded) > _IMAGE_FETCH_ENCODED_MAX_BYTES:
+                raise ValueError("Encoded image data exceeds maximum allowed size")
+            try:
+                content = base64.b64decode(encoded, validate=True)
+            except Exception as ex:
+                raise ValueError("Malformed base64 data URI payload") from ex
+            if len(content) > _IMAGE_FETCH_MAX_BYTES:
+                raise ValueError("Image exceeds maximum allowed size")
+            content, mime_type = self._normalize_image_bytes(content)
+            return mime_type, base64.b64encode(content).decode("utf-8")
+
+        self._assert_public_http_url(data)
+
+        deadline = time.monotonic() + _IMAGE_FETCH_DEADLINE_S
+        current = data
+        content = None
+        try:
+            for _hop in range(_IMAGE_FETCH_MAX_REDIRECTS + 1):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ValueError("Image fetch exceeded total time limit")
+                # read timeout shrinks to the remaining budget so a blocked read
+                # cannot overshoot the deadline (requests timeouts are not totals)
+                buf = bytearray()
+                with requests.get(
+                    current,
+                    timeout=(min(5.0, remaining), max(0.1, min(10.0, remaining))),
+                    stream=True,
+                    allow_redirects=False,
+                ) as response:
+                    if response.status_code in (301, 302, 303, 307, 308):
+                        location = response.headers.get("Location")
+                        if not location:
+                            raise ValueError("Redirect without Location header")
+                        current = urljoin(current, location)
+                        # re-validate every hop: a redirect must not bypass the guard
+                        self._assert_public_http_url(current)
+                        continue
+                    response.raise_for_status()
+                    for chunk in response.iter_content(chunk_size=65536):
+                        buf.extend(chunk)
+                        if len(buf) > _IMAGE_FETCH_MAX_BYTES:
+                            raise ValueError("Image exceeds maximum allowed size")
+                        if time.monotonic() > deadline:
+                            raise ValueError("Image fetch exceeded total time limit")
+                    content = bytes(buf)
+                    break
+            if content is None:
+                raise ValueError("Too many redirects")
+            content, mime_type = self._normalize_image_bytes(content)
+            return mime_type, base64.b64encode(content).decode("utf-8")
+        except ValueError:
+            raise
+        except requests.exceptions.HTTPError as ex:
+            status = ex.response.status_code if ex.response is not None else 0
+            # never echo the URL or query string (may contain SAS tokens)
+            raise ValueError(f"Failed to fetch image (HTTP {status})") from None
+        except Exception as ex:
+            raise ValueError(f"Failed to fetch image ({ex.__class__.__name__})") from None
+
     def _create_document_content(self, content: DocumentPromptMessageContent, is_last_user_message: bool = False) -> dict:
         """Create document content dict."""
         if content.mime_type != "application/pdf":

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -1457,6 +1457,9 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 ip = ipaddress.ip_address(addr)
             except ValueError:
                 continue
+            if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+                # evaluate IPv4-mapped addresses by their embedded IPv4 value
+                ip = ip.ipv4_mapped
             if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
                 raise ValueError("Invalid or inaccessible image URL")
 

--- a/models/anthropic/tests/test_image_fetch.py
+++ b/models/anthropic/tests/test_image_fetch.py
@@ -270,8 +270,8 @@ def test_wall_clock_deadline(monkeypatch, model):
         _FakeResponse(),
     ]
     _install_responses(monkeypatch, responses)
-    # exhaust the deadline before the second hop (first call computes the
-    # deadline, every later call reports "way past it")
+    # replace the time MODULE REFERENCE inside llm.py only (not the global stdlib
+    # module), so the fake clock cannot affect other libraries
     import models.llm.llm as llm_module
 
     real_monotonic = llm_module.time.monotonic
@@ -282,9 +282,73 @@ def test_wall_clock_deadline(monkeypatch, model):
         calls["n"] += 1
         return t0 if calls["n"] == 1 else t0 + 60.0
 
-    monkeypatch.setattr(llm_module.time, "monotonic", _fake_monotonic)
+    monkeypatch.setattr(
+        "models.llm.llm.time", types.SimpleNamespace(monotonic=_fake_monotonic)
+    )
     with pytest.raises(ValueError, match="total time limit"):
         model._process_image_data("https://pub.example.com/a.png")
+
+
+def test_read_timeout_shrinks_with_remaining_budget(monkeypatch, model):
+    _expect_public(monkeypatch)
+    seen_kwargs = {}
+
+    def _fake_get(url, **kwargs):
+        seen_kwargs.update(kwargs)
+        return _FakeResponse(302, headers={"Location": "https://pub2.example.com/b.png"}) if not seen_kwargs else _FakeResponse()
+
+    monkeypatch.setattr("models.llm.llm.requests.get", _fake_get)
+    # clock: t0 at deadline computation, then t0+29.5 on every later call,
+    # so the second hop sees only 0.5s of remaining budget
+    t0 = 1_000_000.0
+    calls = {"n": 0}
+
+    def _fake_monotonic():
+        calls["n"] += 1
+        return t0 if calls["n"] == 1 else t0 + 29.5
+
+    monkeypatch.setattr(
+        "models.llm.llm.time", types.SimpleNamespace(monotonic=_fake_monotonic)
+    )
+    model._process_image_data("https://pub.example.com/a.png")
+    timeouts = seen_kwargs["timeout"]
+    assert timeouts[0] <= 0.5 and timeouts[1] <= 0.5, (
+        "read/connect timeouts must shrink to the remaining wall-clock budget"
+    )
+
+
+@pytest.mark.parametrize(
+    "location",
+    ["file:///etc/passwd", "ftp://pub.example.com/x", "data:image/png;base64,AAAA"],
+)
+def test_redirect_to_non_http_scheme_rejected(model, monkeypatch, location):
+    _expect_public(monkeypatch)
+    responses = [_FakeResponse(302, headers={"Location": location})]
+    _install_responses(monkeypatch, responses)
+    with pytest.raises(ValueError):
+        model._process_image_data("https://pub.example.com/a.png")
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["::ffff:127.0.0.1", "::ffff:169.254.169.254", "::ffff:10.0.0.5"],
+)
+def test_ipv4_mapped_ipv6_targets_rejected(model, monkeypatch, host):
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda h, p: [(socket.AF_INET6, socket.SOCK_STREAM, 6, "", (host, 0))],
+    )
+    with pytest.raises(ValueError, match="Invalid or inaccessible image URL"):
+        model._process_image_data("https://metadata-alias.example.com/a.png")
+
+
+def test_single_oversized_chunk_rejected(model, monkeypatch):
+    _expect_public(monkeypatch)
+    responses = [_FakeResponse(chunks=[b"x" * (25 * 1024 * 1024)])]
+    _install_responses(monkeypatch, responses)
+    with pytest.raises(ValueError, match="maximum allowed size"):
+        model._process_image_data("https://pub.example.com/big.png")
 
 
 # ---------------------------------------------------------------------------
@@ -330,3 +394,61 @@ def test_generic_error_never_leaks_userinfo(model, monkeypatch):
     with pytest.raises(ValueError, match=r"Failed to fetch image \(ConnectionError\)") as excinfo:
         model._process_image_data("https://user:SECRETPW@pub.example.com/a.png")
     assert "SECRETPW" not in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# real Pillow paths (in-memory generated images, no Image.open mocking)
+# ---------------------------------------------------------------------------
+
+
+def _real_image_bytes(fmt):
+    from PIL import Image as RealImage
+
+    img = RealImage.new("RGB", (4, 4), color=(120, 30, 200))
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def _use_real_pillow(monkeypatch):
+    from PIL import Image as RealImage
+
+    monkeypatch.setattr("models.llm.llm.Image", RealImage)
+
+
+def test_real_png_url_passes_through_unconverted(model, monkeypatch):
+    _use_real_pillow(monkeypatch)
+    png_bytes = _real_image_bytes("PNG")
+    responses = [_FakeResponse(chunks=[png_bytes])]
+    _install_responses(monkeypatch, responses)
+    mime, b64 = model._process_image_data("https://pub.example.com/a.png")
+    assert mime == "image/png"
+    assert base64.b64decode(b64) == png_bytes
+
+
+def test_real_bmp_url_converted_to_png(model, monkeypatch):
+    _use_real_pillow(monkeypatch)
+    bmp_bytes = _real_image_bytes("BMP")
+    responses = [_FakeResponse(chunks=[bmp_bytes])]
+    _install_responses(monkeypatch, responses)
+    mime, b64 = model._process_image_data("https://pub.example.com/a.bmp")
+    assert mime == "image/png"
+    converted = base64.b64decode(b64)
+    assert converted[:8] == b"\x89PNG\r\n\x1a\n"
+    assert converted != bmp_bytes
+
+
+def test_real_data_uri_bmp_converted_to_png(model, monkeypatch):
+    _use_real_pillow(monkeypatch)
+    bmp_b64 = base64.b64encode(_real_image_bytes("BMP")).decode()
+    mime, b64 = model._process_image_data("data:image/bmp;base64," + bmp_b64)
+    assert mime == "image/png"
+    assert base64.b64decode(b64)[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_real_non_image_bytes_rejected(model, monkeypatch):
+    _use_real_pillow(monkeypatch)
+    responses = [_FakeResponse(chunks=[b"this is not an image at all"])]
+    _install_responses(monkeypatch, responses)
+    with pytest.raises(ValueError, match="Unsupported image data"):
+        model._process_image_data("https://pub.example.com/text.png")

--- a/models/anthropic/tests/test_image_fetch.py
+++ b/models/anthropic/tests/test_image_fetch.py
@@ -1,0 +1,332 @@
+"""Unit tests for the hardened image fetch in AnthropicLargeLanguageModel.
+
+All network interaction is stubbed: socket.getaddrinfo, requests.get and
+PIL.Image.open are monkeypatched. No test performs real I/O.
+"""
+
+import base64
+import io
+import socket
+import types
+
+import pytest
+import requests as real_requests
+
+from models.llm.llm import AnthropicLargeLanguageModel
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _FakeSaver:
+    def save(self, buf, format=None):
+        buf.write(b"PNGDATA")
+
+
+class _FakeImg:
+    def __init__(self, fmt="PNG", raise_on_open=False):
+        self.format = fmt
+        self._raise = raise_on_open
+
+    def convert(self, mode):
+        return _FakeSaver()
+
+    def __enter__(self):
+        if self._raise:
+            raise real_requests.exceptions.RequestException("bad image")
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, chunks=None, headers=None):
+        self.status_code = status_code
+        self._chunks = [b"IMGbytes"] if chunks is None else chunks
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise real_requests.exceptions.HTTPError(
+                f"{self.status_code} for url (redacted)"
+            )
+
+    def iter_content(self, chunk_size=None):
+        return iter(self._chunks)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+_PUB = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+_HOSTMAP = {
+    "pub.example.com": _PUB,
+    "cdn.example.com": _PUB,
+    "pub2.example.com": _PUB,
+    "127.0.0.1": (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+    "localhost": (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+    "169.254.169.254": (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0)),
+    "10.0.0.5": (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 0)),
+    "172.19.0.10": (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("172.19.0.10", 0)),
+}
+
+
+@pytest.fixture
+def model():
+    return AnthropicLargeLanguageModel()
+
+
+@pytest.fixture(autouse=True)
+def stub_env(monkeypatch):
+    monkeypatch.setattr(
+        socket, "getaddrinfo", lambda host, port: [_HOSTMAP.get(host, _PUB)]
+    )
+    monkeypatch.setattr(
+        "models.llm.llm.Image",
+        types.SimpleNamespace(open=lambda b: _FakeImg("PNG")),
+    )
+    # safety net: no test should ever hit the network
+    def _no_network(*args, **kwargs):
+        raise AssertionError("real network call attempted in test")
+
+    monkeypatch.setattr("models.llm.llm.requests.get", _no_network)
+
+
+def _install_responses(monkeypatch, responses):
+    queue = list(responses)
+
+    def _fake_get(url, **kwargs):
+        assert kwargs.get("allow_redirects") is False, "redirects must not be followed automatically"
+        return queue.pop(0) if queue else _FakeResponse()
+
+    monkeypatch.setattr("models.llm.llm.requests.get", _fake_get)
+    return queue
+
+
+def _expect_public(monkeypatch, responses=None, img_fmt="PNG", raise_on_open=False):
+    monkeypatch.setattr(
+        "models.llm.llm.Image",
+        types.SimpleNamespace(open=lambda b: _FakeImg(img_fmt, raise_on_open)),
+    )
+    _install_responses(monkeypatch, responses if responses is not None else [_FakeResponse()])
+
+
+# ---------------------------------------------------------------------------
+# data URIs
+# ---------------------------------------------------------------------------
+
+_PNG_DATA = "data:image/png;base64," + base64.b64encode(b"PNGDATA").decode()
+
+
+def test_data_uri_roundtrip(model):
+    mime, b64 = model._process_image_data(_PNG_DATA)
+    assert mime == "image/png"
+    assert b64 == base64.b64encode(b"PNGDATA").decode()
+
+
+def test_data_uri_extra_params_tolerated(model):
+    mime, _ = model._process_image_data(
+        "data:image/png;charset=utf-8;base64," + base64.b64encode(b"PNGDATA").decode()
+    )
+    assert mime == "image/png"
+
+
+def test_data_uri_declared_mime_not_trusted(model):
+    # declared image/bmp but bytes sniff as PNG -> sent as PNG
+    mime, _ = model._process_image_data(
+        "data:image/bmp;base64," + base64.b64encode(b"PNGDATA").decode()
+    )
+    assert mime == "image/png"
+
+
+def test_data_uri_invalid_base64_rejected(model):
+    with pytest.raises(ValueError, match="Malformed base64 data URI"):
+        model._process_image_data("data:image/png;base64,!!notb64!!")
+
+
+def test_data_uri_missing_base64_marker_rejected(model):
+    with pytest.raises(ValueError, match="Malformed base64 data URI"):
+        model._process_image_data("data:image/png,hello")
+
+
+def test_data_uri_encoded_cap_enforced_pre_decode(model):
+    with pytest.raises(ValueError, match="Encoded image data exceeds"):
+        model._process_image_data("data:image/png;base64," + "A" * (29 * 1024 * 1024))
+
+
+def test_data_uri_non_image_rejected(model, monkeypatch):
+    _expect_public(monkeypatch, raise_on_open=True)
+    with pytest.raises(ValueError, match="Unsupported image data"):
+        model._process_image_data(_PNG_DATA)
+
+
+# ---------------------------------------------------------------------------
+# SSRF guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://pub.example.com/a.png",
+        "file:///etc/passwd",
+        "http://127.0.0.1/x",
+        "http://localhost/x",
+        "http://169.254.169.254/metadata/instance",
+        "http://10.0.0.5/internal",
+        "http://172.19.0.10:5001/api",
+    ],
+)
+def test_private_and_non_http_targets_rejected(model, url):
+    with pytest.raises(ValueError):
+        model._process_image_data(url)
+
+
+def test_public_url_allowed(model, monkeypatch):
+    _expect_public(monkeypatch)
+    mime, b64 = model._process_image_data("https://pub.example.com/a.png")
+    assert mime == "image/png"
+    assert b64 == base64.b64encode(b"IMGbytes").decode()
+
+
+# ---------------------------------------------------------------------------
+# redirects
+# ---------------------------------------------------------------------------
+
+
+def test_redirect_to_private_blocked(model, monkeypatch):
+    _expect_public(monkeypatch)
+    responses = [
+        _FakeResponse(302, headers={"Location": "http://10.0.0.5/x"}),
+        _FakeResponse(),
+    ]
+    _install_responses(monkeypatch, responses)
+    with pytest.raises(ValueError, match="Invalid or inaccessible image URL"):
+        model._process_image_data("https://pub.example.com/a.png")
+
+
+def test_redirect_to_public_followed(model, monkeypatch):
+    _expect_public(monkeypatch)
+    responses = [
+        _FakeResponse(302, headers={"Location": "https://pub2.example.com/b.png"}),
+        _FakeResponse(chunks=[b"REDIR"]),
+    ]
+    _install_responses(monkeypatch, responses)
+    mime, b64 = model._process_image_data("https://pub.example.com/a.png")
+    assert mime == "image/png"
+    assert b64 == base64.b64encode(b"REDIR").decode()
+
+
+def test_redirect_relative_location_resolved_and_validated(model, monkeypatch):
+    _expect_public(monkeypatch)
+    responses = [
+        _FakeResponse(302, headers={"Location": "/img2.png"}),
+        _FakeResponse(chunks=[b"R2"]),
+    ]
+    _install_responses(monkeypatch, responses)
+    mime, _ = model._process_image_data("https://pub.example.com/a.png")
+    assert mime == "image/png"
+
+
+def test_redirect_chain_over_limit_rejected(model, monkeypatch):
+    _expect_public(monkeypatch)
+    responses = [_FakeResponse(302, headers={"Location": "https://pub.example.com/loop"}) for _ in range(5)]
+    _install_responses(monkeypatch, responses)
+    with pytest.raises(ValueError, match="Too many redirects"):
+        model._process_image_data("https://pub.example.com/a.png")
+
+
+def test_redirect_without_location_rejected(model, monkeypatch):
+    _expect_public(monkeypatch)
+    responses = [_FakeResponse(302, headers={})]
+    _install_responses(monkeypatch, responses)
+    with pytest.raises(ValueError, match="Redirect without Location"):
+        model._process_image_data("https://pub.example.com/a.png")
+
+
+# ---------------------------------------------------------------------------
+# download limits
+# ---------------------------------------------------------------------------
+
+
+def test_download_size_cap(model, monkeypatch):
+    _expect_public(monkeypatch)
+    responses = [_FakeResponse(chunks=[b"x" * (21 * 1024 * 1024)])]
+    _install_responses(monkeypatch, responses)
+    with pytest.raises(ValueError, match="maximum allowed size"):
+        model._process_image_data("https://pub.example.com/big.png")
+
+
+def test_wall_clock_deadline(monkeypatch, model):
+    _expect_public(monkeypatch)
+    responses = [
+        _FakeResponse(302, headers={"Location": "https://pub2.example.com/b.png"}),
+        _FakeResponse(),
+    ]
+    _install_responses(monkeypatch, responses)
+    # exhaust the deadline before the second hop (first call computes the
+    # deadline, every later call reports "way past it")
+    import models.llm.llm as llm_module
+
+    real_monotonic = llm_module.time.monotonic
+    t0 = real_monotonic()
+    calls = {"n": 0}
+
+    def _fake_monotonic():
+        calls["n"] += 1
+        return t0 if calls["n"] == 1 else t0 + 60.0
+
+    monkeypatch.setattr(llm_module.time, "monotonic", _fake_monotonic)
+    with pytest.raises(ValueError, match="total time limit"):
+        model._process_image_data("https://pub.example.com/a.png")
+
+
+# ---------------------------------------------------------------------------
+# format normalization + error hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_bmp_converted_to_png(model, monkeypatch):
+    _expect_public(monkeypatch, img_fmt="BMP")
+    responses = [_FakeResponse()]
+    _install_responses(monkeypatch, responses)
+    mime, b64 = model._process_image_data("https://pub.example.com/a.bmp")
+    assert mime == "image/png"
+    assert b64 == base64.b64encode(b"PNGDATA").decode()
+
+
+def test_http_error_message_carries_no_url_or_query(model, monkeypatch):
+    _expect_public(monkeypatch)
+    err = real_requests.exceptions.HTTPError(
+        "404 Client Error for url: https://pub.example.com/img.png?sig=SECRETTOKEN"
+    )
+    err.response = types.SimpleNamespace(status_code=404)
+
+    def _get(url, **kwargs):
+        raise err
+
+    monkeypatch.setattr("models.llm.llm.requests.get", _get)
+    with pytest.raises(ValueError, match=r"Failed to fetch image \(HTTP 404\)") as excinfo:
+        model._process_image_data("https://pub.example.com/img.png?sig=SECRETTOKEN")
+    assert "SECRETTOKEN" not in str(excinfo.value)
+    assert "pub.example.com" not in str(excinfo.value)
+
+
+def test_generic_error_never_leaks_userinfo(model, monkeypatch):
+    _expect_public(monkeypatch)
+
+    def _get(url, **kwargs):
+        raise real_requests.exceptions.ConnectionError(
+            "boom https://user:SECRETPW@pub.example.com/"
+        )
+
+    monkeypatch.setattr("models.llm.llm.requests.get", _get)
+    with pytest.raises(ValueError, match=r"Failed to fetch image \(ConnectionError\)") as excinfo:
+        model._process_image_data("https://user:SECRETPW@pub.example.com/a.png")
+    assert "SECRETPW" not in str(excinfo.value)


### PR DESCRIPTION
## Summary

`_process_image_data()` fetches image URLs from message content with a plain
`requests.get(data)` — no timeout, no size cap, redirects followed automatically,
no scheme or target validation. This PR hardens it as **defense-in-depth**: it
blocks common direct SSRF targets and bounds the fetch, without behavioral
change for legitimate image URLs (including CDN/storage redirects, up to 3 hops).

| # | Before | After |
|---|---|---|
| 1 | Any URL from message content fetched from the plugin subprocess (bypassing the platform's URL-fetch protections) → docker-network probing / blind SSRF against internal services | http/https only; `getaddrinfo` + `ipaddress` guard blocks loopback / private / link-local / reserved targets (IPv4+IPv6, IPv4-mapped unwrapped, zone-index stripped); **re-validated on every redirect hop** (manual loop, `allow_redirects=False`, max 3) |
| 2 | No timeout → a hanging URL parks the worker indefinitely | connect ≤ 5s, read ≤ 10s, plus a **30s network fetch budget** (checked per hop and per chunk; connect/read timeouts shrink to the remaining budget so a blocked read cannot overshoot) |
| 3 | Unbounded download buffered in RAM (+ ~1.35× again in base64) → memory exhaustion of the plugin subprocess | streaming `iter_content` with a 20 MB cap |
| 4 | `data:` URIs passed through unvalidated, no size limit | pre-decode cap (28 MB encoded), strict base64 (`validate=True`), 20 MB decoded cap, format sniffed via Pillow (declared MIME never trusted) |
| 5 | Unsupported formats (BMP/TIFF/…) forwarded as-is → Messages API `400` | sniffed via Pillow; unsupported formats re-encoded to PNG |
| 6 | Raised errors echo the full URL → SAS tokens / presigned query strings / userinfo can surface in the Dify UI | errors raised by this helper carry no URL, query string or credentials; DNS-failure and private-IP rejections share one message (prevents host-existence enumeration) |

## Known limitations (deliberate, documented in code)

- This is **application-level defense-in-depth, not a complete SSRF solution**:
  a DNS rebinding race (resolve-check vs. actual connection) and proxy-side
  resolution remain possible. Full immunity requires routing plugin media
  fetches through a platform-level SSRF-aware transport; I could not find a
  documented plugin API for that path — happy to follow up if one exists.
- The 30s budget bounds redirect hops and body reads; DNS resolution
  (`getaddrinfo`) and Pillow decode/conversion happen outside it.
- Redirect chains longer than 3 hops fail cleanly.

## Change Type

- [x] LLM plugin

**Areas affected**: Multimodal input (image URL / data-URI handling); Other LLM
functionality (error surfaced to the app on image fetch failures).

## Version

- [x] `manifest.yaml` bumped `0.3.26 → 0.3.27`

## Testing

- [x] **Local deployment — Dify 1.14.2 (docker-compose, plugin daemon)**: an
  equivalent patch has been running in a production deployment since
  2026-08-15 (anthropic 0.3.26).
- New `tests/test_image_fetch.py`: **36 tests, fully stubbed at the network
  boundary** (`socket.getaddrinfo`, `requests.get` monkeypatched, plus a
  safety-net fixture that fails any real network call) and **using real
  in-memory Pillow images** for the passthrough/conversion/rejection paths.
  Covers: data-URI validation/caps/sniffing ×7, SSRF rejections (loopback,
  localhost-via-DNS, IMDS link-local, RFC1918, docker subnet, IPv4-mapped ×3,
  ftp/file schemes) ×10, redirects (to-private blocked, to-public OK, relative
  Location, non-http Location ×3, over-limit, missing Location) ×8, 20 MB caps
  ×2, wall-clock deadline + timeout-shrinks-to-budget ×2, real PNG/BMP/data-URI
  conversion ×4, error hygiene ×2.
- Existing `tests/test_llm.py` (14 tests) still green. Live API tests
  (`test_llm_live.py`) not run — no credentials in this environment.
- `python3 -m py_compile` clean.

## Notes for reviewers

- New stdlib imports only (`ipaddress`, `socket`, `time`, `urllib.parse`), 4
  module-level constants; no new dependencies, no `uv.lock` change.
- Helpers `_assert_public_http_url` / `_normalize_image_bytes` are separate for
  testability and reuse.
