### PR TITLE
fix(tongyi): isolate DashScope sessions per LLM invocation

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.2.12
+version: 0.2.13
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/models/llm/llm.py
+++ b/models/tongyi/models/llm/llm.py
@@ -13,6 +13,7 @@ from typing import Optional, Union, cast
 import dify_plugin  # noqa: F401 - patches gevent before HTTP SDK imports
 # isort: on
 import openai
+import requests
 from dashscope import Generation, MultiModalConversation, get_tokenizer
 from dashscope.api_entities.dashscope_response import GenerationResponse
 from dashscope.common.error import (
@@ -335,6 +336,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         base_address = get_http_base_address(credentials)
 
         qwen_long_files = None
+        session = requests.Session()
         try:
             if ModelFeature.VISION in (model_schema.features or []):
                 params["messages"] = self._convert_prompt_messages_to_tongyi_messages(
@@ -348,6 +350,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                     ),
                     incremental_output=incremental_output,
                     base_address=base_address,
+                    session=session,
                 )
             else:
                 if model.startswith("qwen-long"):
@@ -383,10 +386,12 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                     stream=stream,
                     incremental_output=incremental_output,
                     base_address=base_address,
+                    session=session,
                 )
         except BaseException:
             if qwen_long_files:
                 qwen_long_files.cleanup()
+            session.close()
             raise
 
         if stream:
@@ -399,7 +404,7 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
             )
             if qwen_long_files:
                 result = self._cleanup_qwen_long_stream(result, qwen_long_files)
-            return result
+            return self._cleanup_session_stream(result, session)
         try:
             return self._handle_generate_response(
                 model, credentials, response, prompt_messages
@@ -407,6 +412,14 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
         finally:
             if qwen_long_files:
                 qwen_long_files.cleanup()
+            session.close()
+
+    @staticmethod
+    def _cleanup_session_stream(result: Generator, session: requests.Session) -> Generator:
+        try:
+            yield from result
+        finally:
+            session.close()
 
     @staticmethod
     def _cleanup_qwen_long_stream(
@@ -1061,6 +1074,8 @@ class TongyiLargeLanguageModel(LargeLanguageModel):
                 RequestFailure,
                 openai.APIConnectionError,
                 openai.APITimeoutError,
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
             ],
             InvokeRateLimitError: [openai.RateLimitError],
             InvokeAuthorizationError: [

--- a/models/tongyi/pyproject.toml
+++ b/models/tongyi/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.12"
 dependencies = [
     "dify_plugin>=0.9.0",
     "numpy>=2.4.6",
-    "dashscope>=1.25.18,<1.26.0",
+    "dashscope>=1.26.7,<1.27.0",
     "openai>=2.38.0",
     "pydub>=0.25.1",
     "pyyaml>=6.0.3",

--- a/models/tongyi/tests/test_llm_session_cleanup.py
+++ b/models/tongyi/tests/test_llm_session_cleanup.py
@@ -1,0 +1,156 @@
+import os
+import sys
+from collections.abc import Generator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dify_plugin.entities.model import ModelFeature
+from dify_plugin.entities.model.message import UserPromptMessage
+from dify_plugin.errors.model import InvokeConnectionError
+
+from models.llm.llm import TongyiLargeLanguageModel
+
+
+def _model(vision: bool = False) -> TongyiLargeLanguageModel:
+    model = TongyiLargeLanguageModel(model_schemas=MagicMock())
+    model.get_model_mode = MagicMock(return_value="chat")
+    features = [ModelFeature.VISION] if vision else []
+    model.get_model_schema = MagicMock(
+        return_value=SimpleNamespace(features=features)
+    )
+    model._handle_generate_response = MagicMock(return_value="result")
+    return model
+
+
+def _generate(model: TongyiLargeLanguageModel, stream: bool = False):
+    return model._generate(*_invoke_args(), stream=stream)
+
+
+def _invoke_args():
+    return (
+        "qwen-plus",
+        {"dashscope_api_key": "test-key"},
+        [UserPromptMessage(content="hello")],
+        {},
+    )
+
+
+@contextmanager
+def _sdk_call(*, session=None, sessions=None, vision=False, error=None):
+    factory_options = {"side_effect": sessions} if sessions else {"return_value": session}
+    target = (
+        "models.llm.llm.MultiModalConversation.call"
+        if vision
+        else "models.llm.llm.Generation.call"
+    )
+    call_options = {"return_value": MagicMock()}
+    if error is not None:
+        call_options["side_effect"] = error
+    with patch("models.llm.llm.requests.Session", **factory_options), patch(
+        target, **call_options
+    ) as call:
+        yield call
+
+
+@pytest.fixture
+def session():
+    return MagicMock()
+
+
+@pytest.mark.parametrize("vision", [False, True])
+def test_generate_passes_session_to_text_and_vision_calls(vision: bool, session) -> None:
+    model = _model(vision)
+    with _sdk_call(session=session, vision=vision) as call:
+        assert _generate(model) == "result"
+    assert call.call_args.kwargs["session"] is session
+    session.close.assert_called_once_with()
+
+
+def test_each_generate_call_gets_an_isolated_session() -> None:
+    model = _model()
+    first, second = MagicMock(), MagicMock()
+    with _sdk_call(sessions=[first, second]) as call:
+        _generate(model)
+        _generate(model)
+    assert [item.kwargs["session"] for item in call.call_args_list] == [first, second]
+    first.close.assert_called_once_with()
+    second.close.assert_called_once_with()
+
+
+@contextmanager
+def _stream_call(underlying, session):
+    model = _model()
+    model._handle_generate_stream_response = MagicMock(return_value=underlying)
+    with _sdk_call(session=session):
+        yield model
+
+
+def _public_stream(model: TongyiLargeLanguageModel):
+    model._validate_and_filter_model_parameters = MagicMock(return_value={})
+    return model.invoke(*_invoke_args(), stream=True)
+
+
+@pytest.mark.parametrize("outcome", ["exhaust", "close", "error"])
+def test_stream_closes_session_for_all_exit_paths(outcome, session) -> None:
+    def underlying():
+        yield "chunk"
+        if outcome == "error":
+            raise RuntimeError("broken stream")
+
+    with _stream_call(underlying(), session) as model:
+        stream = _public_stream(model)
+        if outcome == "exhaust":
+            assert list(stream) == ["chunk"]
+        elif outcome == "close":
+            assert next(stream) == "chunk"
+            stream.close()
+        else:
+            with pytest.raises(RuntimeError, match="broken stream"):
+                list(stream)
+    session.close.assert_called_once_with()
+
+
+def test_stream_result_remains_generator_compatible(session) -> None:
+    with _stream_call(iter(["chunk"]), session) as model:
+        result = _generate(model, stream=True)
+        assert isinstance(result, Generator)
+        assert list(result) == ["chunk"]
+    session.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "error_type",
+    [
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+        requests.exceptions.ReadTimeout,
+    ],
+)
+def test_requests_errors_transform_to_connection_error(error_type) -> None:
+    error = error_type("request failed")
+    assert isinstance(_model()._transform_invoke_error(error), InvokeConnectionError)
+
+
+def test_nonstream_handler_error_closes_session(session) -> None:
+    model = _model()
+    model._handle_generate_response.side_effect = RuntimeError("invalid response")
+    with _sdk_call(session=session), pytest.raises(RuntimeError, match="invalid response"):
+        _generate(model)
+    session.close.assert_called_once_with()
+
+
+def test_nonstream_read_timeout_is_not_replayed_and_closes_session(session) -> None:
+    model = _model()
+    with _sdk_call(
+        session=session, error=requests.exceptions.ReadTimeout("timeout")
+    ) as call:
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            _generate(model)
+    call.assert_called_once()
+    session.close.assert_called_once_with()

--- a/models/tongyi/uv.lock
+++ b/models/tongyi/uv.lock
@@ -401,7 +401,7 @@ wheels = [
 
 [[package]]
 name = "dashscope"
-version = "1.26.6"
+version = "1.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -414,9 +414,8 @@ dependencies = [
     { name = "typer" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/81/15ebc18d75e2d35cb00dfc4c0c0c5ea664d8ea6810fa186b67f8af15bee9/dashscope-1.26.6.tar.gz", hash = "sha256:dd862d525e3c9880e97df8ed4ad2e95f91ed91cb5035dc434580385fcab1e64e", size = 1431205, upload-time = "2026-08-07T07:42:46.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/9d/d46e56fd96253d34a3bf7140b7abf3cc4e34cf9042f7dcbd57d729fd9f5d/dashscope-1.26.6-py3-none-any.whl", hash = "sha256:55a333c7b7465831b43b700d41a1209d38f2d952dfe24ca5ff44a3efe8271a87", size = 1536044, upload-time = "2026-08-07T07:42:43.156Z" },
+    { url = "https://files.pythonhosted.org/packages/55/af/6f65d1d46f67206c80a0d24a236b0930cdffc540badba3d9d57fa4fce34b/dashscope-1.26.7-py3-none-any.whl", hash = "sha256:e7797ff99c5335589ecd0b97391611dd68dc3da6a28681dab5c522759b22922d", size = 1537542, upload-time = "2026-08-12T13:03:59.002Z" },
 ]
 
 [[package]]
@@ -1604,7 +1603,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dashscope", specifier = ">=1.25.18,<1.26.0" },
+    { name = "dashscope", specifier = ">=1.26.7,<1.27.0" },
     { name = "dify-plugin", specifier = ">=0.9.0" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "openai", specifier = ">=2.38.0" },


### PR DESCRIPTION
## Summary

Fixes #3624.

DashScope SDK 1.26.5 introduced a process-wide shared synchronous
`requests.Session`. Tongyi LLM calls currently do not provide an explicit
session, so both `Generation.call` and `MultiModalConversation.call` fall back
to that shared connection pool.

In a long-running Dify plugin process, a pooled keep-alive connection can
remain locally established after the remote endpoint or an intermediate
network device has discarded its state. Reusing that connection can leave the
request without a response until DashScope's 300-second read timeout expires.

This PR prevents later LLM invocations from reusing such a pooled connection:

- create one fresh `requests.Session` for each Tongyi LLM invocation;
- pass it explicitly to both text and vision DashScope calls;
- close it when a non-streaming invocation completes or fails;
- tie streaming Session cleanup to the existing result generator lifecycle;
- map `requests.ConnectionError` and `requests.Timeout` (including
  `ReadTimeout`) to `InvokeConnectionError`;
- align the declared and locked DashScope dependency on 1.26.7;
- bump the Tongyi plugin version to 0.2.13.

### Why `ReadTimeout` is not retried

This change deliberately does not replay a generation request after
`ReadTimeout`. By the time a read timeout occurs, the provider may already have
accepted or processed the request. Retrying it could duplicate generation work
and cost.

Per-invocation Session isolation removes cross-invocation stale-pool reuse
without replaying the timed-out POST. DashScope 1.26.7's own retry remains
limited to eligible pre-response `ConnectionError` cases.

### Scope

This PR covers the Tongyi LLM text and vision paths:

- `Generation.call`
- `MultiModalConversation.call`

It does not change TTS, embedding, rerank, or speech-to-text behavior. It also
does not claim to solve every raw HTTP response or structured-stream
early-cancellation lifecycle; those are separate cleanup concerns.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable. This is a transport/session lifecycle fix covered by offline
regression tests.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (transport/session lifecycle and error mapping)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` from 0.2.12 to 0.2.13
- [ ] `dify_plugin>=0.3.0,<0.6.0` declaration — not changed; Tongyi already
  declares `dify_plugin>=0.9.0` and locks 0.10.1

## Testing

Tested in a clean Python 3.12 environment resolved from the updated `uv.lock`:

- [x] Focused session-lifecycle tests: `12 passed`
- [x] Full Tongyi suite: `91 passed, 80 skipped`
- [x] `uv lock --check`
- [x] Plugin packaging and archive integrity check
- [x] `git diff --check`

Focused coverage includes text/vision Session injection, isolation across
consecutive invocations, streaming completion/close/error cleanup,
non-streaming completion/handler-error cleanup, requests error mapping, and
verification that `ReadTimeout` is not replayed.
