### PR TITLE
feat(bedrock): add Claude 4.5+ profile-prefix helpers and document the on-demand gap

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.78
+version: 0.0.79
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/anthropic-claude.yaml
+++ b/models/bedrock/models/llm/anthropic-claude.yaml
@@ -54,8 +54,8 @@ parameter_rules:
       - geographic
       - global
     help:
-      zh_Hans: 跨区域推理会自动选择 AWS 区域内的最佳位置来处理您的推理请求。地理跨区域限于您所在地理区域，全球跨区域可跨所有区域。
-      en_US: Cross-Region inference automatically selects the optimal AWS Region to process your inference request. Geographic limits to your geography, Global spans all regions.
+      zh_Hans: 跨区域推理会自动选择 AWS 区域内的最佳位置来处理您的推理请求。地理跨区域限于您所在地理区域，全球跨区域可跨所有区域。注意：Sonnet 4.5/4.6、Haiku 4.5 和 Opus 4.5–4.8 只能通过推理配置文件调用（不支持 on-demand），请使用 Global 或 Geographic。
+      en_US: Cross-Region inference automatically selects the optimal AWS Region to process your inference request. Geographic limits to your geography, Global spans all regions. Note: Sonnet 4.5/4.6, Haiku 4.5, and Opus 4.5–4.8 are INFERENCE_PROFILE-only on Bedrock (on-demand invocation is rejected with ValidationException) — use Global or Geographic.
   - name: system_cache_checkpoint
     label:
       zh_Hans: 缓存系统提示词

--- a/models/bedrock/models/llm/model_ids.py
+++ b/models/bedrock/models/llm/model_ids.py
@@ -162,6 +162,30 @@ _AU_REGIONS = {'ap-southeast-2', 'ap-southeast-4'}
 
 CLAUDE5_REFUSAL_FALLBACK_BASE_ID = 'anthropic.claude-opus-4-8'
 
+# Claude 4.5-generation models (Sonnet 4.5+, Haiku 4.5+, Opus 4.5-4.8) are
+# invocable ONLY through inference profiles
+# (inferenceTypesSupported == [INFERENCE_PROFILE]; live-verified via
+# `aws bedrock list-inference-profiles --region ap-northeast-1` 2026-08-17 —
+# bare-ID converse returns ValidationException). Geo profile coverage is
+# us./eu./jp./global.; there is no apac. profile for any 4.5+ Anthropic
+# model (apac. stops at Sonnet 4). See issue #3664 and the model cards:
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-5.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-6.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html
+CLAUDE45_PROFILE_PREFIXES = {
+    'anthropic.claude-sonnet-4-5-20250929-v1:0': ('us', 'eu', 'jp', 'global'),
+    'anthropic.claude-haiku-4-5-20251001-v1:0': ('us', 'eu', 'jp', 'global'),
+    'anthropic.claude-opus-4-5-20251101-v1:0': ('us', 'eu', 'jp', 'global'),
+    'anthropic.claude-sonnet-4-6': ('us', 'eu', 'jp', 'global'),
+    'anthropic.claude-opus-4-6-v1': ('us', 'eu', 'jp', 'global'),
+    'anthropic.claude-opus-4-7': ('us', 'eu', 'jp', 'global'),
+    'anthropic.claude-opus-4-8': ('us', 'eu', 'jp', 'global'),
+}
+
 # All cross-region inference profile geo prefixes in use on Bedrock
 # (jp./au. exist for Opus 4.7/4.8-era models).
 _PROFILE_PREFIXES = ('global.', 'us.', 'eu.', 'apac.', 'jp.', 'au.')
@@ -238,3 +262,62 @@ def get_claude5_fallback_model_id(profile_model_id):
     base = strip_profile_prefix(profile_model_id)
     prefix = profile_model_id[: len(profile_model_id) - len(base)]
     return f"{prefix}{CLAUDE5_REFUSAL_FALLBACK_BASE_ID}"
+
+
+def is_claude45_model(model_id):
+    """True if model_id is a bare Claude 4.5-generation base model ID."""
+    return model_id in CLAUDE45_PROFILE_PREFIXES
+
+
+def is_claude45_profile_id(model_id):
+    """True if model_id is a Claude 4.5+ base ID, optionally profile-prefixed."""
+    return strip_profile_prefix(model_id) in CLAUDE45_PROFILE_PREFIXES
+
+
+def resolve_claude45_profile_id(model_id, cross_region, region_name):
+    """
+    Resolve the inference profile ID for a Claude 4.5-generation model.
+
+    :param model_id: bare base model ID (e.g. 'anthropic.claude-sonnet-4-6')
+    :param cross_region: 'disabled' / 'geographic' / 'global'
+    :param region_name: AWS region of the caller (e.g. 'ap-northeast-1')
+    :return: profile-prefixed model ID
+    :raises ValueError: when the combination cannot be served, with a
+        user-actionable message
+    """
+    # GovCloud is a separate AWS partition — commercial us./eu./jp./global.
+    # profile IDs are not valid there.
+    if region_name.startswith('us-gov-'):
+        raise ValueError(
+            f"{model_id} is not available in AWS GovCloud ({region_name}). "
+            f"Claude 4.5+ inference profiles exist only in commercial regions."
+        )
+    allowed = CLAUDE45_PROFILE_PREFIXES[model_id]
+    if cross_region == 'global':
+        return f"global.{model_id}"
+    if cross_region == 'geographic':
+        area = get_region_area(region_name)
+        # 'jp' is a special case — it only applies to ap-northeast-1 and
+        # ap-northeast-3 and is not derivable from the standard area
+        # mapping. Resolve it explicitly here.
+        if region_name in ('ap-northeast-1', 'ap-northeast-3'):
+            area = 'jp'
+        if area in allowed:
+            return f"{area}.{model_id}"
+        raise ValueError(
+            f"{model_id} has no '{area or region_name}' geographic inference profile. "
+            f"From {region_name} this model supports only Global cross-region inference — "
+            f"set Cross-Region Inference to 'global'."
+        )
+    if cross_region == 'disabled':
+        # Claude 4.5+ models are INFERENCE_PROFILE-only on Bedrock; bare-ID
+        # on-demand invocation returns ValidationException. See issue #3664.
+        raise ValueError(
+            f"{model_id} is not available with on-demand throughput. "
+            f"It can only be invoked through an inference profile — "
+            f"set Cross-Region Inference to 'global' (recommended) or 'geographic'."
+        )
+    raise ValueError(
+        f"{model_id} can only be invoked through an inference profile. "
+        f"Set Cross-Region Inference to 'global' (recommended) or 'geographic'."
+    )

--- a/models/bedrock/tests/test_claude45_profile_prefixes.py
+++ b/models/bedrock/tests/test_claude45_profile_prefixes.py
@@ -1,0 +1,241 @@
+"""Unit tests for the Claude 4.5+ profile-prefix helpers in
+``models.llm.model_ids``.
+
+Pins the behavior of:
+
+- ``CLAUDE45_PROFILE_PREFIXES`` membership (7 model IDs)
+- ``is_claude45_model`` (bare-ID exact match)
+- ``is_claude45_profile_id`` (bare or profile-prefixed)
+- ``resolve_claude45_profile_id`` (global, geographic, disabled, GovCloud)
+
+Background: Claude 4.5-generation models (Sonnet 4.5+, Haiku 4.5+, Opus
+4.5–4.8) are INFERENCE_PROFILE-only on Bedrock — bare-ID on-demand
+converse returns ValidationException. They are not invocable through
+the existing Claude 5 path (which only covers the claude-opus-5 /
+claude-sonnet-5 / claude-fable-5 family), so a parallel set of helpers
+is needed.
+
+Issue: #3664.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pytest
+
+model_ids_mod = importlib.import_module("models.llm.model_ids")
+
+CLAUDE45_IDS = [
+    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "anthropic.claude-haiku-4-5-20251001-v1:0",
+    "anthropic.claude-opus-4-5-20251101-v1:0",
+    "anthropic.claude-sonnet-4-6",
+    "anthropic.claude-opus-4-6-v1",
+    "anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-8",
+]
+
+
+class TestClaude45PrefixesMembership:
+    """The 7 live-verified Claude 4.5+ model IDs must all be in
+    ``CLAUDE45_PROFILE_PREFIXES`` with the correct supported prefixes.
+    """
+
+    @pytest.mark.parametrize("model_id", CLAUDE45_IDS)
+    def test_model_id_is_in_claude45_set(self, model_id: str) -> None:
+        assert model_id in model_ids_mod.CLAUDE45_PROFILE_PREFIXES
+
+    @pytest.mark.parametrize("model_id", CLAUDE45_IDS)
+    def test_each_claude45_model_supports_global(self, model_id: str) -> None:
+        assert "global" in model_ids_mod.CLAUDE45_PROFILE_PREFIXES[model_id]
+
+    @pytest.mark.parametrize("model_id", CLAUDE45_IDS)
+    def test_each_claude45_model_supports_us(self, model_id: str) -> None:
+        assert "us" in model_ids_mod.CLAUDE45_PROFILE_PREFIXES[model_id]
+
+    @pytest.mark.parametrize("model_id", CLAUDE45_IDS)
+    def test_each_claude45_model_supports_eu(self, model_id: str) -> None:
+        assert "eu" in model_ids_mod.CLAUDE45_PROFILE_PREFIXES[model_id]
+
+    @pytest.mark.parametrize("model_id", CLAUDE45_IDS)
+    def test_each_claude45_model_supports_jp(self, model_id: str) -> None:
+        """Issue #3664 lists all 4.5+ Anthropic models in ap-northeast-1
+        with jp. profiles. Per the issue body:
+        ``jp.anthropic.claude-sonnet-4-6``, ``jp.anthropic.claude-haiku-4-5``,
+        ``jp.anthropic.claude-opus-4-7``, ``jp.anthropic.claude-opus-4-8``,
+        etc.
+        """
+        assert "jp" in model_ids_mod.CLAUDE45_PROFILE_PREFIXES[model_id]
+
+    @pytest.mark.parametrize("model_id", CLAUDE45_IDS)
+    def test_no_claude45_model_supports_apac(self, model_id: str) -> None:
+        """``apac.anthropic.*`` profiles stop at Sonnet 4. There is no
+        apac. profile for any 4.5-generation Anthropic model.
+        """
+        assert "apac" not in model_ids_mod.CLAUDE45_PROFILE_PREFIXES[model_id]
+
+
+class TestIsClaude45Model:
+    """``is_claude45_model`` returns True for exact bare-ID match only."""
+
+    @pytest.mark.parametrize("model_id", CLAUDE45_IDS)
+    def test_bare_id_is_recognized(self, model_id: str) -> None:
+        assert model_ids_mod.is_claude45_model(model_id) is True
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "anthropic.claude-3-haiku-20240307-v1:0",  # 3.x, on-demand supported
+            "anthropic.claude-sonnet-4-20250514-v1:0",  # 4.0, on-demand supported
+            "anthropic.claude-opus-5",  # 5, handled by CLAUDE5 path
+            "anthropic.claude-fable-5",
+            "anthropic.claude-sonnet-5",
+            "cohere.command-r-plus",  # different family
+            "amazon.nova-pro",
+            "",  # empty
+        ],
+    )
+    def test_non_claude45_id_is_rejected(self, model_id: str) -> None:
+        assert model_ids_mod.is_claude45_model(model_id) is False
+
+
+class TestIsClaude45ProfileId:
+    """``is_claude45_profile_id`` accepts both bare and profile-prefixed
+    forms.
+    """
+
+    @pytest.mark.parametrize("model_id", CLAUDE45_IDS)
+    def test_bare_id_is_recognized(self, model_id: str) -> None:
+        assert model_ids_mod.is_claude45_profile_id(model_id) is True
+
+    @pytest.mark.parametrize("prefix", ["global.", "us.", "eu.", "jp."])
+    @pytest.mark.parametrize("model_id", CLAUDE45_IDS)
+    def test_prefixed_id_is_recognized(self, prefix: str, model_id: str) -> None:
+        assert model_ids_mod.is_claude45_profile_id(f"{prefix}{model_id}") is True
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "anthropic.claude-3-haiku-20240307-v1:0",
+            "anthropic.claude-sonnet-4-20250514-v1:0",
+            "anthropic.claude-opus-5",
+            "cohere.command-r-plus",
+            "",
+        ],
+    )
+    def test_non_claude45_id_is_rejected(self, model_id: str) -> None:
+        assert model_ids_mod.is_claude45_profile_id(model_id) is False
+
+
+class TestResolveClaude45ProfileId:
+    """``resolve_claude45_profile_id`` resolves the bare model ID to a
+    profile-prefixed ID, raising ValueError for combinations that
+    cannot be served.
+    """
+
+    MODEL_ID = "anthropic.claude-sonnet-4-6"
+
+    def test_global_resolves_to_global_prefix(self) -> None:
+        assert (
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "global", "us-east-1")
+            == "global.anthropic.claude-sonnet-4-6"
+        )
+
+    def test_global_works_from_japan(self) -> None:
+        """Global profiles are available from virtually all commercial
+        regions, including ap-northeast-1.
+        """
+        assert (
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "global", "ap-northeast-1")
+            == "global.anthropic.claude-sonnet-4-6"
+        )
+
+    def test_geographic_us_resolves_to_us_prefix(self) -> None:
+        assert (
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "geographic", "us-east-1")
+            == "us.anthropic.claude-sonnet-4-6"
+        )
+
+    def test_geographic_eu_resolves_to_eu_prefix(self) -> None:
+        assert (
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "geographic", "eu-west-1")
+            == "eu.anthropic.claude-sonnet-4-6"
+        )
+
+    def test_geographic_japan_ap_northeast_1_resolves_to_jp_prefix(self) -> None:
+        """The Japan geographic profile is reachable from ap-northeast-1
+        and ap-northeast-3 only. Issue #3664 verified this is the
+        profile needed for data-residency in Japan.
+        """
+        assert (
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "geographic", "ap-northeast-1")
+            == "jp.anthropic.claude-sonnet-4-6"
+        )
+
+    def test_geographic_japan_ap_northeast_3_resolves_to_jp_prefix(self) -> None:
+        assert (
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "geographic", "ap-northeast-3")
+            == "jp.anthropic.claude-sonnet-4-6"
+        )
+
+    def test_geographic_ap_singapore_does_not_resolve_to_apac(self) -> None:
+        """4.5+ models have no apac. profile. From ap-southeast-1 (Singapore)
+        the area resolves to 'apac' which is not in the allowed set —
+        fall back to a user-actionable error.
+        """
+        with pytest.raises(ValueError, match=r"has no 'apac' geographic inference profile"):
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "geographic", "ap-southeast-1")
+
+    def test_geographic_unknown_region_raises(self) -> None:
+        """A region outside the standard area mapping (e.g. me-south-1,
+        af-south-1) has no geo profile. User must use Global.
+        """
+        with pytest.raises(ValueError, match="only Global"):
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "geographic", "me-south-1")
+
+    def test_disabled_raises_for_inference_profile_only_models(self) -> None:
+        """Claude 4.5+ models are INFERENCE_PROFILE-only on Bedrock.
+        Bare-ID on-demand invocation returns ValidationException. The
+        helper must surface this as a clear ValueError, not silently
+        return a bare ID.
+        """
+        with pytest.raises(ValueError, match="on-demand throughput"):
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "disabled", "us-east-1")
+
+    def test_govcloud_raises(self) -> None:
+        """Commercial inference profile IDs are not valid in AWS GovCloud."""
+        with pytest.raises(ValueError, match="GovCloud"):
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "global", "us-gov-west-1")
+
+    def test_invalid_cross_region_raises(self) -> None:
+        """A typo in the cross_region parameter must surface as a
+        user-actionable error.
+        """
+        with pytest.raises(ValueError, match="inference profile"):
+            model_ids_mod.resolve_claude45_profile_id(self.MODEL_ID, "typo", "us-east-1")
+
+
+class TestClaude45AndClaude5AreDisjoint:
+    """The 4.5+ set and the Claude 5 set must be disjoint — no model
+    appears in both. This guards against a future refactor that
+    accidentally double-lists a model.
+    """
+
+    def test_no_overlap_between_sets(self) -> None:
+        claude5_ids = set(model_ids_mod.CLAUDE5_PROFILE_PREFIXES.keys())
+        claude45_ids = set(model_ids_mod.CLAUDE45_PROFILE_PREFIXES.keys())
+        overlap = claude5_ids & claude45_ids
+        assert overlap == set(), (
+            f"Models appear in both CLAUDE5_PROFILE_PREFIXES and "
+            f"CLAUDE45_PROFILE_PREFIXES: {overlap}"
+        )
+
+    def test_is_claude5_and_is_claude45_are_mutually_exclusive(self) -> None:
+        claude5_ids = list(model_ids_mod.CLAUDE5_PROFILE_PREFIXES.keys())
+        claude45_ids = list(model_ids_mod.CLAUDE45_PROFILE_PREFIXES.keys())
+        for mid in claude5_ids:
+            assert model_ids_mod.is_claude5_model(mid) is True
+            assert model_ids_mod.is_claude45_model(mid) is False
+        for mid in claude45_ids:
+            assert model_ids_mod.is_claude5_model(mid) is False
+            assert model_ids_mod.is_claude45_model(mid) is True


### PR DESCRIPTION
## Summary

Adds the foundation for the Claude 4.5+ profile-prefix handling that the existing `CLAUDE5_PROFILE_PREFIXES` provides for Claude 5. Issue #3664 surfaced that Claude 4.5-generation models (Sonnet 4.5+, Haiku 4.5+, Opus 4.5–4.8) are INFERENCE_PROFILE-only on Bedrock, but the plugin's `anthropic-claude.yaml` still offers `disabled` as a cross-region option, which always fails with a `ValidationException`.

This PR adds the helper layer (`CLAUDE45_PROFILE_PREFIXES`, `is_claude45_model`, `is_claude45_profile_id`, `resolve_claude45_profile_id`) and updates the yaml help text. The runtime check (raising `InvokeBadRequestError` for `cross-region=disabled` on a 4.5+ model) is a follow-up PR that builds on these helpers.

4 files, +327/-3, manifest `0.0.78 → 0.0.79`.

## What's in this PR

### New: `CLAUDE45_PROFILE_PREFIXES` (model_ids.py)

7 live-verified model IDs with their supported geo prefixes:

| Model ID | us | eu | jp | global | apac | au |
|---|---|---|---|---|---|---|
| `anthropic.claude-sonnet-4-5-20250929-v1:0` | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
| `anthropic.claude-haiku-4-5-20251001-v1:0` | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
| `anthropic.claude-opus-4-5-20251101-v1:0` | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
| `anthropic.claude-sonnet-4-6` | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
| `anthropic.claude-opus-4-6-v1` | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
| `anthropic.claude-opus-4-7` | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
| `anthropic.claude-opus-4-8` | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |

Key constraints from the issue body (live-verified 2026-08-17):

> `apac.anthropic.*` profiles stop at Sonnet 4. There is no `apac.` profile for any 4.5-generation Anthropic model.

> All 4.5+ Anthropic models have `jp.` profiles in `ap-northeast-1` and `ap-northeast-3`.

### New: helper functions (model_ids.py)

- `is_claude45_model(model_id)` — bare-ID exact match (mirrors `is_claude5_model`).
- `is_claude45_profile_id(model_id)` — accepts bare or profile-prefixed form.
- `resolve_claude45_profile_id(model_id, cross_region, region_name)` — mirrors `resolve_claude5_profile_id` with:
  - **`jp` resolution from ap-northeast-1 / ap-northeast-3** (the Japan-only data-residency profile requested in the issue).
  - **Clear `ValueError` for `cross_region='disabled'`** (instead of silently returning a bare ID and getting `ValidationException` from AWS).
  - **Clear `ValueError` for GovCloud** (commercial profile IDs are not valid there).
  - **User-actionable error for `apac` / `me-south-1` / etc.** (no profile available).

### Updated: `anthropic-claude.yaml` help text

The `cross-region` parameter's `help` text now warns:

> Note: Sonnet 4.5/4.6, Haiku 4.5, and Opus 4.5–4.8 are INFERENCE_PROFILE-only on Bedrock (on-demand invocation is rejected with ValidationException) — use Global or Geographic.

The yaml itself still offers `disabled` because options are static; the runtime check that converts "user picks `disabled` for a 4.5+ model" into a clear `InvokeBadRequestError` is the next PR. The help text is the safe middle step (it makes the constraint visible to the user before they hit it).

## Tests

`tests/test_claude45_profile_prefixes.py` (new, 110 tests):

| Test class | What it pins |
|---|---|
| `TestClaude45PrefixesMembership` | All 7 IDs are in the set, each with `us` / `eu` / `jp` / `global` support, none with `apac` |
| `TestIsClaude45Model` | Bare-ID exact match; rejects 3.x, 4.0, 5.x, and other families |
| `TestIsClaude45ProfileId` | Bare and profile-prefixed forms (`us.`, `eu.`, `jp.`, `global.`) |
| `TestResolveClaude45ProfileId` | global from anywhere, geographic us/eu/jp, Singapore (no apac.), unknown region, `disabled` (raises), GovCloud (raises), typo (raises) |
| `TestClaude45AndClaude5AreDisjoint` | The 4.5+ set and Claude 5 set are disjoint; `is_claude5_*` and `is_claude45_*` are mutually exclusive |

## Verification

```bash
cd models/bedrock && uv run pytest tests/
# 199 passed (89 existing + 110 new), no regressions

cd models/bedrock && uv run pytest tests/test_claude45_profile_prefixes.py -v
# 110 passed in 0.05s

cd models/bedrock && uv run ruff check tests/test_claude45_profile_prefixes.py
# All checks passed!
```

## Why this matters

Issue #3664 documents that **every user with a 4.5+ Anthropic model** who selects `Cross-Region Inference: disabled` (the default for many Dify installations) gets:

```
ValidationException: Invocation of model ID anthropic.claude-sonnet-4-6
with on-demand throughput isn't supported.
```

with no actionable error message. The plugin surfaces a generic `InvokeError` and the user has to dig into AWS docs to figure out why.

This PR makes the constraint visible in the help text AND provides the helper layer for the follow-up yaml-side fix. The follow-up PR will hook `resolve_claude45_profile_id` into `_invoke` and raise a clear `InvokeBadRequestError` before the bad request hits AWS.

## Backward compatibility

No behavior change for any other path. `anthropic.claude.yaml` still offers all three cross-region options; only the help text changes. The helper functions are additive — no existing call site is modified.

## Risks

Negligible. The new helper functions mirror the existing Claude 5 pattern. The yaml help text addition is purely informational.

## Future work (from #3664)

1. **The `japan` cross-region value** requested in the issue body — add a 4th option to the yaml and resolve to the `jp.` prefix. This is the part of sub-problem (1) the user explicitly asked for. The helper layer in this PR is the foundation.
2. **Runtime check in `_invoke`** — hook `resolve_claude45_profile_id` into the dispatch and raise `InvokeBadRequestError` for `cross-region=disabled` on a 4.5+ model. Closes the user-facing "always fails silently" loop.
3. **Data-residency documentation** — sub-problem (3): update the help text to call out the data-residency implications of `global` (worldwide routing).

Fixes sub-problem (a) of #3664. (The other sub-problems are intentionally left as follow-up to keep this PR focused and reviewable.)
