### PR TITLE
fix(anthropic): remove structured-output from claude-sonnet-4-6 until llm.py implements it

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.26
+version: 0.3.27

--- a/models/anthropic/models/llm/claude-sonnet-4-6.yaml
+++ b/models/anthropic/models/llm/claude-sonnet-4-6.yaml
@@ -8,7 +8,6 @@ features:
   - tool-call
   - stream-tool-call
   - document
-  - structured-output
 model_properties:
   mode: chat
   context_size: 1000000


### PR DESCRIPTION
### Summary

`models/anthropic/models/llm/claude-sonnet-4-6.yaml` is the only model file in this plugin that declares `structured-output` in its `features` list, but `models/llm/llm.py` has no handling for it — no reads of `json_schema`, no `output_format`, and no `structured-outputs-2025-11-13` beta header.

Because the feature is declared, Dify core takes its native structured-output branch in `api/core/llm_generator/output_parser/structured_output.py` and **skips the prompt-based fallback**. The plugin then never reads `model_parameters["json_schema"]`, so the schema reaches the model by neither path and no warning appears in the editor.

The net effect is that declaring the feature produces a **worse** outcome than not declaring it: `claude-sonnet-4-5-20250929` and every other model here omit `structured-output`, take the else branch, and do receive prompt-based schema guidance.

### What this changes

One line — removes `structured-output` from the `features` list, plus a patch version bump.

This restores the prompt-based fallback for `claude-sonnet-4-6` and makes it consistent with the other model files in the plugin. It is deliberately the smallest change that removes the silent-drop path, and it does not block or conflict with implementing native support later.

### Not included, and why

The full fix is to implement native structured output in `_chat_generate` — reading `model_parameters["json_schema"]`, translating it into Anthropic's `output_format: {"type": "json_schema", "json_schema": {...}}`, and appending `structured-outputs-2025-11-13` to `extra_headers["anthropic-beta"]` in the same accumulating style the existing five beta flags already use (`task-budgets-2026-03-13`, `context-1m-2025-08-07`, `output-128k-2025-02-19`, `max-tokens-3-5-sonnet-2024-07-15`, `pdfs-2024-09-25`).

I've left that out of this PR because I can't test it against the live API with this plugin's test setup, and an untested change to a widely-installed plugin seemed the wrong trade. Happy to open it as a follow-up if a maintainer would rather review it than write it — the approach was worked through in #3671.

### Related

- Closes #3671 on the interim path
- Core-side issue: langgenius/dify#40907 — the general hazard that a declared-but-unimplemented capability disables the fallback rather than failing visibly
