### PR TITLE
fix(anthropic): stop advertising unsupported structured output

### DIFF
--- a/models/anthropic/models/llm/claude-sonnet-4-6.yaml
+++ b/models/anthropic/models/llm/claude-sonnet-4-6.yaml
@@ -8,7 +8,6 @@ features:
   - tool-call
   - stream-tool-call
   - document
-  - structured-output
 model_properties:
   mode: chat
   context_size: 1000000

--- a/models/anthropic/tests/test_llm.py
+++ b/models/anthropic/tests/test_llm.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 from dify_plugin.entities.model.message import (
     SystemPromptMessage,
     TextPromptMessageContent,
@@ -9,6 +11,13 @@ from dify_plugin.entities.model.message import (
 from dify_plugin.errors.model import CredentialsValidateFailedError
 
 from models.llm.llm import AnthropicLargeLanguageModel, PromptCachingHandler
+
+
+def test_sonnet46_schema_does_not_advertise_structured_output() -> None:
+    schema_path = Path(__file__).parents[1] / "models" / "llm" / "claude-sonnet-4-6.yaml"
+    schema = yaml.safe_load(schema_path.read_text(encoding="utf-8"))
+
+    assert "structured-output" not in schema["features"]
 
 
 def test_get_cache_control_defaults_overrides_and_copies() -> None:


### PR DESCRIPTION
## Summary

- remove the unsupported `structured-output` capability from Claude Sonnet 4.6
- keep the model on Dify's existing prompt-based fallback until native structured output is implemented
- add a schema regression test so the model cannot advertise the unsupported feature again

Fixes #3671

## Validation

- YAML schema check passed
- `python -m compileall -q tests/test_llm.py` passed
- `python -m pytest tests/test_llm.py -q` was attempted but collection requires the repository's `dify_plugin` package, which is not installed in this environment
