### PR TITLE
fix(cot_agent): forward tool-generated files

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.43
+version: 0.0.44
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/strategies/ReAct.py
+++ b/agent-strategies/cot_agent/strategies/ReAct.py
@@ -28,6 +28,8 @@ from output_parser.cot_output_parser import ReactChunk, ReactState, CotAgentOutp
 from prompt.template import REACT_PROMPT_TEMPLATES
 from pydantic import BaseModel, Field
 
+from strategies.tool_response import should_forward_file_message
+
 class LogMetadata:
     """Metadata keys for logging"""
     STARTED_AT = "started_at"
@@ -578,6 +580,8 @@ class ReActAgentStrategy(AgentStrategy):
                         f"result link: {cast(ToolInvokeMessage.TextMessage, response.message).text}."
                         + " please tell user to check it."
                     )
+                    if should_forward_file_message(response):
+                        additional_messages.append(response)
                 elif response.type in {
                     ToolInvokeMessage.MessageType.IMAGE_LINK,
                     ToolInvokeMessage.MessageType.IMAGE,
@@ -610,6 +614,9 @@ class ReActAgentStrategy(AgentStrategy):
                 elif response.type == ToolInvokeMessage.MessageType.VARIABLE:
                     continue
                 elif response.type == ToolInvokeMessage.MessageType.BLOB:
+                    result += "Generated file with ... "
+                    additional_messages.append(response)
+                elif response.type == ToolInvokeMessage.MessageType.FILE:
                     result += "Generated file with ... "
                     additional_messages.append(response)
                 else:

--- a/agent-strategies/cot_agent/strategies/function_calling.py
+++ b/agent-strategies/cot_agent/strategies/function_calling.py
@@ -33,6 +33,8 @@ from dify_plugin.interfaces.agent import (
 )
 from pydantic import BaseModel, field_validator
 
+from strategies.tool_response import should_forward_file_message
+
 THINK_START = "<think>"
 THINK_END = "</think>"
 
@@ -555,6 +557,8 @@ class FunctionCallingAgentStrategy(AgentStrategy):
                                         + "."
                                         + " please tell user to check it."
                                     )
+                                    if should_forward_file_message(tool_invoke_response):
+                                        yield tool_invoke_response
                                 elif tool_invoke_response.type in {
                                     ToolInvokeMessage.MessageType.IMAGE_LINK,
                                     ToolInvokeMessage.MessageType.IMAGE,
@@ -617,6 +621,12 @@ class FunctionCallingAgentStrategy(AgentStrategy):
                                 ):
                                     tool_result += "Generated file ... "
                                     # TODO: convert to agent invoke message
+                                    yield tool_invoke_response
+                                elif (
+                                    tool_invoke_response.type
+                                    == ToolInvokeMessage.MessageType.FILE
+                                ):
+                                    tool_result += "Generated file ... "
                                     yield tool_invoke_response
                                 else:
                                     tool_result += (

--- a/agent-strategies/cot_agent/strategies/tool_response.py
+++ b/agent-strategies/cot_agent/strategies/tool_response.py
@@ -1,0 +1,21 @@
+from collections.abc import Mapping
+
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+def should_forward_file_message(response: ToolInvokeMessage) -> bool:
+    if response.type in {
+        ToolInvokeMessage.MessageType.FILE,
+        ToolInvokeMessage.MessageType.BLOB,
+        ToolInvokeMessage.MessageType.IMAGE,
+        ToolInvokeMessage.MessageType.IMAGE_LINK,
+    }:
+        return True
+    if response.type != ToolInvokeMessage.MessageType.LINK:
+        return False
+
+    meta = response.meta
+    if not isinstance(meta, Mapping):
+        return False
+    tool_file_id = meta.get("tool_file_id")
+    return (isinstance(tool_file_id, str) and bool(tool_file_id)) or "file" in meta

--- a/agent-strategies/cot_agent/tests/test_function_calling.py
+++ b/agent-strategies/cot_agent/tests/test_function_calling.py
@@ -21,11 +21,13 @@ from dify_plugin.entities.model.message import (
 )
 from dify_plugin.entities.tool import ToolInvokeMessage, ToolProviderType
 from dify_plugin.file.file import File, FileType
+from dify_plugin.interfaces.agent import AgentModelConfig, ToolEntity
 
 from strategies.function_calling import (
     FunctionCallingAgentStrategy,
     FunctionCallingParams,
 )
+from strategies.tool_response import should_forward_file_message
 
 
 def _make_tool_call(
@@ -305,6 +307,83 @@ class TestFunctionCallingToolResponseFormatting(unittest.TestCase):
         )
 
         self.assertEqual(result, 'tool response: {"answer": "ok"}.')
+
+
+class TestFunctionCallingFileForwarding(unittest.TestCase):
+    @staticmethod
+    def _tool() -> ToolEntity:
+        return ToolEntity.model_validate(
+            {
+                "identity": {
+                    "author": "test",
+                    "name": "getfile",
+                    "label": {"en_US": "getfile"},
+                    "provider": "workflow-provider",
+                },
+                "provider_type": "workflow",
+                "runtime_parameters": {},
+            }
+        )
+
+    def _invoke_with_tool_response(self, response: ToolInvokeMessage) -> list[ToolInvokeMessage]:
+        call = _make_tool_call("call-1", "getfile", '{"a":"get"}')
+        session = Mock()
+        session.model.llm.invoke.side_effect = [
+            LLMResult(
+                model="test-model",
+                message=AssistantPromptMessage(content="", tool_calls=[call]),
+                usage=LLMUsage.empty_usage(),
+            ),
+            LLMResult(
+                model="test-model",
+                message=AssistantPromptMessage(content="done", tool_calls=[]),
+                usage=LLMUsage.empty_usage(),
+            ),
+        ]
+        session.tool.invoke.return_value = iter([response])
+        strategy = FunctionCallingAgentStrategy(runtime=Mock(), session=session)
+
+        return list(
+            strategy._invoke(
+                {
+                    "query": "get a file",
+                    "instruction": "Use the tool",
+                    "model": AgentModelConfig(provider="test", model="test-model", mode="chat"),
+                    "tools": [self._tool()],
+                    "maximum_iterations": 3,
+                }
+            )
+        )
+
+    def test_forwards_tool_file_link(self):
+        response = ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.LINK,
+            message=ToolInvokeMessage.TextMessage(text="/files/tools/file-1.docx"),
+            meta={"tool_file_id": "file-1", "mime_type": "application/octet-stream"},
+        )
+
+        messages = self._invoke_with_tool_response(response)
+
+        self.assertIn(response, messages)
+
+    def test_does_not_forward_plain_link(self):
+        response = ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.LINK,
+            message=ToolInvokeMessage.TextMessage(text="https://dify.ai"),
+        )
+
+        messages = self._invoke_with_tool_response(response)
+
+        self.assertNotIn(response, messages)
+
+    def test_file_message_is_forwardable(self):
+        response = ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.FILE,
+            message=None,
+            meta={"file": {"transfer_method": "remote_url", "url": "https://example.test/report.pdf"}},
+        )
+
+        self.assertTrue(should_forward_file_message(response))
 
 
 if __name__ == "__main__":

--- a/agent-strategies/cot_agent/tests/test_react.py
+++ b/agent-strategies/cot_agent/tests/test_react.py
@@ -1,0 +1,68 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from dify_plugin.entities.tool import ToolInvokeMessage
+from dify_plugin.interfaces.agent import AgentScratchpadUnit, ToolEntity
+
+from strategies.ReAct import ReActAgentStrategy
+
+
+class TestReActFileForwarding(unittest.TestCase):
+    @staticmethod
+    def _tool() -> ToolEntity:
+        return ToolEntity.model_validate(
+            {
+                "identity": {
+                    "author": "test",
+                    "name": "getfile",
+                    "label": {"en_US": "getfile"},
+                    "provider": "workflow-provider",
+                },
+                "provider_type": "workflow",
+                "runtime_parameters": {},
+            }
+        )
+
+    def _handle(self, response: ToolInvokeMessage) -> tuple[str, list[ToolInvokeMessage]]:
+        session = Mock()
+        session.tool.invoke.return_value = iter([response])
+        strategy = ReActAgentStrategy(runtime=Mock(), session=session)
+
+        result, _, additional_messages = strategy._handle_invoke_action(
+            action=AgentScratchpadUnit.Action(action_name="getfile", action_input={"a": "get"}),
+            tool_instances={"getfile": self._tool()},
+            message_file_ids=[],
+        )
+        return result, additional_messages
+
+    def test_forwards_tool_file_link(self):
+        response = ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.LINK,
+            message=ToolInvokeMessage.TextMessage(text="/files/tools/file-1.docx"),
+            meta={"tool_file_id": "file-1", "mime_type": "application/octet-stream"},
+        )
+
+        result, additional_messages = self._handle(response)
+
+        self.assertIn("result link: /files/tools/file-1.docx", result)
+        self.assertEqual(additional_messages, [response])
+
+    def test_does_not_forward_plain_link(self):
+        response = ToolInvokeMessage(
+            type=ToolInvokeMessage.MessageType.LINK,
+            message=ToolInvokeMessage.TextMessage(text="https://dify.ai"),
+        )
+
+        result, additional_messages = self._handle(response)
+
+        self.assertIn("result link: https://dify.ai", result)
+        self.assertEqual(additional_messages, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- forward file-bearing `LINK` responses from tools in Function Calling and ReAct strategies
- forward native `FILE` responses while retaining the link/file description in the LLM observation
- keep ordinary links text-only to avoid changing the public output contract
- bump `cot_agent` to `0.0.44`

Requires the Dify core normalization in langgenius/dify#40917.

Related: Linear COM-13630

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (agent strategy)
- [ ] LLM plugin

## Screenshots / Videos

Not applicable (backend plugin behavior).

## Version

- [x] Bumped top-level `version` in `manifest.yaml`
- [x] Existing SDK dependency and lockfile remain unchanged

## Testing

- [x] Local tests: 21 passed
- [x] Dify dev deployment: 1.16.1

The packaged `0.0.44` plugin was installed on `agent.dify.dev`. Full E2E runs for both Function Calling and ReAct called a Workflow Tool that downloaded a PDF; each plugin stream forwarded one file-bearing link and Dify produced one Agent file output.