### PR TITLE
feat(ci): require and publish release notes for plugin PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,14 @@ For community contributions, submit to https://github.com/langgenius/dify-plugin
 
 
 
+## Release Notes
+
+<!--
+User-facing summary of what this version changes. Published verbatim on the
+plugin's Marketplace page (Version History → Change Log). English, Markdown.
+Skip only for documentation / non-plugin changes.
+-->
+
 ## Change Type
 
 - [ ] Documentation / non-plugin change

--- a/.github/workflows/pre-pr-check-per-plugin.yaml
+++ b/.github/workflows/pre-pr-check-per-plugin.yaml
@@ -81,6 +81,17 @@ jobs:
         with:
           python-version: 3.12.7
 
+      - name: Check Release Notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view ${{ github.event.pull_request.number }} -R ${{ github.repository }} --json body --jq .body > /tmp/pr_body.md
+          NOTES=$(python3 .scripts/tools/extract-changelog.py --pr-body-file /tmp/pr_body.md --section "Release Notes")
+          if [ -z "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
+            echo "!!! PR body must include a non-empty '## Release Notes' section: it is published on the plugin's Marketplace page."
+            exit 1
+          fi
+
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -162,9 +162,26 @@ jobs:
         run: |
           bash .github/scripts/export-legacy-requirements.sh "${{ matrix.plugin_path }}"
 
+      - name: Extract Release Notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLUGIN_PATH: ${{ matrix.plugin_path }}
+        run: |
+          LAST_SHA=$(git log -1 --format=%H -- "$PLUGIN_PATH")
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/$LAST_SHA/pulls" --jq '.[0].number // empty' || true)
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr view "$PR_NUMBER" -R "${{ github.repository }}" --json body --jq .body > /tmp/pr_body.md
+          else
+            echo "No associated PR found for $LAST_SHA; uploading without release notes."
+            : > /tmp/pr_body.md
+          fi
+          python3 .scripts/tools/extract-changelog.py --pr-body-file /tmp/pr_body.md --section "Release Notes" > /tmp/changelog.md
+          echo "--- extracted release notes ---"
+          cat /tmp/changelog.md
+
       - name: Upload Plugin (production)
         run: |
-          uv run --with requests --with dify_plugin python .scripts/uploader -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f
+          uv run --with requests --with dify_plugin python .scripts/uploader -d "${{ matrix.plugin_path }}" -t "${{ secrets.MARKETPLACE_TOKEN }}" --plugin-daemon-path .scripts/dify -u "${{ secrets.MARKETPLACE_BASE_URL }}" -f --with-changelog < /tmp/changelog.md
 
       # Staging only becomes testable once uploads reach it: the backend rebuilds
       # latest/recommended on an upload signal. Never blocking, though -- a red run
@@ -182,7 +199,7 @@ jobs:
             exit 0
           fi
           uv run --with requests --with dify_plugin python .scripts/uploader -d "$PLUGIN_PATH" -t "$STAGING_TOKEN" \
-            --plugin-daemon-path .scripts/dify -u "$STAGING_BASE_URL" -f
+            --plugin-daemon-path .scripts/dify -u "$STAGING_BASE_URL" -f --with-changelog < /tmp/changelog.md
 
       - name: Report a failed staging upload
         if: steps.upload-staging.outcome == 'failure'


### PR DESCRIPTION
Plugin PRs now carry user-facing release notes, and the pipeline publishes them to the Marketplace.

```mermaid
flowchart LR
    T["PR body\n## Release Notes"] -->|"pre-check: must be non-empty"| M["merge"]
    M --> R["resolve merged PR\nper plugin directory"] --> E["extract-changelog.py"] --> UP["uploader --with-changelog\nproduction + staging"]
```

- PR template: new `## Release Notes` section.
- Pre-check: plugin PRs with an empty section fail; docs-only PRs stay exempt via detect-changes. In-flight PRs only need their body edited and re-approved, no re-push.
- Upload: per plugin, the merged PR is resolved from the last commit touching the plugin directory; a missing PR or empty section uploads without notes.

Depends on langgenius/dify-marketplace-toolkit#7 and the deploy of langgenius/dify-marketplace#82 (keeps notes on forced re-uploads).
