### PR TITLE
fix(openai_api_compatible): count all messages in streaming prompt_tokens fallback (#40752)

### DIFF
--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -13,7 +13,7 @@ from dify_plugin.entities.model import (
     ParameterRule,
     ParameterType,
 )
-from dify_plugin.entities.model.llm import LLMMode, LLMResult
+from dify_plugin.entities.model.llm import LLMMode, LLMResult, LLMResultChunk, LLMResultChunkDelta
 from dify_plugin.entities.model.message import (
     AudioPromptMessageContent,
     DocumentPromptMessageContent,
@@ -732,4 +732,60 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             model=response_json.get("model", model),
             message=assistant_message,
             usage=usage,
+        )
+
+    def _create_final_llm_result_chunk(
+        self,
+        index: int,
+        message: AssistantPromptMessage,
+        finish_reason: str,
+        usage: dict,
+        model: str,
+        prompt_messages: list[PromptMessage],
+        credentials: dict,
+        full_content: str,
+    ) -> LLMResultChunk:
+        """Override the SDK default so the streaming fallback counts every
+        message in the conversation, not just the first one.
+
+        The base ``OAICompatLargeLanguageModel._create_final_llm_result_chunk``
+        falls back to ``self._num_tokens_from_string(text=prompt_messages[0].content)``
+        when the upstream omits ``usage`` from the final streaming chunk (or
+        sends it as a usage object without ``prompt_tokens``). That fallback
+        only tokenises the system prompt — every user / assistant turn
+        contributes 0 tokens — so callers see ``prompt_tokens`` matching the
+        system prompt alone, which is what #40752 reports (56593 actual vs.
+        ~298 visible).
+
+        Counting the full message list via ``_num_tokens_from_messages`` brings
+        the fallback in line with the non-streaming path
+        (``_handle_generate_response``), which already uses
+        ``_num_tokens_from_messages`` in its own no-usage branch.
+        """
+        prompt_tokens = usage and usage.get("prompt_tokens")
+        if prompt_tokens is None:
+            prompt_tokens = self._num_tokens_from_messages(
+                prompt_messages,
+                credentials=credentials,
+            )
+        completion_tokens = usage and usage.get("completion_tokens")
+        if completion_tokens is None:
+            completion_tokens = self._num_tokens_from_string(text=full_content)
+
+        # transform usage
+        usage = self._calc_response_usage(
+            model,
+            credentials,
+            prompt_tokens,
+            completion_tokens,
+        )
+
+        return LLMResultChunk(
+            model=model,
+            delta=LLMResultChunkDelta(
+                index=index,
+                message=message,
+                finish_reason=finish_reason,
+                usage=usage,
+            ),
         )

--- a/models/openai_api_compatible/tests/test_handle_response.py
+++ b/models/openai_api_compatible/tests/test_handle_response.py
@@ -1,7 +1,11 @@
 from unittest.mock import Mock, patch
 
 from dify_plugin.errors.model import InvokeError
-from dify_plugin.entities.model.message import SystemPromptMessage, UserPromptMessage
+from dify_plugin.entities.model.message import (
+    AssistantPromptMessage,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
 
 from models.llm.llm import OpenAILargeLanguageModel
 
@@ -165,3 +169,103 @@ def test_handle_generate_response_raises_when_choices_missing():
         assert str(exc) == "LLM response returned no choices"
     else:
         raise AssertionError("Expected InvokeError for empty choices")
+
+
+# Regression for #40752: the streaming path's _create_final_llm_result_chunk
+# (inherited from the SDK's OAICompatLargeLanguageModel) falls back to
+# _num_tokens_from_string(prompt_messages[0].content) when the upstream
+# omits the final ``usage`` chunk. That fallback only tokenises the system
+# prompt, so callers see prompt_tokens that excludes every user/assistant
+# turn. The override here counts the full message list instead.
+
+
+def test_final_chunk_uses_upstream_usage_when_present():
+    """When the streaming handler captured an upstream usage block, the
+    final chunk must pass the reported prompt_tokens/completion_tokens
+    straight through to the result."""
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    usage = {"prompt_tokens": 56593, "completion_tokens": 312, "total_tokens": 56905}
+
+    with (
+        patch.object(model, "_num_tokens_from_messages") as mock_prompt_counter,
+        patch.object(model, "_num_tokens_from_string") as mock_string_counter,
+    ):
+        chunk = model._create_final_llm_result_chunk(
+            index=7,
+            message=AssistantPromptMessage(content=""),
+            finish_reason="stop",
+            usage=usage,
+            model="gpt-5-mini",
+            prompt_messages=[SystemPromptMessage(content="system"), UserPromptMessage(content="user")],
+            credentials={},
+            full_content="reply",
+        )
+
+    mock_prompt_counter.assert_not_called()
+    mock_string_counter.assert_not_called()
+    assert chunk.delta.usage.prompt_tokens == 56593
+    assert chunk.delta.usage.completion_tokens == 312
+
+
+def test_final_chunk_counts_all_messages_when_usage_missing():
+    """When no usage was reported in the stream, fall back to the full
+    message list — not just prompt_messages[0].content — so user and
+    assistant turns are included in prompt_tokens."""
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    prompt_messages = [
+        SystemPromptMessage(content="system prompt"),
+        UserPromptMessage(content="latest user message"),
+        AssistantPromptMessage(content="prior assistant turn"),
+    ]
+    credentials = {"mode": "chat"}
+
+    with (
+        patch.object(model, "_num_tokens_from_messages", return_value=42) as mock_prompt_counter,
+        patch.object(model, "_num_tokens_from_string", return_value=5) as mock_string_counter,
+    ):
+        chunk = model._create_final_llm_result_chunk(
+            index=7,
+            message=AssistantPromptMessage(content=""),
+            finish_reason="stop",
+            usage=None,
+            model="gpt-5-mini",
+            prompt_messages=prompt_messages,
+            credentials=credentials,
+            full_content="final reply",
+        )
+
+    mock_prompt_counter.assert_called_once_with(prompt_messages, credentials=credentials)
+    mock_string_counter.assert_called_once_with(text="final reply")
+    assert chunk.delta.usage.prompt_tokens == 42
+    assert chunk.delta.usage.completion_tokens == 5
+
+
+def test_final_chunk_counts_all_messages_when_usage_dict_omits_prompt_tokens():
+    """Some providers send ``{"usage": {"completion_tokens": N}}`` without
+    ``prompt_tokens``. The fallback should still tokenise every message,
+    not just the first one."""
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    prompt_messages = [
+        SystemPromptMessage(content="system"),
+        UserPromptMessage(content="ask me anything"),
+    ]
+    usage_partial = {"completion_tokens": 7}  # no prompt_tokens key
+
+    with (
+        patch.object(model, "_num_tokens_from_messages", return_value=99) as mock_prompt_counter,
+        patch.object(model, "_num_tokens_from_string", return_value=7),
+    ):
+        chunk = model._create_final_llm_result_chunk(
+            index=1,
+            message=AssistantPromptMessage(content=""),
+            finish_reason="stop",
+            usage=usage_partial,
+            model="gpt-5-mini",
+            prompt_messages=prompt_messages,
+            credentials={},
+            full_content="reply",
+        )
+
+    mock_prompt_counter.assert_called_once_with(prompt_messages, credentials={})
+    assert chunk.delta.usage.prompt_tokens == 99
+    assert chunk.delta.usage.completion_tokens == 7


### PR DESCRIPTION
Fixes #40752.

The streaming path's `_create_final_llm_result_chunk` (inherited from the SDK's `OAICompatLargeLanguageModel`) falls back to `self._num_tokens_from_string(text=prompt_messages[0].content)` when the upstream omits the final `usage` chunk (or sends it without `prompt_tokens`). That fallback only tokenises the system prompt — every user and assistant turn contributes 0 — so callers see `prompt_tokens` matching the system prompt alone, which is what #40752 reports (56593 actual vs. ~298 visible).

The non-streaming path (`_handle_generate_response`) already uses `_num_tokens_from_messages` in its own no-usage branch, so the two paths disagreed. The override here brings the streaming fallback in line:

```python
prompt_tokens = usage and usage.get("prompt_tokens")
if prompt_tokens is None:
    prompt_tokens = self._num_tokens_from_messages(
        prompt_messages,
        credentials=credentials,
    )
```

## Tests

All 46 tests in `tests/` pass (3 new + 43 pre-existing). The new cases:

- `test_final_chunk_uses_upstream_usage_when_present` — happy path: upstream usage is passed through unchanged
- `test_final_chunk_counts_all_messages_when_usage_missing` — usage is None: `_num_tokens_from_messages` is called with the full prompt_messages list
- `test_final_chunk_counts_all_messages_when_usage_dict_omits_prompt_tokens` — usage dict has only completion_tokens: same all-messages fallback fires

## Out of scope

- The upstream fix in the `dify_plugin` SDK (`OAICompatLargeLanguageModel._create_final_llm_result_chunk`) would benefit every model plugin; this PR only changes the `openai_api_compatible` plugin to keep the diff tight. A separate SDK PR can drop the override once the base is patched.
- Setting `stream_options.include_usage = true` on the streaming request would avoid the fallback entirely for OpenAI-spec backends, but it requires overriding `_generate` and is not honoured by every provider (e.g. vLLM, LiteLLM-via-non-OpenAI-routes).