### PR TITLE
fix(anthropic): persist thinking blocks on the message, not the model instance

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.27
+version: 0.3.28

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -215,8 +215,6 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
 
     def __init__(self, model_schemas=None):
         super().__init__(model_schemas or [])
-        self.previous_thinking_blocks = []
-        self.previous_redacted_thinking_blocks = []
         # Flag to indicate whether tool definitions should include cache_control
         self._tool_cache_enabled = False
         self._system_cache_enabled = False
@@ -659,10 +657,6 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             else:
                 extra_headers["anthropic-beta"] = "pdfs-2024-09-25"
 
-        if not any(isinstance(msg, ToolPromptMessage) for msg in prompt_messages):
-            self.previous_thinking_blocks = []
-            self.previous_redacted_thinking_blocks = []
-
         if tools:
             extra_model_kwargs["tools"] = [
                 self._transform_tool_prompt(tool) for tool in tools
@@ -942,16 +936,23 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         :param prompt_messages: prompt messages
         :return: llm response
         """
-        self.previous_thinking_blocks = []
-        self.previous_redacted_thinking_blocks = []
-        
+        thinking_blocks: list[dict[str, Any]] = []
+        redacted_thinking_blocks: list[dict[str, Any]] = []
+
         assistant_prompt_message = AssistantPromptMessage(content="", tool_calls=[])
-        
+
         for content in response.content:
             if content.type == "thinking":
-                self.previous_thinking_blocks.append(content)
+                thinking_blocks.append({
+                    "type": "thinking",
+                    "thinking": content.thinking,
+                    "signature": content.signature,
+                })
             elif content.type == "redacted_thinking":
-                self.previous_redacted_thinking_blocks.append(content)
+                redacted_thinking_blocks.append({
+                    "type": "redacted_thinking",
+                    "data": content.data,
+                })
             elif content.type == "text" and isinstance(
                 assistant_prompt_message.content, str
             ):
@@ -1011,6 +1012,12 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             completion_tokens=completion_tokens
         )
         
+        # A fresh model instance is created per RPC (ModelFactory.get_instance()), so
+        # thinking blocks must travel with the persisted message, not on self.
+        opaque_body = self._thinking_opaque_body(thinking_blocks, redacted_thinking_blocks)
+        if opaque_body is not None:
+            assistant_prompt_message.opaque_body = opaque_body
+
         result = LLMResult(
             model=response.model,
             prompt_messages=list(prompt_messages),
@@ -1044,11 +1051,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         current_tool_name = None
         current_tool_id = None
         tool_params_by_id: dict[str, str] = {}
-        
-        if not any(isinstance(msg, ToolPromptMessage) for msg in prompt_messages):
-            self.previous_thinking_blocks = []
-            self.previous_redacted_thinking_blocks = []
-            
+
         current_thinking_blocks = []
         current_redacted_thinking_blocks = []
         
@@ -1222,11 +1225,13 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     )
                     tool_calls.append(fallback_tool_call)
                 
-                if tool_calls and current_thinking_blocks:
-                    self.previous_thinking_blocks = current_thinking_blocks
-                if tool_calls and current_redacted_thinking_blocks:
-                    self.previous_redacted_thinking_blocks = current_redacted_thinking_blocks
-                
+                # A fresh model instance is created per RPC (ModelFactory.get_instance()),
+                # so thinking blocks must travel with the persisted message, not on self.
+                opaque_body = self._thinking_opaque_body(
+                    current_thinking_blocks if tool_calls else [],
+                    current_redacted_thinking_blocks if tool_calls else [],
+                )
+
                 # Adjust prompt tokens for cache operations
                 adjusted_prompt_tokens = PromptCachingHandler.calc_adjusted_prompt_tokens(
                     input_tokens,
@@ -1253,7 +1258,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     delta=LLMResultChunkDelta(
                         index=index + 1,
                         message=AssistantPromptMessage(
-                            content="", tool_calls=tool_calls
+                            content="", tool_calls=tool_calls, opaque_body=opaque_body
                         ),
                         finish_reason=finish_reason,
                         usage=usage,
@@ -1482,23 +1487,52 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             result["cache_control"] = self._cache_control()
         
         return result
-    
+
+    @staticmethod
+    def _thinking_opaque_body(
+        thinking_blocks: list[dict[str, Any]],
+        redacted_thinking_blocks: list[dict[str, Any]],
+    ) -> Optional[dict[str, Any]]:
+        """Bundle thinking/redacted_thinking blocks for storage on opaque_body.
+
+        dify_plugin.ModelFactory.get_instance() builds a fresh model instance per
+        RPC, so state kept on self does not survive to the next invocation; the
+        Anthropic API requires these blocks to be echoed back verbatim on the
+        following tool-result turn, so they are attached to the assistant message
+        that Dify persists instead.
+        """
+        if not thinking_blocks and not redacted_thinking_blocks:
+            return None
+        return {
+            "thinking_blocks": thinking_blocks,
+            "redacted_thinking_blocks": redacted_thinking_blocks,
+        }
+
+    @staticmethod
+    def _thinking_content_blocks(message: AssistantPromptMessage) -> list[dict[str, Any]]:
+        """Recover the thinking/redacted_thinking content blocks stashed on opaque_body."""
+        opaque_body = message.opaque_body
+        if not isinstance(opaque_body, dict):
+            return []
+        thinking_blocks = opaque_body.get("thinking_blocks") or []
+        redacted_thinking_blocks = opaque_body.get("redacted_thinking_blocks") or []
+        return [*thinking_blocks, *redacted_thinking_blocks]
+
     def _process_assistant_message(
-        self, 
+        self,
         message: AssistantPromptMessage,
         all_messages: Sequence[PromptMessage]
     ) -> dict:
         """Process assistant message into API format."""
         content = []
-        
+
         # Check if we need to include thinking blocks
         has_tool_messages = any(
             isinstance(msg, ToolPromptMessage) for msg in all_messages
         )
         
         if has_tool_messages:
-            content.extend(self.previous_thinking_blocks)
-            content.extend(self.previous_redacted_thinking_blocks)
+            content.extend(self._thinking_content_blocks(message))
         
         # Dify stores assistant text and tool calls separately; Anthropic expects the next
         # user tool_result message to immediately follow the assistant tool_use turn.

--- a/models/anthropic/tests/test_llm.py
+++ b/models/anthropic/tests/test_llm.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
 
 import pytest
+from anthropic.types import Message, ThinkingBlock, ToolUseBlock, Usage
 from dify_plugin.entities.model.message import (
     SystemPromptMessage,
     TextPromptMessageContent,
+    ToolPromptMessage,
     UserPromptMessage,
 )
 from dify_plugin.errors.model import CredentialsValidateFailedError
@@ -126,3 +128,47 @@ def test_model_classification(model: str, expected: tuple[bool, ...]) -> None:
         llm._supports_task_budget(model),
         llm._enforces_disabled_thinking_effort_cap(model),
     ) == expected
+
+
+def test_thinking_blocks_survive_a_fresh_model_instance() -> None:
+    # dify_plugin.core.model_factory.ModelFactory.get_instance() builds a new model
+    # instance per RPC ("generate stateless model instances"), so state kept on
+    # self does not survive from the turn that produced a thinking block to the
+    # turn that must echo it back on a tool-result continuation.
+    response = Message(
+        id="msg_1",
+        model="claude-sonnet-5",
+        role="assistant",
+        stop_reason="tool_use",
+        type="message",
+        usage=Usage(input_tokens=10, output_tokens=5),
+        content=[
+            ThinkingBlock(
+                type="thinking", thinking="working out the weather query", signature="sig-1"
+            ),
+            ToolUseBlock(type="tool_use", id="toolu_1", name="get_weather", input={"city": "Paris"}),
+        ],
+    )
+    user_message = UserPromptMessage(content="what is the weather in Paris?")
+
+    responding_instance = AnthropicLargeLanguageModel()
+    assistant_message = responding_instance._handle_chat_generate_response(
+        model="claude-sonnet-5",
+        credentials={},
+        response=response,
+        prompt_messages=[user_message],
+    ).message
+
+    all_messages = [
+        user_message,
+        assistant_message,
+        ToolPromptMessage(content="18C, sunny", tool_call_id="toolu_1"),
+    ]
+
+    # A separate instance, exactly as ModelFactory.get_instance() would build for
+    # the follow-up RPC that sends the tool result back to Anthropic.
+    followup_instance = AnthropicLargeLanguageModel()
+    processed = followup_instance._process_assistant_message(assistant_message, all_messages)
+
+    block_types = [block["type"] for block in processed["content"]]
+    assert "thinking" in block_types


### PR DESCRIPTION
## Summary

`dify_plugin`'s `ModelFactory.get_instance()` builds a fresh `AnthropicLargeLanguageModel` instance for every RPC (its own docstring: "generate stateless model instances"), and `plugin_registration.get_model_instance()` is called from every handler in `plugin_executor.py`. This plugin stores a response's thinking/`redacted_thinking` blocks on `self.previous_thinking_blocks` / `self.previous_redacted_thinking_blocks`, then reads them back in `_process_assistant_message` while building the next request. The follow-up tool-result turn runs on a different instance, so those lists are always empty by the time they're read: Anthropic requires the blocks to be echoed back verbatim on that turn, and never gets them.

Confirmed by exercising `ModelFactory.get_instance()` (`self.models[model_type](self.provider.models)`, a fresh call each time) directly, and by driving `_handle_chat_generate_response` / `_process_assistant_message` from two separate `AnthropicLargeLanguageModel()` instances with a synthetic thinking + tool_use response.

## What this changes

Moves the state onto `AssistantPromptMessage.opaque_body`, the field Dify persists with the message itself, so it survives whichever instance handles the next turn. This is the same pattern `models/moonshot/models/llm/llm.py` already uses for `reasoning_content`. Both the non-streaming and streaming response handlers now attach the blocks to the message they return instead of to `self`; the `self.previous_*` resets, which existed only to guard against same-instance reuse across unrelated conversations, are removed as dead code now that nothing reads them.

## Not included, and why

Scoped to the in-memory, same-session tool-loop case this issue reports. Persistence across a chat reload or workflow pause-resume, and signature invalidation on a model switch, are open questions the issue itself raises; this PR does not attempt to answer them, since I can't verify Dify core's persistence layer end-to-end from this side of the plugin boundary.

## Release Notes

Fix: extended-thinking tool calls on Anthropic models no longer lose their thinking blocks on the follow-up turn, which previously caused the request to be rejected or degraded whenever Dify routed it to a new plugin instance (nearly always, in production).

## Change Type

- [x] LLM plugin

## Screenshots / Videos

N/A, backend fix with no UI surface.

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)

</details>

## Version

- [x] Bumped `version` in `manifest.yaml`: `0.3.27` -> `0.3.28`.
- [x] `dify_plugin>=0.9.0` remains declared in `pyproject.toml` and locked in `uv.lock` (unchanged by this PR).

## Testing

- [x] New regression test drives `_handle_chat_generate_response` on one instance and `_process_assistant_message` on a second, separate instance (mirroring `ModelFactory.get_instance()`), and confirms the thinking block survives the boundary. Fails on `main`, passes on this branch.
- [x] `uv run --frozen pytest`: 28 passed, 14 skipped (skipped suite needs a live `ANTHROPIC_API_KEY`), in a clean `python:3.12-slim` container matching this plugin's `requires-python`.
- [x] `uv run --frozen pyrefly check`: 0 errors, same as `main`.
- [ ] Not tested against a running Dify server (local or SaaS); the mechanism is verified at the plugin/message level, not end-to-end through Dify's own conversation persistence.

- [ ] Local deployment
- [ ] SaaS (cloud.dify.ai)

Refs #3658
