### PR TITLE
fix(stepfun): add international endpoint option to models plugin

### DIFF
--- a/models/stepfun/manifest.yaml
+++ b/models/stepfun/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.1.0
+version: 0.1.1

--- a/models/stepfun/models/llm/llm.py
+++ b/models/stepfun/models/llm/llm.py
@@ -25,6 +25,7 @@ from dify_plugin.entities.model.message import (
     UserPromptMessage,
 )
 from dify_plugin import OAICompatLargeLanguageModel
+from dify_plugin.errors.model import CredentialsValidateFailedError
 
 
 class StepfunLargeLanguageModel(OAICompatLargeLanguageModel):
@@ -50,7 +51,14 @@ class StepfunLargeLanguageModel(OAICompatLargeLanguageModel):
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
         self._add_custom_parameters(credentials)
-        super().validate_credentials(model, credentials)
+        try:
+            super().validate_credentials(model, credentials)
+        except CredentialsValidateFailedError as ex:
+            # api.stepfun.com and api.stepfun.ai return byte-identical 401
+            # bodies, so the error must say which endpoint rejected the key.
+            raise CredentialsValidateFailedError(
+                f"{ex} (endpoint validated: {credentials.get('endpoint_url', 'unknown')})"
+            ) from ex
 
     def get_customizable_model_schema(
         self, model: str, credentials: dict

--- a/models/stepfun/models/llm/llm.py
+++ b/models/stepfun/models/llm/llm.py
@@ -100,7 +100,10 @@ class StepfunLargeLanguageModel(OAICompatLargeLanguageModel):
 
     def _add_custom_parameters(self, credentials: dict) -> None:
         credentials["mode"] = "chat"
-        credentials["endpoint_url"] = "https://api.stepfun.com/v1"
+        if credentials.get("use_international_endpoint", "false") == "true":
+            credentials["endpoint_url"] = "https://api.stepfun.ai/v1"
+        else:
+            credentials["endpoint_url"] = "https://api.stepfun.com/v1"
 
     def _add_function_call(self, model: str, credentials: dict) -> None:
         model_schema = self.get_model_schema(model, credentials)

--- a/models/stepfun/provider/stepfun.yaml
+++ b/models/stepfun/provider/stepfun.yaml
@@ -33,6 +33,22 @@ model_credential_schema:
     required: true
     type: secret-input
     variable: api_key
+  - label:
+      en_US: Use International Endpoint
+      zh_Hans: 使用国际站端点
+    type: radio
+    required: false
+    default: 'false'
+    variable: use_international_endpoint
+    options:
+    - label:
+        en_US: 'True'
+        zh_Hans: 是
+      value: 'true'
+    - label:
+        en_US: 'False'
+        zh_Hans: 否
+      value: 'false'
   - default: '8192'
     label:
       en_US: Model context size
@@ -87,5 +103,21 @@ provider_credential_schema:
     required: true
     type: secret-input
     variable: api_key
+  - label:
+      en_US: Use International Endpoint
+      zh_Hans: 使用国际站端点
+    type: radio
+    required: false
+    default: 'false'
+    variable: use_international_endpoint
+    options:
+    - label:
+        en_US: 'True'
+        zh_Hans: 是
+      value: 'true'
+    - label:
+        en_US: 'False'
+        zh_Hans: 否
+      value: 'false'
 supported_model_types:
 - llm

--- a/models/stepfun/tests/test_endpoint.py
+++ b/models/stepfun/tests/test_endpoint.py
@@ -49,3 +49,30 @@ def test_radio_offered_in_both_credential_schemas():
         "the endpoint radio must exist in BOTH provider_credential_schema and "
         "model_credential_schema, or customizable models stay .com-only"
     )
+
+
+def test_validation_401_names_the_endpoint_it_hit():
+    """Unmocked, real-network: proves validate_credentials itself flows through
+    the endpoint switch, and that the failure names the host that rejected the
+    key. Both StepFun hosts return byte-identical 401 bodies for a bad key, so
+    without the endpoint in the message a wrong-region 401 is undiagnosable
+    (2026-08-10 lesson: a monkeypatched dependency is an untested dependency)."""
+    import dify_plugin  # noqa: F401  (gevent-patches ssl; must precede requests)
+    import pytest
+
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+    from dify_plugin.errors.model import CredentialsValidateFailedError
+    from models.llm.llm import StepfunLargeLanguageModel
+
+    model = StepfunLargeLanguageModel([])
+    for flag, host in (("true", "api.stepfun.ai"), ("false", "api.stepfun.com")):
+        credentials = {
+            "api_key": "sk-invalid-on-purpose",
+            "use_international_endpoint": flag,
+        }
+        with pytest.raises(CredentialsValidateFailedError) as excinfo:
+            model.validate_credentials("step-3.7-flash", credentials)
+        assert host in str(excinfo.value), (
+            f"validation error must name {host}: {excinfo.value}"
+        )
+        assert credentials["endpoint_url"] == f"https://{host}/v1"

--- a/models/stepfun/tests/test_endpoint.py
+++ b/models/stepfun/tests/test_endpoint.py
@@ -1,0 +1,51 @@
+"""In-process tests for StepFun endpoint selection (pytest-shaped).
+
+Fails before this change: _add_custom_parameters unconditionally hardcoded
+https://api.stepfun.com/v1, so keys minted on the international platform
+(platform.stepfun.ai) could never validate or invoke."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_PLUGIN_ROOT = _HERE.parent
+
+_LLM_PY = _PLUGIN_ROOT / "models" / "llm" / "llm.py"
+
+
+def _add_custom_parameters(credentials):
+    """The switch under test, extracted by AST so the test needs no SDK
+    install: executes the real _add_custom_parameters body."""
+    tree = ast.parse(_LLM_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_add_custom_parameters":
+            fn = ast.Module(body=[node], type_ignores=[])
+            ns = {}
+            exec(compile(fn, str(_LLM_PY), "exec"), ns)  # noqa: S102
+            ns["_add_custom_parameters"](None, credentials)
+            return credentials
+    raise AssertionError("_add_custom_parameters not found")
+
+
+def test_default_is_byte_identical_com():
+    for creds in ({}, {"use_international_endpoint": "false"},
+                  {"use_international_endpoint": ""}):
+        out = _add_custom_parameters(dict(creds))
+        assert out["endpoint_url"] == "https://api.stepfun.com/v1"
+        assert out["mode"] == "chat"
+
+
+def test_international_opt_in():
+    out = _add_custom_parameters({"use_international_endpoint": "true"})
+    assert out["endpoint_url"] == "https://api.stepfun.ai/v1"
+
+
+def test_radio_offered_in_both_credential_schemas():
+    text = (_PLUGIN_ROOT / "provider" / "stepfun.yaml").read_text(encoding="utf-8")
+    assert text.count("variable: use_international_endpoint") == 2, (
+        "the endpoint radio must exist in BOTH provider_credential_schema and "
+        "model_credential_schema, or customizable models stay .com-only"
+    )


### PR DESCRIPTION
## Summary

Fixes #3606

`main` currently ships a StepFun README that documents a setting the code does not have. #3609 (merged 2026-08-19) added `models/stepfun/README.md` guidance telling users to *"enable the **Use International Endpoint** option"* if their key is from `platform.stepfun.ai` — but no such option exists in `provider/stepfun.yaml` or `models/llm/llm.py`. This PR is the implementation that documentation describes.

The plugin hardcodes `https://api.stepfun.com/v1` in `_add_custom_parameters`, so keys from StepFun's international platform (`platform.stepfun.ai` / `api.stepfun.ai` — a separate account system) always fail validation with upstream's misleading `invalid_api_key`.

This mirrors the approach merged for siliconflow in #2394: an optional **`use_international_endpoint`** radio (default `"false"`). One deliberate extension: the radio is offered in **both** `provider_credential_schema` and `model_credential_schema`, so customizable models get the same choice rather than staying pinned to the China host.

- **Zero change for existing users:** with the option absent or `"false"`, `endpoint_url` resolves byte-identically to the current hardcoded value (asserted by test).
- **Endpoint-aware validation error:** both hosts return byte-identical 401 bodies, so `validate_credentials` now names the endpoint it validated against (`... (endpoint validated: https://api.stepfun.ai/v1)`) — otherwise a wrong-region failure is indistinguishable from a genuinely bad key.
- Empirical receipt (same key): 200 on `api.stepfun.ai/v1/models`, 401 on `api.stepfun.com/v1/models`.

**Class context.** This is instance 3 of the bounded dual-host class tracked by umbrella #3611 (audit: 102 LOCKED / 76 ESCAPED / 41 N/A). Instances 1 and 2 — #3601 (minimax_tts) and #3604 (siliconflow) — merged 2026-08-11 in 4h52m and 4h17m. #3611 currently has zero open PRs against it.

**History.** This supersedes #3607, which carried the same change and was closed unmerged on 2026-08-20 as part of a governance sweep that closed 22 PRs across ~17 authors in a single minute. #3607 received zero reviews and no comment on the code; the closure was queue hygiene, not a judgment on the change. Rebased onto current `main` here, with the newly required Release Notes section added.

## Release Notes

Adds an optional **Use International Endpoint** setting so API keys issued on StepFun's international platform (`platform.stepfun.ai`) authenticate against `api.stepfun.ai`. Existing configurations are unaffected — the default remains `api.stepfun.com` — and credential-validation errors now name the endpoint that was checked, so a wrong-region key is no longer reported as an invalid key.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| <img width="1280" height="1203" alt="stepfun-before" src="https://github.com/user-attachments/assets/6c791ef2-a1a3-44f7-9680-f9999f0c8444" /> | <img width="1280" height="1203" alt="stepfun-after-1" src="https://github.com/user-attachments/assets/0d635010-9ad3-4d68-81e7-ad5a95914487" /> |

**Before** — international key → upstream `invalid_api_key` (hardcoded `.com` host).
**After (0.1.1)** — same key + International Endpoint = True → request routed to and authenticated by `api.stepfun.ai`; validation error now names the endpoint.

<img width="1280" height="1203" alt="stepfun-after-2" src="https://github.com/user-attachments/assets/22ec3808-e34a-4df7-876e-2b2a4e7c733a" />

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.) — endpoint selection only; no message-flow or model changes
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.1.0 → 0.1.1
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

Not ticked, because it is not literally true and I would rather flag it than tick it: `models/stepfun` declares `dify_plugin>=0.9.0` and locks `0.9.0`, which is outside the `>=0.3.0,<0.6.0` range this checkbox asserts. That is `main`'s existing state — this PR does not touch `pyproject.toml` or `uv.lock`. The declaration is present and locked as the checkbox intends; only the version range in the template text is stale. Happy to adjust if the range is meant to be enforced.

## Testing

- [x] Local deployment — Dify version: 1.16.1 (self-hosted, Docker). Installed the packaged 0.1.1 build. With International Endpoint = True, the international key is routed to `api.stepfun.ai` and authenticated there (the request reaches the correct host — verified; the account returned a quota response rather than the wrong-host `invalid_api_key`, which is the failure this fixes). The validation error names the endpoint. The default path (option absent/False) resolves to `api.stepfun.com/v1`, byte-identical to the current hardcode (asserted by test). A billed chat completion was not exercised (international credit had not propagated to the account); the endpoint routing, authentication, and endpoint-naming error are demonstrated.
- [ ] SaaS (cloud.dify.ai) — not tested

In-process tests: default byte-identity (the real `_add_custom_parameters` body under test), international opt-in, radio presence in both credential schemas, and endpoint-naming on a 401. **4/4 pass**, run the way CI runs them (packaged with the Dify CLI, extracted, `uv sync --all-groups --frozen --python 3.12`, then `pytest`).