### PR TITLE
feat(huaweicloud_maas): add openpangu-2.0-pro model

### DIFF
--- a/models/huaweicloud_maas/manifest.yaml
+++ b/models/huaweicloud_maas/manifest.yaml
@@ -26,5 +26,5 @@ resource:
       enabled: true
       llm: true
 type: plugin
-version: 0.0.24
+version: 0.0.25
 created_at: 2025-06-04T12:32:17.824356+08:00

--- a/models/huaweicloud_maas/models/llm/_position.yaml
+++ b/models/huaweicloud_maas/models/llm/_position.yaml
@@ -1,4 +1,5 @@
 - openpangu-2.0-flash
+- openpangu-2.0-pro
 - deepseek-v4-flash
 - deepseek-v4-pro
 - deepseek-v3.2

--- a/models/huaweicloud_maas/models/llm/deepseek-v4-pro.yaml
+++ b/models/huaweicloud_maas/models/llm/deepseek-v4-pro.yaml
@@ -13,7 +13,7 @@ model_properties:
 parameter_rules:
   - name: temperature
     use_template: temperature
-    default: 0.6
+    default: 1.0
   - name: top_p
     use_template: top_p
     default: 0.95

--- a/models/huaweicloud_maas/models/llm/llm.py
+++ b/models/huaweicloud_maas/models/llm/llm.py
@@ -3,13 +3,19 @@ from typing import Optional, Union
 from dify_plugin import OAICompatLargeLanguageModel
 from dify_plugin.entities.model import AIModelEntity, ModelFeature
 from dify_plugin.entities.model.llm import LLMResult
-from dify_plugin.entities.model.message import PromptMessage, PromptMessageTool
+import re
+from dify_plugin.entities.model.message import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+)
 
 
 class HuaweiCloudMaasLargeLanguageModel(OAICompatLargeLanguageModel):
     _BASE_URL_V2 = "https://api.modelarts-maas.com/v2"
     _THINKING_PATH_XDS = "thinking.type.enabled"
     _THINKING_PATH_VLLM = "chat_template_kwargs.enable_thinking.true"
+    _THINK_PATTERN = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
 
     thinking_mapping = {
         "deepseek-v3.2": _THINKING_PATH_XDS,
@@ -54,6 +60,10 @@ class HuaweiCloudMaasLargeLanguageModel(OAICompatLargeLanguageModel):
                 value = bool(enable_thinking)
             model_parameters[path[0]] = {path[1]: value}
 
+        # DeepSeek models require reasoning content split in the tool use context
+        if model.lower().startswith("deepseek"):
+            self.insert_cot_tool_call(prompt_messages)
+
         return super()._invoke(
             model, credentials, prompt_messages, model_parameters, tools, stop, stream
         )
@@ -80,3 +90,41 @@ class HuaweiCloudMaasLargeLanguageModel(OAICompatLargeLanguageModel):
         entity = super().get_customizable_model_schema(model, credentials)
 
         return entity
+
+    def insert_cot_tool_call(self, messages: list[PromptMessage]) -> None:
+        for message in messages:
+            if isinstance(message, AssistantPromptMessage) and message.tool_calls:
+                content, reasoning_content = (
+                    HuaweiCloudMaasLargeLanguageModel._extract_reasoning_content(message.content)
+                )
+                message.content = content
+                opaque_body = message.opaque_body if isinstance(message.opaque_body, dict) else {}
+                message.opaque_body = {
+                    **opaque_body,
+                    "reasoning_content": reasoning_content,
+                }
+
+    @staticmethod
+    def _extract_reasoning_content(text: str) -> tuple[str, Optional[str]]:
+        if not text:
+            return text, None
+
+        # Find all <think>...</think> blocks
+        matches = HuaweiCloudMaasLargeLanguageModel._THINK_PATTERN.findall(text)
+        reasoning_content = "\n".join(match.strip() for match in matches) if matches else None
+
+        # Remove all <think>...</think> blocks from original text
+        clean_text = HuaweiCloudMaasLargeLanguageModel._THINK_PATTERN.sub("", text)
+
+        # Clean up extra whitespace
+        clean_text = re.sub(r"\n\s*\n", "\n\n", clean_text).strip()
+
+        return clean_text, reasoning_content
+
+    def _convert_prompt_message_to_dict(
+        self, message: PromptMessage, credentials: dict | None = None
+    ) -> dict:
+        message_dict = super()._convert_prompt_message_to_dict(message, credentials)
+        if isinstance(message, AssistantPromptMessage) and message.opaque_body:
+            message_dict["reasoning_content"] = message.opaque_body.get("reasoning_content")
+        return message_dict

--- a/models/huaweicloud_maas/models/llm/openpangu-2.0-flash.yaml
+++ b/models/huaweicloud_maas/models/llm/openpangu-2.0-flash.yaml
@@ -13,7 +13,7 @@ model_properties:
 parameter_rules:
   - name: temperature
     use_template: temperature
-    default: 0.6
+    default: 1.0
   - name: top_p
     use_template: top_p
     default: 0.95

--- a/models/huaweicloud_maas/models/llm/openpangu-2.0-pro.yaml
+++ b/models/huaweicloud_maas/models/llm/openpangu-2.0-pro.yaml
@@ -1,6 +1,6 @@
-model: deepseek-v4-flash
+model: openpangu-2.0-pro
 label:
-  en_US: DeepSeek-V4-Flash
+  en_US: openPangu-2.0-pro
 model_type: llm
 features:
   - agent-thought
@@ -9,7 +9,7 @@ features:
   - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 64000
+  context_size: 512000
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -20,7 +20,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     min: 1
-    max: 16384
+    max: 128000
     default: 16384
   - name: frequency_penalty
     use_template: frequency_penalty
@@ -43,7 +43,7 @@ parameter_rules:
       zh_Hans: 是否开启思考模式。
       en_US: Whether to enable thinking mode.
 pricing:
-  input: '1'
-  output: '2'
+  input: '3.2'
+  output: '14.5'
   unit: '0.000001'
   currency: RMB


### PR DESCRIPTION

## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

1. add openpangu-2.0-pro model
2. fix: reasoning content is not returned for deepseek models in tool use context

## Release Notes

- add openpangu-2.0-pro model
- fix: reasoning content is not returned for deepseek models in tool use conte

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.11.4
- [ ] SaaS (cloud.dify.ai)
