### PR TITLE
feat(cot_agent): optional allowed_tools allowlist for Function Calling and ReAct

### DIFF
--- a/agent-strategies/cot_agent/README.md
+++ b/agent-strategies/cot_agent/README.md
@@ -1,6 +1,8 @@
 # Overview
 The Agent node in Dify Chatflow/Workflow lets LLMs autonomously use tools. This plugin features two official Dify Agent reasoning strategies, enabling LLMs to dynamically select and run tools during runtime for multi-step problem-solving.
 
+The Agent node also accepts an optional **Allowed tools** list (`array[string]`). If the list has names, only those tools from the node’s tool list are sent to the model and allowed to run. Leave it unset or empty to keep the full tool list.
+
 ## Strategies
 
 ### 1. Function Calling

--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.44
+version: 0.0.45
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/strategies/ReAct.py
+++ b/agent-strategies/cot_agent/strategies/ReAct.py
@@ -26,8 +26,9 @@ from dify_plugin.interfaces.agent import (
 )
 from output_parser.cot_output_parser import ReactChunk, ReactState, CotAgentOutputParser
 from prompt.template import REACT_PROMPT_TEMPLATES
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from strategies.tool_allowlist import coerce_allowed_tools, filter_allowed_tools
 from strategies.tool_response import should_forward_file_message
 
 class LogMetadata:
@@ -54,8 +55,14 @@ class ReActParams(BaseModel):
     instruction: str
     model: AgentModelConfig
     tools: list[ToolEntity] | None
+    allowed_tools: list[str] | None = None
     maximum_iterations: int = 3
     context: list[ContextItem] | None = None
+
+    @field_validator("allowed_tools", mode="before")
+    @classmethod
+    def normalize_allowed_tools(cls, value: Any) -> list[str] | None:
+        return coerce_allowed_tools(value)
 
 
 class AgentPromptEntity(BaseModel):
@@ -143,7 +150,7 @@ class ReActAgentStrategy(AgentStrategy):
         self.history_prompt_messages = model.history_prompt_messages
 
         # convert tools into ModelRuntime Tool format
-        tools = react_params.tools
+        tools = filter_allowed_tools(react_params.tools, react_params.allowed_tools)
         tool_instances = {tool.identity.name: tool for tool in tools} if tools else {}
         react_params.model.completion_params = (
             react_params.model.completion_params or {}

--- a/agent-strategies/cot_agent/strategies/ReAct.yaml
+++ b/agent-strategies/cot_agent/strategies/ReAct.yaml
@@ -20,6 +20,18 @@ parameters:
       en_US: Model
       zh_Hans: 模型
       pt_BR: Model
+  - name: allowed_tools
+    type: any
+    scope: array[string]
+    required: false
+    label:
+      en_US: Allowed tools
+      zh_Hans: 允许的工具
+      pt_BR: Ferramentas permitidas
+    help:
+      en_US: Optional. If this list has tool names, only those tools are sent to the model and allowed to run. Leave unset or empty to use the full tool list.
+      zh_Hans: 可选。若填写工具名称，则仅这些工具会暴露给模型并允许调用。留空则使用完整工具列表。
+      pt_BR: Opcional. Se esta lista tiver nomes, somente essas ferramentas são enviadas ao modelo e podem ser executadas. Vazio usa a lista completa.
   - name: tools
     type: array[tools]
     required: true

--- a/agent-strategies/cot_agent/strategies/function_calling.py
+++ b/agent-strategies/cot_agent/strategies/function_calling.py
@@ -33,6 +33,7 @@ from dify_plugin.interfaces.agent import (
 )
 from pydantic import BaseModel, field_validator
 
+from strategies.tool_allowlist import coerce_allowed_tools, filter_allowed_tools
 from strategies.tool_response import should_forward_file_message
 
 THINK_START = "<think>"
@@ -97,6 +98,7 @@ class FunctionCallingParams(BaseModel):
     model: AgentModelConfig
     tools: list[ToolEntity] | None
     files: list[File] | None = None
+    allowed_tools: list[str] | None = None
     maximum_iterations: int = 3
     context: list[ContextItem] | None = None
 
@@ -106,6 +108,11 @@ class FunctionCallingParams(BaseModel):
         if isinstance(value, list):
             return [item for item in value if item is not None]
         return value
+
+    @field_validator("allowed_tools", mode="before")
+    @classmethod
+    def normalize_allowed_tools(cls, value: Any) -> list[str] | None:
+        return coerce_allowed_tools(value)
 
 
 class FunctionCallingAgentStrategy(AgentStrategy):
@@ -211,7 +218,7 @@ class FunctionCallingAgentStrategy(AgentStrategy):
         history_prompt_messages.append(self._user_prompt_message)
 
         # convert tool messages
-        tools = fc_params.tools
+        tools = filter_allowed_tools(fc_params.tools, fc_params.allowed_tools)
         tool_instances = {tool.identity.name: tool for tool in tools} if tools else {}
         prompt_messages_tools = self._init_prompt_tools(tools)
 
@@ -499,14 +506,16 @@ class FunctionCallingAgentStrategy(AgentStrategy):
                     )
             else:
                 for tool_call_id, tool_call_name, tool_call_args in tool_calls:
-                    tool_instance = tool_instances[tool_call_name]
+                    tool_instance = tool_instances.get(tool_call_name)
                     tool_call_started_at = time.perf_counter()
                     tool_call_log = self.create_log_message(
                         label=f"CALL {tool_call_name}",
                         data={},
                         metadata={
                             LogMetadata.STARTED_AT: time.perf_counter(),
-                            LogMetadata.PROVIDER: tool_instance.identity.provider,
+                            LogMetadata.PROVIDER: tool_instance.identity.provider
+                            if tool_instance
+                            else "",
                         },
                         parent=round_log,
                         status=ToolInvokeMessage.LogMessage.LogStatus.START,
@@ -651,7 +660,9 @@ class FunctionCallingAgentStrategy(AgentStrategy):
                         },
                         metadata={
                             LogMetadata.STARTED_AT: tool_call_started_at,
-                            LogMetadata.PROVIDER: tool_instance.identity.provider,
+                            LogMetadata.PROVIDER: tool_instance.identity.provider
+                            if tool_instance
+                            else "",
                             LogMetadata.FINISHED_AT: time.perf_counter(),
                             LogMetadata.ELAPSED_TIME: time.perf_counter()
                             - tool_call_started_at,

--- a/agent-strategies/cot_agent/strategies/function_calling.yaml
+++ b/agent-strategies/cot_agent/strategies/function_calling.yaml
@@ -20,6 +20,18 @@ parameters:
       en_US: Model
       zh_Hans: 模型
       pt_BR: Model
+  - name: allowed_tools
+    type: any
+    scope: array[string]
+    required: false
+    label:
+      en_US: Allowed tools
+      zh_Hans: 允许的工具
+      pt_BR: Ferramentas permitidas
+    help:
+      en_US: Optional. If this list has tool names, only those tools are sent to the model and allowed to run. Leave unset or empty to use the full tool list.
+      zh_Hans: 可选。若填写工具名称，则仅这些工具会暴露给模型并允许调用。留空则使用完整工具列表。
+      pt_BR: Opcional. Se esta lista tiver nomes, somente essas ferramentas são enviadas ao modelo e podem ser executadas. Vazio usa a lista completa.
   - name: tools
     type: array[tools]
     required: true

--- a/agent-strategies/cot_agent/strategies/tool_allowlist.py
+++ b/agent-strategies/cot_agent/strategies/tool_allowlist.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dify_plugin.interfaces.agent import ToolEntity
+
+
+def filter_allowed_tools(
+    tools: list[ToolEntity] | None,
+    allowed_tools: Any,
+) -> list[ToolEntity] | None:
+    """Return tools unchanged unless allowed_tools contains at least one name."""
+    names = allowed_tool_names(allowed_tools)
+    if names is None:
+        return tools
+    return [tool for tool in (tools or []) if tool.identity.name in names]
+
+
+def allowed_tool_names(value: Any) -> set[str] | None:
+    """Parse an optional allowlist. None/empty means no restriction."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            value = json.loads(stripped)
+        except json.JSONDecodeError:
+            value = [stripped]
+    if not isinstance(value, list) or not value:
+        return None
+    names = {
+        item.strip()
+        for item in value
+        if isinstance(item, str) and item.strip()
+    }
+    return names or None
+
+
+def coerce_allowed_tools(value: Any) -> list[str] | None:
+    names = allowed_tool_names(value)
+    return list(names) if names else None

--- a/agent-strategies/cot_agent/tests/test_function_calling.py
+++ b/agent-strategies/cot_agent/tests/test_function_calling.py
@@ -386,5 +386,77 @@ class TestFunctionCallingFileForwarding(unittest.TestCase):
         self.assertTrue(should_forward_file_message(response))
 
 
+class TestFunctionCallingAllowedTools(unittest.TestCase):
+    @staticmethod
+    def _tool(name: str) -> ToolEntity:
+        return ToolEntity.model_validate(
+            {
+                "identity": {
+                    "author": "test",
+                    "name": name,
+                    "label": {"en_US": name},
+                    "provider": "test",
+                },
+                "provider_type": "mcp",
+                "runtime_parameters": {},
+            }
+        )
+
+    def _invoke(self, allowed_tools):
+        lookup = self._tool("lookup")
+        create_ticket = self._tool("create_ticket")
+        call = _make_tool_call(
+            "call-1", "create_ticket", '{"id":"000"}'
+        )
+        session = Mock()
+        session.model.llm.invoke.side_effect = [
+            LLMResult(
+                model="test-model",
+                message=AssistantPromptMessage(content="", tool_calls=[call]),
+                usage=LLMUsage.empty_usage(),
+            ),
+            LLMResult(
+                model="test-model",
+                message=AssistantPromptMessage(content="done", tool_calls=[]),
+                usage=LLMUsage.empty_usage(),
+            ),
+        ]
+        session.tool.invoke.return_value = iter(
+            [
+                ToolInvokeMessage(
+                    type=ToolInvokeMessage.MessageType.TEXT,
+                    message=ToolInvokeMessage.TextMessage(text="registered"),
+                )
+            ]
+        )
+        strategy = FunctionCallingAgentStrategy(runtime=Mock(), session=session)
+        list(
+            strategy._invoke(
+                {
+                    "query": "create a ticket",
+                    "instruction": "Use the tools",
+                    "model": AgentModelConfig(
+                        provider="test", model="test-model", mode="chat"
+                    ),
+                    "tools": [lookup, create_ticket],
+                    "allowed_tools": allowed_tools,
+                    "maximum_iterations": 3,
+                }
+            )
+        )
+        return session.tool.invoke
+
+    def test_unrestricted_invokes_the_requested_tool(self):
+        invoke = self._invoke(None)
+        invoke.assert_called()
+        self.assertEqual(
+            invoke.call_args.kwargs["tool_name"], "create_ticket"
+        )
+
+    def test_allowlist_blocks_tools_outside_the_list(self):
+        invoke = self._invoke(["lookup"])
+        invoke.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/agent-strategies/cot_agent/tests/test_tool_allowlist.py
+++ b/agent-strategies/cot_agent/tests/test_tool_allowlist.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import Mock
+
+from strategies.tool_allowlist import allowed_tool_names, filter_allowed_tools
+
+
+def _tool(name: str):
+    tool = Mock()
+    tool.identity.name = name
+    return tool
+
+
+class TestAllowedToolNames(unittest.TestCase):
+    def test_none_means_unrestricted(self):
+        self.assertIsNone(allowed_tool_names(None))
+
+    def test_empty_list_means_unrestricted(self):
+        self.assertIsNone(allowed_tool_names([]))
+
+    def test_empty_string_means_unrestricted(self):
+        self.assertIsNone(allowed_tool_names("  "))
+
+    def test_names_are_stripped(self):
+        self.assertEqual(
+            allowed_tool_names([" lookup ", ""]),
+            {"lookup"},
+        )
+
+    def test_json_string_is_parsed(self):
+        self.assertEqual(
+            allowed_tool_names('["lookup"]'),
+            {"lookup"},
+        )
+
+    def test_plain_string_is_a_single_name(self):
+        self.assertEqual(allowed_tool_names("lookup"), {"lookup"})
+
+
+class TestFilterAllowedTools(unittest.TestCase):
+    def setUp(self):
+        self.tools = [
+            _tool("lookup"),
+            _tool("create_ticket"),
+        ]
+
+    def test_unrestricted_keeps_all_tools(self):
+        self.assertEqual(filter_allowed_tools(self.tools, None), self.tools)
+        self.assertEqual(filter_allowed_tools(self.tools, []), self.tools)
+
+    def test_allowlist_keeps_matching_names(self):
+        filtered = filter_allowed_tools(self.tools, ["lookup"])
+        self.assertEqual([tool.identity.name for tool in filtered], ["lookup"])
+
+    def test_unknown_names_remove_everything(self):
+        filtered = filter_allowed_tools(self.tools, ["does_not_exist"])
+        self.assertEqual(filtered, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replaces #3678 after the maintainer asked for a fresh PR on current `main` with the current template.

Adds an optional **Allowed tools** parameter (`array[string]`) to the Agent node strategies Function Calling and ReAct, placed above the tool list.

- If the list has names, only those tools from the node’s tool list are sent to the model and allowed to run (match on `tool.identity.name`).
- Unset or empty keeps the current unrestricted behavior. There is no extra boolean toggle.
- Function Calling now uses `tool_instances.get(...)` when resolving a tool call, so a model-invented name after filtering returns `there is not a tool named …` instead of raising `KeyError`.

This stays in the plugin (no Dify core change). Related discussion: [langgenius/dify#27887](https://github.com/langgenius/dify/issues/27887).

## Release Notes

Agent node: optional Allowed tools list for Function Calling and ReAct. When set, only those tools are exposed to the model and can run. Leave empty to use the full tool list.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

The Agent node form is driven by strategy YAML parameter order. This change inserts `allowed_tools` immediately above `tools`. The new field uses the same `type: any` + `scope:` pattern as **Context** (`array[object]`), so the node renders a variable picker that accepts `array[string]` conversation/workflow variables.

| Before | After |
| ------ | ----- |
| Model → Tool list → Instruction → … | Model → **Allowed tools** → Tool list → Instruction → … |

**Before** (`function_calling.yaml` / `ReAct.yaml` on `main`):

```yaml
  - name: model
    type: model-selector
    ...
  - name: tools
    type: array[tools]
    required: true
```

**After:**

```yaml
  - name: model
    type: model-selector
    ...
  - name: allowed_tools
    type: any
    scope: array[string]
    required: false
    label:
      en_US: Allowed tools
  - name: tools
    type: array[tools]
    required: true
```

Unset/empty keeps the current unrestricted tool list. A live canvas screenshot of the Agent node can be attached after installing `langgenius/agent` 0.0.45; the schema above is what the node reads.

## LLM Plugin Checklist

Not applicable — this is an agent-strategy plugin, and the template marks this section as required only when "LLM plugin" is checked under Change Type. Section retained rather than deleted so the body keeps the template's full structure.

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — `0.0.44` → `0.0.45`
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

Not ticked, because it is not literally true: `agent-strategies/cot_agent` already declares `dify_plugin>=0.9.0` and locks that range, which is outside `>=0.3.0,<0.6.0`. That is `main`'s existing state — this PR does not touch `pyproject.toml` or `uv.lock`. Happy to adjust if the range in the template is meant to be enforced.

## Testing

- [x] Local deployment — Dify version: 1.16.1 (self-hosted, Docker). Plugin `langgenius/agent` 0.0.44 is the installed baseline; this PR is the 0.0.45 bump on top of current `main`.
- [ ] SaaS (cloud.dify.ai) — not tested

Local checks (32 passed):

```text
cd agent-strategies/cot_agent
uv run --frozen --with pytest pytest tests/ -q
```

Covered behavior:

- Unset / empty allowlist does not change existing tool selection
- Non-empty list keeps only matching `tool.identity.name` values
- Unknown names leave the agent with no tools (strict allowlist)
- Function Calling does not invoke tools outside the list (`there is not a tool named …` instead of `KeyError`)
