### PR TITLE
fix(tongyi): return valid WAV TTS output

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.2.13
+version: 0.2.14
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/models/tts/qwen3-tts-flash.yaml
+++ b/models/tongyi/models/tts/qwen3-tts-flash.yaml
@@ -34,7 +34,7 @@ model_properties:
       name: "不吃鱼"
       language: [ "zh-Hans", "en-US", "fr-FR", "de-DE", "ru-RU", "it-IT", "es-ES", "pt-PT", "ja-JP", "ko-KR" ]
   word_limit: 512
-  audio_type: 'mp3'
+  audio_type: 'wav'
   max_workers: 5
 pricing:
   input: '1'

--- a/models/tongyi/models/tts/tts.py
+++ b/models/tongyi/models/tts/tts.py
@@ -12,7 +12,6 @@ from dify_plugin.errors.model import (
     InvokeError,
 )
 from dify_plugin.interfaces.model.tts_model import TTSModel
-
 from models._common import _CommonTongyi, get_http_base_address
 
 
@@ -54,8 +53,13 @@ def merge_wav_segments(segments: list[bytes]) -> bytes:
                             "DashScope returned WAVE segments with incompatible audio formats"
                         )
 
-                    writer.writeframes(reader.readframes(reader.getnframes()))
-    except wave.Error as ex:
+                    frame_count = reader.getnframes()
+                    frames = reader.readframes(frame_count)
+                    expected_frame_bytes = frame_count * reader.getnchannels() * reader.getsampwidth()
+                    if len(frames) != expected_frame_bytes:
+                        raise InvokeBadRequestError(f"DashScope returned truncated WAVE segment {index}")
+                    writer.writeframes(frames)
+    except (EOFError, wave.Error) as ex:
         raise InvokeBadRequestError(f"DashScope returned an invalid WAVE segment: {ex}") from ex
 
     return output.getvalue()

--- a/models/tongyi/models/tts/tts.py
+++ b/models/tongyi/models/tts/tts.py
@@ -1,7 +1,10 @@
+import io
 import threading
-from urllib.request import urlopen
+import wave
 from queue import Queue
-from typing import Any, Optional
+from typing import Any
+from urllib.request import urlopen
+
 from dashscope import MultiModalConversation
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,
@@ -9,7 +12,53 @@ from dify_plugin.errors.model import (
     InvokeError,
 )
 from dify_plugin.interfaces.model.tts_model import TTSModel
+
 from models._common import _CommonTongyi, get_http_base_address
+
+
+def merge_wav_segments(segments: list[bytes]) -> bytes:
+    """Join compatible PCM WAVE files into one valid WAVE container.
+
+    DashScope returns one standalone WAVE file for each sentence when input is
+    split at the provider word limit. Concatenating those containers produces a
+    corrupt file; rebuilding one header around the combined PCM frames keeps
+    long TTS output playable by browsers and API consumers.
+    """
+    if not segments:
+        raise InvokeBadRequestError("No audio data returned by DashScope")
+
+    output = io.BytesIO()
+    expected_format: tuple[int, int, int, str] | None = None
+    try:
+        with wave.open(output, "wb") as writer:
+            for index, segment in enumerate(segments, start=1):
+                with wave.open(io.BytesIO(segment), "rb") as reader:
+                    format_ = (
+                        reader.getnchannels(),
+                        reader.getsampwidth(),
+                        reader.getframerate(),
+                        reader.getcomptype(),
+                    )
+                    if format_[3] != "NONE":
+                        raise InvokeBadRequestError(
+                            f"DashScope returned unsupported compressed WAVE segment {index}"
+                        )
+                    if expected_format is None:
+                        expected_format = format_
+                        writer.setnchannels(format_[0])
+                        writer.setsampwidth(format_[1])
+                        writer.setframerate(format_[2])
+                        writer.setcomptype(format_[3], "not compressed")
+                    elif format_ != expected_format:
+                        raise InvokeBadRequestError(
+                            "DashScope returned WAVE segments with incompatible audio formats"
+                        )
+
+                    writer.writeframes(reader.readframes(reader.getnframes()))
+    except wave.Error as ex:
+        raise InvokeBadRequestError(f"DashScope returned an invalid WAVE segment: {ex}") from ex
+
+    return output.getvalue()
 
 
 class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
@@ -24,7 +73,7 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
         credentials: dict,
         content_text: str,
         voice: str,
-        user: Optional[str] = None,
+        user: str | None = None,
     ) -> Any:
         """
         _invoke text2speech model
@@ -46,7 +95,7 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
         )
 
     def validate_credentials(
-        self, model: str, credentials: dict, user: Optional[str] = None
+        self, model: str, credentials: dict, user: str | None = None
     ) -> None:
         """
         validate credentials text2speech model
@@ -86,6 +135,7 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
 
             def invoke_remote(content, m, api_key, wl, base_address):
                 try:
+                    audio_segments: list[bytes] = []
                     if len(content) < wl:
                         sentences = [content]
                     else:
@@ -101,31 +151,29 @@ class TongyiText2SpeechModel(_CommonTongyi, TTSModel):
                             stream=True,
                             base_address=base_address,
                         )
+                        audio_url: str | None = None
                         for chunk in response_stream:
                             if chunk.status_code != 200:
                                 error_msg = chunk.message or f"API error: {chunk.status_code}"
                                 error_queue.put(InvokeBadRequestError(error_msg))
                                 audio_queue.put(None)
                                 return
-                            if not chunk.output or not chunk.output.audio:
-                                error_queue.put(InvokeBadRequestError("No audio in response"))
-                                audio_queue.put(None)
-                                return
-                            audio_url = chunk.output.audio.get("url")
-                            if not audio_url:
-                                error_queue.put(InvokeBadRequestError("No audio URL in response"))
-                                audio_queue.put(None)
-                                return
-                            try:
-                                with urlopen(audio_url, timeout=30) as response:
-                                    audio_data = response.read()
-                                audio_queue.put(audio_data)
-                            except Exception as e:
-                                error_queue.put(
-                                    InvokeBadRequestError(f"Failed to download audio: {str(e)}")
-                                )
-                                audio_queue.put(None)
-                                return
+                            audio = getattr(getattr(chunk, "output", None), "audio", None)
+                            if audio:
+                                audio_url = audio.get("url") or audio_url
+                        if not audio_url:
+                            error_queue.put(InvokeBadRequestError("No audio URL in response"))
+                            audio_queue.put(None)
+                            return
+                        try:
+                            with urlopen(audio_url, timeout=30) as response:
+                                audio_data = response.read()
+                            audio_segments.append(audio_data)
+                        except Exception as e:
+                            error_queue.put(InvokeBadRequestError(f"Failed to download audio: {e!s}"))
+                            audio_queue.put(None)
+                            return
+                    audio_queue.put(merge_wav_segments(audio_segments))
                     audio_queue.put(None)
                 except Exception as e:
                     error_queue.put(self._map_invoke_error(e))

--- a/models/tongyi/pyproject.toml
+++ b/models/tongyi/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.10.2,<0.11.0",
     "numpy>=2.4.6",
     "dashscope>=1.26.7,<1.27.0",
     "openai>=2.38.0",

--- a/models/tongyi/tests/test_tts.py
+++ b/models/tongyi/tests/test_tts.py
@@ -1,5 +1,6 @@
 import io
 import os
+import struct
 import sys
 import wave
 from types import SimpleNamespace
@@ -42,6 +43,27 @@ def test_merge_wav_segments_builds_one_valid_container() -> None:
 def test_merge_wav_segments_rejects_incompatible_formats() -> None:
     with pytest.raises(InvokeBadRequestError, match="incompatible audio formats"):
         merge_wav_segments([_wav(b"\x00\x00"), _wav(b"\x00\x00", sample_rate=24_000)])
+
+
+def test_merge_wav_segments_rejects_truncated_header() -> None:
+    with pytest.raises(InvokeBadRequestError, match="invalid WAVE segment"):
+        merge_wav_segments([b"RIFF"])
+
+
+def test_merge_wav_segments_rejects_truncated_frame_data() -> None:
+    truncated_segment = (
+        b"RIFF"
+        + struct.pack("<I", 40)
+        + b"WAVE"
+        + b"fmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, 8_000, 16_000, 2, 16)
+        + b"data"
+        + struct.pack("<I", 4)
+        + b"\x00\x00"
+    )
+
+    with pytest.raises(InvokeBadRequestError, match="truncated WAVE segment 1"):
+        merge_wav_segments([truncated_segment])
 
 
 def test_long_tts_output_is_merged_before_it_is_emitted() -> None:

--- a/models/tongyi/tests/test_tts.py
+++ b/models/tongyi/tests/test_tts.py
@@ -1,0 +1,109 @@
+import io
+import os
+import sys
+import wave
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dify_plugin.errors.model import InvokeBadRequestError
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models.tts.tts import TongyiText2SpeechModel, merge_wav_segments
+
+
+def _wav(frames: bytes, *, sample_rate: int = 16_000) -> bytes:
+    output = io.BytesIO()
+    with wave.open(output, "wb") as writer:
+        writer.setnchannels(1)
+        writer.setsampwidth(2)
+        writer.setframerate(sample_rate)
+        writer.writeframes(frames)
+    return output.getvalue()
+
+
+def _wav_frames(audio: bytes) -> tuple[int, bytes]:
+    with wave.open(io.BytesIO(audio), "rb") as reader:
+        return reader.getframerate(), reader.readframes(reader.getnframes())
+
+
+def test_merge_wav_segments_builds_one_valid_container() -> None:
+    first = _wav(b"\x01\x00\x02\x00")
+    second = _wav(b"\x03\x00\x04\x00")
+
+    merged = merge_wav_segments([first, second])
+
+    assert merged.startswith(b"RIFF")
+    assert merged[8:12] == b"WAVE"
+    assert _wav_frames(merged) == (16_000, b"\x01\x00\x02\x00\x03\x00\x04\x00")
+
+
+def test_merge_wav_segments_rejects_incompatible_formats() -> None:
+    with pytest.raises(InvokeBadRequestError, match="incompatible audio formats"):
+        merge_wav_segments([_wav(b"\x00\x00"), _wav(b"\x00\x00", sample_rate=24_000)])
+
+
+def test_long_tts_output_is_merged_before_it_is_emitted() -> None:
+    model = TongyiText2SpeechModel(model_schemas=MagicMock())
+    first = _wav(b"\x01\x00")
+    second = _wav(b"\x02\x00")
+    remote_responses = [
+        [
+            SimpleNamespace(status_code=200, output=SimpleNamespace(audio={"data": "pcm"})),
+            SimpleNamespace(status_code=200, output=SimpleNamespace(audio={"url": "first"})),
+        ],
+        [
+            SimpleNamespace(status_code=200, output=SimpleNamespace(audio={"data": "pcm"})),
+            SimpleNamespace(status_code=200, output=SimpleNamespace(audio={"url": "second"})),
+        ],
+    ]
+
+    def urlopen_response(audio: bytes) -> MagicMock:
+        response = MagicMock()
+        response.read.return_value = audio
+        response.__enter__.return_value = response
+        return response
+
+    with (
+        patch.object(model, "_get_model_word_limit", return_value=3),
+        patch("models.tts.tts.get_http_base_address", return_value=None),
+        patch("models.tts.tts.MultiModalConversation.call", side_effect=remote_responses),
+        patch(
+            "models.tts.tts.urlopen",
+            side_effect=[urlopen_response(first), urlopen_response(second)],
+        ),
+    ):
+        output = list(
+            model._tts_invoke_streaming(
+                model="qwen3-tts-flash",
+                credentials={"dashscope_api_key": "test-key"},
+                content_text="abcdef",
+                voice="Cherry",
+            )
+        )
+
+    assert len(output) == 1
+    assert _wav_frames(output[0]) == (16_000, b"\x01\x00\x02\x00")
+
+
+def test_tts_requires_the_final_audio_url() -> None:
+    model = TongyiText2SpeechModel(model_schemas=MagicMock())
+
+    with (
+        patch.object(model, "_get_model_word_limit", return_value=512),
+        patch("models.tts.tts.get_http_base_address", return_value=None),
+        patch(
+            "models.tts.tts.MultiModalConversation.call",
+            return_value=[SimpleNamespace(status_code=200, output=SimpleNamespace(audio={"data": "pcm"}))],
+        ),
+        pytest.raises(InvokeBadRequestError, match="No audio URL in response"),
+    ):
+        list(
+            model._tts_invoke_streaming(
+                model="qwen3-tts-flash",
+                credentials={"dashscope_api_key": "test-key"},
+                content_text="hello",
+                voice="Cherry",
+            )
+        )

--- a/models/tongyi/uv.lock
+++ b/models/tongyi/uv.lock
@@ -420,7 +420,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
@@ -437,9 +437,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/bc/a8dd795c7dd33947a90a2832a7d32c6b7f5a771554cb3890369244d72331/dify_plugin-0.10.1.tar.gz", hash = "sha256:875fe38d7a97d05fabb3b4f1ab467f2dc50ad2458a1eac68e6e212e29e7e1d29", size = 320686, upload-time = "2026-08-05T16:52:22.828Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5a/885909338df3e32604f45c579457c5dcfe982d35857994805735e5487d4b/dify_plugin-0.10.2.tar.gz", hash = "sha256:e37e707b3903c439cd09924b2125ba794ffdc886bfdbcb8f75db28ba64cb795b", size = 320685, upload-time = "2026-08-10T07:04:08.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/d1/21ef487ef4bbb38ea1e19489a2c7a81f4a91865ba91fedd921226ede862c/dify_plugin-0.10.1-py3-none-any.whl", hash = "sha256:b36161c72d4235af4241b8e417edea78689f3d6e4598cf2368b2a1523bf96809", size = 379287, upload-time = "2026-08-05T16:52:21.112Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/5897c50381eb23a10fd7ab770288d8656f3325d3407e4ee4f6fb7e70f76a/dify_plugin-0.10.2-py3-none-any.whl", hash = "sha256:5a30db98cc4c3f36bdcc70ecd217b6bb37279c39fc0a843a985b05581dc461d3", size = 379282, upload-time = "2026-08-10T07:04:07.068Z" },
 ]
 
 [[package]]
@@ -1604,7 +1604,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dashscope", specifier = ">=1.26.7,<1.27.0" },
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.2,<0.11.0" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "openai", specifier = ">=2.38.0" },
     { name = "pydub", specifier = ">=0.25.1" },


### PR DESCRIPTION
## Summary

Related to langgenius/dify#40012. This companion plugin change makes qwen3-tts-flash accurately describe and produce browser-playable WAV output.

- declare qwen3-tts-flash audio_type as WAV;
- ignore intermediate Base64 PCM stream packets and wait for the final complete-audio URL for each provider sentence;
- download each completed WAV, validate compatible PCM parameters, and merge long-text segments into one valid WAV container;
- raise an explicit provider error when the final audio URL is absent or returned WAV segments are invalid or incompatible.

Companion Dify Core PR: langgenius/dify#41043. That PR validates the provider MIME against model metadata and magic bytes, exposes it to the API and web player, and documents the remaining Graphon protocol follow-up. This plugin PR has no Graphon dependency change.

## Release Notes

Fixed qwen3-tts-flash output to use WAV and produce one valid WAV file for long text, enabling reliable browser playback.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

No visual change. This is an audio-container correctness fix.

| Before | After |
| ------ | ----- |
| Multiple WAV containers could be concatenated as raw bytes. | Long text returns one valid WAV container. |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change</summary>

- [x] Multimodal output (audio)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level version in manifest.yaml from 0.2.13 to 0.2.14.
- [x] Updated and locked the SDK dependency to dify_plugin>=0.10.2,<0.11.0 so daemon MIME metadata is available. The template range is older than the current SDK line.

## Testing

- [ ] Local deployment — real DashScope credentials are not available in this environment.
- [ ] SaaS (cloud.dify.ai)
- [x] Unit tests: merge success, incompatible WAV rejection, intermediate stream packet handling, and missing final URL rejection.
- [x] Static checks and plugin package creation completed locally.

From Codex