### PR TITLE
feat(openai_api_compatible): add OpenAI Responses API support with web search domain filtering

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.62
+version: 0.0.63
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.63
+version: 0.0.64
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -1,7 +1,8 @@
+import json
 import re
 from contextlib import suppress
-from typing import Mapping, Optional, Union, Generator, List
-from urllib.parse import urljoin
+from typing import Any, Mapping, Optional, Union, Generator, List
+from urllib.parse import urljoin, urlparse
 
 import requests
 from dify_plugin.entities.model import (
@@ -12,7 +13,12 @@ from dify_plugin.entities.model import (
     ParameterRule,
     ParameterType,
 )
-from dify_plugin.entities.model.llm import LLMMode, LLMResult
+from dify_plugin.entities.model.llm import (
+    LLMMode,
+    LLMResult,
+    LLMResultChunk,
+    LLMResultChunkDelta,
+)
 from dify_plugin.entities.model.message import (
     AudioPromptMessageContent,
     DocumentPromptMessageContent,
@@ -23,6 +29,7 @@ from dify_plugin.entities.model.message import (
     PromptMessageTool,
     SystemPromptMessage,
     AssistantPromptMessage,
+    ToolPromptMessage,
     UserPromptMessage,
     VideoPromptMessageContent,
 )
@@ -38,7 +45,9 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
     # Models that require max_completion_tokens (OpenAI Responses API family)
     _NEEDS_MAX_COMPLETION_TOKENS_PATTERN = re.compile(r"^(o1|o3|gpt-5)", re.IGNORECASE)
 
-    def _wrap_thinking_by_reasoning_content(self, delta: dict, is_reasoning: bool) -> tuple[str, bool]:
+    def _wrap_thinking_by_reasoning_content(
+        self, delta: dict, is_reasoning: bool
+    ) -> tuple[str, bool]:
         """
         Override base wrapper to support both legacy 'reasoning_content' and
         newer 'reasoning' fields (e.g., vLLM >= 0.17.1), emitting <think> blocks
@@ -110,9 +119,8 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         # instead of letting the base class fail with max_tokens first.
         param_pref = credentials.get("token_param_name", "auto")
         endpoint_model = credentials.get("endpoint_model_name") or model
-        if (
-            param_pref == "max_completion_tokens"
-            or (param_pref == "auto" and self._needs_max_completion_tokens(endpoint_model))
+        if param_pref == "max_completion_tokens" or (
+            param_pref == "auto" and self._needs_max_completion_tokens(endpoint_model)
         ):
             self._retry_with_safe_min_tokens(model, credentials)
             return
@@ -124,17 +132,14 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
 
             # --- Retry path 1: token parameter incompatibility ---
             should_retry_floor = (
-                "Invalid 'max_output_tokens'" in msg
-                or "integer_below_min_value" in msg
+                "Invalid 'max_output_tokens'" in msg or "integer_below_min_value" in msg
             )
             if should_retry_floor:
                 self._retry_with_safe_min_tokens(model, credentials)
                 return
 
             # --- Retry path 2: thinking / budget_tokens constraints ---
-            should_retry_thinking = (
-                "budget_tokens" in msg or "thinking" in msg
-            )
+            should_retry_thinking = "budget_tokens" in msg or "thinking" in msg
             if should_retry_thinking:
                 self._retry_with_thinking_disabled(model, credentials)
                 return
@@ -156,9 +161,8 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         mode = credentials.get("mode", "chat")
 
         param_pref = credentials.get("token_param_name", "auto")
-        use_max_completion = (
-            param_pref == "max_completion_tokens"
-            or (param_pref == "auto" and self._needs_max_completion_tokens(endpoint_model))
+        use_max_completion = param_pref == "max_completion_tokens" or (
+            param_pref == "auto" and self._needs_max_completion_tokens(endpoint_model)
         )
 
         SAFE_MIN_TOKENS = 16
@@ -224,7 +228,9 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
 
         try:
             response = requests.post(
-                endpoint_url, headers=headers, json=data,
+                endpoint_url,
+                headers=headers,
+                json=data,
                 timeout=self._VALIDATE_TIMEOUT,
             )
             if response.status_code != 200:
@@ -283,7 +289,10 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         agent_thought_support = credentials.get("agent_thought_support", "not_supported")
 
         # Add AGENT_THOUGHT feature if thinking mode is supported (either mode)
-        if agent_thought_support in ["supported", "only_thinking_supported"] and ModelFeature.AGENT_THOUGHT not in entity.features:
+        if (
+            agent_thought_support in ["supported", "only_thinking_supported"]
+            and ModelFeature.AGENT_THOUGHT not in entity.features
+        ):
             entity.features.append(ModelFeature.AGENT_THOUGHT)
 
         # Only add the enable_thinking parameter if the model supports both modes
@@ -332,7 +341,8 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
 
         # Configure web search parameter if supported
         web_search_support = credentials.get("web_search_support", "not_supported")
-        if web_search_support != "not_supported":
+        api_type = credentials.get("api_type", "chat_completions")
+        if web_search_support != "not_supported" or api_type == "responses":
             entity.parameter_rules.append(
                 ParameterRule(
                     name="web_search",
@@ -347,6 +357,57 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                 )
             )
 
+        if api_type == "responses":
+            entity.parameter_rules.append(
+                ParameterRule(
+                    name="web_search_allowed_domains",
+                    label=I18nObject(en_us="Allowed Domains", zh_hans="允许的搜索域名"),
+                    help=I18nObject(
+                        en_us="Comma or newline-separated list of allowed domains for web search results (e.g., openai.com, github.com). Max 100 domains. Requires Responses API.",
+                        zh_hans="允许的搜索域名列表，支持逗号或换行分隔（例如 openai.com, github.com）。最多 100 个域名。需要 Responses API。",
+                    ),
+                    type=ParameterType.STRING,
+                    required=False,
+                )
+            )
+            entity.parameter_rules.append(
+                ParameterRule(
+                    name="web_search_blocked_domains",
+                    label=I18nObject(en_us="Blocked Domains", zh_hans="屏蔽的搜索域名"),
+                    help=I18nObject(
+                        en_us="Comma or newline-separated list of blocked domains for web search results (e.g., reddit.com, quora.com). Max 100 domains. Requires Responses API.",
+                        zh_hans="屏蔽的搜索域名列表，支持逗号或换行分隔（例如 reddit.com, quora.com）。最多 100 个域名。需要 Responses API。",
+                    ),
+                    type=ParameterType.STRING,
+                    required=False,
+                )
+            )
+            entity.parameter_rules.append(
+                ParameterRule(
+                    name="web_search_context_size",
+                    label=I18nObject(en_us="Search Context Size", zh_hans="搜索上下文大小"),
+                    help=I18nObject(
+                        en_us="Controls amount of web search result context provided to model ('low', 'medium', 'high'). Requires Responses API.",
+                        zh_hans="控制提供给模型的网络搜索结果上下文量（'low', 'medium', 'high'）。需要 Responses API。",
+                    ),
+                    type=ParameterType.STRING,
+                    options=["medium", "low", "high"],
+                    required=False,
+                )
+            )
+            entity.parameter_rules.append(
+                ParameterRule(
+                    name="web_search_user_country",
+                    label=I18nObject(en_us="Search User Country", zh_hans="搜索用户国家/地区"),
+                    help=I18nObject(
+                        en_us="Optional 2-letter ISO country code (e.g., US, JP) to refine search location. Requires Responses API.",
+                        zh_hans="可选的 2 位 ISO 国家/地区代码（例如 US、JP）以优化搜索地理位置。需要 Responses API。",
+                    ),
+                    type=ParameterType.STRING,
+                    required=False,
+                )
+            )
+
         # Register VIDEO/AUDIO/DOCUMENT features when the corresponding credential is enabled.
         # Without these on entity.features, Dify host filters out non-image attachments
         # before they reach _convert_prompt_message_to_dict, causing silent drop.
@@ -355,7 +416,10 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             ("audio_support", ModelFeature.AUDIO),
             ("document_support", ModelFeature.DOCUMENT),
         ):
-            if credentials.get(credential_key, "no_support") == "support" and feature not in entity.features:
+            if (
+                credentials.get(credential_key, "no_support") == "support"
+                and feature not in entity.features
+            ):
                 entity.features.append(feature)
 
         return entity
@@ -459,6 +523,17 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         stream: bool = True,
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator]:
+        if credentials.get("api_type") == "responses":
+            return self._chat_generate_with_responses(
+                model=model,
+                credentials=credentials,
+                prompt_messages=prompt_messages,
+                model_parameters=model_parameters,
+                tools=tools,
+                stop=stop,
+                stream=stream,
+                user=user,
+            )
         # Compatibility adapter for Dify's 'json_schema' structured output mode.
         # The base class does not natively handle the 'json_schema' parameter. This block
         # translates it into a standard OpenAI-compatible request by:
@@ -538,7 +613,7 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                 # `chat_template_kwargs` is a non-standard parameter.
                 chat_template_kwargs = model_parameters.setdefault("chat_template_kwargs", {})
                 chat_template_kwargs["reasoning_effort"] = reasoning_effort_value
-        
+
         # Handle web search based on credential configuration
         web_search_support = credentials.get("web_search_support", "not_supported")
         enable_web_search = model_parameters.pop("web_search", False)
@@ -576,9 +651,8 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         def _needs_max_completion_tokens(m: str) -> bool:
             return bool(re.match(r"^(o1|o3|gpt-5)", m, re.IGNORECASE))
 
-        use_max_completion = (
-            (param_pref == "max_completion_tokens")
-            or (param_pref == "auto" and _needs_max_completion_tokens(model))
+        use_max_completion = (param_pref == "max_completion_tokens") or (
+            param_pref == "auto" and _needs_max_completion_tokens(model)
         )
 
         if use_max_completion:
@@ -615,7 +689,7 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                 return self._filter_thinking_stream(result)
             else:
                 return self._filter_thinking_result(result)
-        
+
         return result
 
     def _filter_thinking_result(self, result: LLMResult) -> LLMResult:
@@ -633,18 +707,18 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         buffer = ""
         in_thinking = False
         thinking_started = False
-        
+
         for chunk in stream:
             if chunk.delta and chunk.delta.message and chunk.delta.message.content:
                 content = chunk.delta.message.content
                 buffer += content
-                
+
                 # Detect start of thinking block
                 if not thinking_started and buffer.startswith("<think>"):
                     in_thinking = True
                     thinking_started = True
                     # Don't continue here - check for end tag in same iteration
-                
+
                 # Detect end of thinking block
                 if in_thinking and "</think>" in buffer:
                     # Find the end of thinking block
@@ -662,7 +736,7 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                         buffer = ""
                         yield chunk
                     continue
-                
+
                 # If not in thinking block, yield content
                 if not in_thinking:
                     yield chunk
@@ -745,4 +819,510 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             model=response_json.get("model", model),
             message=assistant_message,
             usage=usage,
+        )
+
+    def _create_openai_client(self, credentials: dict) -> OpenAI:
+        api_key = credentials.get("api_key") or "dummy"
+        endpoint_url = credentials.get("endpoint_url")
+        base_url = None
+        if endpoint_url:
+            base_url = endpoint_url.rstrip("/")
+            if not base_url.endswith("/v1"):
+                base_url += "/v1"
+        extra_headers = credentials.get("extra_headers") or None
+        return OpenAI(api_key=api_key, base_url=base_url, default_headers=extra_headers)
+
+    @staticmethod
+    def _normalize_domains(raw_domains: Any) -> list[str]:
+        if raw_domains is None:
+            return []
+        if isinstance(raw_domains, str):
+            candidates = re.split(r"[\s,\n\r]+", raw_domains)
+        elif isinstance(raw_domains, (list, tuple)):
+            candidates = [str(item) for item in raw_domains]
+        else:
+            candidates = [str(raw_domains)]
+
+        normalized_domains: list[str] = []
+        seen_domains: set[str] = set()
+
+        for candidate in candidates:
+            token = candidate.strip()
+            if not token:
+                continue
+
+            parsed = urlparse(token if "://" in token else f"https://{token}")
+            host = parsed.netloc or parsed.path
+            host = host.strip().lower().rstrip(".")
+            if ":" in host:
+                host = host.split(":", 1)[0]
+
+            if not host:
+                continue
+            if not re.fullmatch(r"[a-z0-9.-]+", host):
+                continue
+
+            if host not in seen_domains:
+                seen_domains.add(host)
+                normalized_domains.append(host)
+
+        return normalized_domains[:100]
+
+    def _extract_responses_web_search_config(
+        self, model_parameters: dict, credentials: dict
+    ) -> Optional[dict[str, Any]]:
+        enable_web_search = model_parameters.pop("web_search", False)
+        allowed_domains = model_parameters.pop("web_search_allowed_domains", None)
+        blocked_domains = model_parameters.pop("web_search_blocked_domains", None)
+        context_size = model_parameters.pop("web_search_context_size", None)
+        country = model_parameters.pop("web_search_user_country", None)
+
+        if not enable_web_search:
+            return None
+
+        web_search_tool: dict[str, Any] = {"type": "web_search"}
+
+        filters: dict[str, Any] = {}
+        norm_allowed = self._normalize_domains(allowed_domains)
+        norm_blocked = self._normalize_domains(blocked_domains)
+        if norm_allowed:
+            filters["allowed_domains"] = norm_allowed
+        if norm_blocked:
+            filters["blocked_domains"] = norm_blocked
+
+        if filters:
+            web_search_tool["filters"] = filters
+
+        if context_size:
+            web_search_tool["search_context_size"] = context_size
+
+        if country:
+            country_code = str(country).strip().upper()
+            if re.fullmatch(r"[A-Z]{2}", country_code):
+                web_search_tool["user_location"] = {
+                    "type": "approximate",
+                    "country": country_code,
+                }
+
+        return web_search_tool
+
+    def _convert_prompt_messages_to_responses_input(
+        self, prompt_messages: list[PromptMessage]
+    ) -> list[dict]:
+        input_messages = []
+        for message in prompt_messages:
+            if isinstance(message, SystemPromptMessage):
+                if isinstance(message.content, str):
+                    input_messages.append({"role": "developer", "content": message.content})
+                else:
+                    parts = self._convert_multimodal_content_to_responses_parts(message.content)
+                    if parts:
+                        input_messages.append({"role": "developer", "content": parts})
+            elif isinstance(message, UserPromptMessage):
+                if isinstance(message.content, str):
+                    input_messages.append({"role": "user", "content": message.content})
+                else:
+                    parts = self._convert_multimodal_content_to_responses_parts(message.content)
+                    if parts:
+                        input_messages.append({"role": "user", "content": parts})
+            elif isinstance(message, AssistantPromptMessage):
+                if message.tool_calls:
+                    for tc in message.tool_calls:
+                        input_messages.append(
+                            {
+                                "type": "function_call",
+                                "call_id": tc.id,
+                                "name": tc.function.name,
+                                "arguments": tc.function.arguments,
+                            }
+                        )
+                elif message.content:
+                    input_messages.append({"role": "assistant", "content": message.content})
+            elif isinstance(message, ToolPromptMessage):
+                input_messages.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": message.tool_call_id,
+                        "output": message.content,
+                    }
+                )
+        return input_messages
+
+    @staticmethod
+    def _convert_multimodal_content_to_responses_parts(
+        content_items: Optional[list],
+    ) -> list[dict[str, Any]]:
+        content_parts: list[dict[str, Any]] = []
+        for content_item in content_items or []:
+            if content_item.type == PromptMessageContentType.TEXT:
+                content_parts.append({"type": "input_text", "text": content_item.data})
+            elif content_item.type == PromptMessageContentType.IMAGE:
+                image_c: ImagePromptMessageContent = content_item
+                image_part = {"type": "input_image"}
+                if image_c.url:
+                    image_part["image_url"] = image_c.url
+                else:
+                    image_part["image_url"] = image_c.data
+                if image_c.detail:
+                    image_part["detail"] = image_c.detail.value
+                content_parts.append(image_part)
+            elif content_item.type == PromptMessageContentType.DOCUMENT:
+                doc_c: DocumentPromptMessageContent = content_item
+                file_part: dict[str, Any] = {"type": "input_file"}
+                if doc_c.url:
+                    file_part["file_url"] = doc_c.url
+                elif doc_c.base64_data:
+                    file_part["filename"] = doc_c.filename or "document"
+                    file_part["file_data"] = f"data:{doc_c.mime_type};base64,{doc_c.base64_data}"
+                if len(file_part) > 1:
+                    content_parts.append(file_part)
+        return content_parts
+
+    def _chat_generate_with_responses(
+        self,
+        model: str,
+        credentials: dict,
+        prompt_messages: list[PromptMessage],
+        model_parameters: dict,
+        tools: Optional[list[PromptMessageTool]] = None,
+        stop: Optional[list[str]] = None,
+        stream: bool = True,
+        user: Optional[str] = None,
+    ) -> Union[LLMResult, Generator]:
+        client = self._create_openai_client(credentials)
+        endpoint_model = credentials.get("endpoint_model_name") or model
+
+        input_messages = self._convert_prompt_messages_to_responses_input(prompt_messages)
+
+        responses_params: dict[str, Any] = {
+            "model": endpoint_model,
+            "input": input_messages,
+        }
+
+        if "temperature" in model_parameters:
+            responses_params["temperature"] = model_parameters.get("temperature")
+        if "top_p" in model_parameters:
+            responses_params["top_p"] = model_parameters.get("top_p")
+        if "max_tokens" in model_parameters:
+            responses_params["max_output_tokens"] = model_parameters.pop("max_tokens")
+        elif "max_completion_tokens" in model_parameters:
+            responses_params["max_output_tokens"] = model_parameters.pop("max_completion_tokens")
+
+        web_search_tool = self._extract_responses_web_search_config(model_parameters, credentials)
+        response_tools = []
+
+        if tools:
+            for tool in tools:
+                parameters = tool.parameters
+                if isinstance(parameters, str):
+                    try:
+                        parameters = json.loads(parameters)
+                    except json.JSONDecodeError:
+                        parameters = {"type": "object", "properties": {}}
+                elif not isinstance(parameters, dict):
+                    parameters = {"type": "object", "properties": {}}
+
+                tool_dict = {
+                    "type": "function",
+                    "name": tool.name,
+                    "description": tool.description or "",
+                    "parameters": parameters,
+                }
+                response_tools.append(tool_dict)
+
+        if web_search_tool:
+            response_tools.append(web_search_tool)
+
+        if response_tools:
+            responses_params["tools"] = response_tools
+            responses_params["tool_choice"] = "auto"
+
+        if user and credentials.get("user_identity_support", "support") != "no_support":
+            responses_params["safety_identifier"] = user
+
+        if stop:
+            responses_params["stop"] = stop
+
+        response_format = model_parameters.get("response_format")
+        if response_format:
+            if response_format == "json_schema":
+                json_schema_data = model_parameters.get("json_schema", {})
+                if isinstance(json_schema_data, str):
+                    try:
+                        json_schema_data = json.loads(json_schema_data)
+                    except json.JSONDecodeError:
+                        json_schema_data = {}
+                responses_params["text"] = {
+                    "format": {
+                        "type": "json_schema",
+                        "name": json_schema_data.get("name", "response"),
+                        "schema": json_schema_data.get("schema", {}),
+                    }
+                }
+            else:
+                responses_params["text"] = {"format": {"type": response_format}}
+
+        reasoning_effort = model_parameters.get("reasoning_effort")
+        if reasoning_effort:
+            responses_params["reasoning"] = {"effort": reasoning_effort}
+
+        response = client.responses.create(
+            **responses_params,
+            stream=stream,
+        )
+
+        if stream:
+            return self._handle_responses_stream_response(
+                model, credentials, response, prompt_messages, tools
+            )
+        else:
+            return self._handle_responses_response(
+                model, credentials, response, prompt_messages, tools
+            )
+
+    def _handle_responses_response(
+        self,
+        model: str,
+        credentials: dict,
+        response: Any,
+        prompt_messages: list[PromptMessage],
+        tools: Optional[list[PromptMessageTool]] = None,
+    ) -> LLMResult:
+        content = ""
+        if hasattr(response, "output") and response.output:
+            for item in response.output:
+                item_type = getattr(item, "type", "")
+                if item_type == "reasoning":
+                    summary_list = getattr(item, "summary", [])
+                    summary_text = "\n".join(
+                        s.text for s in summary_list if hasattr(s, "text") and s.text
+                    )
+                    if summary_text:
+                        content += "<think>\n" + summary_text + "\n</think>"
+                elif item_type == "message":
+                    item_content = getattr(item, "content", None)
+                    if isinstance(item_content, str):
+                        if item_content:
+                            content += item_content
+                    elif isinstance(item_content, list):
+                        for part in item_content:
+                            part_type = getattr(part, "type", "")
+                            if part_type in ("output_text", "text", "input_text"):
+                                text_val = getattr(part, "text", "")
+                                if text_val:
+                                    content += text_val
+                elif item_type in ("output_text", "text"):
+                    text_val = getattr(item, "text", "")
+                    if text_val:
+                        content += text_val
+        elif hasattr(response, "text") and response.text:
+            content = response.text
+        elif hasattr(response, "content") and response.content:
+            content = response.content
+
+        tool_calls = []
+        if hasattr(response, "output") and response.output:
+            for item in response.output:
+                item_type = getattr(item, "type", "")
+                if item_type == "function_call":
+                    function_name = getattr(item, "name", "")
+                    function_args = getattr(item, "arguments", "")
+                    call_id = getattr(item, "call_id", "") or getattr(item, "id", "")
+
+                    if isinstance(function_args, dict):
+                        args_str = json.dumps(function_args)
+                    elif isinstance(function_args, str):
+                        args_str = function_args
+                    else:
+                        args_str = "{}"
+
+                    tool_call = AssistantPromptMessage.ToolCall(
+                        id=call_id,
+                        type="function",
+                        function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                            name=function_name, arguments=args_str
+                        ),
+                    )
+                    tool_calls.append(tool_call)
+
+        assistant_prompt_message = AssistantPromptMessage(content=content, tool_calls=tool_calls)
+
+        prompt_tokens = 0
+        completion_tokens = 0
+        if hasattr(response, "usage") and response.usage:
+            usage_obj = response.usage
+            prompt_tokens = getattr(usage_obj, "input_tokens", None) or getattr(
+                usage_obj, "prompt_tokens", 0
+            )
+            completion_tokens = getattr(usage_obj, "output_tokens", None) or getattr(
+                usage_obj, "completion_tokens", 0
+            )
+        else:
+            prompt_tokens = self._num_tokens_from_messages(prompt_messages, credentials=credentials)
+            completion_tokens = self._num_tokens_from_string(assistant_prompt_message.content or "")
+
+        usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+
+        return LLMResult(
+            model=model,
+            message=assistant_prompt_message,
+            usage=usage,
+        )
+
+    def _handle_responses_stream_response(
+        self,
+        model: str,
+        credentials: dict,
+        response: Any,
+        prompt_messages: list[PromptMessage],
+        tools: Optional[list[PromptMessageTool]] = None,
+    ) -> Generator:
+        full_text = ""
+        index = 0
+        is_first = True
+        is_reasoning = False
+
+        pending_tool_calls = {}
+        current_tool_call = None
+
+        for chunk in response:
+            if is_first:
+                is_first = False
+
+            chunk_type = getattr(chunk, "type", "")
+
+            if chunk_type == "response.reasoning_summary_text.delta":
+                delta_text = getattr(chunk, "delta", "")
+                if delta_text:
+                    if not is_reasoning:
+                        delta_text = "<think>\n" + delta_text
+                        is_reasoning = True
+                    full_text += delta_text
+
+                    assistant_prompt_message = AssistantPromptMessage(
+                        content=delta_text, tool_calls=[]
+                    )
+
+                    yield LLMResultChunk(
+                        model=model,
+                        delta=LLMResultChunkDelta(index=index, message=assistant_prompt_message),
+                    )
+                    index += 1
+
+            elif chunk_type == "response.output_text.delta":
+                delta_text = getattr(chunk, "delta", "")
+                if delta_text:
+                    if is_reasoning:
+                        delta_text = "\n</think>" + delta_text
+                        is_reasoning = False
+                    full_text += delta_text
+
+                    assistant_prompt_message = AssistantPromptMessage(
+                        content=delta_text, tool_calls=[]
+                    )
+
+                    yield LLMResultChunk(
+                        model=model,
+                        delta=LLMResultChunkDelta(index=index, message=assistant_prompt_message),
+                    )
+                    index += 1
+
+            elif chunk_type == "response.output_item.added":
+                item = getattr(chunk, "item", None)
+                if item and hasattr(item, "type"):
+                    item_type = getattr(item, "type", "")
+
+                    if item_type == "function_call":
+                        function_name = getattr(item, "name", "")
+                        call_id = getattr(item, "call_id", "")
+
+                        if function_name and call_id:
+                            pending_tool_calls[call_id] = {
+                                "id": call_id,
+                                "name": function_name,
+                                "arguments": "",
+                            }
+                            current_tool_call = call_id
+
+            elif chunk_type == "response.function_call_arguments.delta":
+                delta_args = getattr(chunk, "delta", "")
+                if current_tool_call and current_tool_call in pending_tool_calls:
+                    pending_tool_calls[current_tool_call]["arguments"] += delta_args
+
+            elif chunk_type == "response.function_call_arguments.done":
+                call_id = getattr(chunk, "item_id", "")
+                final_args = getattr(chunk, "arguments", "")
+                if call_id and call_id in pending_tool_calls:
+                    pending_tool_calls[call_id]["arguments"] = final_args
+
+            elif chunk_type == "response.output_item.done":
+                item = getattr(chunk, "item", None)
+                if item and hasattr(item, "type"):
+                    item_type = getattr(item, "type", "")
+
+                    if item_type == "function_call":
+                        function_name = getattr(item, "name", "")
+                        function_args = getattr(item, "arguments", "")
+                        call_id = getattr(item, "call_id", "")
+
+                        if call_id in pending_tool_calls:
+                            final_args = pending_tool_calls[call_id]["arguments"] or function_args
+                        else:
+                            final_args = function_args
+
+                        if function_name:
+                            tool_call = AssistantPromptMessage.ToolCall(
+                                id=call_id,
+                                type="function",
+                                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                                    name=function_name,
+                                    arguments=final_args or "{}",
+                                ),
+                            )
+
+                            assistant_prompt_message = AssistantPromptMessage(
+                                content="", tool_calls=[tool_call]
+                            )
+
+                            yield LLMResultChunk(
+                                model=model,
+                                delta=LLMResultChunkDelta(
+                                    index=index, message=assistant_prompt_message
+                                ),
+                            )
+                            index += 1
+
+                            if call_id in pending_tool_calls:
+                                del pending_tool_calls[call_id]
+                            if call_id == current_tool_call:
+                                current_tool_call = None
+
+            elif hasattr(chunk, "delta") and hasattr(chunk.delta, "text"):
+                delta_text = chunk.delta.text or ""
+                if delta_text:
+                    full_text += delta_text
+                    assistant_prompt_message = AssistantPromptMessage(
+                        content=delta_text, tool_calls=[]
+                    )
+                    yield LLMResultChunk(
+                        model=model,
+                        delta=LLMResultChunkDelta(index=index, message=assistant_prompt_message),
+                    )
+                    index += 1
+
+        prompt_tokens = self._num_tokens_from_messages(prompt_messages, credentials=credentials)
+        full_assistant_prompt_message = AssistantPromptMessage(content=full_text)
+        completion_tokens = self._num_tokens_from_string(
+            full_assistant_prompt_message.content or ""
+        )
+        usage = self._calc_response_usage(model, credentials, prompt_tokens, completion_tokens)
+
+        yield LLMResultChunk(
+            model=model,
+            delta=LLMResultChunkDelta(
+                index=index,
+                message=AssistantPromptMessage(content=""),
+                finish_reason="stop",
+                usage=usage,
+            ),
         )

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -821,6 +821,66 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             usage=usage,
         )
 
+    @staticmethod
+    def _adapt_schema_for_structured_outputs(schema: dict) -> dict:
+        """
+        Adapt a JSON Schema for OpenAI Structured Outputs (Responses API).
+        Requirements:
+        1. All object schemas must specify 'additionalProperties': False
+        2. All properties defined in an object must be listed in 'required'
+        3. Optional properties have their type expanded to include 'null' (e.g. ['string', 'null'])
+        """
+        if not isinstance(schema, dict):
+            return schema
+        schema = dict(schema)
+        schema_type = schema.get("type")
+
+        # Handle arrays of objects by recursing into `items`
+        is_array = schema_type == "array" or (
+            isinstance(schema_type, list) and "array" in schema_type
+        )
+        if is_array and "items" in schema and isinstance(schema.get("items"), dict):
+            schema["items"] = OpenAILargeLanguageModel._adapt_schema_for_structured_outputs(
+                schema["items"]
+            )
+
+        # Handle objects
+        is_object = (
+            schema_type == "object"
+            or (isinstance(schema_type, list) and "object" in schema_type)
+            or "properties" in schema
+        )
+        if is_object:
+            # Enforce additionalProperties: False as required by OpenAI Structured Outputs
+            if "additionalProperties" not in schema or schema["additionalProperties"] is not False:
+                schema["additionalProperties"] = False
+
+            if "properties" in schema and isinstance(schema["properties"], dict):
+                required = list(schema.get("required", []))
+                new_properties = {}
+                for key, prop in schema["properties"].items():
+                    prop = dict(prop) if isinstance(prop, dict) else prop
+                    if isinstance(prop, dict):
+                        if key not in required:
+                            # Convert fields not in 'required' to null union type to emulate optional
+                            original_type = prop.get("type")
+                            if original_type is None:
+                                pass
+                            elif isinstance(original_type, list):
+                                if "null" not in original_type:
+                                    prop["type"] = original_type + ["null"]
+                            else:
+                                prop["type"] = [original_type, "null"]
+                            required.append(key)
+                        new_properties[key] = (
+                            OpenAILargeLanguageModel._adapt_schema_for_structured_outputs(prop)
+                        )
+                    else:
+                        new_properties[key] = prop
+                schema["properties"] = new_properties
+                schema["required"] = required
+        return schema
+
     def _create_openai_client(self, credentials: dict) -> OpenAI:
         api_key = credentials.get("api_key") or "dummy"
         endpoint_url = credentials.get("endpoint_url")
@@ -1052,11 +1112,18 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                         json_schema_data = json.loads(json_schema_data)
                     except json.JSONDecodeError:
                         json_schema_data = {}
+
+                schema_name = json_schema_data.get("name", "response")
+                raw_schema = json_schema_data.get("schema")
+                if raw_schema is None or not isinstance(raw_schema, dict):
+                    raw_schema = json_schema_data if isinstance(json_schema_data, dict) else {}
+
+                adapted_schema = self._adapt_schema_for_structured_outputs(raw_schema)
                 responses_params["text"] = {
                     "format": {
                         "type": "json_schema",
-                        "name": json_schema_data.get("name", "response"),
-                        "schema": json_schema_data.get("schema", {}),
+                        "name": schema_name,
+                        "schema": adapted_schema,
                     }
                 }
             else:

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -330,6 +330,28 @@ model_credential_schema:
       help:
         en_US: Choose strict OpenAI compatibility or extended settings that add extra parameters (e.g., thinking, chat_template_kwargs, enable_thinking).
         zh_Hans: 选择严格的 OpenAI 兼容或扩展设置（会添加额外参数，例如 thinking、chat_template_kwargs、enable_thinking）。
+    - variable: api_type
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        en_US: API Type
+        zh_Hans: API 类型
+      type: select
+      required: false
+      default: chat_completions
+      options:
+        - value: chat_completions
+          label:
+            en_US: Chat Completions API (/chat/completions)
+            zh_Hans: Chat Completions API (/chat/completions)
+        - value: responses
+          label:
+            en_US: Responses API (/responses)
+            zh_Hans: Responses API (/responses)
+      help:
+        en_US: Choose Chat Completions API (standard endpoint) or Responses API (required for OpenAI native web search with domain filtering).
+        zh_Hans: 选择 Chat Completions API（标准端点）或 Responses API（适用于包含域名过滤的 OpenAI 原生联网搜索）。
     - variable: token_param_name
       show_on:
         - variable: __model_type

--- a/models/openai_api_compatible/tests/test_responses_api.py
+++ b/models/openai_api_compatible/tests/test_responses_api.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock, patch
+
+from dify_plugin.entities.model.message import (
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from models.llm.llm import OpenAILargeLanguageModel
+
+
+def test_normalize_domains():
+    raw = "https://openai.com, github.com/test, https://docs.dify.ai:443, openai.com"
+    normalized = OpenAILargeLanguageModel._normalize_domains(raw)
+    assert normalized == ["openai.com", "github.com", "docs.dify.ai"]
+
+
+def test_extract_responses_web_search_config():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    params = {
+        "web_search": True,
+        "web_search_allowed_domains": "openai.com, github.com",
+        "web_search_blocked_domains": "reddit.com",
+        "web_search_context_size": "high",
+        "web_search_user_country": "US",
+    }
+    creds = {"api_type": "responses"}
+    config = model._extract_responses_web_search_config(params, creds)
+    assert config is not None
+    assert config["type"] == "web_search"
+    assert config["filters"]["allowed_domains"] == ["openai.com", "github.com"]
+    assert config["filters"]["blocked_domains"] == ["reddit.com"]
+    assert config["search_context_size"] == "high"
+    assert config["user_location"] == {"type": "approximate", "country": "US"}
+
+
+def test_responses_api_schema_rules():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    creds = {
+        "api_type": "responses",
+        "mode": "chat",
+        "context_size": "4096",
+    }
+    schema = model.get_customizable_model_schema("gpt-5", creds)
+    param_names = [rule.name for rule in schema.parameter_rules]
+    assert "web_search" in param_names
+    assert "web_search_allowed_domains" in param_names
+    assert "web_search_blocked_domains" in param_names
+    assert "web_search_context_size" in param_names
+    assert "web_search_user_country" in param_names
+
+
+def test_chat_completions_schema_rules_without_responses():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    # When api_type is chat_completions and web_search_support is not_supported
+    creds = {
+        "api_type": "chat_completions",
+        "web_search_support": "not_supported",
+        "mode": "chat",
+        "context_size": "4096",
+    }
+    schema = model.get_customizable_model_schema("gpt-5", creds)
+    param_names = [rule.name for rule in schema.parameter_rules]
+    assert "web_search" not in param_names
+    assert "web_search_allowed_domains" not in param_names
+    assert "web_search_blocked_domains" not in param_names
+    assert "web_search_context_size" not in param_names
+    assert "web_search_user_country" not in param_names
+
+    # When web_search_support is tool_standard but api_type is chat_completions
+    creds["web_search_support"] = "tool_standard"
+    schema2 = model.get_customizable_model_schema("gpt-5", creds)
+    param_names2 = [rule.name for rule in schema2.parameter_rules]
+    assert "web_search" in param_names2
+    # Domain filtering should NOT appear because api_type is NOT responses
+    assert "web_search_allowed_domains" not in param_names2
+    assert "web_search_blocked_domains" not in param_names2
+    assert "web_search_context_size" not in param_names2
+    assert "web_search_user_country" not in param_names2
+
+
+def test_invoke_routes_to_responses_api():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    prompt_messages = [
+        SystemPromptMessage(content="You are a helpful assistant."),
+        UserPromptMessage(content="Hello"),
+    ]
+    creds = {
+        "api_type": "responses",
+        "endpoint_url": "https://api.openai.com/v1",
+        "api_key": "sk-test",
+        "mode": "chat",
+    }
+    params = {
+        "web_search": True,
+        "web_search_allowed_domains": "openai.com",
+    }
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.output = [MagicMock(type="message", content="Hello! How can I help you today?")]
+    mock_response.usage = MagicMock(input_tokens=10, output_tokens=12)
+    mock_client.responses.create.return_value = mock_response
+
+    with patch.object(model, "_create_openai_client", return_value=mock_client):
+        result = model._invoke(
+            model="gpt-5",
+            credentials=creds,
+            prompt_messages=prompt_messages,
+            model_parameters=params,
+            stream=False,
+        )
+
+    assert mock_client.responses.create.called
+    call_kwargs = mock_client.responses.create.call_args[1]
+    assert call_kwargs["model"] == "gpt-5"
+    assert any(t.get("type") == "web_search" for t in call_kwargs["tools"])
+    assert result.message.content == "Hello! How can I help you today?"

--- a/models/openai_api_compatible/tests/test_responses_api.py
+++ b/models/openai_api_compatible/tests/test_responses_api.py
@@ -114,3 +114,71 @@ def test_invoke_routes_to_responses_api():
     assert call_kwargs["model"] == "gpt-5"
     assert any(t.get("type") == "web_search" for t in call_kwargs["tools"])
     assert result.message.content == "Hello! How can I help you today?"
+
+
+def test_adapt_schema_for_structured_outputs():
+    raw_schema = {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "summary": {"type": "string"},
+            "tags": {
+                "type": "array",
+                "items": {"type": "object", "properties": {"tag_name": {"type": "string"}}},
+            },
+        },
+        "required": ["title"],
+    }
+
+    adapted = OpenAILargeLanguageModel._adapt_schema_for_structured_outputs(raw_schema)
+
+    assert adapted["additionalProperties"] is False
+    assert set(adapted["required"]) == {"title", "summary", "tags"}
+    assert adapted["properties"]["summary"]["type"] == ["string", "null"]
+    # Check nested item
+    assert adapted["properties"]["tags"]["items"]["additionalProperties"] is False
+    assert adapted["properties"]["tags"]["items"]["required"] == ["tag_name"]
+
+
+def test_invoke_responses_api_with_json_schema():
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    prompt_messages = [
+        UserPromptMessage(content="Summarize this"),
+    ]
+    creds = {
+        "api_type": "responses",
+        "endpoint_url": "https://api.openai.com/v1",
+        "api_key": "sk-test",
+        "mode": "chat",
+    }
+    params = {
+        "response_format": "json_schema",
+        "json_schema": {
+            "name": "llm_response",
+            "schema": {"type": "object", "properties": {"summary": {"type": "string"}}},
+        },
+    }
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.output = [MagicMock(type="message", content='{"summary": "test"}')]
+    mock_response.usage = MagicMock(input_tokens=10, output_tokens=12)
+    mock_client.responses.create.return_value = mock_response
+
+    with patch.object(model, "_create_openai_client", return_value=mock_client):
+        result = model._invoke(
+            model="gpt-5.4-mini",
+            credentials=creds,
+            prompt_messages=prompt_messages,
+            model_parameters=params,
+            stream=False,
+        )
+
+    assert result.message.content == '{"summary": "test"}'
+    call_kwargs = mock_client.responses.create.call_args[1]
+    assert "text" in call_kwargs
+    text_format = call_kwargs["text"]["format"]
+    assert text_format["type"] == "json_schema"
+    assert text_format["name"] == "llm_response"
+    assert text_format["schema"]["additionalProperties"] is False
+    assert text_format["schema"]["required"] == ["summary"]


### PR DESCRIPTION
## Summary

Add OpenAI Responses API support with web search domain filtering to the `openai_api_compatible` plugin.

This enables users to use the Responses API endpoint (`/responses`) instead of Chat Completions, which is required for OpenAI's native web search with domain filtering (allowed/blocked domains, context size, user country).

Modeled after the pattern in the official `azure_openai` plugin.

## Release Notes

- **New**: Added `API Type` credential to choose between Chat Completions API and Responses API.
- **New**: Web search domain filtering parameters (`allowed_domains`, `blocked_domains`, `context_size`, `user_country`) when `Responses API` is selected.
- **New**: Full Responses API support including streaming, tool calling, reasoning tokens, and structured outputs.

## Change Type

- [x] LLM plugin

## Screenshots / Videos

<!-- Silakan drag and drop screenshot Dify Anda di sini -->
| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Message flow (system messages, user ↔ assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [x] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (0.0.62 -> 0.0.63)
- [x] `dify_plugin>=0.9.0` is declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [x] Local deployment — Dify version: 1.7.0
