### PR TITLE
fix(openai_api_compatible): keep text embeddings from promoting image…

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.62
+version: 0.0.63
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/text_embedding/text_embedding.py
+++ b/models/openai_api_compatible/models/text_embedding/text_embedding.py
@@ -24,6 +24,7 @@ from dify_plugin.entities.model import (
 from dify_plugin.entities.model.text_embedding import (
     TextEmbeddingResult,
     EmbeddingUsage,
+    MultiModalEmbeddingResult,
 )
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,
@@ -113,66 +114,25 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
         input_type: EmbeddingInputType = EmbeddingInputType.DOCUMENT,
     ) -> TextEmbeddingResult:
         """
-        Invoke text embedding model with multimodal support
-
-        Supports both text-only and multimodal (text + image) inputs.
-        When vision_support is enabled, texts can contain JSON with "text" and "image" fields.
+        Invoke text embedding model.
 
         :param model: model name
         :param credentials: model credentials
-        :param texts: texts to embed (can be JSON strings for multimodal)
+        :param texts: texts to embed
         :param user: unique user id
         :param input_type: input type
         :return: embeddings result
         """
-        # Check if vision support is enabled
-        vision_support = credentials.get("vision_support", "no_support")
-
-        # Process inputs - convert to multimodal format if needed
-        processed_inputs = []
-        multimodal_flags = []
-        for text in texts:
-            processed = self._process_input(text, vision_support == "support")
-            processed_inputs.append(processed)
-            multimodal_flags.append(self._is_multimodal_input(processed))
-
-        # Apply prefix
         prefix = self._get_prefix(credentials, input_type)
-        if prefix:
-            processed_inputs = self._add_prefix_to_inputs(processed_inputs, prefix)
+        inputs = [f"{prefix} {text}" if prefix else text for text in texts]
 
-        # Get context size and max chunks from credentials or model properties
-        context_size = self._get_context_size(model, credentials)
-        max_chunks = self._get_max_chunks(model, credentials)
-
-        # Truncate long texts (similar to Tongyi's approach)
-        inputs = []
-        for input_data in processed_inputs:
-            if isinstance(input_data, list):
-                # Multimodal - convert to text first
-                text_parts = []
-                for content in input_data:
-                    if content.get("type") == "text":
-                        text_parts.append(content.get("text", ""))
-                    elif content.get("type") == "image_url":
-                        #text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
-                        text_parts.append(f"Image:{content.get('image_url', {}).get('url', '')}")
-                text = " ".join(text_parts) if text_parts else ""
-            else:
-                text = input_data if isinstance(input_data, str) else str(input_data)
-
-            # Check token count and truncate if necessary
-            #num_tokens = self._get_num_tokens_by_gpt2(text)
-            #if num_tokens >= context_size:
-                # Truncate to fit within context size
-            #    cutoff = int(len(text) * (context_size / num_tokens))
-            #    text = text[0:cutoff]
-
-            inputs.append(text)
-
-        # Call API in batches
         return self._embed_in_batches(
-            model, credentials, inputs, multimodal_flags, user, input_type
+            model,
+            credentials,
+            inputs,
+            [False] * len(inputs),
+            user,
+            input_type,
         )
 
     def _embed_in_batches(
@@ -759,48 +719,36 @@ class OpenAITextEmbeddingModel(OAICompatEmbeddingModel):
         self,
         model: str,
         credentials: dict,
-        inputs: list,
+        documents: list[MultiModalContent],
         user: Optional[str] = None,
         input_type: EmbeddingInputType = EmbeddingInputType.DOCUMENT,
-    ) -> TextEmbeddingResult:
-        """
-        Invoke embedding model with potentially multimodal inputs.
-        This method delegates to _invoke for processing.
-        """
-        # Convert inputs back to texts format and use _invoke
-        texts = []
-        for input_data in inputs:
-            if isinstance(input_data, list):
-                # Multimodal - convert to text
-                text_parts = []
-                for content in input_data:
-                    if content.get("type") == "text":
-                        text_parts.append(content.get("text", ""))
-                    elif content.get("type") == "image_url":
-                        #text_parts.append(f"[Image: {content.get('image_url', {}).get('url', '')}]")
-                        text_parts.append(f"Image:{content.get('image_url', {}).get('url', '')}")
-                texts.append(" ".join(text_parts) if text_parts else "")
-            elif input_data.content_type == MultiModalContentType.TEXT:
-                input = {
-                    "text": input_data.content
-                }
-                input_str = json.dumps(input, ensure_ascii=False)
-                texts.append(input_str)
-            elif input_data.content_type == MultiModalContentType.IMAGE:
-                image_format = self._detect_image_format_from_base64(input_data.content)
-                if len(image_format)>0:
-                    input = {
-                        "image": "data:image/" + image_format + ";base64," + input_data.content
-                    }
-                else:
-                    input = {
-                        "image": "data:image" + ";base64," + input_data.content
-                    }
-                input_str = json.dumps(input, ensure_ascii=False)
-                texts.append(input_str)
+    ) -> MultiModalEmbeddingResult:
+        """Invoke explicitly typed text and base64 image embedding inputs."""
+        inputs: list[str] = []
+        multimodal_flags: list[bool] = []
+        prefix = self._get_prefix(credentials, input_type)
+
+        for document in documents:
+            if document.content_type == MultiModalContentType.TEXT:
+                text = f"{prefix} {document.content}" if prefix else document.content
+                inputs.append(text)
+                multimodal_flags.append(False)
+            elif document.content_type == MultiModalContentType.IMAGE:
+                image_format = self._detect_image_format_from_base64(document.content)
+                mime_type = f"image/{image_format}" if image_format else "image"
+                inputs.append(f"Image:data:{mime_type};base64,{document.content}")
+                multimodal_flags.append(True)
             else:
-                texts.append(
-                    input_data if isinstance(input_data, str) else str(input_data)
+                raise InvokeError(
+                    f"Unsupported multimodal content type: {document.content_type}"
                 )
 
-        return self._invoke(model, credentials, texts, user, input_type)
+        result = self._embed_in_batches(
+            model,
+            credentials,
+            inputs,
+            multimodal_flags,
+            user,
+            input_type,
+        )
+        return MultiModalEmbeddingResult(**result.model_dump())

--- a/models/openai_api_compatible/tests/test_text_embedding.py
+++ b/models/openai_api_compatible/tests/test_text_embedding.py
@@ -2,14 +2,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from dify_plugin.entities.model.text_embedding import (
+    MultiModalContent,
+    MultiModalContentType,
+)
 from models.text_embedding.text_embedding import OpenAITextEmbeddingModel
 
 
-def _successful_embedding_response() -> MagicMock:
+def _successful_embedding_response(
+    embeddings: list[list[float]] | None = None,
+) -> MagicMock:
+    embeddings = embeddings or [[0.1, 0.2, 0.3]]
     response = MagicMock()
     response.status_code = 200
     response.json.return_value = {
-        "data": [{"embedding": [0.1, 0.2, 0.3]}],
+        "data": [{"embedding": embedding} for embedding in embeddings],
         "usage": {"total_tokens": 3},
     }
     return response
@@ -91,6 +98,27 @@ def test_plain_text_containing_image_marker_uses_text_embedding(
     assert result.embeddings == [[0.1, 0.2, 0.3]]
 
 
+@patch("models.text_embedding.text_embedding.OpenAI")
+@patch("models.text_embedding.text_embedding.requests.post")
+def test_markdown_image_in_text_is_not_promoted_to_multimodal(mock_post, mock_openai):
+    mock_post.return_value = _successful_embedding_response()
+    model = OpenAITextEmbeddingModel(model_schemas=[])
+    text = "before ![image](http://192.168.1.100/files/id/file-preview) after"
+
+    result = model._invoke(
+        model="display-name",
+        credentials=_credentials(vision_support="support"),
+        texts=[text],
+    )
+
+    mock_openai.assert_not_called()
+    assert mock_post.call_args.kwargs["json"] == {
+        "model": "Qwen3-Embedding-8B",
+        "input": [text],
+    }
+    assert result.embeddings == [[0.1, 0.2, 0.3]]
+
+
 def _chat_embedding_response() -> MagicMock:
     response = MagicMock()
     response.data = [MagicMock(embedding=[0.4, 0.5, 0.6])]
@@ -107,13 +135,62 @@ def test_multimodal_embedding_sends_endpoint_model_name(mock_create, _mock_opena
     mock_create.return_value = _chat_embedding_response()
     model = OpenAITextEmbeddingModel(model_schemas=[])
 
-    result = model._invoke(
+    result = model._invoke_multimodal(
         model="Qwen3-VL-Embedding",
         credentials=_credentials(
             endpoint_model_name="qwen3-vl-embedding-8b-awq", vision_support="support"
         ),
-        texts=["https://example.com/image.png"],
+        documents=[
+            MultiModalContent(
+                content_type=MultiModalContentType.IMAGE,
+                content="iVBORw0KGgo=",
+            )
+        ],
     )
 
     assert mock_create.call_args.kwargs["model"] == "qwen3-vl-embedding-8b-awq"
+    user_content = mock_create.call_args.kwargs["messages"][1]["content"]
+    assert user_content[0] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+    }
     assert result.embeddings == [[0.4, 0.5, 0.6]]
+
+
+@patch("models.text_embedding.text_embedding.OpenAI")
+@patch("models.text_embedding.text_embedding.create_chat_embeddings")
+@patch("models.text_embedding.text_embedding.requests.post")
+def test_multimodal_embedding_preserves_mixed_input_order(
+    mock_post, mock_create, _mock_openai
+):
+    mock_post.side_effect = [
+        _successful_embedding_response([[0.1, 0.0]]),
+        _successful_embedding_response([[0.3, 0.0]]),
+    ]
+    mock_create.return_value = _chat_embedding_response()
+    model = OpenAITextEmbeddingModel(model_schemas=[])
+
+    result = model._invoke_multimodal(
+        model="Qwen3-VL-Embedding",
+        credentials=_credentials(vision_support="support"),
+        documents=[
+            MultiModalContent(
+                content_type=MultiModalContentType.TEXT,
+                content="first text",
+            ),
+            MultiModalContent(
+                content_type=MultiModalContentType.IMAGE,
+                content="iVBORw0KGgo=",
+            ),
+            MultiModalContent(
+                content_type=MultiModalContentType.TEXT,
+                content="second text",
+            ),
+        ],
+    )
+
+    assert [call.kwargs["json"]["input"] for call in mock_post.call_args_list] == [
+        ["first text"],
+        ["second text"],
+    ]
+    assert result.embeddings == [[0.1, 0.0], [0.4, 0.5, 0.6], [0.3, 0.0]]


### PR DESCRIPTION
## Summary

Fixes #3702.

When vision support was enabled, the OpenAI API Compatible text-embedding path parsed Markdown image links from otherwise textual document chunks and promoted those chunks to the vLLM chat-embeddings request format.

This caused provider-dependent failures before Dify could use its explicit multimodal embedding path:

- Gemini embedding endpoints rejected the unexpected `messages`, `continue_final_message`, and `add_special_tokens` fields.
- Services that accepted `image_url` could attempt to fetch Dify's unsigned `/file-preview` URL and fail authentication.

This change:

- keeps `_invoke()` strictly text-only, including text containing Markdown image links;
- handles explicitly typed multimodal inputs only in `_invoke_multimodal()`;
- sends Dify-provided image content as a Base64 data URI instead of a Dify file-preview URL;
- preserves embedding order for mixed text and image inputs;
- adds regression coverage for Markdown image text, Base64 image payloads, endpoint model names, and mixed-input ordering.

## Release Notes

Fixed multimodal text embeddings incorrectly treating Markdown image links as remotely fetched image inputs. Text chunks now remain text-only, while explicitly provided images use Base64 multimodal payloads.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable. This is a backend request-routing fix covered by automated payload assertions.

## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

The plugin uses the current `dify_plugin>=0.9.0` dependency declared in `pyproject.toml` and `uv.lock`.

## Testing

- [ ] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

Automated verification:

```text
uv run --project models/openai_api_compatible pytest models/openai_api_compatible/tests -q
50 passed
```

- `git diff --check`
- Ruff check for the updated regression test file
