### PR TITLE
fix(cot_agent): recover wrapped action JSON and surface ReAct parse failures

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.45
+version: 0.0.46
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/output_parser/cot_output_parser.py
+++ b/agent-strategies/cot_agent/output_parser/cot_output_parser.py
@@ -12,6 +12,89 @@ THINK_START = "<think>"
 THINK_END = "</think>"
 
 
+# Keys that may carry the tool name, checked in priority order.
+ACTION_NAME_KEYS = ("action", "tool", "tool_name", "name", "function")
+# Keys that may carry the tool input, checked in priority order.
+ACTION_INPUT_KEYS = ("action_input", "tool_input", "input", "arguments", "parameters", "args")
+# Keys that are never the tool name or input (metadata the model may include).
+IGNORED_KEYS = frozenset({"thought", "reasoning", "id", "type"})
+# Single-key wrappers some models use around the whole payload, e.g. {"tool_call": {...}}.
+WRAPPER_KEYS = frozenset({"tool_call", "tool_calling", "tool_calls", "function"})
+
+
+def _extract_action(payload: dict) -> "AgentScratchpadUnit.Action | None":
+    """Extract a canonical Action from a flat dict, or None when it is not one."""
+    lowered = {key.lower(): value for key, value in payload.items()}
+    action_name = None
+    for key in ACTION_NAME_KEYS:
+        # non-string values (e.g. an OpenAI-style nested "function" dict) are
+        # skipped so a following known key can still provide the name
+        if isinstance(lowered.get(key), str):
+            action_name = lowered[key]
+            break
+    if action_name is None and any("input" in key for key in lowered):
+        # Legacy fallback: when no known name key is present, a remaining
+        # string-valued key may carry the tool name - but only if the payload
+        # also carries an input-like key, so arbitrary JSON blobs inside a
+        # thought are not misread as tool calls.
+        for key, value in payload.items():
+            lowered_key = key.lower()
+            if "input" in lowered_key or lowered_key in IGNORED_KEYS:
+                continue
+            if isinstance(value, str) and value.strip():
+                action_name = value
+                break
+    if not isinstance(action_name, str) or not action_name.strip():
+        return None
+
+    action_input = None
+    for key in ACTION_INPUT_KEYS:
+        if key in lowered:
+            action_input = lowered[key]
+            break
+    if action_input is None:
+        for key, value in payload.items():
+            if "input" in key.lower():
+                action_input = value
+                break
+    if action_input is None:
+        # Tools without parameters may legitimately omit the input.
+        action_input = {}
+    return AgentScratchpadUnit.Action(action_name=action_name.strip(), action_input=action_input)
+
+
+def parse_action(json_str: str) -> "AgentScratchpadUnit.Action | None":
+    """Parse a JSON blob into an Action, or return None when it is not one.
+
+    Returns None (instead of the raw string, as the previous in-place
+    heuristic did) so the caller can distinguish a parse failure from a
+    valid action and surface it instead of silently ending the round.
+    """
+    try:
+        payload = json.loads(json_str, strict=False)
+    except (TypeError, ValueError):
+        return None
+    # cohere always returns a list
+    if isinstance(payload, list):
+        if len(payload) != 1:
+            return None
+        payload = payload[0]
+    if not isinstance(payload, dict):
+        return None
+    # Unwrap recognized single-key wrappers, e.g. {"tool_call": {...}}.
+    if len(payload) == 1:
+        key, value = next(iter(payload.items()))
+        if key in WRAPPER_KEYS and isinstance(value, (dict, list)):
+            if isinstance(value, list):
+                if len(value) != 1:
+                    return None
+                value = value[0]
+            if not isinstance(value, dict):
+                return None
+            payload = value
+    return _extract_action(payload)
+
+
 class ReactState(Enum):
     THINKING = ("Thought:", "THINKING")
     ANSWER = ("FinalAnswer:", "ANSWER")
@@ -23,9 +106,13 @@ class ReactState(Enum):
 
 
 class ReactChunk:
-    def __init__(self, state: ReactState, content: str):
+    def __init__(self, state: ReactState, content: str, parse_failed: bool = False):
         self.state = state
         self.content = content
+        # True when a JSON blob was captured but could not be parsed as an
+        # Action, so the strategy can surface the failure instead of ending
+        # the round silently (see issue #3699).
+        self.parse_failed = parse_failed
 
 
 class CotAgentOutputParser:
@@ -33,32 +120,6 @@ class CotAgentOutputParser:
     def handle_react_stream_output(
         cls, llm_response: Generator[LLMResultChunk, None, None], usage_dict: dict
     ) -> Generator[Union[ReactChunk, AgentScratchpadUnit.Action], None, None]:
-        def parse_action(json_str):
-            try:
-                action = json.loads(json_str, strict=False)
-                action_name = None
-                action_input = None
-
-                # cohere always returns a list
-                if isinstance(action, list) and len(action) == 1:
-                    action = action[0]
-
-                for key, value in action.items():
-                    if "input" in key.lower():
-                        action_input = value
-                    else:
-                        action_name = value
-
-                if action_name is not None and action_input is not None:
-                    return AgentScratchpadUnit.Action(
-                        action_name=action_name,
-                        action_input=action_input,
-                    )
-                else:
-                    return json_str or ""
-            except Exception:
-                return json_str or ""
-
         json_cache = ""
         in_json = False
         got_json = False
@@ -203,13 +264,18 @@ class CotAgentOutputParser:
                         index += steps
                         continue
 
-                    yield_raw_delta, emitted_chunk, delta_consumed, _ = thought_matcher.step(delta)
-                    if emitted_chunk is not None:
-                        yield emitted_chunk
-                    yield_delta = yield_delta or yield_raw_delta
-                    if delta_consumed:
-                        index += steps
-                        continue
+                    if cur_state is not ReactState.ANSWER:
+                        yield_raw_delta, emitted_chunk, delta_consumed, _ = thought_matcher.step(delta)
+                        if emitted_chunk is not None:
+                            yield emitted_chunk
+                        yield_delta = yield_delta or yield_raw_delta
+                        if delta_consumed:
+                            index += steps
+                            continue
+                    # In the answer state a later "Thought:" must not switch
+                    # the parser back to thinking mode: the final answer is
+                    # terminal, so JSON emitted after "FinalAnswer:" can never
+                    # become a tool call.
 
                     if yield_delta:
                         index += steps
@@ -260,10 +326,17 @@ class CotAgentOutputParser:
                 if got_json:
                     got_json = False
                     last_character = delta
-                    parsed_result = parse_action(json_cache)
-                    if isinstance(parsed_result, AgentScratchpadUnit.Action):
-                        yield parsed_result
+                    action = parse_action(json_cache)
+                    if action is not None and cur_state is ReactState.THINKING:
+                        yield action
+                    elif action is None and cur_state is ReactState.THINKING:
+                        # JSON that is not a valid action: keep it as thought
+                        # text but flag the parse failure so the strategy can
+                        # surface it instead of ending the round silently.
+                        yield ReactChunk(cur_state, json_cache, parse_failed=True)
                     else:
+                        # In the answer state a JSON blob is part of the final
+                        # answer and can never become a tool call.
                         yield ReactChunk(cur_state, json_cache)
                     json_cache = ""
                     in_json = False
@@ -278,8 +351,10 @@ class CotAgentOutputParser:
                 index += steps
 
         if json_cache:
-            parsed_result = parse_action(json_cache)
-            if isinstance(parsed_result, AgentScratchpadUnit.Action):
-                yield parsed_result
+            action = parse_action(json_cache)
+            if action is not None and cur_state is ReactState.THINKING:
+                yield action
+            elif action is None and cur_state is ReactState.THINKING:
+                yield ReactChunk(cur_state, json_cache, parse_failed=True)
             else:
                 yield ReactChunk(cur_state, json_cache)

--- a/agent-strategies/cot_agent/strategies/ReAct.py
+++ b/agent-strategies/cot_agent/strategies/ReAct.py
@@ -172,6 +172,9 @@ class ReActAgentStrategy(AgentStrategy):
             )
             yield round_log
             message_file_ids: list[str] = []
+            # True when the model emitted a JSON blob in this round that could
+            # not be parsed as a valid Action (issue #3699).
+            round_parse_failed = False
 
             # recalc llm max tokens
             prompt_messages = self._organize_prompt_messages(
@@ -225,6 +228,8 @@ class ReActAgentStrategy(AgentStrategy):
                     assert isinstance(react_chunk, ReactChunk)
                     chunk = react_chunk.content
                     scratchpad.agent_response = (scratchpad.agent_response or "") + chunk
+                    if react_chunk.parse_failed:
+                        round_parse_failed = True
                     if react_chunk.state == ReactState.ANSWER and not scratchpad.action:
                         final_answer += chunk
                         yield self.create_text_message(chunk)
@@ -271,6 +276,28 @@ class ReActAgentStrategy(AgentStrategy):
                 else:
                     final_answer = scratchpad.thought
                     final_answer_already_streamed = False
+                    if round_parse_failed:
+                        # The model attempted structured output that could not
+                        # be parsed as an Action or FinalAnswer (e.g. an
+                        # unexpected JSON wrapper). Surface the failure in the
+                        # agent log instead of ending the round silently; the
+                        # thought is kept as the final answer for backward
+                        # compatibility.
+                        yield self.create_log_message(
+                            label="Action parse failed",
+                            data={
+                                "error": (
+                                    "Model output did not contain a valid "
+                                    "Action or FinalAnswer, so no tool was "
+                                    "invoked and the round ended early. The "
+                                    "thought was used as the final answer."
+                                ),
+                                # parser-normalized model output, truncated
+                                "model_output": (scratchpad.agent_response or "")[:500],
+                            },
+                            parent=round_log,
+                            status=ToolInvokeMessage.LogMessage.LogStatus.ERROR,
+                        )
             else:
                 if scratchpad.action.action_name.lower() == "final answer":
                     try:

--- a/agent-strategies/cot_agent/tests/test_cot_output_parser.py
+++ b/agent-strategies/cot_agent/tests/test_cot_output_parser.py
@@ -1,0 +1,215 @@
+import sys
+import unittest
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from dify_plugin.entities.model.llm import LLMResultChunk, LLMResultChunkDelta
+from dify_plugin.entities.model.message import AssistantPromptMessage
+from dify_plugin.interfaces.agent import AgentScratchpadUnit
+
+from output_parser.cot_output_parser import (
+    CotAgentOutputParser,
+    ReactChunk,
+    ReactState,
+    parse_action,
+)
+
+
+def _chunks(*contents: str) -> list[LLMResultChunk]:
+    return [
+        LLMResultChunk(
+            model="test-model",
+            delta=LLMResultChunkDelta(
+                index=0, message=AssistantPromptMessage(content=content), usage=None
+            ),
+        )
+        for content in contents
+    ]
+
+
+def _parse(*contents: str) -> list:
+    usage_dict: dict = {"usage": None}
+    return list(CotAgentOutputParser.handle_react_stream_output(_chunks(*contents), usage_dict))
+
+
+class TestParseAction(unittest.TestCase):
+    def test_flat_valid_action(self):
+        action = parse_action('{"action": "webSearch", "action_input": {"query": "x"}}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "webSearch")
+        self.assertEqual(action.action_input, {"query": "x"})
+
+    def test_tool_call_wrapper(self):
+        # Issue #3699: the model wraps the payload in an outer "tool_call" key
+        raw = (
+            '{"tool_call": {"thought": "获取。", "action": "webSearch", '
+            '"action_input": {"input": "上海银行"}}}'
+        )
+        action = parse_action(raw)
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "webSearch")
+        self.assertEqual(action.action_input, {"input": "上海银行"})
+
+    def test_wrapper_key_order_does_not_clobber_name(self):
+        # "thought" must never be misread as the tool name, in any key order
+        raw = (
+            '{"tool_call": {"action": "webSearch", "thought": "reasoning", '
+            '"action_input": {"input": "x"}}}'
+        )
+        action = parse_action(raw)
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "webSearch")
+
+    def test_input_only_is_not_an_action(self):
+        self.assertIsNone(parse_action('{"input": "x"}'))
+
+    def test_non_string_name_is_not_an_action(self):
+        self.assertIsNone(parse_action('{"action": {"nested": 1}, "action_input": "y"}'))
+
+    def test_empty_name_is_not_an_action(self):
+        self.assertIsNone(parse_action('{"action": "   ", "action_input": {}}'))
+
+    def test_missing_input_defaults_to_empty_dict(self):
+        # parameterless tools may omit the input entirely
+        action = parse_action('{"action": "get_time"}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_input, {})
+
+    def test_cohere_single_item_list(self):
+        action = parse_action('[{"action": "t", "action_input": {}}]')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "t")
+
+    def test_multi_item_list_is_not_an_action(self):
+        self.assertIsNone(parse_action('[{"a": 1}, {"b": 2}]'))
+
+    def test_invalid_json_is_not_an_action(self):
+        self.assertIsNone(parse_action("not json"))
+        self.assertIsNone(parse_action("42"))
+
+    def test_arbitrary_blob_without_input_key_is_not_an_action(self):
+        # a JSON blob quoted inside a thought must not become a tool call
+        self.assertIsNone(parse_action('{"foo": "bar"}'))
+
+    def test_legacy_unknown_keys_with_input(self):
+        action = parse_action('{"my_tool": "search", "my_input": {"q": 1}}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "search")
+        self.assertEqual(action.action_input, {"q": 1})
+
+    def test_name_is_stripped(self):
+        action = parse_action('{"action": " webSearch ", "action_input": {}}')
+        self.assertEqual(action.action_name, "webSearch")
+
+    def test_alias_keys(self):
+        action = parse_action('{"tool_name": "t2", "arguments": {"q": 1}}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "t2")
+        self.assertEqual(action.action_input, {"q": 1})
+
+    def test_tool_calls_list_wrapper(self):
+        action = parse_action('{"tool_calls": [{"action": "t3", "action_input": {}}]}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "t3")
+
+    def test_name_keys_are_case_insensitive(self):
+        action = parse_action('{"Action": "get_time"}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "get_time")
+        self.assertEqual(action.action_input, {})
+
+    def test_non_string_name_key_value_is_skipped(self):
+        # an OpenAI-style nested "function" dict must not shadow a real name key
+        action = parse_action('{"function": {"name": "x"}, "tool_name": "t", "input": {}}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "t")
+
+
+class TestReActStreamParsing(unittest.TestCase):
+    def test_action_prefix_yields_action(self):
+        results = _parse(
+            'Thought: let me search\nAction: {"action": "webSearch", "action_input": {"q": 1}}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0].action_name, "webSearch")
+
+    def test_tool_call_wrapper_yields_action(self):
+        # Issue #3699: previously the wrapper JSON was yielded as thought text
+        # and the round ended silently without invoking the tool.
+        raw = (
+            '{"tool_call": {"thought": "获取。", "action": "webSearch", '
+            '"action_input": {"input": "x"}}}'
+        )
+        results = _parse(raw)
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0].action_name, "webSearch")
+        failed = [r for r in results if isinstance(r, ReactChunk) and r.parse_failed]
+        self.assertEqual(failed, [])
+
+    def test_flat_action_json_without_prefix_still_works(self):
+        results = _parse('{"action": "webSearch", "action_input": {"q": 1}}')
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(len(actions), 1)
+
+    def test_action_input_free_text_flags_parse_failure(self):
+        # Issue #3699 (2nd scenario): "Action_input: {...}" written as free
+        # text inside the thought instead of a properly formatted action line.
+        results = _parse('Thought: I need to search\nAction_input: {"input": "x"}')
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(actions, [])
+        failed = [r for r in results if isinstance(r, ReactChunk) and r.parse_failed]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0].content, '{"input": "x"}')
+
+    def test_json_after_final_answer_is_not_an_action(self):
+        results = _parse('FinalAnswer: {"action": "webSearch", "action_input": {"q": 1}}')
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(actions, [])
+        chunks = [r for r in results if isinstance(r, ReactChunk)]
+        self.assertTrue(all(c.state == ReactState.ANSWER for c in chunks))
+        self.assertTrue(all(not c.parse_failed for c in chunks))
+
+    def test_thought_after_final_answer_cannot_trigger_action(self):
+        # the final answer is terminal: a later "Thought:" with an
+        # action-looking JSON blob must stay answer text, never a tool call
+        results = _parse(
+            'FinalAnswer: done\nThought: {"action": "webSearch", "action_input": {"q": 1}}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(actions, [])
+        chunks = [r for r in results if isinstance(r, ReactChunk)]
+        self.assertTrue(all(c.state == ReactState.ANSWER for c in chunks))
+        self.assertTrue(all(not c.parse_failed for c in chunks))
+
+    def test_truncated_json_at_stream_end_flags_parse_failure(self):
+        results = _parse('Action: {"action": "webSearch", "action_input": {"q": 1')
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(actions, [])
+        failed = [r for r in results if isinstance(r, ReactChunk) and r.parse_failed]
+        self.assertEqual(len(failed), 1)
+
+    def test_think_tags_are_stripped(self):
+        # The tags are built via chr() to keep this test file free of raw tag
+        # literals (see the constants in output_parser.cot_output_parser).
+        open_tag = chr(60) + "think" + chr(62)
+        close_tag = chr(60) + "/think" + chr(62)
+        results = _parse(
+            open_tag + "inner" + close_tag + 'Action: {"action": "t", "action_input": {}}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0].action_name, "t")
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        self.assertNotIn(open_tag, text)
+        self.assertNotIn(close_tag, text)
+
+    def test_parse_failed_defaults_to_false(self):
+        self.assertFalse(ReactChunk(ReactState.THINKING, "x").parse_failed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-strategies/cot_agent/tests/test_react.py
+++ b/agent-strategies/cot_agent/tests/test_react.py
@@ -6,8 +6,15 @@ from unittest.mock import Mock
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PLUGIN_ROOT))
 
+from dify_plugin.entities.agent import AgentInvokeMessage
+from dify_plugin.entities.model.llm import LLMResultChunk, LLMResultChunkDelta
+from dify_plugin.entities.model.message import AssistantPromptMessage
 from dify_plugin.entities.tool import ToolInvokeMessage
-from dify_plugin.interfaces.agent import AgentScratchpadUnit, ToolEntity
+from dify_plugin.interfaces.agent import (
+    AgentModelConfig,
+    AgentScratchpadUnit,
+    ToolEntity,
+)
 
 from strategies.ReAct import ReActAgentStrategy
 
@@ -62,6 +69,153 @@ class TestReActFileForwarding(unittest.TestCase):
 
         self.assertIn("result link: https://dify.ai", result)
         self.assertEqual(additional_messages, [])
+
+
+class TestReActSilentRoundTermination(unittest.TestCase):
+    """Regression tests for issue #3699: ReAct rounds must not end silently."""
+
+    @staticmethod
+    def _tool() -> ToolEntity:
+        return ToolEntity.model_validate(
+            {
+                "identity": {
+                    "author": "test",
+                    "name": "getfile",
+                    "label": {"en_US": "getfile"},
+                    "provider": "workflow-provider",
+                },
+                "provider_type": "workflow",
+                "runtime_parameters": {},
+                "parameters": [
+                    {
+                        "name": "q",
+                        "label": {"en_US": "q"},
+                        "human_description": {"en_US": "query"},
+                        "type": "string",
+                        "form": "llm",
+                        "required": True,
+                    }
+                ],
+            }
+        )
+
+    @staticmethod
+    def _model() -> AgentModelConfig:
+        return AgentModelConfig(
+            provider="test-provider",
+            model="test-model",
+            mode="chat",
+            completion_params={},
+            history_prompt_messages=[],
+        )
+
+    @staticmethod
+    def _llm_chunks(*contents: str) -> list[LLMResultChunk]:
+        return [
+            LLMResultChunk(
+                model="test-model",
+                delta=LLMResultChunkDelta(
+                    index=0,
+                    message=AssistantPromptMessage(content=content),
+                    usage=None,
+                ),
+            )
+            for content in contents
+        ]
+
+    def _strategy(
+        self, llm_rounds: list[list[LLMResultChunk]], tool_result: str = "file-content"
+    ) -> ReActAgentStrategy:
+        session = Mock()
+        session.model.llm.invoke.side_effect = [iter(round_chunks) for round_chunks in llm_rounds]
+        session.tool.invoke.return_value = iter(
+            [
+                ToolInvokeMessage(
+                    type=ToolInvokeMessage.MessageType.TEXT,
+                    message=ToolInvokeMessage.TextMessage(text=tool_result),
+                )
+            ]
+        )
+        return ReActAgentStrategy(runtime=Mock(), session=session)
+
+    def _run(self, strategy: ReActAgentStrategy, maximum_iterations: int = 1) -> list:
+        return list(
+            strategy._invoke(
+                {
+                    "query": "give me the file",
+                    "instruction": "you are a helpful agent",
+                    "model": self._model(),
+                    "tools": [self._tool()],
+                    "maximum_iterations": maximum_iterations,
+                }
+            )
+        )
+
+    @staticmethod
+    def _error_logs(messages: list) -> list:
+        return [
+            message
+            for message in messages
+            if message.type == AgentInvokeMessage.MessageType.LOG
+            and message.message.status == ToolInvokeMessage.LogMessage.LogStatus.ERROR
+        ]
+
+    @staticmethod
+    def _texts(messages: list) -> list[str]:
+        return [
+            message.message.text
+            for message in messages
+            if message.type == AgentInvokeMessage.MessageType.TEXT
+        ]
+
+    def test_tool_call_wrapper_invokes_tool(self):
+        # Issue #3699: a {"tool_call": {...}} wrapper used to end the round
+        # silently; it must now be parsed as a tool call.
+        raw = (
+            '{"tool_call": {"thought": "get.", "action": "getfile", '
+            '"action_input": {"q": "x"}}}'
+        )
+        strategy = self._strategy(
+            [self._llm_chunks(raw), self._llm_chunks("FinalAnswer: done")]
+        )
+        messages = self._run(strategy, maximum_iterations=2)
+
+        strategy.session.tool.invoke.assert_called_once()
+        kwargs = strategy.session.tool.invoke.call_args.kwargs
+        self.assertEqual(kwargs["tool_name"], "getfile")
+        self.assertEqual(kwargs["parameters"], {"q": "x"})
+        # the final answer is streamed chunk by chunk
+        self.assertEqual("".join(self._texts(messages)).strip(), "done")
+
+    def test_unparseable_output_surfaces_error_log(self):
+        # Issue #3699 (2nd scenario): "Action_input: {...}" written as free
+        # text must surface a visible error instead of ending the round
+        # silently; the thought is still used as the final answer.
+        raw = 'Thought: I need to search\nAction_input: {"input": "x"}'
+        strategy = self._strategy([self._llm_chunks(raw)])
+        messages = self._run(strategy)
+
+        strategy.session.tool.invoke.assert_not_called()
+        error_logs = self._error_logs(messages)
+        self.assertEqual(len(error_logs), 1)
+        self.assertEqual(error_logs[0].message.label, "Action parse failed")
+        self.assertIn(
+            "did not contain a valid Action", error_logs[0].message.data["error"]
+        )
+        self.assertEqual(
+            self._texts(messages)[-1], 'I need to search\nAction_input: {"input": "x"}'
+        )
+
+    def test_direct_answer_without_prefix_still_succeeds(self):
+        # A model that answers directly (no tool, no "FinalAnswer:" prefix)
+        # must keep working without an error log.
+        raw = "Thought: The capital of France is Paris."
+        strategy = self._strategy([self._llm_chunks(raw)])
+        messages = self._run(strategy)
+
+        strategy.session.tool.invoke.assert_not_called()
+        self.assertEqual(self._error_logs(messages), [])
+        self.assertEqual(self._texts(messages)[-1], "The capital of France is Paris.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #3699 — the ReAct strategy could end a round **silently** (no tool call, no FinalAnswer, workflow still `succeeded`) when the model emitted structured output the parser did not recognize:

- a payload wrapped in an outer key, e.g. `{"tool_call": {"action": "webSearch", "action_input": {...}}}`
- `Action_input: {...}` written as free text inside the `Thought` instead of a properly formatted `Action: {json}` line

The old heuristic treated that raw JSON as thought text; the ReAct loop then saw no `Action`, used the thought as the final answer and exited without any error.

Changes:

- `parse_action` is now explicit and unit-testable: it unwraps recognized single-key wrappers (`tool_call`, `tool_calling`, `tool_calls`, `function`), matches known name/input keys case-insensitively (with a conservative legacy fallback), requires a string tool name, defaults a missing input to `{}` (parameterless tools), and returns `None` on failure instead of the raw string.
- The stream handler only treats a JSON blob as an `Action` while in the `THINKING` state, and the `ANSWER` state is now terminal (a later `Thought:` cannot switch back), so JSON emitted after `FinalAnswer:` can never become a tool call. Unparseable blobs in the `THINKING` state are flagged via `ReactChunk.parse_failed`.
- `ReAct` logs a visible `ERROR` entry ("Action parse failed", with the model output truncated to 500 chars) when a round ends without a valid Action/FinalAnswer after a parse failure. The thought is still used as the final answer, so existing workflows keep working and the workflow still succeeds.

## Release Notes

- Fixed the ReAct agent strategy ending rounds silently (no tool call, no final answer, no error) when the model wrapped the action JSON in an outer key (e.g. `{"tool_call": {...}}`) or wrote `Action_input: {...}` as free text. Wrapped action JSON is now parsed correctly and the tool is invoked; when the model output still cannot be parsed, the agent log now surfaces a visible "Action parse failed" error instead of ending the round silently.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| `ROUND n` START logged, then nothing: no tool call, no FinalAnswer, workflow `succeeded` (silent) | `{"tool_call": {...}}` JSON is parsed and the tool is invoked; unparseable output produces a visible "Action parse failed" ERROR log entry under the round |

(Covered by the new unit / stream / strategy-level tests below — 61 tests pass.)

## LLM Plugin Checklist

Skipped — this is an agent strategy plugin, not an LLM provider plugin.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`): 0.0.45 → 0.0.46
- [x] `dify_plugin` SDK is declared in `pyproject.toml` and locked in `uv.lock` (untouched by this change)

## Testing

- [ ] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)
- [x] Clean venv matching `manifest.yaml` / `pyproject.toml` / `uv.lock` (Python 3.12, `uv sync`): full plugin suite `uv run pytest` → **61 passed**
  - 18 new parser tests (wrapper shapes, key aliases, case-insensitivity, parameterless tools, invalid/truncated JSON, ANSWER-state JSON, think-tag stripping)
  - 3 new strategy-level regression tests running the real `_invoke` generator: the reported wrapper JSON now invokes the tool; the free-text `Action_input:` scenario now yields the ERROR log with the thought as final answer; a plain direct answer is unaffected (no error log)

## Notes

Pre-existing parser weaknesses found during this fix, intentionally left out of scope — tracked in #3705:

- adjacent JSON roots (`{...}{...}` with no delimiter) can drop the first blob (`got_json` is processed after the next `{` is accepted)
- two-level OpenAI-style envelopes (`{"tool_call": {"function": {"name": ..., "arguments": ...}}}`) degrade gracefully to the parse-failure path but are not unwrapped
- `
think`/`
/think>` tags split across stream chunks are not stripped

