### PR TITLE
fix(cot_agent): ReAct parser edge cases from #3705 (adjacent JSON, function envelopes, split think tags)

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.46
+version: 0.0.47
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/output_parser/cot_output_parser.py
+++ b/agent-strategies/cot_agent/output_parser/cot_output_parser.py
@@ -84,7 +84,7 @@ def parse_action(json_str: str) -> "AgentScratchpadUnit.Action | None":
     # Unwrap recognized single-key wrappers, e.g. {"tool_call": {...}}.
     if len(payload) == 1:
         key, value = next(iter(payload.items()))
-        if key in WRAPPER_KEYS and isinstance(value, (dict, list)):
+        if key.lower() in WRAPPER_KEYS and isinstance(value, (dict, list)):
             if isinstance(value, list):
                 if len(value) != 1:
                     return None
@@ -92,7 +92,43 @@ def parse_action(json_str: str) -> "AgentScratchpadUnit.Action | None":
             if not isinstance(value, dict):
                 return None
             payload = value
+    # Unwrap OpenAI-style function envelopes, e.g.
+    # {"function": {"name": "tool", "arguments": {...}}} (optionally alongside
+    # a "type": "function" key). Explicit canonical name keys (action, tool,
+    # tool_name, name) take precedence over the envelope, and a "function"
+    # value that is not a dict with a string "name" leaves the payload
+    # untouched.
+    lowered = {key.lower(): value for key, value in payload.items()}
+    has_explicit_name = any(isinstance(lowered.get(key), str) for key in ACTION_NAME_KEYS)
+    if not has_explicit_name:
+        function = lowered.get("function")
+        if isinstance(function, dict) and isinstance(function.get("name"), str):
+            arguments = function.get("arguments")
+            if arguments is None:
+                arguments = function.get("input")
+            if arguments is None:
+                arguments = {}
+            payload = {"action": function["name"], "action_input": arguments}
     return _extract_action(payload)
+
+
+# Maximum number of trailing characters that could still be the start of a
+# (split) think tag at a chunk boundary: longest tag length minus one.
+_MAX_PARTIAL_TAG = max(len(THINK_START), len(THINK_END)) - 1
+
+
+def _partial_tag_suffix(text: str) -> int:
+    """Length of the longest suffix of text that is a prefix of a think tag.
+
+    Used to hold back a chunk tail that may complete into a think tag on the
+    next chunk, so tags split across stream chunks are still stripped.
+    """
+    limit = min(_MAX_PARTIAL_TAG, len(text))
+    for length in range(limit, 0, -1):
+        suffix = text[-length:]
+        if THINK_START.startswith(suffix) or THINK_END.startswith(suffix):
+            return length
+    return 0
 
 
 class ReactState(Enum):
@@ -131,6 +167,21 @@ class CotAgentOutputParser:
 
         cur_state = ReactState.THINKING
         last_character = ""
+
+        def emit_json_blob(blob: str):
+            """Yield a completed JSON blob as an Action or as (flagged) text."""
+            action = parse_action(blob)
+            if action is not None and cur_state is ReactState.THINKING:
+                yield action
+            elif action is None and cur_state is ReactState.THINKING:
+                # JSON that is not a valid action: keep it as thought text
+                # but flag the parse failure so the strategy can surface it
+                # instead of ending the round silently.
+                yield ReactChunk(cur_state, blob, parse_failed=True)
+            else:
+                # In the answer state a JSON blob is part of the final answer
+                # and can never become a tool call.
+                yield ReactChunk(cur_state, blob)
 
         class PrefixMatcher:
             __slots__ = ("prefix", "state_on_full_match", "cache", "idx")
@@ -200,41 +251,46 @@ class CotAgentOutputParser:
                 continue
             if not response_content:
                 continue
-            # When include_thoughts=True, Gemini injects <think>...</think>; strip across chunks so
-            # ReAct parser only sees Thought:/Action:/FinalAnswer: from the model reply.
-            # Nested <think> tags are supported via a depth counter.
-            if THINK_START in response_content or THINK_END in response_content or _in_think:
-                buf = _think_buf + response_content
-                _think_buf = ""
-                out = []
-                i = 0
-                while i < len(buf):
-                    if _in_think:
-                        end_j = buf.find(THINK_END, i)
-                        start_j = buf.find(THINK_START, i)
-                        if end_j == -1 and start_j == -1:
-                            _think_buf = buf[i:]
-                            break
-                        if start_j != -1 and (end_j == -1 or start_j < end_j):
-                            _think_depth += 1
-                            i = start_j + len(THINK_START)
-                        else:
-                            j = end_j
-                            _think_depth -= 1
-                            if _think_depth <= 0:
-                                _in_think = False
-                                _think_depth = 0
-                            i = j + len(THINK_END)
+            # When include_thoughts=True, Gemini injects think tags around
+            # model reasoning; strip them across chunks so the ReAct parser
+            # only sees Thought:/Action:/FinalAnswer: from the model reply.
+            # Nested tags are supported via a depth counter, and a chunk tail
+            # that could still be the start of a tag is held back in
+            # _think_buf until the next chunk, so tags split across chunks
+            # are stripped as well.
+            buf = _think_buf + response_content
+            _think_buf = ""
+            out = []
+            i = 0
+            while i < len(buf):
+                if _in_think:
+                    end_j = buf.find(THINK_END, i)
+                    start_j = buf.find(THINK_START, i)
+                    if end_j == -1 and start_j == -1:
+                        _think_buf = buf[i:]
+                        break
+                    if start_j != -1 and (end_j == -1 or start_j < end_j):
+                        _think_depth += 1
+                        i = start_j + len(THINK_START)
                     else:
-                        j = buf.find(THINK_START, i)
-                        if j == -1:
-                            out.append(buf[i:])
-                            break
-                        out.append(buf[i:j])
-                        _in_think = True
-                        _think_depth = 1
-                        i = j + len(THINK_START)
-                response_content = "".join(out)
+                        j = end_j
+                        _think_depth -= 1
+                        if _think_depth <= 0:
+                            _in_think = False
+                            _think_depth = 0
+                        i = j + len(THINK_END)
+                else:
+                    j = buf.find(THINK_START, i)
+                    if j == -1:
+                        hold = _partial_tag_suffix(buf[i:])
+                        out.append(buf[i : len(buf) - hold])
+                        _think_buf = buf[len(buf) - hold :]
+                        break
+                    out.append(buf[i:j])
+                    _in_think = True
+                    _think_depth = 1
+                    i = j + len(THINK_START)
+            response_content = "".join(out)
             if not response_content:
                 continue
 
@@ -244,6 +300,18 @@ class CotAgentOutputParser:
                 steps = 1
                 delta = response_content[index: index + steps]
                 yield_delta = False
+
+                # Flush a completed JSON blob before processing the next
+                # character, so that adjacent roots like {...}{...} cannot
+                # overwrite an unprocessed blob in json_cache.
+                if got_json:
+                    got_json = False
+                    yield from emit_json_blob(json_cache)
+                    json_cache = ""
+                    in_json = False
+                    json_in_string = False
+                    json_escape = False
+                    json_stack = []
 
                 if not in_json:
                     yield_raw_delta, emitted_chunk, delta_consumed, matched_action_prefix = action_matcher.step(delta)
@@ -323,27 +391,6 @@ class CotAgentOutputParser:
                                 index += steps
                                 continue
 
-                if got_json:
-                    got_json = False
-                    last_character = delta
-                    action = parse_action(json_cache)
-                    if action is not None and cur_state is ReactState.THINKING:
-                        yield action
-                    elif action is None and cur_state is ReactState.THINKING:
-                        # JSON that is not a valid action: keep it as thought
-                        # text but flag the parse failure so the strategy can
-                        # surface it instead of ending the round silently.
-                        yield ReactChunk(cur_state, json_cache, parse_failed=True)
-                    else:
-                        # In the answer state a JSON blob is part of the final
-                        # answer and can never become a tool call.
-                        yield ReactChunk(cur_state, json_cache)
-                    json_cache = ""
-                    in_json = False
-                    json_in_string = False
-                    json_escape = False
-                    json_stack = []
-
                 if not in_json:
                     last_character = delta
                     yield ReactChunk(cur_state, delta)
@@ -351,10 +398,11 @@ class CotAgentOutputParser:
                 index += steps
 
         if json_cache:
-            action = parse_action(json_cache)
-            if action is not None and cur_state is ReactState.THINKING:
-                yield action
-            elif action is None and cur_state is ReactState.THINKING:
-                yield ReactChunk(cur_state, json_cache, parse_failed=True)
-            else:
-                yield ReactChunk(cur_state, json_cache)
+            yield from emit_json_blob(json_cache)
+
+        # Flush the chunk tail held back as a possible partial think tag.
+        # (If the stream ended inside an unclosed think block, the buffered
+        # content is still dropped, as before.)
+        if _think_buf and not _in_think:
+            yield ReactChunk(cur_state, _think_buf)
+            _think_buf = ""

--- a/agent-strategies/cot_agent/tests/test_cot_output_parser.py
+++ b/agent-strategies/cot_agent/tests/test_cot_output_parser.py
@@ -120,11 +120,66 @@ class TestParseAction(unittest.TestCase):
         self.assertEqual(action.action_name, "get_time")
         self.assertEqual(action.action_input, {})
 
-    def test_non_string_name_key_value_is_skipped(self):
-        # an OpenAI-style nested "function" dict must not shadow a real name key
-        action = parse_action('{"function": {"name": "x"}, "tool_name": "t", "input": {}}')
+    def test_function_dict_without_name_is_not_unwrapped(self):
+        # a "function" dict without a string "name" is not an OpenAI-style
+        # envelope, so it must not shadow a real name key
+        action = parse_action('{"function": {"other": 1}, "tool_name": "t", "input": {}}')
         self.assertIsNotNone(action)
         self.assertEqual(action.action_name, "t")
+        self.assertIsNone(parse_action('{"function": {"other": 1}, "input": {}}'))
+
+    def test_openai_style_function_envelope(self):
+        # {"function": {"name": ..., "arguments": ...}} is unwrapped (issue #3705)
+        action = parse_action('{"function": {"name": "t", "arguments": {"q": 1}}}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "t")
+        self.assertEqual(action.action_input, {"q": 1})
+
+    def test_openai_style_function_envelope_wrapped(self):
+        action = parse_action(
+            '{"tool_call": {"function": {"name": "webSearch", "arguments": {"query": "x"}}}}'
+        )
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "webSearch")
+        self.assertEqual(action.action_input, {"query": "x"})
+
+    def test_openai_style_function_envelope_with_type_key(self):
+        # arguments may arrive as a JSON string (OpenAI format) and is kept as-is
+        action = parse_action('{"type": "function", "function": {"name": "t", "arguments": "{}"}}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_input, "{}")
+
+    def test_openai_style_function_envelope_without_arguments(self):
+        action = parse_action('{"function": {"name": "t"}}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_input, {})
+
+    def test_openai_style_function_envelope_null_arguments(self):
+        # null arguments (and null input) still yield an empty dict input
+        action = parse_action('{"function": {"name": "t", "arguments": null, "input": null}}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "t")
+        self.assertEqual(action.action_input, {})
+
+    def test_openai_style_function_envelope_empty_name(self):
+        # an empty envelope name is not a usable tool name
+        self.assertIsNone(parse_action('{"function": {"name": "", "arguments": {}}}'))
+
+    def test_explicit_name_key_takes_precedence_over_envelope(self):
+        # an explicit canonical name key wins over a nested function envelope
+        action = parse_action(
+            '{"action": "explicit", "action_input": {"a": 1}, '
+            '"function": {"name": "nested", "arguments": {}}}'
+        )
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "explicit")
+        self.assertEqual(action.action_input, {"a": 1})
+
+    def test_wrapper_keys_are_case_insensitive(self):
+        action = parse_action('{"Tool_call": {"action": "webSearch", "action_input": {"q": 1}}}')
+        self.assertIsNotNone(action)
+        self.assertEqual(action.action_name, "webSearch")
+        self.assertEqual(action.action_input, {"q": 1})
 
 
 class TestReActStreamParsing(unittest.TestCase):
@@ -192,6 +247,29 @@ class TestReActStreamParsing(unittest.TestCase):
         failed = [r for r in results if isinstance(r, ReactChunk) and r.parse_failed]
         self.assertEqual(len(failed), 1)
 
+    def test_adjacent_json_roots_in_same_chunk(self):
+        # issue #3705: the first blob used to be dropped when a second
+        # JSON root started immediately after the first closed
+        results = _parse('{"action": "first", "action_input": {}}{"action": "second", "action_input": {}}')
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual([a.action_name for a in actions], ["first", "second"])
+
+    def test_adjacent_json_roots_across_chunks(self):
+        results = _parse(
+            '{"action": "first", "action_input": {}}',
+            '{"action": "second", "action_input": {}}',
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual([a.action_name for a in actions], ["first", "second"])
+
+    def test_adjacent_non_action_blobs_are_both_flagged(self):
+        results = _parse('{"foo": 1}{"bar": 2}')
+        self.assertEqual(
+            [r for r in results if isinstance(r, AgentScratchpadUnit.Action)], []
+        )
+        failed = [r for r in results if isinstance(r, ReactChunk) and r.parse_failed]
+        self.assertEqual(len(failed), 2)
+
     def test_think_tags_are_stripped(self):
         # The tags are built via chr() to keep this test file free of raw tag
         # literals (see the constants in output_parser.cot_output_parser).
@@ -206,6 +284,40 @@ class TestReActStreamParsing(unittest.TestCase):
         text = "".join(r.content for r in results if isinstance(r, ReactChunk))
         self.assertNotIn(open_tag, text)
         self.assertNotIn(close_tag, text)
+
+    def test_think_tags_split_across_chunks(self):
+        # issue #3705: tags split across stream chunks used to leak as text
+        open_tag = chr(60) + "think" + chr(62)
+        close_tag = chr(60) + "/think" + chr(62)
+        results = _parse(
+            "pre" + open_tag[:4],
+            open_tag[4:] + "inner" + close_tag[:5],
+            close_tag[5:] + "post",
+        )
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        self.assertEqual(text, "prepost")
+
+    def test_closing_think_tag_split_across_chunks(self):
+        open_tag = chr(60) + "think" + chr(62)
+        close_tag = chr(60) + "/think" + chr(62)
+        results = _parse("a" + open_tag + "x" + close_tag[:4], close_tag[4:] + "b")
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        self.assertEqual(text, "ab")
+
+    def test_trailing_partial_tag_flushed_at_stream_end(self):
+        # a chunk tail that looks like the start of a tag but never completes
+        # must be flushed as content at stream end, not lost
+        close_tag = chr(60) + "/think" + chr(62)
+        results = _parse("hello" + close_tag[:6])
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        self.assertEqual(text, "hello" + close_tag[:6])
+
+    def test_unclosed_think_at_stream_end_drops_content(self):
+        # pre-existing policy: an unclosed think block is discarded
+        open_tag = chr(60) + "think" + chr(62)
+        results = _parse("keep" + open_tag[:1], open_tag[1:] + "secret")
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        self.assertNotIn("secret", text)
 
     def test_parse_failed_defaults_to_false(self):
         self.assertFalse(ReactChunk(ReactState.THINKING, "x").parse_failed)


### PR DESCRIPTION
## Summary

Fixes the three edge cases tracked in #3705 in the `cot_agent` ReAct output parser (`CotAgentOutputParser`):

1. **Adjacent JSON roots** — `{"action": "first", ...}{"action": "second", ...}` (no delimiter between roots) dropped the first blob: a completed blob was only processed at the *bottom* of the per-character loop, by which time the next `{` could already have overwritten `json_cache`. A completed blob is now flushed **before** the next character is accepted.
2. **OpenAI-style function envelopes** — `{"function": {"name": ..., "arguments": ...}}` (bare, wrapped in a single-key container such as `tool_call`, optionally alongside a `"type": "function"` key) is now normalized to a canonical action before extraction. Explicit canonical name keys (`action`, `tool`, `tool_name`, `name`) still take precedence over the envelope, and a `function` value that is not a dict with a string `name` leaves the payload untouched.
3. **Think tags split across stream chunks** — the think-tag stripper (for `include_thoughts` models) only matched complete tags inside a single chunk. A chunk tail that could still be the start of a tag is now held back until the next chunk (and flushed at stream end), so tags split across chunk boundaries are stripped as well.

> [!IMPORTANT]
> **This PR is stacked on #3703** (same file — both touch the ReAct output parser). Please review it as the incremental diff on top of #3703 and merge it after #3703. Once #3703 is merged I will rebase, and the diff against `main` will then show only these changes.

## Release Notes

- ReAct: fix silently dropped tool calls when the model emits two JSON action blocks with no delimiter between them
- ReAct: recognize OpenAI-style function envelopes (`{"function": {"name": ..., "arguments": ...}}`) as tool calls
- ReAct: strip model think tags even when they are split across stream chunks (prevents leaked tag fragments in thoughts/answers)

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

Not applicable — parser behavior only, covered by the unit tests below.

| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

Not applicable — this is an agent strategy plugin, not an LLM provider plugin.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.46 → 0.0.47
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [x] Local deployment — clean `uv` venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock`: **76 unit tests pass**, including 13 new regression tests covering each fixed case (adjacent roots in one chunk and across chunks, non-action adjacent blobs, envelope bare/wrapped/typed/no-arguments/null-arguments/empty-name, explicit-key precedence, case-insensitive wrapper keys, think tags split on the opening tag, the closing tag, and a trailing partial tag at stream end); `ruff check` clean (no new findings)
- [ ] SaaS (cloud.dify.ai)

Known limitation (unchanged by this PR, noted in #3705): the think-tag stripper is not JSON-string-aware, so a literal complete think tag inside a JSON string value is stripped, exactly as it already was before this change.
