### PR TITLE
fix(cot_agent): handle 3 ReAct stream parser edge cases (issue #3705)

### DIFF
--- a/agent-strategies/cot_agent/manifest.yaml
+++ b/agent-strategies/cot_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.45
+version: 0.0.46
 type: plugin
 author: "langgenius"
 name: "agent"

--- a/agent-strategies/cot_agent/output_parser/cot_output_parser.py
+++ b/agent-strategies/cot_agent/output_parser/cot_output_parser.py
@@ -43,6 +43,54 @@ class CotAgentOutputParser:
                 if isinstance(action, list) and len(action) == 1:
                     action = action[0]
 
+                # Unwrap OpenAI-style tool_call / tool_calls envelopes
+                # (e.g. {"tool_call": {"function": {"name": ..., "arguments": ...}}})
+                # so the for-loop below sees the inner function dict directly.
+                # Without this, "tool_call" becomes action_name and the inner
+                # function dict is rejected as not-a-string, so the action
+                # degrades to the parse-failure path. See issue #3705.
+                if isinstance(action, dict):
+                    if (
+                        "tool_call" in action
+                        and isinstance(action["tool_call"], dict)
+                    ):
+                        action = action["tool_call"]
+                    elif (
+                        "tool_calls" in action
+                        and isinstance(action["tool_calls"], list)
+                        and len(action["tool_calls"]) == 1
+                        and isinstance(action["tool_calls"][0], dict)
+                    ):
+                        action = action["tool_calls"][0]
+
+                    # Unwrap the OpenAI function envelope inside the
+                    # (now unwrapped) action dict. After the previous step,
+                    # `action` is the inner function-call dict; strip one
+                    # more `function` layer so the OpenAI-shape check below
+                    # sees {"name": ..., "arguments": ...} directly.
+                    if (
+                        isinstance(action, dict)
+                        and "function" in action
+                        and isinstance(action["function"], dict)
+                    ):
+                        action = action["function"]
+
+                # OpenAI function-call shape: {"name": "...", "arguments": ...}.
+                # The for-loop below would set action_name = "webSearch" (from
+                # "name") and then overwrite action_name with the arguments
+                # dict (from "arguments"), leaving action_input unset. Detect
+                # this shape explicitly before the generic loop runs.
+                if (
+                    isinstance(action, dict)
+                    and "name" in action
+                    and "arguments" in action
+                    and isinstance(action["name"], str)
+                ):
+                    return AgentScratchpadUnit.Action(
+                        action_name=action["name"],
+                        action_input=action["arguments"],
+                    )
+
                 for key, value in action.items():
                     if "input" in key.lower():
                         action_input = value
@@ -142,7 +190,24 @@ class CotAgentOutputParser:
             # When include_thoughts=True, Gemini injects <think>...</think>; strip across chunks so
             # ReAct parser only sees Thought:/Action:/FinalAnswer: from the model reply.
             # Nested <think> tags are supported via a depth counter.
-            if THINK_START in response_content or THINK_END in response_content or _in_think:
+            #
+            # Also enter the if-block when the chunk is a partial prefix of
+            # either tag (e.g. "<th" or "</thin") so the trailing partial
+            # prefix is buffered in _think_buf and reassembled with the
+            # next chunk. Without this, a tag split across chunks leaks
+            # the partial prefix as raw content. See issue #3705.
+            _chunk_with_buf = _think_buf + response_content
+            _is_partial_prefix = any(
+                _chunk_with_buf.endswith(THINK_START[:n])
+                or _chunk_with_buf.endswith(THINK_END[:n])
+                for n in range(1, max(len(THINK_START), len(THINK_END)))
+            )
+            if (
+                THINK_START in response_content
+                or THINK_END in response_content
+                or _in_think
+                or _is_partial_prefix
+            ):
                 buf = _think_buf + response_content
                 _think_buf = ""
                 out = []
@@ -167,7 +232,28 @@ class CotAgentOutputParser:
                     else:
                         j = buf.find(THINK_START, i)
                         if j == -1:
-                            out.append(buf[i:])
+                            # Buffer the trailing partial-prefix of <think>
+                            # (or </think>) so that a tag split across stream
+                            # chunks (e.g. chunk 1 = "<th", chunk 2 =
+                            # "ink>inner</think>") is reassembled instead of
+                            # leaked as raw text. Only buffer when the tail
+                            # is short enough to be a partial prefix AND
+                            # actually matches one; otherwise emit normally.
+                            # See issue #3705.
+                            tail = buf[i:]
+                            partial_max = max(len(THINK_START), len(THINK_END)) - 1
+                            is_partial_prefix = (
+                                len(tail) <= partial_max
+                                and any(
+                                    tail.endswith(THINK_START[:n])
+                                    or tail.endswith(THINK_END[:n])
+                                    for n in range(1, len(tail) + 1)
+                                )
+                            )
+                            if is_partial_prefix:
+                                _think_buf = tail
+                            else:
+                                out.append(tail)
                             break
                         out.append(buf[i:j])
                         _in_think = True
@@ -183,6 +269,28 @@ class CotAgentOutputParser:
                 steps = 1
                 delta = response_content[index: index + steps]
                 yield_delta = False
+
+                # Process a completed JSON blob before matching a new one. Without
+                # this, when the model emits two adjacent JSON roots with no
+                # delimiter (e.g. {}{}), the first blob is dropped because the
+                # 'start new JSON' branch below resets got_json=False and
+                # overwrites json_cache before the first blob is ever parsed.
+                # See issue #3705.
+                if not in_json and got_json:
+                    got_json = False
+                    last_character = delta
+                    parsed_result = parse_action(json_cache)
+                    if isinstance(parsed_result, AgentScratchpadUnit.Action):
+                        yield parsed_result
+                    else:
+                        yield ReactChunk(cur_state, json_cache)
+                    json_cache = ""
+                    json_in_string = False
+                    json_escape = False
+                    json_stack = []
+                    # Note: we intentionally do NOT `continue` here so the
+                    # current delta (which may be the next JSON root's `{`)
+                    # also flows through the loop and starts the next JSON.
 
                 if not in_json:
                     yield_raw_delta, emitted_chunk, delta_consumed, matched_action_prefix = action_matcher.step(delta)

--- a/agent-strategies/cot_agent/tests/test_cot_stream_edge_cases.py
+++ b/agent-strategies/cot_agent/tests/test_cot_stream_edge_cases.py
@@ -1,0 +1,271 @@
+"""Regression tests for three ReAct stream parser edge cases in
+``agent-strategies.cot_agent.output_parser.cot_output_parser``.
+
+These tests cover issues that were intentionally left out of PR #3703
+(fix for #3699) and filed as separate follow-ups in #3705:
+
+1. Adjacent JSON roots — when the model emits two JSON objects with no
+   delimiter (e.g. ``{}{}``), the first blob was silently dropped because
+   the 'start new JSON' branch overwrote the json_cache before the first
+   blob was parsed.
+
+2. Two-level OpenAI-style function envelopes — ``{"tool_call":
+   {"function": {"name": "...", "arguments": ...}}}`` and the list
+   variant were rejected because the outer ``tool_call`` key became the
+   action_name and the inner function dict was rejected as not-a-string.
+
+3. Split think tags — Gemini's ``<think>`` / ``</think>`` injection was
+   only stripped when the tag arrived complete in one chunk. If the tag
+   was split (e.g. chunk 1 = ``"\\nthi"``, chunk 2 = ``"nk>inner\\n/think>"``),
+   the partial prefix leaked as raw text and corrupted ReAct parsing.
+
+The test harness is independent of the one added in PR #3703 (which
+is not yet on main). Each test feeds a synthetic chunk sequence to
+``CotAgentOutputParser.handle_react_stream_output`` and asserts the
+resulting stream.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from output_parser.cot_output_parser import (  # noqa: E402
+    CotAgentOutputParser,
+    ReactChunk,
+)
+from dify_plugin.entities.model.llm import LLMResultChunk  # noqa: E402
+from dify_plugin.interfaces.agent import AgentScratchpadUnit  # noqa: E402
+
+
+def _make_chunk(content: Any) -> LLMResultChunk:
+    """Build a minimal ``LLMResultChunk`` carrying the given content."""
+    delta = MagicMock()
+    delta.message.content = content
+    delta.usage = None
+    chunk = MagicMock(spec=LLMResultChunk)
+    chunk.delta = delta
+    return chunk
+
+
+def _stream(*contents: Any) -> Generator[LLMResultChunk, None, None]:
+    for content in contents:
+        yield _make_chunk(content)
+
+
+def _collect(
+    *contents: Any,
+) -> list[Any]:
+    """Run the parser on a single combined stream and return all yielded items."""
+    parser = CotAgentOutputParser()
+    usage: dict = {}
+    return list(parser.handle_react_stream_output(_stream(*contents), usage))
+
+
+# ---------------------------------------------------------------------------
+# 1. Adjacent JSON roots
+# ---------------------------------------------------------------------------
+
+
+class TestAdjacentJsonRoots:
+    """The pre-fix parser dropped the first blob when the model emitted
+    two JSON roots with no delimiter (``{}{}``). After the fix, both
+    blobs must be processed in order.
+    """
+
+    def test_two_adjacent_actions_are_both_yielded(self) -> None:
+        results = _collect(
+            '{"action": "first", "action_input": {}}{"action": "second", "action_input": {}}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert len(actions) == 2, f"Expected 2 Action yields, got {len(actions)}: {results}"
+        assert actions[0].action_name == "first"
+        assert actions[1].action_name == "second"
+
+    def test_first_action_invocation_appears_before_second(self) -> None:
+        results = _collect(
+            '{"action": "alpha", "action_input": {}}{"action": "beta", "action_input": {}}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert [a.action_name for a in actions] == ["alpha", "beta"]
+
+    def test_three_adjacent_actions_all_yielded(self) -> None:
+        results = _collect(
+            '{"action": "a", "action_input": {}}'
+            '{"action": "b", "action_input": {}}'
+            '{"action": "c", "action_input": {}}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert [a.action_name for a in actions] == ["a", "b", "c"]
+
+    def test_adjacent_arrays_also_processed(self) -> None:
+        results = _collect(
+            '[{"action": "x", "action_input": {}}]' '[{"action": "y", "action_input": {}}]'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert [a.action_name for a in actions] == ["x", "y"]
+
+
+# ---------------------------------------------------------------------------
+# 2. OpenAI-style tool_call / tool_calls envelopes
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIToolCallEnvelope:
+    """The pre-fix parser rejected ``{"tool_call": {"function":
+    {"name": ..., "arguments": ...}}}`` because the outer ``tool_call``
+    key became action_name and the inner function dict was rejected as
+    not-a-string. After the fix, both single and list variants are
+    unwrapped and parsed correctly.
+    """
+
+    def test_single_tool_call_envelope(self) -> None:
+        results = _collect(
+            '{"tool_call": {"function": {"name": "webSearch", "arguments": {"query": "x"}}}}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert len(actions) == 1
+        assert actions[0].action_name == "webSearch"
+        assert actions[0].action_input == {"query": "x"}
+
+    def test_single_tool_calls_list_envelope(self) -> None:
+        results = _collect(
+            '{"tool_calls": [{"function": {"name": "lookup", "arguments": {"k": "v"}}}]}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert len(actions) == 1
+        assert actions[0].action_name == "lookup"
+        assert actions[0].action_input == {"k": "v"}
+
+    def test_envelope_with_action_and_action_input_keys_still_works(self) -> None:
+        """The original ReAct format (no envelope) must continue to work."""
+        results = _collect('{"action": "search", "action_input": {"q": "rust"}}')
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert len(actions) == 1
+        assert actions[0].action_name == "search"
+        assert actions[0].action_input == {"q": "rust"}
+
+    def test_envelope_does_not_trigger_when_tool_call_value_is_not_dict(self) -> None:
+        """If ``tool_call`` is present but its value is a string (unusual but
+        legal JSON), the parser should not crash. It degrades to the
+        parse-failure path (the blob is yielded as a ReactChunk).
+        """
+        results = _collect('{"tool_call": "not-a-dict"}')
+        # No Action yielded; the blob itself is emitted as a raw chunk.
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert actions == []
+        chunks = [r for r in results if isinstance(r, ReactChunk)]
+        assert any("tool_call" in c.content for c in chunks)
+
+
+# ---------------------------------------------------------------------------
+# 3. Split think tags across chunks
+# ---------------------------------------------------------------------------
+
+
+class TestSplitThinkTags:
+    """The pre-fix parser only stripped complete ``<think>`` /
+    ``</think>`` tags within a single chunk. If the tag was split across
+    chunks, the partial prefix leaked as raw text. After the fix, the
+    trailing partial-prefix of up to ``len(<think>) - 1`` chars is
+    buffered across chunks.
+
+    The pre-fix input from the issue body was malformed; the real
+    model-emitted shape is a normal ``<think>...</think>`` block that
+    the stream just happened to split mid-tag. The tests below use
+    correctly-shaped inputs.
+    """
+
+    def test_think_split_in_middle_of_open_tag(self) -> None:
+        # Model emits <think>inner</think> but the stream splits the open
+        # tag: chunk 1 = "<th", chunk 2 = "ink>inner</think>". Pre-fix,
+        # the partial "<th" was emitted as raw content. Post-fix, the
+        # trailing "<th" is buffered and reassembled with the next
+        # chunk so the think block is stripped cleanly.
+        results = _collect("<th", "ink>inner</think>")
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        assert "<think>" not in text
+        assert "</think>" not in text
+        assert "inner" not in text  # think content is stripped
+        # The leaked partial prefix "<th" must NOT be in the output.
+        assert "<th" not in text
+
+    def test_think_split_at_th_in_close_tag(self) -> None:
+        # Model emits <think>x</think> but the stream splits the close
+        # tag: chunk 1 = "<think>x</thin", chunk 2 = "k>". Pre-fix, the
+        # partial "</thin" was emitted as raw content. Post-fix, the
+        # trailing partial close tag is buffered and reassembled.
+        results = _collect("<think>x</think>"[0:9], "<think>x</think>"[9:])
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        assert "<think>" not in text
+        assert "</think>" not in text
+        assert "x" not in text  # think content is stripped
+
+    def test_complete_think_in_single_chunk_still_stripped(self) -> None:
+        """Regression: a complete tag in a single chunk must still be
+        stripped (the original behavior must not regress).
+        """
+        results = _collect("<think>reasoning</think>after")
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        assert "<think>" not in text
+        assert "reasoning" not in text
+        assert "after" in text
+
+    def test_think_split_across_three_chunks(self) -> None:
+        # chunk 1 = "<th", chunk 2 = "in", chunk 3 = "k>inner</think>"
+        # Each chunk is shorter than len(<think>) - 1, so all three must be
+        # buffered before the open tag can be recognized.
+        results = _collect("<th", "in", "k>inner</think>")
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        assert "<think>" not in text
+        assert "inner" not in text  # think content is stripped
+        # The leaked partial open tag must NOT be in the output.
+        assert "<th" not in text
+        assert "ink" not in text.split("<think>")[-1] if "<think>" in text else "ink" not in text
+
+
+# ---------------------------------------------------------------------------
+# 4. Sanity: existing behavior must not regress
+# ---------------------------------------------------------------------------
+
+
+class TestExistingBehaviorUnchanged:
+    """The three fixes are additive. These tests pin the original
+    behavior so a future refactor cannot silently break it.
+    """
+
+    def test_single_action_yields_one_action(self) -> None:
+        results = _collect('{"action": "search", "action_input": {"q": "rust"}}')
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert len(actions) == 1
+
+    def test_incomplete_json_does_not_yield_action(self) -> None:
+        """An incomplete JSON blob (no closing brace) at end of stream
+        should not produce a spurious Action.
+        """
+        results = _collect('{"action": "search", "action_input":')
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        # The trailing partial blob is yielded as a raw ReactChunk, not
+        # an Action. (Matches pre-fix behavior for incomplete JSON.)
+        assert actions == []
+
+    def test_complete_think_then_action(self) -> None:
+        """Standard ReAct sequence with a complete think block must
+        produce both the stripped thought content and the action.
+        """
+        results = _collect(
+            "<think>step 1</think>",
+            'Action: {"action": "search", "action_input": {"q": "x"}}',
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        assert len(actions) == 1
+        assert actions[0].action_name == "search"
+        # Think content must be stripped.
+        text = "".join(r.content for r in results if isinstance(r, ReactChunk))
+        assert "step 1" not in text


### PR DESCRIPTION
## Summary

Fixes three silent misparses in `CotAgentOutputParser.handle_react_stream_output` (issue #3705). All three were intentionally left out of PR #3703 (fix for #3699) as separate follow-ups.

3 files, +382/-3, manifest `0.0.45 → 0.0.46`.

## What's fixed

### 1. Adjacent JSON roots drop the first blob

When the model emits two JSON objects with no delimiter (`{}{}`), the first blob was silently discarded. The `start new JSON` branch reset `got_json=False` and overwrote `json_cache` before the first blob was parsed.

**Fix:** process a completed JSON blob (`got_json=True`) at the top of the next iteration, before the new-JSON branch can reset state.

### 2. Two-level OpenAI-style function envelopes not unwrapped

`{"tool_call": {"function": {"name": "webSearch", "arguments": ...}}}` was rejected because:
- `tool_call` became `action_name` (the value was a dict, not a string)
- The inner function dict was also not unwrapped, so the for-loop overwrote `action_name` with the arguments dict

Same for the list variant `{"tool_calls": [{"function": {...}}]}`.

**Fix:** unwrap both `tool_call` / `tool_calls` AND the inner `function` envelope, then detect the OpenAI function-call shape (`{"name", "arguments"}`) explicitly before the generic for-loop runs.

### 3. Split think tags across chunks

Gemini's `<think>` / `</think>` injection was only stripped when the tag arrived complete in a single chunk. If the tag was split (`<th` + `ink>inner</think>`), the partial prefix leaked as raw content and corrupted ReAct parsing.

**Fix:** extend the if-block condition to also enter when the chunk ends with a partial prefix of either tag. Buffer the trailing partial-prefix (up to `max(tag-length) - 1` chars) only when it actually matches a partial prefix; otherwise emit normally so non-think content (e.g. `after` in `<think>...</think>after`) is not held back by one chunk.

## Tests

`tests/test_cot_stream_edge_cases.py` (new, 15 tests):

| Test class | What it pins |
|---|---|
| `TestAdjacentJsonRoots` | 2 adjacent actions both yielded (4 tests) |
| `TestOpenAIToolCallEnvelope` | Single + list envelope unwrapped; original format still works; non-dict `tool_call` value degrades safely (4 tests) |
| `TestSplitThinkTags` | Open tag split across 2/3 chunks; close tag split; complete tag in single chunk still stripped (4 tests) |
| `TestExistingBehaviorUnchanged` | Single action, incomplete JSON, complete think-then-action (3 regression tests) |

## Verification

```bash
cd agent-strategies/cot_agent && uv run pytest tests/
# 47 passed (32 existing + 15 new), no regressions

cd agent-strategies/cot_agent && uv run pytest tests/test_cot_stream_edge_cases.py -v
# 15 passed in 0.24s

cd agent-strategies/cot_agent && uv run ruff check tests/test_cot_stream_edge_cases.py
# All checks passed!
```

## Why this matters

All three bugs are **silent misparses** — no exception is raised, the user just sees wrong behavior. The visible effects:

1. **Adjacent JSON roots dropped:** the first `Action` invocation in a multi-action round is silently lost. The model "called" the action but the agent never executed it.
2. **Function envelopes rejected:** the agent degrades to the parse-failure path with a "Action parse failed" log. The tool never gets called.
3. **Split think tags leaked:** raw think-tag text corrupts `Thought:` / `Action:` parsing — the same territory as the underlying #3699 bug.

These are the most common silent failures a ReAct agent can hit on streaming responses.

## Backward compatibility

No behavior change for any other path. The three fixes are additive:

- **Bug 1** is a no-op when the model emits properly-delimited JSON (the standard case).
- **Bug 2** is a no-op when the model emits the standard ReAct format (no envelope). The OpenAI-format detection only runs when the unwrapped dict has both `name` (string) and `arguments` keys.
- **Bug 3** is a no-op when the chunk does not end with a partial tag prefix. The buffering only triggers when the trailing chars actually match a partial prefix of `<think>` or `</think>`.

## Risks

Negligible. Each fix is a small, targeted change with both positive and regression tests.

## Future work

- The `cot_agent/tests/test_function_calling.py` and `tests/test_react.py` test files predate this PR; their setup is the same `sys.path.insert(0, str(PLUGIN_ROOT))` pattern as this PR's new file.
- The fix in #3705 sub-problem (3) for "split think tags" interacts with the depth counter (`_think_depth`) used for nested think blocks. A future edge case to test: a think-open tag that arrives across 4+ chunks (the buffer is `max(tag-length) - 1 = 7` chars, so a chunk shorter than 7 chars that ends with a partial prefix is held correctly).

Fixes #3705.
