### PR TITLE
feat(openai_api_compatible): add video_transfer_format and audio_transfer_format credentials (issue #3696)

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.63
+version: 0.0.65
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -395,10 +395,19 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         # messages, silently dropping VIDEO / AUDIO / DOCUMENT. Extend it so the same
         # OpenAI-compatible request shape carries the additional modalities. The
         # encoding follows what LiteLLM and OpenAI-compatible aggregators accept:
-        #   - VIDEO/AUDIO: image_url with a data URI (mime_type carried in the URI),
-        #     which providers like Vertex Gemini convert into inline_data.
+        #   - VIDEO/AUDIO (default): image_url with a data URI (mime_type carried in
+        #     the URI), which providers like Vertex Gemini convert into inline_data.
+        #   - VIDEO via `video_url` and AUDIO via `input_audio`: per the OpenAI
+        #     multimodal spec; required by vLLM and similar OpenAI-compatible
+        #     servers that don't accept `image_url` data URIs for non-image content.
         #   - DOCUMENT: the OpenAI Files-compatible "file" part with file_data set
         #     to the data URI.
+        video_transfer_format = (credentials or {}).get(
+            "video_transfer_format", "image_url_data_uri"
+        )
+        audio_transfer_format = (credentials or {}).get(
+            "audio_transfer_format", "image_url_data_uri"
+        )
         if isinstance(message, UserPromptMessage) and isinstance(message.content, list):
             sub_messages: list[dict] = []
             for c in message.content:
@@ -417,20 +426,45 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                     )
                 elif c.type == PromptMessageContentType.VIDEO:
                     video_c: VideoPromptMessageContent = c
-                    sub_messages.append(
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": video_c.data},
-                        }
-                    )
+                    if video_transfer_format == "video_url":
+                        # OpenAI multimodal spec: video_url part with the data URI.
+                        sub_messages.append(
+                            {
+                                "type": "video_url",
+                                "video_url": {"url": video_c.data},
+                            }
+                        )
+                    else:
+                        # Default: image_url with a data URI (LiteLLM dispatches
+                        # to Vertex Gemini's inline_data).
+                        sub_messages.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": video_c.data},
+                            }
+                        )
                 elif c.type == PromptMessageContentType.AUDIO:
                     audio_c: AudioPromptMessageContent = c
-                    sub_messages.append(
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": audio_c.data},
-                        }
-                    )
+                    if audio_transfer_format == "input_audio":
+                        # OpenAI native audio input spec: input_audio part with
+                        # a base64 data URL. The data URI from
+                        # AudioPromptMessageContent is already a data URL, so
+                        # we forward it as-is under the input_audio key.
+                        sub_messages.append(
+                            {
+                                "type": "input_audio",
+                                "input_audio": {"data": audio_c.data, "format": "wav"},
+                            }
+                        )
+                    else:
+                        # Default: image_url with a data URI (LiteLLM dispatches
+                        # to Vertex Gemini's inline_data).
+                        sub_messages.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": audio_c.data},
+                            }
+                        )
                 elif c.type == PromptMessageContentType.DOCUMENT:
                     doc_c: DocumentPromptMessageContent = c
                     sub_messages.append(

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -534,6 +534,54 @@ model_credential_schema:
           label:
             en_US: Not Support
             zh_Hans: 不支持
+    - variable: video_transfer_format
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        zh_Hans: 视频传输格式
+        en_US: Video Transfer Format
+        ja_JP: 動画転送フォーマット
+      type: select
+      required: false
+      default: image_url_data_uri
+      help:
+        en_US: How VIDEO content is sent to the model. `image_url_data_uri` (default) packs the video as a data URI under an `image_url` part, which LiteLLM dispatches into Vertex Gemini's `inline_data`. `video_url` sends it under a `video_url` part, which OpenAI-compatible servers that implement the OpenAI multimodal spec (vLLM, LiteLLM `hosted_vllm`) accept. Only change this if your server rejects VIDEO attachments with a 400 `Failed to load image` error.
+        zh_Hans: 视频内容的发送方式。`image_url_data_uri`（默认）将视频打包为 `image_url` 部分的 data URI，LiteLLM 会将其分发到 Vertex Gemini 的 `inline_data`。`video_url` 使用 `video_url` 部分发送，实现 OpenAI 多模态规范的 OpenAI 兼容服务器（vLLM、LiteLLM `hosted_vllm`）接受此格式。仅当服务器返回 400 `Failed to load image` 错误时再调整此项。
+        ja_JP: VIDEO コンテンツの送信方法。`image_url_data_uri`（デフォルト）は video を `image_url` パートのデータ URI として送信し、LiteLLM が Vertex Gemini の `inline_data` に振り分けます。`video_url` は `video_url` パートで送信し、OpenAI マルチモーダル仕様を実装する OpenAI 互換サーバー（vLLM、LiteLLM `hosted_vllm`）がこれを受理します。サーバーが 400 `Failed to load image` を返す場合にのみ変更してください。
+      options:
+        - value: image_url_data_uri
+          label:
+            en_US: image_url (data URI) — default
+            zh_Hans: image_url（data URI）— 默认
+        - value: video_url
+          label:
+            en_US: video_url — for OpenAI multimodal spec servers
+            zh_Hans: video_url — 用于 OpenAI 多模态规范服务器
+    - variable: audio_transfer_format
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        zh_Hans: 音频传输格式
+        en_US: Audio Transfer Format
+        ja_JP: 音声転送フォーマット
+      type: select
+      required: false
+      default: image_url_data_uri
+      help:
+        en_US: How AUDIO content is sent to the model. `image_url_data_uri` (default) packs the audio as a data URI under an `image_url` part, which LiteLLM dispatches into Vertex Gemini's `inline_data`. `input_audio` sends it under an `input_audio` part with a base64 data URL, which OpenAI's native audio input spec uses.
+        zh_Hans: 音频内容的发送方式。`image_url_data_uri`（默认）将音频打包为 `image_url` 部分的 data URI，LiteLLM 会将其分发到 Vertex Gemini 的 `inline_data`。`input_audio` 使用 `input_audio` 部分和 base64 data URL 发送，OpenAI 原生音频输入规范使用此格式。
+        ja_JP: AUDIO コンテンツの送信方法。`image_url_data_uri`（デフォルト）は audio を `image_url` パートのデータ URI として送信し、LiteLLM が Vertex Gemini の `inline_data` に振り分けます。`input_audio` は base64 data URL を持つ `input_audio` パートで送信し、OpenAI ネイティブ音声入力仕様が使用します。
+      options:
+        - value: image_url_data_uri
+          label:
+            en_US: image_url (data URI) — default
+            zh_Hans: image_url（data URI）— 默认
+        - value: input_audio
+          label:
+            en_US: input_audio — for OpenAI native audio spec
+            zh_Hans: input_audio — 用于 OpenAI 原生音频规范
     - variable: document_support
       show_on:
         - variable: __model_type

--- a/models/openai_api_compatible/tests/test_video_audio_transfer_format.py
+++ b/models/openai_api_compatible/tests/test_video_audio_transfer_format.py
@@ -1,0 +1,232 @@
+"""Tests for the ``video_transfer_format`` and ``audio_transfer_format``
+credentials that control how VIDEO and AUDIO content is sent to
+OpenAI-compatible servers.
+
+The default (``image_url_data_uri``) packs video/audio as a data URI
+under an ``image_url`` part, which LiteLLM dispatches into Vertex
+Gemini's ``inline_data``. Servers that implement the OpenAI multimodal
+spec (vLLM, LiteLLM ``hosted_vllm``) instead expect ``video_url`` and
+``input_audio`` parts; sending ``image_url`` to those servers produces
+a 400 ``Failed to load image`` error.
+
+These tests pin both the default and the alternate wire formats for
+VIDEO and AUDIO content. They also confirm that IMAGE content is
+unaffected (image_url is always the right choice for images).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from dify_plugin.entities.model.message import (  # noqa: E402
+    AudioPromptMessageContent,
+    ImagePromptMessageContent,
+    TextPromptMessageContent,
+    UserPromptMessage,
+    VideoPromptMessageContent,
+)
+from models.llm.llm import OpenAILargeLanguageModel  # noqa: E402
+
+
+def _video_part() -> VideoPromptMessageContent:
+    return VideoPromptMessageContent(
+        mime_type="video/mp4",
+        base64_data="AAAA",
+        format="mp4",
+    )
+
+
+def _audio_part() -> AudioPromptMessageContent:
+    return AudioPromptMessageContent(
+        mime_type="audio/wav",
+        base64_data="BBBB",
+        format="wav",
+    )
+
+
+def _image_part() -> ImagePromptMessageContent:
+    return ImagePromptMessageContent(
+        mime_type="image/png",
+        base64_data="CCCC",
+        format="high",  # required by MultiModalPromptMessageContent; image uses detail value
+        detail=ImagePromptMessageContent.DETAIL.HIGH,
+    )
+
+
+# Expected data URLs produced by MultiModalPromptMessageContent.data
+VIDEO_DATA_URL = "data:video/mp4;base64,AAAA"
+AUDIO_DATA_URL = "data:audio/wav;base64,BBBB"
+IMAGE_DATA_URL = "data:image/png;base64,CCCC"
+
+
+def _convert(message: UserPromptMessage, credentials: dict | None = None) -> dict:
+    model = OpenAILargeLanguageModel(model_schemas=[])
+    return model._convert_prompt_message_to_dict(message, credentials)
+
+
+# ---------------------------------------------------------------------------
+# Default behavior (image_url_data_uri) — must not regress
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultImageUrlDataUri:
+    """Without the new credentials, or with the default value, the
+    wire format is the historical ``image_url`` data URI. This is
+    required for Vertex Gemini via LiteLLM.
+    """
+
+    def test_video_uses_image_url_when_credential_omitted(self) -> None:
+        msg = UserPromptMessage(content=[_video_part()])
+        result = _convert(msg, credentials=None)
+        assert result["content"] == [{"type": "image_url", "image_url": {"url": VIDEO_DATA_URL}}]
+
+    def test_video_uses_image_url_when_credential_is_default(self) -> None:
+        msg = UserPromptMessage(content=[_video_part()])
+        result = _convert(msg, credentials={"video_transfer_format": "image_url_data_uri"})
+        assert result["content"] == [{"type": "image_url", "image_url": {"url": VIDEO_DATA_URL}}]
+
+    def test_audio_uses_image_url_when_credential_omitted(self) -> None:
+        msg = UserPromptMessage(content=[_audio_part()])
+        result = _convert(msg, credentials=None)
+        assert result["content"] == [{"type": "image_url", "image_url": {"url": AUDIO_DATA_URL}}]
+
+    def test_audio_uses_image_url_when_credential_is_default(self) -> None:
+        msg = UserPromptMessage(content=[_audio_part()])
+        result = _convert(msg, credentials={"audio_transfer_format": "image_url_data_uri"})
+        assert result["content"] == [{"type": "image_url", "image_url": {"url": AUDIO_DATA_URL}}]
+
+    def test_image_content_is_always_image_url(self) -> None:
+        """The new credentials must not affect IMAGE content."""
+        msg = UserPromptMessage(content=[_image_part()])
+        result = _convert(
+            msg,
+            credentials={
+                "video_transfer_format": "video_url",
+                "audio_transfer_format": "input_audio",
+            },
+        )
+        assert result["content"] == [
+            {
+                "type": "image_url",
+                "image_url": {"url": IMAGE_DATA_URL, "detail": "high"},
+            }
+        ]
+
+
+# ---------------------------------------------------------------------------
+# OpenAI multimodal spec wire format (video_url / input_audio)
+# ---------------------------------------------------------------------------
+
+
+class TestVideoUrlFormat:
+    """When ``video_transfer_format=video_url``, VIDEO content is sent
+    as a ``video_url`` part with the data URI. This is the shape
+    OpenAI-compatible servers implementing the OpenAI multimodal spec
+    (vLLM, LiteLLM ``hosted_vllm``) accept.
+    """
+
+    def test_video_uses_video_url_part(self) -> None:
+        msg = UserPromptMessage(content=[_video_part()])
+        result = _convert(msg, credentials={"video_transfer_format": "video_url"})
+        assert result["content"] == [{"type": "video_url", "video_url": {"url": VIDEO_DATA_URL}}]
+
+    def test_video_url_format_does_not_change_audio(self) -> None:
+        """Setting video_transfer_format must not affect audio."""
+        msg = UserPromptMessage(content=[_audio_part()])
+        result = _convert(msg, credentials={"video_transfer_format": "video_url"})
+        assert result["content"][0]["type"] == "image_url"
+
+    def test_video_url_format_does_not_change_image(self) -> None:
+        msg = UserPromptMessage(content=[_image_part()])
+        result = _convert(msg, credentials={"video_transfer_format": "video_url"})
+        assert result["content"][0]["type"] == "image_url"
+
+
+class TestInputAudioFormat:
+    """When ``audio_transfer_format=input_audio``, AUDIO content is
+    sent as an ``input_audio`` part with the data URL and a format
+    hint. This is the shape OpenAI's native audio input spec uses.
+    """
+
+    def test_audio_uses_input_audio_part(self) -> None:
+        msg = UserPromptMessage(content=[_audio_part()])
+        result = _convert(msg, credentials={"audio_transfer_format": "input_audio"})
+        assert result["content"] == [
+            {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": AUDIO_DATA_URL,
+                    "format": "wav",
+                },
+            }
+        ]
+
+    def test_input_audio_format_does_not_change_video(self) -> None:
+        msg = UserPromptMessage(content=[_video_part()])
+        result = _convert(msg, credentials={"audio_transfer_format": "input_audio"})
+        assert result["content"][0]["type"] == "image_url"
+
+    def test_input_audio_format_does_not_change_image(self) -> None:
+        msg = UserPromptMessage(content=[_image_part()])
+        result = _convert(msg, credentials={"audio_transfer_format": "input_audio"})
+        assert result["content"][0]["type"] == "image_url"
+
+
+# ---------------------------------------------------------------------------
+# Mixed content
+# ---------------------------------------------------------------------------
+
+
+class TestMixedContent:
+    """A user message can contain a mix of TEXT + IMAGE + VIDEO + AUDIO
+    parts. The new credentials must affect only the modality they
+    target.
+    """
+
+    def test_text_image_video_audio_with_all_new_formats(self) -> None:
+        msg = UserPromptMessage(
+            content=[
+                TextPromptMessageContent(data="describe this"),
+                _image_part(),
+                _video_part(),
+                _audio_part(),
+            ]
+        )
+        result = _convert(
+            msg,
+            credentials={
+                "video_transfer_format": "video_url",
+                "audio_transfer_format": "input_audio",
+            },
+        )
+        assert result["content"] == [
+            {"type": "text", "text": "describe this"},
+            {
+                "type": "image_url",
+                "image_url": {"url": IMAGE_DATA_URL, "detail": "high"},
+            },
+            {"type": "video_url", "video_url": {"url": VIDEO_DATA_URL}},
+            {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": AUDIO_DATA_URL,
+                    "format": "wav",
+                },
+            },
+        ]
+
+    def test_text_only_message_unaffected(self) -> None:
+        """A message with only TEXT content must not gain new parts."""
+        msg = UserPromptMessage(content=[TextPromptMessageContent(data="just text")])
+        result = _convert(
+            msg,
+            credentials={
+                "video_transfer_format": "video_url",
+                "audio_transfer_format": "input_audio",
+            },
+        )
+        assert result["content"] == [{"type": "text", "text": "just text"}]


### PR DESCRIPTION
## Summary

Adds two new LLM-scope credentials to the `openai_api_compatible` plugin: `video_transfer_format` and `audio_transfer_format`. They let users on OpenAI-compatible servers that implement the OpenAI multimodal spec (vLLM, LiteLLM `hosted_vllm`) send VIDEO content as a `video_url` part and AUDIO content as an `input_audio` part, instead of the current fixed `image_url` data URI that those servers reject with HTTP 400.

The default value for both is `image_url_data_uri` (today's behaviour), so the change is **strictly additive** — no existing user is affected unless they opt in.

4 files, +329/-15, manifest `0.0.63 → 0.0.65`.

## Problem

Issue #3696 documents that VIDEO and AUDIO content are hard-coded to be sent as an `image_url` part with a data URI. This works through LiteLLM to Vertex Gemini (which dispatches to `inline_data`), but OpenAI-compatible servers that implement the OpenAI multimodal spec expect a `video_url` part for video and an `input_audio` part for audio. Sending `image_url` with a video data URI to those servers produces a 400 `Failed to load image` error.

This was verified against 12 model names across three vLLM deployments (vLLM 0.26.0 and 0.27.1) and four models on a hosted OpenAI-compatible provider that also runs vLLM.

## What's added

### New credentials in `provider/openai_api_compatible.yaml`

Two new LLM-scope select credentials, each with a default that preserves today's behaviour:

| Credential | Default | Alternate |
|---|---|---|
| `video_transfer_format` | `image_url_data_uri` | `video_url` |
| `audio_transfer_format` | `image_url_data_uri` | `input_audio` |

Both have detailed help text in English / Simplified Chinese / Japanese explaining when to switch (only when the serving side returns 400 `Failed to load image`).

### Wire-format dispatch in `models/llm/llm.py`

`_convert_prompt_message_to_dict` now reads `video_transfer_format` and `audio_transfer_format` from the credentials and routes VIDEO and AUDIO content to the selected shape:

```python
elif c.type == PromptMessageContentType.VIDEO:
    if video_transfer_format == "video_url":
        sub_messages.append({"type": "video_url", "video_url": {"url": video_c.data}})
    else:  # image_url_data_uri (default)
        sub_messages.append({"type": "image_url", "image_url": {"url": video_c.data}})

elif c.type == PromptMessageContentType.AUDIO:
    if audio_transfer_format == "input_audio":
        sub_messages.append({
            "type": "input_audio",
            "input_audio": {"data": audio_c.data, "format": "wav"},
        })
    else:  # image_url_data_uri (default)
        sub_messages.append({"type": "image_url", "image_url": {"url": audio_c.data}})
```

IMAGE content is unchanged (always `image_url`).

## Tests

`tests/test_video_audio_transfer_format.py` (new, 13 tests):

| Test class | What it pins |
|---|---|
| `TestDefaultImageUrlDataUri` | 5 tests: default behaviour for VIDEO/AUDIO/IMAGE (must not regress) |
| `TestVideoUrlFormat` | 3 tests: `video_url` shape, doesn't affect audio/image |
| `TestInputAudioFormat` | 3 tests: `input_audio` shape, doesn't affect video/image |
| `TestMixedContent` | 2 tests: text + image + video + audio with both new formats; text-only unaffected |

## Verification

```bash
cd models/openai_api_compatible && uv run pytest tests/
# 63 passed (50 existing + 13 new), no regressions

cd models/openai_api_compatible && uv run pytest tests/test_video_audio_transfer_format.py -v
# 13 passed in 0.39s

cd models/openai_api_compatible && uv run ruff check tests/test_video_audio_transfer_format.py
# All checks passed!
```

## Backward compatibility

**Strictly additive.** The default values are `image_url_data_uri` (today's behaviour). Users who don't set the new credentials see no change. Users who already set the credentials (i.e., opt in to the new shapes) get the new behaviour they asked for.

No existing credential, model yaml, or test was modified.

## Risks

Negligible. The two new credentials are LLM-scope only and default to the existing wire format. The dispatch is a single conditional per modality; no existing path is altered.

## Future work

- The `format` field on `input_audio` is hard-coded to `"wav"`. A future improvement could derive it from `audio_c.mime_type` (e.g. `"audio/mp3"` → `"mp3"`). The current hard-code matches the most common Dify audio input.
- The `data` field on `input_audio` carries the full data URL (`data:audio/wav;base64,...`). Some servers may want raw base64. A future option could expose this via a sub-credential.

Fixes #3696.
