### PR TITLE
fix(anthropic): round-trip thinking blocks through opaque_body (issue #3658)

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.27
+version: 0.3.28

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -1017,6 +1017,18 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             message=assistant_prompt_message,
             usage=usage,
         )
+
+        # Round-trip the thinking blocks through the persisted message so
+        # the follow-up request (built in a fresh model instance) can
+        # echo them back to Anthropic. See issue #3658. Without this,
+        # the next request is built with self.previous_thinking_blocks
+        # already reset to [] in the new instance, so tool-result turns
+        # drop the thinking blocks and Anthropic rejects with 400.
+        if self.previous_thinking_blocks or self.previous_redacted_thinking_blocks:
+            assistant_prompt_message.opaque_body = {
+                "anthropic_thinking_blocks": self.previous_thinking_blocks,
+                "anthropic_redacted_thinking_blocks": self.previous_redacted_thinking_blocks,
+            }
         return result
 
 
@@ -1247,14 +1259,25 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 for tool_call in tool_calls:
                     if not tool_call.function.arguments:
                         tool_call.function.arguments = "{}"
+
+                # Build the final assistant message with the thinking
+                # blocks stored in opaque_body. The follow-up request
+                # (built in a fresh model instance) reads them back via
+                # _process_assistant_message. See issue #3658.
+                final_message = AssistantPromptMessage(
+                    content="", tool_calls=tool_calls
+                )
+                if current_thinking_blocks or current_redacted_thinking_blocks:
+                    final_message.opaque_body = {
+                        "anthropic_thinking_blocks": current_thinking_blocks,
+                        "anthropic_redacted_thinking_blocks": current_redacted_thinking_blocks,
+                    }
                 yield LLMResultChunk(
                     model=return_model,
                     prompt_messages=prompt_messages,
                     delta=LLMResultChunkDelta(
                         index=index + 1,
-                        message=AssistantPromptMessage(
-                            content="", tool_calls=tool_calls
-                        ),
+                        message=final_message,
                         finish_reason=finish_reason,
                         usage=usage,
                     ),
@@ -1484,21 +1507,40 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         return result
     
     def _process_assistant_message(
-        self, 
+        self,
         message: AssistantPromptMessage,
         all_messages: Sequence[PromptMessage]
     ) -> dict:
         """Process assistant message into API format."""
         content = []
-        
+
         # Check if we need to include thinking blocks
         has_tool_messages = any(
             isinstance(msg, ToolPromptMessage) for msg in all_messages
         )
-        
+
         if has_tool_messages:
-            content.extend(self.previous_thinking_blocks)
-            content.extend(self.previous_redacted_thinking_blocks)
+            # Prefer the thinking blocks round-tripped through the
+            # assistant message's opaque_body (set by the previous
+            # invocation's response handler). This survives across
+            # dify_plugin's per-RPC model-instance reset, unlike
+            # self.previous_thinking_blocks. Fall back to the
+            # in-memory instance state for the rare case where the
+            # caller hands us an AssistantPromptMessage without
+            # opaque_body (e.g. tests). See issue #3658.
+            thinking_blocks: list = []
+            redacted_thinking_blocks: list = []
+            opaque_body = message.opaque_body
+            if isinstance(opaque_body, dict):
+                thinking_blocks = list(opaque_body.get("anthropic_thinking_blocks") or [])
+                redacted_thinking_blocks = list(
+                    opaque_body.get("anthropic_redacted_thinking_blocks") or []
+                )
+            if not thinking_blocks and not redacted_thinking_blocks:
+                thinking_blocks = self.previous_thinking_blocks
+                redacted_thinking_blocks = self.previous_redacted_thinking_blocks
+            content.extend(thinking_blocks)
+            content.extend(redacted_thinking_blocks)
         
         # Dify stores assistant text and tool calls separately; Anthropic expects the next
         # user tool_result message to immediately follow the assistant tool_use turn.

--- a/models/anthropic/tests/test_thinking_blocks_opaque_body.py
+++ b/models/anthropic/tests/test_thinking_blocks_opaque_body.py
@@ -1,0 +1,279 @@
+"""Regression tests for issue #3658: Anthropic thinking blocks are not
+preserved across plugin invocation boundaries on tool-result turns.
+
+The pre-fix code stored thinking blocks on the model instance
+(`self.previous_thinking_blocks`). Because dify_plugin creates a fresh
+model instance per RPC, that state was always empty by the time the
+follow-up request was constructed. The fix round-trips the thinking
+blocks through `AssistantPromptMessage.opaque_body`, which IS
+preserved across invocations because it's part of the persisted
+message.
+
+These tests pin:
+1. The non-streaming handler stores thinking blocks in `opaque_body`.
+2. The streaming handler stores thinking blocks in `opaque_body` on
+   the final chunk.
+3. `_process_assistant_message` reads from `opaque_body` first, and
+   falls back to instance state when `opaque_body` is empty.
+4. IMAGE content is unchanged (always `image_url`).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from dify_plugin.entities.model.message import (  # noqa: E402
+    AssistantPromptMessage,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+from models.llm.llm import AnthropicLargeLanguageModel  # noqa: E402
+
+
+# Stub thinking / redacted-thinking content blocks (the shape that the
+# Anthropic SDK returns).
+def _thinking_block(signature: str = "sig-abc") -> dict:
+    return {"type": "thinking", "thinking": "let me think...", "signature": signature}
+
+
+def _redacted_block(data: str = "enc-data-xyz") -> dict:
+    return {"type": "redacted_thinking", "data": data}
+
+
+def _make_instance() -> AnthropicLargeLanguageModel:
+    return object.__new__(AnthropicLargeLanguageModel)
+
+
+def _process(message: AssistantPromptMessage, all_messages: list) -> dict:
+    instance = _make_instance()
+    # Seed the instance-state fallback with empty lists (the realistic
+    # state on a fresh RPC instance).
+    instance.previous_thinking_blocks = []
+    instance.previous_redacted_thinking_blocks = []
+    return instance._process_assistant_message(message, all_messages)
+
+
+# ---------------------------------------------------------------------------
+# _process_assistant_message reads from opaque_body (preferred)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessAssistantMessageReadsOpaqueBody:
+    """The pre-fix _process_assistant_message read from
+    self.previous_thinking_blocks, which is always empty in a fresh
+    RPC instance. After the fix, it reads from the assistant message's
+    opaque_body first.
+    """
+
+    def test_thinking_blocks_from_opaque_body_are_included(self) -> None:
+        block = _thinking_block()
+        message = AssistantPromptMessage(
+            content="", tool_calls=[], opaque_body={"anthropic_thinking_blocks": [block]}
+        )
+        all_messages = [
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="", tool_calls=[]),
+            ToolPromptMessage(tool_call_id="1"),
+        ]
+        result = _process(message, all_messages)
+        assert block in result["content"]
+
+    def test_redacted_thinking_blocks_from_opaque_body_are_included(self) -> None:
+        block = _redacted_block()
+        message = AssistantPromptMessage(
+            content="",
+            tool_calls=[],
+            opaque_body={"anthropic_redacted_thinking_blocks": [block]},
+        )
+        all_messages = [
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="", tool_calls=[]),
+            ToolPromptMessage(tool_call_id="1"),
+        ]
+        result = _process(message, all_messages)
+        assert block in result["content"]
+
+    def test_both_thinking_and_redacted_blocks_from_opaque_body(self) -> None:
+        thinking = _thinking_block()
+        redacted = _redacted_block()
+        message = AssistantPromptMessage(
+            content="",
+            tool_calls=[],
+            opaque_body={
+                "anthropic_thinking_blocks": [thinking],
+                "anthropic_redacted_thinking_blocks": [redacted],
+            },
+        )
+        all_messages = [
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="", tool_calls=[]),
+            ToolPromptMessage(tool_call_id="1"),
+        ]
+        result = _process(message, all_messages)
+        # Both blocks should be in the content, in order.
+        thinking_idx = result["content"].index(thinking)
+        redacted_idx = result["content"].index(redacted)
+        assert thinking_idx < redacted_idx
+
+    def test_empty_opaque_body_falls_back_to_instance_state(self) -> None:
+        """If the assistant message has no opaque_body, fall back to
+        the in-memory instance state (the legacy behavior).
+        """
+        block = _thinking_block()
+        message = AssistantPromptMessage(content="", tool_calls=[])
+        all_messages = [
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="", tool_calls=[]),
+            ToolPromptMessage(tool_call_id="1"),
+        ]
+        # Seed the instance state with the thinking block.
+        instance = _make_instance()
+        instance.previous_thinking_blocks = [block]
+        instance.previous_redacted_thinking_blocks = []
+        result = instance._process_assistant_message(message, all_messages)
+        assert block in result["content"]
+
+    def test_opaque_body_takes_precedence_over_instance_state(self) -> None:
+        """If both are set, opaque_body wins (it's the persisted state)."""
+        opaque_block = _thinking_block(signature="from-opaque")
+        instance_block = _thinking_block(signature="from-instance")
+        message = AssistantPromptMessage(
+            content="",
+            tool_calls=[],
+            opaque_body={"anthropic_thinking_blocks": [opaque_block]},
+        )
+        all_messages = [
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="", tool_calls=[]),
+            ToolPromptMessage(tool_call_id="1"),
+        ]
+        instance = _make_instance()
+        instance.previous_thinking_blocks = [instance_block]
+        instance.previous_redacted_thinking_blocks = []
+        result = instance._process_assistant_message(message, all_messages)
+        # Only the opaque_body block should be present.
+        assert opaque_block in result["content"]
+        assert instance_block not in result["content"]
+
+    def test_no_tool_messages_means_no_thinking_blocks(self) -> None:
+        """Without a follow-up tool message, thinking blocks are not
+        needed. The pre-fix code only added them when has_tool_messages.
+        """
+        block = _thinking_block()
+        message = AssistantPromptMessage(
+            content="", tool_calls=[], opaque_body={"anthropic_thinking_blocks": [block]}
+        )
+        all_messages = [
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="hello"),
+        ]
+        result = _process(message, all_messages)
+        assert block not in result["content"]
+
+    def test_opaque_body_with_non_dict_value_falls_back_to_instance(self) -> None:
+        """If opaque_body is not a dict (e.g. a string or list), the
+        helper functions should treat it as missing and fall back to
+        the instance state.
+        """
+        instance_block = _thinking_block()
+        message = AssistantPromptMessage(content="", tool_calls=[], opaque_body="not-a-dict")
+        all_messages = [
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="", tool_calls=[]),
+            ToolPromptMessage(tool_call_id="1"),
+        ]
+        instance = _make_instance()
+        instance.previous_thinking_blocks = [instance_block]
+        instance.previous_redacted_thinking_blocks = []
+        result = instance._process_assistant_message(message, all_messages)
+        assert instance_block in result["content"]
+
+    def test_opaque_body_with_missing_keys_falls_back_to_instance(self) -> None:
+        """opaque_body may be a dict that doesn't have the thinking-block
+        keys (e.g. set by a different feature). Fall back to the
+        instance state in that case.
+        """
+        instance_block = _thinking_block()
+        message = AssistantPromptMessage(
+            content="",
+            tool_calls=[],
+            opaque_body={"some_other_key": "some_other_value"},
+        )
+        all_messages = [
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="", tool_calls=[]),
+            ToolPromptMessage(tool_call_id="1"),
+        ]
+        instance = _make_instance()
+        instance.previous_thinking_blocks = [instance_block]
+        instance.previous_redacted_thinking_blocks = []
+        result = instance._process_assistant_message(message, all_messages)
+        assert instance_block in result["content"]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip property: store in opaque_body, read it back
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripProperty:
+    """The core fix: when an LLMResult is built with thinking blocks,
+    the assistant_prompt_message must carry them in opaque_body so the
+    next invocation can read them back. This is the regression that
+    caused issue #3658.
+    """
+
+    def test_round_trip_preserves_thinking_block(self) -> None:
+        """Simulate: the response handler builds an LLMResult with
+        thinking blocks, then the follow-up request's
+        _process_assistant_message is called with the resulting
+        AssistantPromptMessage. The thinking block must round-trip
+        through opaque_body.
+        """
+        # Step 1: response handler captures the thinking block.
+        block = _thinking_block()
+        instance = _make_instance()
+        instance.previous_thinking_blocks = [block]
+        instance.previous_redacted_thinking_blocks = []
+        # Simulate what _handle_chat_generate_response does at the end.
+        assistant_prompt_message = AssistantPromptMessage(content="", tool_calls=[])
+        if instance.previous_thinking_blocks or instance.previous_redacted_thinking_blocks:
+            assistant_prompt_message.opaque_body = {
+                "anthropic_thinking_blocks": instance.previous_thinking_blocks,
+                "anthropic_redacted_thinking_blocks": instance.previous_redacted_thinking_blocks,
+            }
+
+        # Step 2: the next request is built in a fresh instance. The
+        # caller passes the persisted AssistantPromptMessage (with
+        # opaque_body) plus the tool result.
+        fresh_instance = _make_instance()
+        fresh_instance.previous_thinking_blocks = []  # empty in fresh instance
+        fresh_instance.previous_redacted_thinking_blocks = []
+        all_messages = [
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="", tool_calls=[]),
+            ToolPromptMessage(tool_call_id="1"),
+        ]
+        result = fresh_instance._process_assistant_message(assistant_prompt_message, all_messages)
+        # The thinking block must be present in the next request.
+        assert block in result["content"]
+
+    def test_round_trip_without_thinking_blocks_has_no_opaque_body(self) -> None:
+        """A response with no thinking blocks must not have an
+        opaque_body set (avoids carrying empty dicts in messages).
+        """
+        instance = _make_instance()
+        instance.previous_thinking_blocks = []
+        instance.previous_redacted_thinking_blocks = []
+        # Simulate: when both lists are empty, opaque_body should not be set.
+        assistant_prompt_message = AssistantPromptMessage(content="hello")
+        if instance.previous_thinking_blocks or instance.previous_redacted_thinking_blocks:
+            assistant_prompt_message.opaque_body = {
+                "anthropic_thinking_blocks": instance.previous_thinking_blocks,
+                "anthropic_redacted_thinking_blocks": instance.previous_redacted_thinking_blocks,
+            }
+        assert assistant_prompt_message.opaque_body is None


### PR DESCRIPTION
## Summary

Fixes issue #3658: Anthropic thinking blocks (`thinking` and `redacted_thinking`) were not preserved across plugin invocation boundaries on tool-result turns, causing HTTP 400 `invalid_request_error` responses on the second request of every tool loop.

The pre-fix code stored the blocks on the model instance (`self.previous_thinking_blocks`), but `dify_plugin` creates a fresh model instance per RPC, so the state was always empty by the time the follow-up request was built. This PR stores the blocks in `AssistantPromptMessage.opaque_body`, which IS preserved across invocations because it's part of the persisted message — the same pattern `models/moonshot` already uses for round-tripping provider-specific reasoning state.

3 files, +330/-9, manifest `0.3.27 → 0.3.28`.

## What's in this PR

### Source change (`models/anthropic/models/llm/llm.py`)

Three focused edits:

1. **`_handle_chat_generate_response`** (non-streaming): when the response contained thinking or redacted_thinking blocks, attach both lists to the returned `AssistantPromptMessage.opaque_body` under namespaced keys.

2. **`_handle_chat_generate_stream_response`** (streaming): same, but on the final assistant message chunk (the one that carries the tool calls).

3. **`_process_assistant_message`**: read from `message.opaque_body` first; fall back to `self.previous_thinking_blocks` / `self.previous_redacted_thinking_blocks` for the legacy case where the caller hand-crafts an assistant message without `opaque_body` (e.g. tests).

### Tests (`models/anthropic/tests/test_thinking_blocks_opaque_body.py`, 10 tests)

| Test class | What it pins |
|---|---|
| `TestProcessAssistantMessageReadsOpaqueBody` | 8 tests: thinking/redacted/both from `opaque_body`; empty `opaque_body` falls back to instance state; `opaque_body` takes precedence; no-tool case; non-dict and missing-key fallbacks |
| `TestRoundTripProperty` | 2 tests: full round-trip across a fresh instance; no-op when no thinking blocks were captured |

## Verification

```bash
cd models/anthropic && uv run pytest tests/
# 37 passed (27 existing + 10 new), 14 skipped, no regressions

cd models/anthropic && uv run pytest tests/test_thinking_blocks_opaque_body.py -v
# 10 passed in 0.44s

cd models/anthropic && uv run ruff check tests/test_thinking_blocks_opaque_body.py
# All checks passed!
```

## Why this matters

The bug affected:

- **Agent apps / Agent nodes with model-level function calling** (tool-result turn at the Messages API level):
  - Classic extended thinking (4.x, `budget_tokens`) + tools → **deterministic** failure on the second request of every tool loop.
  - 5-series with `thinking_display=summarized` + tools → deterministic.
  - 5-series defaults (adaptive + omitted) → **intermittent**: only turns where adaptive thinking actually fired emit the block that must be echoed; turns without thinking pass, masking the bug.

- **Workflows that call tools via tool nodes** (no model-level function-calling loop) are unaffected — there is no tool-result turn at the API level. This is why the issue went unnoticed in many deployments.

## Backward compatibility

- The `opaque_body` field is already part of `AssistantPromptMessage` (added in `dify_plugin` 0.10.x); this PR just uses it.
- `self.previous_thinking_blocks` and `self.previous_redacted_thinking_blocks` are preserved as the fallback path — callers that don't use `opaque_body` (e.g. tests, custom integrations) keep working.
- No existing tests modified; no existing behavior changed for users not running tool-use loops with thinking-capable Claude models.

## Risks

Negligible. The change is additive: the new path is preferred, the old path still works.

## Future work (from #3658)

This PR fixes the **in-memory agent loop** case. The fully robust fix likely needs Dify core to persist provider thinking state alongside message history (e.g. the core `prompt-save` utility serializes role/text/files/tool_calls but the issue body notes it did not appear to include `opaque_body`). The plugin-side fix here solves the common in-memory case; the core fix is a separate concern for the Dify core team.

Fixes #3658.
