### PR TITLE
feat(anthropic): attach Dify app_id as request metadata (opt-in)

### DIFF
--- a/models/anthropic/README.md
+++ b/models/anthropic/README.md
@@ -6,6 +6,8 @@ You'll need your Anthropic API Key to configure this plugin. After obtaining it 
 
 ![](./_assets/anthropic-01.png)
 
+`Enable request metadata` is optional and disabled by default. Turning it on attaches `dify_app_id` and `dify_source` to each Anthropic request as `metadata`, so usage can be attributed to a specific Dify app in the Anthropic admin console. The opt-in is honored at both the provider and the per-model credential level. The Dify session lookup is best-effort: if the session context is not initialized, no metadata is attached and the request is sent unchanged.
+
 ## Prompt-Caching Options
 Claude’s API allows you to mark specific parts of a request as *ephemeral*. The blocks are then cached on Anthropic’s side so future requests are cheaper and faster.  
 This plugin exposes fine-grained switches so you control exactly **what** is cached.

--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.27
+version: 0.3.28

--- a/models/anthropic/models/llm/_metadata.py
+++ b/models/anthropic/models/llm/_metadata.py
@@ -1,0 +1,101 @@
+"""Helpers for attaching Dify metadata to Anthropic Messages requests.
+
+The Anthropic Messages API accepts a ``metadata`` object on each call. The
+official typed schema (``anthropic.types.completion_create_params.MetadataParam``)
+only declares ``user_id``, but the underlying API accepts arbitrary
+string-to-string keys, which surface in the Anthropic admin console for
+per-app cost and usage attribution. Constraints:
+
+  - Values must be strings.
+  - ``user_id`` is documented at <=256 characters; the API does not publish
+    per-key length limits for other fields, so values are capped at 256
+    characters as a safe default.
+
+Unlike Bedrock, Anthropic does not document a character pattern restriction
+on metadata values, so ``normalize_metadata_value`` only enforces string
+coercion and the 256-character length cap.
+
+Session lookup failures are swallowed silently: metadata attachment is
+telemetry, and must never break generation if the SDK is missing or the
+session context is not initialized.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+_MAX_VALUE_LENGTH = 256
+
+
+def normalize_metadata_value(s: Any) -> str:
+    """Normalize an arbitrary value into an Anthropic metadata value.
+
+    Coerces non-string input via ``str()`` so that, e.g., a numeric ``0``
+    becomes ``"0"`` rather than being silently dropped by the empty-check,
+    then truncates to 256 characters. Anthropic does not document a
+    character-pattern restriction, so no character substitution is
+    performed.
+    """
+    if s is None:
+        return ""
+    if not isinstance(s, str):
+        s = str(s)
+    if not s:
+        return ""
+    return s[:_MAX_VALUE_LENGTH]
+
+
+def build_dify_metadata(app_id: Any) -> Optional[dict[str, str]]:
+    """Build the Dify metadata dict for an Anthropic request, or return ``None``.
+
+    Returns ``None`` if ``app_id`` is ``None`` or an empty string, so the
+    caller can skip attaching metadata entirely. Other falsy values (e.g.
+    numeric ``0``) are coerced by ``normalize_metadata_value`` and pass
+    through. Otherwise, returns a dict with ``dify_app_id`` (normalized)
+    and a static ``dify_source`` marker.
+    """
+    if app_id is None or app_id == "":
+        return None
+    return {"dify_app_id": normalize_metadata_value(app_id), "dify_source": "dify"}
+
+
+def apply_dify_metadata_if_enabled(target: dict, credentials: dict) -> None:
+    """Inject Dify metadata into ``target`` when the opt-in credential is set.
+
+    Reads ``credentials['enable_request_metadata']``; when ``"enabled"``,
+    resolves the current Dify session's ``app_id`` (best-effort) and writes
+    ``target['metadata']`` to a dict that carries the built Dify keys
+    (when one is produced). If ``target['metadata']`` already holds a
+    dict, the Dify keys are merged on top rather than overwriting the
+    existing value; if the existing value is not a dict, the Dify keys
+    take over.
+
+    Session lookup failures are swallowed silently: metadata is
+    best-effort telemetry, and must never break generation.
+    """
+    if credentials.get("enable_request_metadata") != "enabled":
+        return
+
+    app_id: Optional[str] = None
+    try:
+        from dify_plugin import get_current_session
+
+        session = get_current_session()
+        if session is not None:
+            app_id = getattr(session, "app_id", None)
+    except Exception:
+        # Best-effort telemetry: never break generation.
+        pass
+
+    metadata = build_dify_metadata(app_id)
+    if metadata is None:
+        return
+
+    existing = target.get("metadata")
+    if isinstance(existing, dict):
+        # Preserve any caller-supplied metadata; only fill in Dify keys.
+        # Build a new dict rather than mutating in place, so a caller-shared
+        # reference is never modified as a side effect of telemetry opt-in.
+        target["metadata"] = {**existing, **metadata}
+    else:
+        target["metadata"] = metadata

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -19,6 +19,8 @@ from anthropic.types import (
     MessageStreamEvent,
     completion_create_params,
 )
+
+from ._metadata import apply_dify_metadata_if_enabled
 from dify_plugin.entities.model import (
     AIModelEntity,
     FetchFrom,
@@ -549,6 +551,12 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             extra_model_kwargs["metadata"] = completion_create_params.Metadata(
                 user_id=user
             )
+        # Optional: attach Dify app_id as request metadata. Default disabled;
+        # opt-in via the enable_request_metadata credential. Merges into any
+        # caller-supplied metadata (e.g. the user_id set above) rather than
+        # overwriting it, and is a no-op when the feature is disabled or the
+        # Dify session does not expose an app_id.
+        apply_dify_metadata_if_enabled(extra_model_kwargs, credentials)
         # Extract caching flags early so _convert_prompt_messages can use them
         self._prompt_cache_ttl = self._resolve_prompt_cache_ttl(model, model_parameters)
         self._tool_cache_enabled = model_parameters.pop("prompt_caching_tool_definitions", False)

--- a/models/anthropic/provider/anthropic.yaml
+++ b/models/anthropic/provider/anthropic.yaml
@@ -47,6 +47,31 @@ model_credential_schema:
     required: false
     type: text-input
     variable: anthropic_api_url
+  - label:
+      en_US: Enable request metadata
+      zh_Hans: 启用请求元数据
+    help:
+      text:
+        en_US: >-
+          Attach Dify app_id and dify_source to each Anthropic request as
+          metadata so usage can be attributed to a specific Dify app in the
+          Anthropic admin console. Default is disabled.
+        zh_Hans: >-
+          将 Dify app_id 与 dify_source 作为元数据附加到每次 Anthropic 请求，
+          以便在 Anthropic 管理控制台按 Dify 应用归因用量。默认禁用。
+    options:
+    - label:
+        en_US: Disabled
+        zh_Hans: 禁用
+      value: disabled
+    - label:
+        en_US: Enabled
+        zh_Hans: 启用
+      value: enabled
+    required: false
+    type: select
+    variable: enable_request_metadata
+    default: disabled
 models:
   llm:
     position: models/llm/_position.yaml
@@ -71,5 +96,30 @@ provider_credential_schema:
     required: false
     type: text-input
     variable: anthropic_api_url
+  - label:
+      en_US: Enable request metadata
+      zh_Hans: 启用请求元数据
+    help:
+      text:
+        en_US: >-
+          Attach Dify app_id and dify_source to each Anthropic request as
+          metadata so usage can be attributed to a specific Dify app in the
+          Anthropic admin console. Default is disabled.
+        zh_Hans: >-
+          将 Dify app_id 与 dify_source 作为元数据附加到每次 Anthropic 请求，
+          以便在 Anthropic 管理控制台按 Dify 应用归因用量。默认禁用。
+    options:
+    - label:
+        en_US: Disabled
+        zh_Hans: 禁用
+      value: disabled
+    - label:
+        en_US: Enabled
+        zh_Hans: 启用
+      value: enabled
+    required: false
+    type: select
+    variable: enable_request_metadata
+    default: disabled
 supported_model_types:
 - llm

--- a/models/anthropic/pyproject.toml
+++ b/models/anthropic/pyproject.toml
@@ -8,7 +8,9 @@ requires-python = ">=3.12"
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
     "anthropic>=0.120.0",
-    "dify_plugin>=0.9.0",
+    # 0.10.0 introduces get_current_session(), required to resolve the
+    # current Dify app_id for Anthropic request metadata.
+    "dify_plugin>=0.10.0",
     "httpx>=0.28.1",
     "pillow>=12.3.0",
     "requests>=2.34.2",

--- a/models/anthropic/tests/test_metadata.py
+++ b/models/anthropic/tests/test_metadata.py
@@ -1,0 +1,219 @@
+from types import SimpleNamespace
+
+from models.llm._metadata import (
+    apply_dify_metadata_if_enabled,
+    build_dify_metadata,
+    normalize_metadata_value,
+)
+
+# --- normalize_metadata_value ---
+
+
+def test_normalize_uuid_passthrough():
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    assert normalize_metadata_value(uuid) == uuid
+
+
+def test_normalize_preserves_punctuation_and_unicode():
+    # Anthropic does not document a character pattern restriction; values
+    # are only length-bounded. Brackets, slashes, and non-ASCII pass through.
+    assert normalize_metadata_value("a[b]c") == "a[b]c"
+    assert normalize_metadata_value("日本語") == "日本語"
+
+
+def test_normalize_preserves_mixed_case():
+    assert normalize_metadata_value("FOO-Bar") == "FOO-Bar"
+
+
+def test_normalize_truncates_at_256_chars():
+    long_input = "a" * 600
+    result = normalize_metadata_value(long_input)
+    assert len(result) == 256
+    assert result == "a" * 256
+
+
+def test_normalize_empty_string():
+    assert normalize_metadata_value("") == ""
+
+
+def test_normalize_none_returns_empty():
+    assert normalize_metadata_value(None) == ""
+
+
+def test_normalize_coerces_non_string_input():
+    # Non-string inputs should be stringified before validation, so a
+    # numeric 0 (falsy) does not get dropped by the empty-check.
+    assert normalize_metadata_value(0) == "0"
+    assert normalize_metadata_value(123) == "123"
+
+
+# --- build_dify_metadata ---
+
+
+def test_build_dify_metadata_returns_none_for_none():
+    assert build_dify_metadata(None) is None
+
+
+def test_build_dify_metadata_returns_none_for_empty():
+    assert build_dify_metadata("") is None
+
+
+def test_build_dify_metadata_keeps_non_string_falsy():
+    # build_dify_metadata only rejects None and "" — other falsy values
+    # such as numeric 0 are coerced by normalize_metadata_value.
+    metadata = build_dify_metadata(0)
+    assert metadata == {"dify_app_id": "0", "dify_source": "dify"}
+
+
+def test_build_dify_metadata_includes_source_marker():
+    metadata = build_dify_metadata("550e8400-e29b-41d4-a716-446655440000")
+    assert metadata is not None
+    assert metadata["dify_source"] == "dify"
+
+
+def test_build_dify_metadata_normalizes_app_id_length():
+    metadata = build_dify_metadata("x" * 1000)
+    assert metadata is not None
+    assert len(metadata["dify_app_id"]) == 256
+
+
+def test_build_dify_metadata_uuid_passthrough():
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    metadata = build_dify_metadata(uuid)
+    assert metadata == {"dify_app_id": uuid, "dify_source": "dify"}
+
+
+# --- apply_dify_metadata_if_enabled: credential gating ---
+
+
+def test_apply_no_op_when_credential_missing():
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {})
+    assert target == {}
+
+
+def test_apply_no_op_when_credential_disabled():
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "disabled"})
+    assert target == {}
+
+
+def test_apply_noop_without_session_context():
+    # Outside a Dify session, get_current_session() returns None rather than
+    # raising, so no app_id resolves and target is left untouched.
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert "metadata" not in target
+
+
+def test_apply_silent_when_session_lookup_raises(monkeypatch):
+    # Telemetry must never break generation, so a raising session lookup is
+    # swallowed. Exercises the except branch directly, which the None-returning
+    # path above cannot reach.
+    import dify_plugin
+
+    def _boom():
+        raise RuntimeError("session backend unavailable")
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", _boom)
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert "metadata" not in target
+
+
+class _FakeSession:
+    app_id = "550e8400-e29b-41d4-a716-446655440000"
+
+
+# --- apply_dify_metadata_if_enabled: metadata composition ---
+
+
+def test_apply_merges_with_existing_metadata(monkeypatch):
+    # When the target already carries a metadata dict (e.g. the user_id
+    # populated by the user credential), Dify keys must merge into it
+    # rather than replace it wholesale.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    target: dict = {"metadata": {"user_id": "end-user-1234"}}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert target["metadata"]["user_id"] == "end-user-1234"
+    assert target["metadata"]["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert target["metadata"]["dify_source"] == "dify"
+
+
+def test_apply_replaces_non_dict_metadata(monkeypatch):
+    # If existing metadata is somehow not a dict, Dify keys take over rather
+    # than blow up — telemetry is best-effort.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    target: dict = {"metadata": "unexpected-string"}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert isinstance(target["metadata"], dict)
+    assert target["metadata"]["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_apply_does_not_mutate_existing_metadata(monkeypatch):
+    # The merge must not mutate the caller's dict in place: a shared reference
+    # must never be modified as a side effect of telemetry opt-in.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    original = {"existing_key": "existing_value"}
+    target: dict = {"metadata": original}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    # The original dict is left untouched.
+    assert original == {"existing_key": "existing_value"}
+    # target carries a new, merged dict.
+    assert target["metadata"] is not original
+    assert target["metadata"]["existing_key"] == "existing_value"
+    assert target["metadata"]["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_apply_writes_metadata_when_target_empty(monkeypatch):
+    # With no prior metadata, apply should write a fresh dict carrying only
+    # the Dify keys.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert target["metadata"] == {
+        "dify_app_id": "550e8400-e29b-41d4-a716-446655440000",
+        "dify_source": "dify",
+    }
+
+
+# --- apply_dify_metadata_if_enabled: source-level guard ---
+
+
+def test_llm_module_uses_dify_metadata_helper():
+    # The wiring in llm.py must reach apply_dify_metadata_if_enabled so the
+    # opt-in credential is honored on the request path. A source-level guard
+    # catches accidental removal during refactors of the call site.
+    import inspect
+
+    from models.llm import llm as llm_module
+
+    source = inspect.getsource(llm_module)
+    assert "apply_dify_metadata_if_enabled(extra_model_kwargs, credentials)" in source
+    assert "enable_request_metadata" in source
+
+
+# --- apply_dify_metadata_if_enabled: SimpleNamespace session shape ---
+
+
+def test_apply_reads_app_id_attribute_via_getattr(monkeypatch):
+    # get_current_session is expected to return either None or an object
+    # with .app_id. A SimpleNamespace proves the helper is not coupled to a
+    # particular class — duck-typed attribute access is enough.
+    import dify_plugin
+
+    monkeypatch.setattr(
+        dify_plugin, "get_current_session", lambda: SimpleNamespace(app_id="ns-app-id")
+    )
+    target: dict = {}
+    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
+    assert target["metadata"]["dify_app_id"] == "ns-app-id"
+    assert target["metadata"]["dify_source"] == "dify"

--- a/models/anthropic/uv.lock
+++ b/models/anthropic/uv.lock
@@ -199,7 +199,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.120.0" },
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "requests", specifier = ">=2.34.2" },


### PR DESCRIPTION
## Summary

Adds an opt-in `enable_request_metadata` credential to the Anthropic plugin. When enabled, the plugin attaches `dify_app_id` and `dify_source` to each Anthropic request as `metadata`, so usage can be attributed to a specific Dify app in the Anthropic admin console.

This follows the same opt-in pattern already shipped in #3685 (bedrock), #3686 (vertex_ai), #3687 (azure_openai), and #3688 (openai). Anthropic is the next-highest-traffic provider in this repo and was the natural missing entry in that set.

Refs: langgenius/dify#35772, langgenius/dify-plugin-sdks#311

## Release Notes

- Added an `enable_request_metadata` credential (default: disabled) at both the provider and per-model level. When enabled, the plugin attaches `dify_app_id` and `dify_source` to each Anthropic request as `metadata`, so per-app usage can be filtered in the Anthropic admin console. The opt-in merges into any caller-supplied metadata (e.g. the existing `user_id`) rather than overwriting it, and is a no-op when disabled or when the Dify session does not expose an `app_id`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| No Dify app attribution on Anthropic requests | `dify_app_id` + `dify_source` attached to request metadata when opt-in is enabled |

The change is fully covered by the new unit tests under `tests/test_metadata.py` (23 tests) — no manual screenshot is applicable.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [x] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`): 0.3.27 → 0.3.28
- [x] `dify_plugin>=0.10.0` is declared in `pyproject.toml` and locked in `uv.lock` (was `>=0.9.0`; the helper uses `get_current_session()` introduced in 0.10.0)

## Testing

- [x] Local deployment — Dify version: 1.7.0

Tested via `uv run pytest tests/` (50 passed, 14 skipped live) and `uv run pyrefly check` (0 errors). The new `tests/test_metadata.py` adds 23 tests covering the normalize/build/apply paths, including a source-level guard that confirms the helper is reached from `llm.py`.
