### PR TITLE
fix(self_refine_agent): repair the execution path so a single attempt can run

### DIFF
--- a/agent-strategies/self_refine_agent/manifest.yaml
+++ b/agent-strategies/self_refine_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 type: plugin
 author: "langgenius"
 name: "self_refine_agent"

--- a/agent-strategies/self_refine_agent/strategies/self_refine.py
+++ b/agent-strategies/self_refine_agent/strategies/self_refine.py
@@ -132,7 +132,6 @@ class SelfRefineStrategy(AgentStrategy):
             try:
                 execution_result = yield from self._execute_agent(
                     params=params,
-                    previous_output=final_output if refinement_count > 0 else None,
                     previous_critique=previous_critique,
                     attempt_number=attempt_number
                 )
@@ -148,7 +147,7 @@ class SelfRefineStrategy(AgentStrategy):
                 yield self.create_log_message(
                     label=f"Attempt {attempt_number} Complete",
                     data={"output_length": len(final_output)},
-                    status=ToolInvokeMessage.LogMessage.LogStatus.FINISH
+                    status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS
                 )
 
             except Exception as e:
@@ -187,7 +186,7 @@ class SelfRefineStrategy(AgentStrategy):
                     yield self.create_log_message(
                         label="Quality Check: PASS",
                         data={"score": evaluation.score},
-                        status=ToolInvokeMessage.LogMessage.LogStatus.FINISH
+                        status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS
                     )
                     logger.info(f"Output satisfactory (score: {evaluation.score})")
                     break
@@ -198,7 +197,7 @@ class SelfRefineStrategy(AgentStrategy):
                             "score": evaluation.score,
                             "issues": evaluation.issues
                         },
-                        status=ToolInvokeMessage.LogMessage.LogStatus.FINISH
+                        status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS
                     )
                     logger.info(f"Output needs improvement: {evaluation.issues}")
                     previous_critique = evaluation.issues
@@ -308,7 +307,7 @@ class SelfRefineStrategy(AgentStrategy):
             if stream and isinstance(chunks, Generator):
                 for chunk in chunks:
                     if chunk.delta and chunk.delta.message and chunk.delta.message.content:
-                        response_text += chunk.delta.message.content
+                        response_text += chunk.delta.message.get_text_content()
 
                     if chunk.delta and chunk.delta.message and chunk.delta.message.tool_calls:
                         for tool_call in chunk.delta.message.tool_calls:
@@ -324,7 +323,7 @@ class SelfRefineStrategy(AgentStrategy):
             else:
                 result = chunks if isinstance(chunks, LLMResult) else next(chunks)
                 if result.message and result.message.content:
-                    response_text = result.message.content
+                    response_text = result.message.get_text_content()
 
                 if result.message and result.message.tool_calls:
                     for tool_call in result.message.tool_calls:
@@ -347,7 +346,7 @@ class SelfRefineStrategy(AgentStrategy):
                     "response": response_text[:200] + "..." if len(response_text) > 200 else response_text,
                     "tool_calls": len(tool_calls)
                 },
-                status=ToolInvokeMessage.LogMessage.LogStatus.FINISH
+                status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS
             )
 
             # Execute tool calls if any
@@ -415,7 +414,7 @@ class SelfRefineStrategy(AgentStrategy):
                 yield self.create_log_message(
                     label=f"Tool {tool_name} Complete",
                     data={"result": result_text[:100] + "..." if len(result_text) > 100 else result_text},
-                    status=ToolInvokeMessage.LogMessage.LogStatus.FINISH
+                    status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS
                 )
 
             except Exception as e:
@@ -461,7 +460,7 @@ class SelfRefineStrategy(AgentStrategy):
             if isinstance(result, Generator):
                 result = next(result)
 
-            eval_text = result.message.content if result.message and result.message.content else ""
+            eval_text = result.message.get_text_content() if result.message and result.message.content else ""
 
             # Parse JSON response
             try:

--- a/agent-strategies/self_refine_agent/tests/test_self_refine.py
+++ b/agent-strategies/self_refine_agent/tests/test_self_refine.py
@@ -1,0 +1,154 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from dify_plugin.entities.model import AIModelEntity, ModelFeature, ModelType
+from dify_plugin.entities.model.llm import (
+    LLMResult,
+    LLMResultChunk,
+    LLMResultChunkDelta,
+    LLMUsage,
+)
+from dify_plugin.entities.model.message import (
+    AssistantPromptMessage,
+    TextPromptMessageContent,
+)
+from dify_plugin.interfaces.agent import AgentModelConfig
+
+from strategies.self_refine import SelfRefineParams, SelfRefineStrategy
+
+
+def _list_content_message(text: str) -> AssistantPromptMessage:
+    return AssistantPromptMessage(
+        content=[TextPromptMessageContent(data=text)]
+    )
+
+
+def _params(model: AgentModelConfig) -> SelfRefineParams:
+    return SelfRefineParams(
+        query="hello",
+        instruction="answer briefly",
+        model=model,
+    )
+
+
+class TestSelfRefineListContent(unittest.TestCase):
+    def setUp(self):
+        self.strategy = SelfRefineStrategy(runtime=Mock(), session=Mock())
+
+    def test_execute_agent_streaming_list_content(self):
+        model = AgentModelConfig(
+            provider="google",
+            model="gemini-1.5-pro",
+            mode="chat",
+            entity=AIModelEntity(
+                model="gemini-1.5-pro",
+                model_type=ModelType.LLM,
+                model_properties={},
+                features=[ModelFeature.STREAM_TOOL_CALL],
+            ),
+        )
+
+        def chunks():
+            yield LLMResultChunk(
+                model="gemini-1.5-pro",
+                delta=LLMResultChunkDelta(
+                    index=0,
+                    message=_list_content_message("hi from gemini"),
+                    usage=LLMUsage.empty_usage(),
+                ),
+            )
+
+        self.strategy.session.model.llm.invoke = Mock(return_value=chunks())
+
+        gen = self.strategy._execute_agent(_params(model), None, 1)
+        result = None
+        try:
+            while True:
+                next(gen)
+        except StopIteration as stop:
+            result = stop.value
+
+        self.assertEqual(result["output"], "hi from gemini")
+
+    def test_execute_agent_non_streaming_list_content(self):
+        model = AgentModelConfig(provider="openrouter", model="gpt-4o", mode="chat")
+
+        self.strategy.session.model.llm.invoke = Mock(
+            return_value=LLMResult(
+                model="gpt-4o",
+                message=_list_content_message("hi from openrouter"),
+                usage=LLMUsage.empty_usage(),
+            )
+        )
+
+        gen = self.strategy._execute_agent(_params(model), None, 1)
+        result = None
+        try:
+            while True:
+                next(gen)
+        except StopIteration as stop:
+            result = stop.value
+
+        self.assertEqual(result["output"], "hi from openrouter")
+
+    def test_evaluate_output_list_content(self):
+        model = AgentModelConfig(provider="google", model="gemini-1.5-pro", mode="chat")
+
+        eval_json = '{"is_satisfactory": true, "issues": "", "score": 9}'
+        self.strategy.session.model.llm.invoke = Mock(
+            return_value=LLMResult(
+                model="gemini-1.5-pro",
+                message=_list_content_message(eval_json),
+                usage=LLMUsage.empty_usage(),
+            )
+        )
+
+        result = self.strategy._evaluate_output(_params(model), "some output")
+
+        self.assertTrue(result.is_satisfactory)
+        self.assertEqual(result.score, 9)
+
+    def test_invoke_end_to_end_satisfactory_on_first_attempt(self):
+        model = AgentModelConfig(provider="google", model="gemini-1.5-pro", mode="chat")
+
+        eval_json = '{"is_satisfactory": true, "issues": "", "score": 10}'
+        responses = [
+            LLMResult(
+                model="gemini-1.5-pro",
+                message=_list_content_message("the answer"),
+                usage=LLMUsage.empty_usage(),
+            ),
+            LLMResult(
+                model="gemini-1.5-pro",
+                message=_list_content_message(eval_json),
+                usage=LLMUsage.empty_usage(),
+            ),
+        ]
+        self.strategy.session.model.llm.invoke = Mock(side_effect=responses)
+
+        messages = list(
+            self.strategy._invoke(
+                {
+                    "query": "hello",
+                    "instruction": "answer briefly",
+                    "model": model.model_dump(mode="json"),
+                }
+            )
+        )
+
+        errors = [
+            m.message.data.get("error")
+            for m in messages
+            if getattr(m.message, "status", None) is not None
+            and m.message.status.value == "error"
+        ]
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #3718: `self_refine_agent` cannot complete a single execution attempt, for any model provider.

The entry point, `SelfRefineStrategy._invoke`, calls `_execute_agent` with a `previous_output` keyword argument that `_execute_agent`'s signature has never accepted (one commit ever touched this file: `7b24b02b`, the plugin's introduction). Every attempt raises `TypeError`, caught by the broad `except Exception`, and the strategy always ends with `Error: Execution failed - ...`. The refinement prompt template only interpolates `{{critique}}`, never a prior output, so the smallest correct fix is to drop the unused argument rather than add a parameter nothing consumes.

Two more bugs sit immediately behind that one, on the same call path, unreachable until it is fixed:

- `_execute_agent` (streaming loop and non-streaming branch) and `_evaluate_output` read `AssistantPromptMessage.content` assuming `str`. The SDK's own type is `str | list[PromptMessageContentUnionTypes] | None`, and providers that always emit list content (Gemini, OpenRouter) raise `TypeError`/`AttributeError`. `cot_agent/strategies/function_calling.py` already handles this correctly in the same monorepo; this plugin uses `PromptMessage.get_text_content()` instead, the SDK's own helper for the same normalization.
- Five call sites pass `LogStatus.FINISH` for the success-path log status, which does not exist in `dify_plugin` (only `START`, `ERROR`, `SUCCESS`). This is the only file in the monorepo using `FINISH`; swapped to `SUCCESS` to match every other plugin here.

## Release Notes

Fixed self_refine_agent: the strategy could not complete a single execution attempt for any provider (wrong keyword argument on an internal call). Also fixed two crashes reachable once execution proceeds: a `TypeError` on providers that return list-shaped message content (Gemini, OpenRouter), and an `AttributeError` on the success-path log status.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

No UI change; this is an internal control-flow and type-handling fix in the strategy's Python code.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) - `0.0.1` -> `0.0.2`
- [x] `dify_plugin>=0.9.0` is declared in `pyproject.toml` and locked in `uv.lock` (unchanged by this PR)

## Testing

- [ ] Local deployment - not run against a live Dify install
- [ ] SaaS (cloud.dify.ai) - not tested

Not run through a real Dify instance; verified directly against the plugin's own code in a clean Docker container (`python:3.12-slim`, matching this plugin's `uv.lock`-pinned `dify_plugin==0.9.1`), packaged with the actual `dify` CLI and run the same way CI does (`uv run --frozen --with pytest pytest`, from the extracted `.difypkg`):

```
cd agent-strategies/self_refine_agent
uv run --frozen --with pytest pytest tests/ -v
```

- 4 new regression tests, all failing on `main` and passing on this branch, confirmed both ways in the same container:
  - `test_invoke_end_to_end_satisfactory_on_first_attempt` drives the real `_invoke` entry point end to end (this is the one that catches the `previous_output` signature mismatch; a test that calls `_execute_agent` directly cannot).
  - `test_execute_agent_streaming_list_content` / `test_execute_agent_non_streaming_list_content` / `test_evaluate_output_list_content` cover list-shaped content on each of the three affected sites.
- Not checked: a live provider call (Gemini/OpenRouter) or a real Dify agent-node run; the tests above construct the exact response shapes those providers' own SDK code builds (`models/gemini/models/llm/llm.py::_parse_parts`, verified by reading it), not a live API response.
