### PR TITLE
fix(anthropic): use native structured output for the json_schema parameter

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.27
+version: 0.3.28

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -526,6 +526,17 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 for key in ("temperature", "top_p", "top_k"):
                     model_parameters.pop(key, None)
 
+        # Native structured output: when Dify provides a JSON schema, send it via
+        # output_config.format (API constrained decoding) instead of the code-fence
+        # prompt hack. Merges with effort/task_budget set above for adaptive models.
+        json_schema = self._parse_json_schema(model_parameters.pop("json_schema", None))
+        if json_schema is not None:
+            output_config = extra_model_kwargs.setdefault("output_config", {})
+            output_config["format"] = {
+                "type": "json_schema",
+                "schema": json_schema,
+            }
+
         # 1M context is GA / native on adaptive-thinking models here (no opt-in header). Older models
         # (e.g. Sonnet 4) still need the `context-1m-2025-08-07` beta header to opt in.
         if context_1m and not uses_adaptive_thinking:
@@ -711,6 +722,34 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             model, credentials, response, prompt_messages
         )
 
+    @staticmethod
+    def _parse_json_schema(raw: Any) -> Optional[dict[str, Any]]:
+        """Parse the Dify-provided ``json_schema`` parameter into a schema dict.
+
+        Dify passes the schema as a JSON string (ParameterType.TEXT). Returns
+        ``None`` when no usable schema was provided.
+
+        Raises:
+            ValueError: if the value is not a valid non-empty JSON object.
+        """
+        if raw is None:
+            return None
+        if isinstance(raw, str):
+            raw = raw.strip()
+            if not raw:
+                return None
+            try:
+                schema = json.loads(raw)
+            except json.JSONDecodeError as ex:
+                raise ValueError(f"Invalid json_schema: not valid JSON ({ex})") from ex
+        elif isinstance(raw, dict):
+            schema = raw
+        else:
+            raise ValueError(f"Unsupported json_schema type: {type(raw).__name__}")
+        if not isinstance(schema, dict) or not schema:
+            raise ValueError("Invalid json_schema: must be a non-empty JSON object")
+        return schema
+
     def _code_block_mode_wrapper(
         self,
         model: str,
@@ -726,18 +765,33 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         Code block mode wrapper for invoking large language model
         """
         if model_parameters.get("response_format"):
-            stop = stop or []
-            self._transform_chat_json_prompts(
-                model=model,
-                credentials=credentials,
-                prompt_messages=prompt_messages,
-                model_parameters=model_parameters,
-                tools=tools,
-                stop=stop,
-                stream=stream,
-                user=user,
-                response_format=model_parameters["response_format"],
+            response_format = model_parameters["response_format"]
+            # JSON mode with a user-provided schema uses the API's native structured
+            # output (output_config.format, consumed in _chat_generate); the code-fence
+            # prompt hack is unnecessary and would wrap the constrained JSON in fences.
+            # Only None / blank strings count as "no schema", so that invalid values
+            # still reach _parse_json_schema validation in _chat_generate.
+            raw_json_schema = model_parameters.get("json_schema")
+            has_json_schema = (
+                raw_json_schema is not None and bool(str(raw_json_schema).strip())
             )
+            if not (response_format == "JSON" and has_json_schema):
+                stop = stop or []
+                self._transform_chat_json_prompts(
+                    model=model,
+                    credentials=credentials,
+                    prompt_messages=prompt_messages,
+                    model_parameters=model_parameters,
+                    tools=tools,
+                    stop=stop,
+                    stream=stream,
+                    user=user,
+                    response_format=response_format,
+                )
+                if "json_schema" in model_parameters:
+                    # Only JSON mode consumes json_schema (natively); drop it for other
+                    # formats so it never reaches the API call.
+                    model_parameters.pop("json_schema")
             model_parameters.pop("response_format")
         return self._invoke(
             model,

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -772,8 +772,14 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
             # Only None / blank strings count as "no schema", so that invalid values
             # still reach _parse_json_schema validation in _chat_generate.
             raw_json_schema = model_parameters.get("json_schema")
+            # Any non-string value counts as provided (only blank strings mean
+            # "no schema"), so invalid values always reach _parse_json_schema.
             has_json_schema = (
-                raw_json_schema is not None and bool(str(raw_json_schema).strip())
+                raw_json_schema is not None
+                and (
+                    not isinstance(raw_json_schema, str)
+                    or bool(raw_json_schema.strip())
+                )
             )
             if not (response_format == "JSON" and has_json_schema):
                 stop = stop or []

--- a/models/anthropic/tests/test_json_schema.py
+++ b/models/anthropic/tests/test_json_schema.py
@@ -140,7 +140,7 @@ def test_parse_json_schema_rejects_non_objects(raw: str) -> None:
         AnthropicLargeLanguageModel._parse_json_schema(raw)
 
 
-@pytest.mark.parametrize("raw", [0, 1.5, ["a"], (1,)])
+@pytest.mark.parametrize("raw", [0, 1.5, False, ["a"], (1,)])
 def test_parse_json_schema_rejects_unsupported_types(raw: object) -> None:
     with pytest.raises(ValueError, match="Unsupported json_schema type"):
         AnthropicLargeLanguageModel._parse_json_schema(raw)
@@ -240,6 +240,37 @@ def test_wrapper_falsy_non_string_schema_not_dropped(monkeypatch) -> None:
     )
 
     assert captured["model_parameters"]["json_schema"] == {}
+    assert "response_format" not in captured["model_parameters"]
+    assert prompt_messages[0].content == "original system"
+    assert len(prompt_messages) == 2
+
+
+def test_wrapper_empty_str_object_not_treated_as_absent(monkeypatch) -> None:
+    class _BlankStr:
+        def __str__(self) -> str:
+            return ""
+
+    llm, captured = _capture_invoke(monkeypatch, {})
+    prompt_messages = [
+        SystemPromptMessage(content="original system"),
+        UserPromptMessage(content="hi"),
+    ]
+
+    llm._code_block_mode_wrapper(
+        model="claude-sonnet-4-5",
+        credentials={"anthropic_api_key": "test-key"},
+        prompt_messages=prompt_messages,
+        model_parameters={
+            "max_tokens": 1024,
+            "response_format": "JSON",
+            "json_schema": _BlankStr(),
+        },
+        stream=True,
+    )
+
+    # Non-string values are always treated as provided, never silently dropped
+    # as "blank".
+    assert "json_schema" in captured["model_parameters"]
     assert "response_format" not in captured["model_parameters"]
     assert prompt_messages[0].content == "original system"
     assert len(prompt_messages) == 2

--- a/models/anthropic/tests/test_json_schema.py
+++ b/models/anthropic/tests/test_json_schema.py
@@ -1,0 +1,270 @@
+"""Tests for native structured output (output_config.format) handling.
+
+The previous permissive mock (``create(**kwargs)``) could not detect that the
+real ``messages.create()`` rejects unknown keyword arguments — which is how the
+unconsumed ``json_schema`` parameter caused a TypeError crash in JSON mode with
+a user-defined schema. These tests use a signature-compatible mock that mirrors
+the real SDK boundary.
+"""
+
+import inspect
+import json
+
+import pytest
+from anthropic.resources.messages.messages import Messages as _SdkMessages
+from dify_plugin.entities.model.message import (
+    AssistantPromptMessage,
+    SystemPromptMessage,
+    UserPromptMessage,
+)
+from models.llm import llm as llm_module
+from models.llm.llm import AnthropicLargeLanguageModel
+
+SCHEMA = (
+    '{"type": "object", "properties": {"answer": {"type": "string"}}, '
+    '"required": ["answer"]}'
+)
+PARSED_SCHEMA = json.loads(SCHEMA)
+
+
+class _SignatureCheckedMessages:
+    """Mimics the real SDK: rejects unknown keyword arguments like messages.create()."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self._valid_params = set(inspect.signature(_SdkMessages.create).parameters)
+
+    def create(self, **kwargs):
+        unknown = set(kwargs) - self._valid_params
+        if unknown:
+            raise TypeError(
+                f"create() got an unexpected keyword argument {min(unknown)!r}"
+            )
+        self.calls.append(kwargs)
+        return object()
+
+
+class _Anthropic:
+    instances: list["_Anthropic"] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.messages = _SignatureCheckedMessages()
+        self.instances.append(self)
+
+
+def _capture_payload(
+    monkeypatch,
+    model_parameters: dict,
+    model: str = "claude-opus-5",
+) -> dict:
+    _Anthropic.instances = []
+    monkeypatch.setattr(llm_module, "Anthropic", _Anthropic)
+
+    AnthropicLargeLanguageModel()._chat_generate(
+        model=model,
+        credentials={"anthropic_api_key": "test-key"},
+        prompt_messages=[UserPromptMessage(content="Hello")],
+        model_parameters=dict(model_parameters),
+        stream=True,
+    )
+
+    return _Anthropic.instances[0].messages.calls[0]
+
+
+def test_json_schema_uses_native_structured_output(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {"max_tokens": 1024, "json_schema": SCHEMA},
+    )
+
+    # The schema must not leak as an unknown kwarg (mock raises TypeError on that).
+    assert "json_schema" not in payload
+    assert payload["output_config"] == {
+        "format": {"type": "json_schema", "schema": PARSED_SCHEMA}
+    }
+
+
+def test_json_schema_merges_with_adaptive_effort(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {
+            "max_tokens": 1024,
+            "thinking": True,
+            "thinking_display": "summarized",
+            "effort": "max",
+            "json_schema": SCHEMA,
+        },
+    )
+
+    assert payload["output_config"] == {
+        "effort": "max",
+        "format": {"type": "json_schema", "schema": PARSED_SCHEMA},
+    }
+    assert payload["thinking"] == {"type": "adaptive", "display": "summarized"}
+
+
+def test_json_schema_empty_string_is_ignored(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {"max_tokens": 1024, "json_schema": "   "},
+    )
+
+    assert "output_config" not in payload
+    assert "json_schema" not in payload
+
+
+def test_json_schema_invalid_json_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid json_schema"):
+        AnthropicLargeLanguageModel._parse_json_schema("{not json")
+
+
+def test_json_schema_non_object_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty JSON object"):
+        AnthropicLargeLanguageModel._parse_json_schema('["answer"]')
+
+
+def test_json_schema_dict_passthrough() -> None:
+    schema = {"type": "object", "properties": {"a": {"type": "string"}}}
+    assert AnthropicLargeLanguageModel._parse_json_schema(schema) == schema
+    assert AnthropicLargeLanguageModel._parse_json_schema(None) is None
+    assert AnthropicLargeLanguageModel._parse_json_schema("") is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["null", "false", "0", "[]", "{}"],
+)
+def test_parse_json_schema_rejects_non_objects(raw: str) -> None:
+    with pytest.raises(ValueError, match="non-empty JSON object"):
+        AnthropicLargeLanguageModel._parse_json_schema(raw)
+
+
+@pytest.mark.parametrize("raw", [0, 1.5, ["a"], (1,)])
+def test_parse_json_schema_rejects_unsupported_types(raw: object) -> None:
+    with pytest.raises(ValueError, match="Unsupported json_schema type"):
+        AnthropicLargeLanguageModel._parse_json_schema(raw)
+
+
+def _capture_invoke(monkeypatch, model_parameters: dict, model: str = "claude-sonnet-4-5"):
+    llm = AnthropicLargeLanguageModel()
+    captured: dict = {}
+
+    def fake_invoke(
+        model, credentials, prompt_messages, model_parameters,
+        tools=None, stop=None, stream=True, user=None,
+    ):
+        captured["model_parameters"] = dict(model_parameters)
+        captured["prompt_messages"] = list(prompt_messages)
+        return iter(())
+
+    monkeypatch.setattr(llm, "_invoke", fake_invoke)
+    return llm, captured
+
+
+def test_wrapper_skips_fence_hack_with_json_schema(monkeypatch) -> None:
+    llm, captured = _capture_invoke(monkeypatch, {})
+    prompt_messages = [
+        SystemPromptMessage(content="original system"),
+        UserPromptMessage(content="hi"),
+    ]
+
+    llm._code_block_mode_wrapper(
+        model="claude-sonnet-4-5",
+        credentials={"anthropic_api_key": "test-key"},
+        prompt_messages=prompt_messages,
+        model_parameters={
+            "max_tokens": 1024,
+            "response_format": "JSON",
+            "json_schema": SCHEMA,
+        },
+        stream=True,
+    )
+
+    # Native path: prompts untouched, response_format consumed, json_schema kept
+    # for _chat_generate to send via output_config.format.
+    assert captured["model_parameters"]["json_schema"] == SCHEMA
+    assert "response_format" not in captured["model_parameters"]
+    assert isinstance(prompt_messages[0], SystemPromptMessage)
+    assert prompt_messages[0].content == "original system"
+    assert len(prompt_messages) == 2
+
+
+def test_wrapper_keeps_fence_hack_without_schema(monkeypatch) -> None:
+    llm, captured = _capture_invoke(monkeypatch, {})
+    prompt_messages = [
+        SystemPromptMessage(content="original system"),
+        UserPromptMessage(content="hi"),
+    ]
+
+    llm._code_block_mode_wrapper(
+        model="claude-sonnet-4-5",
+        credentials={"anthropic_api_key": "test-key"},
+        prompt_messages=prompt_messages,
+        model_parameters={
+            "max_tokens": 1024,
+            "response_format": "JSON",
+        },
+        stream=True,
+    )
+
+    # Legacy path: system prompt rewritten, assistant prefill appended.
+    assert "response_format" not in captured["model_parameters"]
+    assert "json_schema" not in captured["model_parameters"]
+    assert "output a valid JSON object" in str(prompt_messages[0].content)
+    assert "original system" in str(prompt_messages[0].content)
+    assert isinstance(prompt_messages[-1], AssistantPromptMessage)
+    assert "```JSON" in str(prompt_messages[-1].content)
+
+
+def test_wrapper_falsy_non_string_schema_not_dropped(monkeypatch) -> None:
+    # An empty dict is a *provided* (invalid) schema: the wrapper must keep it so
+    # _chat_generate / _parse_json_schema can raise, not silently fall back to
+    # the legacy fence hack.
+    llm, captured = _capture_invoke(monkeypatch, {})
+    prompt_messages = [
+        SystemPromptMessage(content="original system"),
+        UserPromptMessage(content="hi"),
+    ]
+
+    llm._code_block_mode_wrapper(
+        model="claude-sonnet-4-5",
+        credentials={"anthropic_api_key": "test-key"},
+        prompt_messages=prompt_messages,
+        model_parameters={
+            "max_tokens": 1024,
+            "response_format": "JSON",
+            "json_schema": {},
+        },
+        stream=True,
+    )
+
+    assert captured["model_parameters"]["json_schema"] == {}
+    assert "response_format" not in captured["model_parameters"]
+    assert prompt_messages[0].content == "original system"
+    assert len(prompt_messages) == 2
+
+
+def test_wrapper_xml_mode_drops_json_schema(monkeypatch) -> None:
+    llm, captured = _capture_invoke(monkeypatch, {})
+    prompt_messages = [
+        SystemPromptMessage(content="original system"),
+        UserPromptMessage(content="hi"),
+    ]
+
+    llm._code_block_mode_wrapper(
+        model="claude-sonnet-4-5",
+        credentials={"anthropic_api_key": "test-key"},
+        prompt_messages=prompt_messages,
+        model_parameters={
+            "max_tokens": 1024,
+            "response_format": "XML",
+            "json_schema": SCHEMA,
+        },
+        stream=True,
+    )
+
+    # XML keeps the fence hack; json_schema must not reach the API call.
+    assert "json_schema" not in captured["model_parameters"]
+    assert "response_format" not in captured["model_parameters"]
+    assert "output a valid XML object" in str(prompt_messages[0].content)


### PR DESCRIPTION
## Summary

Fixes a crash in the Anthropic provider: the `json_schema` parameter is declared in the `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, and `claude-mythos-5` schemas, but was **never consumed** in the code. In JSON output mode with a user-defined schema, the value survived the SDK's parameter filtering and was spread into `client.messages.create(**model_parameters)` — which raised `TypeError: unexpected keyword argument 'json_schema'` (the Anthropic SDK signature has no such parameter and no `**kwargs`).

The schema is now sent via the API's **native structured output** (`output_config.format` with `type: json_schema`, GA — API-side constrained decoding instead of the prompt hack):

- `_chat_generate` pops `json_schema`, validates/parses it (`_parse_json_schema`: JSON string → non-empty object; invalid values raise a clear `ValueError`), and merges `{"format": {...}}` into `output_config` — coexisting with `effort`/`task_budget` on adaptive-thinking models.
- `_code_block_mode_wrapper` skips the code-fence prompt hack when JSON mode has a schema (the hack would wrap API-constrained JSON in markdown fences); JSON mode **without** a schema and XML mode keep the legacy behavior exactly, and `json_schema` is dropped for non-JSON formats so it can never reach the API call.
- The test suite now uses a **signature-compatible mock** built from `inspect.signature` of the real `anthropic` `Messages.create` — it rejects unknown kwargs exactly like the SDK boundary, which is what the previous permissive `create(**kwargs)` mock masked.

## Release Notes

- Fixed a crash when using JSON output with a custom schema on Claude Opus 5 / Sonnet 5 / Fable 5 / Mythos 5
- JSON output with a custom schema now uses Anthropic's native structured output (API-enforced schema) for more reliable, valid JSON
- JSON output without a schema and XML output are unchanged

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable — provider parameter handling, covered by unit tests.

| Before | After |
| ------ | ----- |
| JSON mode + custom schema → `TypeError` crash | JSON mode + custom schema → native constrained decoding |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.3.27 → 0.3.28
- [x] `dify_plugin>=0.9.0` is declared in `pyproject.toml` and locked in `uv.lock` (locked at 0.10.0)

## Testing

- [x] Local deployment — clean `uv` venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock`: **48 unit tests pass** (21 new), including regression tests that fail against the pre-fix code; `ruff check` shows no new findings beyond the file's pre-existing style
- [ ] SaaS (cloud.dify.ai)

Note: live API calls with `output_config.format` on Claude 5 models are not covered by unit tests (no API key in CI); the request shape was verified against the installed `anthropic` SDK types (`OutputConfigParam` / `JSONOutputFormatParam`) and the SDK's own test suite.


