### PR TITLE
feat(gemini): attach Dify app_id as request labels (opt-in)

### DIFF
--- a/models/gemini/README.md
+++ b/models/gemini/README.md
@@ -11,3 +11,5 @@ After installing the Gemini plugin, configure it with your API key, which you ca
 
 If you use `url` mode for `MULTIMODAL_SEND_FORMAT` in gemeni and other vision models meantime, you can set `Files URL` to gain better performance.
 
+`Enable request metadata` is optional and disabled by default. Turning it on attaches `dify_app_id` and `dify_source` to each Gemini request as `labels` on `GenerateContentConfig`, so usage can be attributed to a specific Dify app in Cloud Billing. The opt-in applies to the `generate_content` route only; the Interactions API does not surface labels in its billing breakdown and is intentionally left untouched. The Dify session lookup is best-effort: if the session context is not initialized, no labels are attached and the request is sent unchanged.
+

--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.5
+version: 0.9.6

--- a/models/gemini/models/llm/_labels.py
+++ b/models/gemini/models/llm/_labels.py
@@ -1,0 +1,106 @@
+"""Helpers for attaching Dify metadata to Gemini requests as labels.
+
+The Gemini API (``google-genai`` SDK) accepts a ``labels`` field on
+``GenerateContentConfig``. The values are surfaced in the Cloud Billing
+breakdown and Cloud Logging for per-app cost and usage attribution.
+Constraints, from the Google Cloud documentation:
+
+  - Keys must begin with a lowercase letter.
+  - Keys and values may contain only lowercase letters, digits, underscores,
+    and hyphens.
+  - Keys and values must be 63 characters or less.
+
+UUIDs (36 characters, lowercase hex with hyphens) already satisfy these
+constraints. ``normalize_label_value`` exists as a safety net for any
+non-UUID value (e.g. emails, non-ASCII text) that may flow through in the
+future.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+_INVALID_CHAR_RE = re.compile(r"[^a-z0-9_-]")
+_MAX_LABEL_LENGTH = 63
+
+
+def normalize_label_value(s: Any) -> str:
+    """Normalize an arbitrary value into a Gemini label-compatible value.
+
+    Lowercases the input, replaces any character outside ``[a-z0-9_-]`` with
+    ``_``, and truncates to 63 characters. An empty input returns an empty
+    string (no exception raised). Non-string inputs are coerced via ``str()``
+    first so that, e.g., a numeric ``0`` becomes ``"0"`` rather than being
+    silently dropped by the empty-check.
+    """
+    if s is None:
+        return ""
+    if not isinstance(s, str):
+        s = str(s)
+    if not s:
+        return ""
+    # Truncate first to bound the cost of lower()/sub() on pathological input.
+    # lower() can still expand certain Unicode chars, so re-truncate at the end.
+    s = s[:_MAX_LABEL_LENGTH]
+    lowered = s.lower()
+    sanitized = _INVALID_CHAR_RE.sub("_", lowered)
+    return sanitized[:_MAX_LABEL_LENGTH]
+
+
+def build_dify_labels(app_id: Any) -> Optional[dict[str, str]]:
+    """Build the Dify labels dict for a Gemini request, or return ``None``.
+
+    Returns ``None`` if ``app_id`` is ``None`` or an empty string, so the
+    caller can skip attaching labels entirely. Other falsy values (e.g.
+    numeric ``0``) are coerced by ``normalize_label_value`` and pass
+    through. Otherwise, returns a dict with ``dify_app_id`` (normalized)
+    and a static ``dify_source`` marker.
+    """
+    if app_id is None or app_id == "":
+        return None
+    return {
+        "dify_app_id": normalize_label_value(app_id),
+        "dify_source": "dify",
+    }
+
+
+def apply_dify_labels_if_enabled(config: Any, credentials: dict) -> None:
+    """Inject Dify labels into a ``GenerateContentConfig`` when opt-in is set.
+
+    Reads ``credentials['enable_request_metadata']``; when ``"enabled"``,
+    resolves the current Dify session's ``app_id`` (best-effort) and writes
+    the built labels into ``config.labels``. If existing labels are present
+    as a dict, Dify keys are merged in alongside caller-supplied ones; if
+    absent (or not a dict), the Dify-only dict is set.
+
+    Session lookup failures are swallowed silently: label attachment is
+    telemetry, and must never break generation if the SDK is missing or
+    the session context is not initialized.
+    """
+    if credentials.get("enable_request_metadata") != "enabled":
+        return
+
+    app_id: Optional[str] = None
+    try:
+        from dify_plugin import get_current_session
+
+        session = get_current_session()
+        if session is not None:
+            app_id = getattr(session, "app_id", None)
+    except Exception:
+        # Best-effort telemetry: never break generation.
+        pass
+
+    labels = build_dify_labels(app_id)
+    if labels is None:
+        return
+
+    existing = getattr(config, "labels", None)
+    if isinstance(existing, dict):
+        # Preserve any caller-supplied labels; only fill in Dify keys.
+        # Build a new dict rather than mutating in place, so a caller-shared
+        # reference is never modified as a side effect of telemetry opt-in.
+        config.labels = {**existing, **labels}
+    else:
+        config.labels = labels

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -1320,6 +1320,15 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
             last_nonempty_content.role if last_nonempty_content else None,
         )
 
+        # Optional: attach Dify app_id as Gemini labels for Cloud Billing
+        # breakdown. Default disabled; opt-in via the enable_request_metadata
+        # credential. Scoped to the generate_content route only; the
+        # Interactions API below does not surface labels in its billing
+        # breakdown, so it is intentionally left untouched.
+        from ._labels import apply_dify_labels_if_enabled
+
+        apply_dify_labels_if_enabled(config, credentials)
+
         if stream:
             response = genai_client.models.generate_content_stream(
                 model=model, contents=contents, config=config

--- a/models/gemini/provider/google.yaml
+++ b/models/gemini/provider/google.yaml
@@ -58,6 +58,31 @@ provider_credential_schema:
     required: false
     type: text-input
     variable: file_url
+  - label:
+      en_US: Enable request metadata
+      zh_Hans: 启用请求元数据
+    help:
+      text:
+        en_US: >-
+          Attach Dify app_id and dify_source to each Gemini request as
+          labels, so usage can be attributed to a specific Dify app in
+          Cloud Billing. Default is disabled.
+        zh_Hans: >-
+          将 Dify app_id 与 dify_source 作为标签附加到每次 Gemini 请求，
+          以便在 Cloud Billing 中按 Dify 应用归因用量。默认禁用。
+    options:
+    - label:
+        en_US: Disabled
+        zh_Hans: 禁用
+      value: disabled
+    - label:
+        en_US: Enabled
+        zh_Hans: 启用
+      value: enabled
+    required: false
+    type: select
+    variable: enable_request_metadata
+    default: disabled
 supported_model_types:
   - llm
   - text-embedding

--- a/models/gemini/pyproject.toml
+++ b/models/gemini/pyproject.toml
@@ -7,7 +7,9 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "dify-plugin>=0.9.0",
+    # 0.10.0 introduces get_current_session(), required to resolve the
+    # current Dify app_id for Gemini request labels.
+    "dify-plugin>=0.10.0",
     "google-genai>=2.5.0",
     "numpy>=2.4.6",
     "requests>=2.34.2",

--- a/models/gemini/tests/test_labels.py
+++ b/models/gemini/tests/test_labels.py
@@ -1,0 +1,214 @@
+from types import SimpleNamespace
+
+from models.llm._labels import (
+    apply_dify_labels_if_enabled,
+    build_dify_labels,
+    normalize_label_value,
+)
+
+
+# --- normalize_label_value ---
+
+
+def test_normalize_uuid_passthrough():
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    assert normalize_label_value(uuid) == uuid
+
+
+def test_normalize_replaces_invalid_chars():
+    # GCP label values are restricted to [a-z0-9_-]; any other character
+    # is replaced with an underscore.
+    assert normalize_label_value("a@b.c") == "a_b_c"
+
+
+def test_normalize_lowercases_uppercase():
+    assert normalize_label_value("FOO-BAR") == "foo-bar"
+
+
+def test_normalize_preserves_underscore_and_hyphen():
+    assert normalize_label_value("a_b-c") == "a_b-c"
+
+
+def test_normalize_truncates_at_63_chars():
+    long_input = "a" * 100
+    result = normalize_label_value(long_input)
+    assert len(result) == 63
+    assert result == "a" * 63
+
+
+def test_normalize_truncation_bound_applied_before_substitution():
+    # Truncation happens before regex substitution so that pathological
+    # inputs do not incur unbounded regex work on the tail.
+    long_input = "Z" * 200
+    result = normalize_label_value(long_input)
+    assert len(result) == 63
+
+
+def test_normalize_empty_string():
+    assert normalize_label_value("") == ""
+
+
+def test_normalize_none_returns_empty():
+    assert normalize_label_value(None) == ""
+
+
+def test_normalize_coerces_non_string_input():
+    # Non-string inputs are stringified before validation, so a numeric 0
+    # (falsy) does not get dropped by the empty-check.
+    assert normalize_label_value(0) == "0"
+    assert normalize_label_value(123) == "123"
+
+
+# --- build_dify_labels ---
+
+
+def test_build_dify_labels_returns_none_for_none():
+    assert build_dify_labels(None) is None
+
+
+def test_build_dify_labels_returns_none_for_empty():
+    assert build_dify_labels("") is None
+
+
+def test_build_dify_labels_includes_source_marker():
+    labels = build_dify_labels("550e8400-e29b-41d4-a716-446655440000")
+    assert labels is not None
+    assert labels["dify_source"] == "dify"
+
+
+def test_build_dify_labels_normalizes_app_id():
+    labels = build_dify_labels("My App@Example.com/" + "x" * 100)
+    assert labels is not None
+    app_id = labels["dify_app_id"]
+    assert len(app_id) <= 63
+    assert all(c.islower() or c.isdigit() or c in "_-" for c in app_id)
+
+
+def test_build_dify_labels_keeps_non_string_falsy():
+    # build_dify_labels only rejects None and "" — other falsy values
+    # such as numeric 0 are coerced by normalize_label_value.
+    labels = build_dify_labels(0)
+    assert labels == {"dify_app_id": "0", "dify_source": "dify"}
+
+
+def test_build_dify_labels_uuid_passthrough():
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    labels = build_dify_labels(uuid)
+    assert labels == {"dify_app_id": uuid, "dify_source": "dify"}
+
+
+# --- apply_dify_labels_if_enabled: credential gating ---
+
+
+def test_apply_no_op_when_credential_missing():
+    config = SimpleNamespace()
+    apply_dify_labels_if_enabled(config, {})
+    assert not hasattr(config, "labels")
+
+
+def test_apply_no_op_when_credential_disabled():
+    config = SimpleNamespace()
+    apply_dify_labels_if_enabled(config, {"enable_request_metadata": "disabled"})
+    assert not hasattr(config, "labels")
+
+
+def test_apply_noop_without_session_context():
+    # Outside a Dify session, get_current_session() returns None rather
+    # than raising, so no app_id resolves and the config is left untouched.
+    config = SimpleNamespace()
+    apply_dify_labels_if_enabled(config, {"enable_request_metadata": "enabled"})
+    assert not hasattr(config, "labels")
+
+
+def test_apply_silent_when_session_lookup_raises(monkeypatch):
+    # Telemetry must never break generation, so a raising session lookup
+    # is swallowed. Exercises the except branch directly, which the
+    # None-returning path above cannot reach.
+    import dify_plugin
+
+    def _boom():
+        raise RuntimeError("session backend unavailable")
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", _boom)
+    config = SimpleNamespace()
+    apply_dify_labels_if_enabled(config, {"enable_request_metadata": "enabled"})
+    assert not hasattr(config, "labels")
+
+
+class _FakeSession:
+    app_id = "550e8400-e29b-41d4-a716-446655440000"
+
+
+# --- apply_dify_labels_if_enabled: label composition ---
+
+
+def test_apply_merges_with_existing_labels(monkeypatch):
+    # When the config already carries labels (e.g. caller-supplied
+    # labels), Dify keys must merge in rather than replace the whole dict.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    config = SimpleNamespace(labels={"existing": "value"})
+    apply_dify_labels_if_enabled(config, {"enable_request_metadata": "enabled"})
+    assert config.labels["existing"] == "value"
+    assert config.labels["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert config.labels["dify_source"] == "dify"
+
+
+def test_apply_replaces_non_dict_labels(monkeypatch):
+    # If existing labels is somehow not a dict, Dify keys take over rather
+    # than blow up — telemetry is best-effort.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    config = SimpleNamespace(labels="unexpected-string")
+    apply_dify_labels_if_enabled(config, {"enable_request_metadata": "enabled"})
+    assert isinstance(config.labels, dict)
+    assert config.labels["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_apply_does_not_mutate_existing_labels(monkeypatch):
+    # The merge must not mutate the caller's dict in place: a shared
+    # reference must never be modified as a side effect of telemetry opt-in.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    original = {"existing_key": "existing_value"}
+    config = SimpleNamespace(labels=original)
+    apply_dify_labels_if_enabled(config, {"enable_request_metadata": "enabled"})
+    # The original dict is left untouched.
+    assert original == {"existing_key": "existing_value"}
+    # config carries a new, merged dict.
+    assert config.labels is not original
+    assert config.labels["existing_key"] == "existing_value"
+    assert config.labels["dify_app_id"] == "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_apply_writes_labels_when_config_empty(monkeypatch):
+    # With no prior labels, apply should write a fresh dict carrying only
+    # the Dify keys.
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
+    config = SimpleNamespace()
+    apply_dify_labels_if_enabled(config, {"enable_request_metadata": "enabled"})
+    assert config.labels == {
+        "dify_app_id": "550e8400-e29b-41d4-a716-446655440000",
+        "dify_source": "dify",
+    }
+
+
+# --- apply_dify_labels_if_enabled: source-level guard ---
+
+
+def test_llm_module_uses_dify_labels_helper():
+    # The wiring in llm.py must reach apply_dify_labels_if_enabled so the
+    # opt-in credential is honored on the request path. A source-level
+    # guard catches accidental removal during refactors of the call site.
+    import inspect
+
+    from models.llm import llm as llm_module
+
+    source = inspect.getsource(llm_module)
+    assert "apply_dify_labels_if_enabled(config, credentials)" in source
+    assert "from ._labels import apply_dify_labels_if_enabled" in source

--- a/models/gemini/uv.lock
+++ b/models/gemini/uv.lock
@@ -438,7 +438,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.0" },
     { name = "google-genai", specifier = ">=2.5.0" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "requests", specifier = ">=2.34.2" },


### PR DESCRIPTION
## Summary

Adds an opt-in `enable_request_metadata` credential to the Gemini plugin. When enabled, the plugin attaches `dify_app_id` and `dify_source` to each Gemini request as `labels` on `GenerateContentConfig`, so usage can be attributed to a specific Dify app in Cloud Billing.

This follows the same opt-in pattern already shipped in #3685 (bedrock), #3686 (vertex_ai), #3687 (azure_openai), #3688 (openai), and #3717 (anthropic). Gemini is the next-highest-traffic Gemini-family provider in this repo and was the natural missing entry in that set.

Refs: langgenius/dify#35772, langgenius/dify-plugin-sdks#311

## Release Notes

- Added an `enable_request_metadata` credential (default: disabled) at the provider level. When enabled, the plugin attaches `dify_app_id` and `dify_source` to each Gemini request as `labels`, so per-app usage can be filtered in Cloud Billing. The opt-in applies to the `generate_content` route only; the Interactions API does not surface labels in its billing breakdown and is intentionally left untouched. The opt-in merges into any caller-supplied labels rather than overwriting them, and is a no-op when disabled or when the Dify session does not expose an `app_id`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| No Dify app attribution on Gemini requests | `dify_app_id` + `dify_source` attached to GenerateContentConfig labels when opt-in is enabled |

The change is fully covered by the new unit tests under `tests/test_labels.py` (24 tests) — no manual screenshot is applicable.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [x] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`): 0.9.5 → 0.9.6
- [x] `dify_plugin>=0.10.0` is declared in `pyproject.toml` and locked in `uv.lock` (was `>=0.9.0`; the helper uses `get_current_session()` introduced in 0.10.0)

## Testing

- [x] Local deployment — Dify version: 1.7.0

Tested via `uv run pytest tests/test_labels.py` (24 passed) and `uv run ruff check` (clean). The new `tests/test_labels.py` adds 24 tests covering the normalize/build/apply paths, including a source-level guard that confirms the helper is reached from `llm.py`.
