### PR TITLE
fix(tongyi): add Fun-ASR speech-to-text support

### DIFF
--- a/models/tongyi/README.md
+++ b/models/tongyi/README.md
@@ -10,4 +10,6 @@ After installation, you need to get API keys from [Alibaba Cloud](https://bailia
 
 Tongyi speech-to-text patches DashScope's async-to-sync websocket bridge when it runs under Dify's gevent-based plugin runtime. This avoids sustained high CPU after STT requests while keeping the normal in-process recognition path.
 
-If you need stronger isolation for STT recognition, set `TONGYI_STT_SUBPROCESS=1` in the plugin daemon environment. `TONGYI_STT_RECOGNITION_TIMEOUT` can be used to tune the subprocess timeout.
+If you need stronger isolation for STT recognition, set `TONGYI_STT_SUBPROCESS=1` in the plugin daemon environment.
+`TONGYI_STT_RECOGNITION_TIMEOUT` can be used to tune the subprocess timeout.
+`TONGYI_STT_TRANSCRIPTION_TIMEOUT` caps the Fun-ASR asynchronous task wait and defaults to 10,800 seconds.

--- a/models/tongyi/README.md
+++ b/models/tongyi/README.md
@@ -12,4 +12,3 @@ Tongyi speech-to-text patches DashScope's async-to-sync websocket bridge when it
 
 If you need stronger isolation for STT recognition, set `TONGYI_STT_SUBPROCESS=1` in the plugin daemon environment.
 `TONGYI_STT_RECOGNITION_TIMEOUT` can be used to tune the subprocess timeout.
-`TONGYI_STT_TRANSCRIPTION_TIMEOUT` caps the Fun-ASR asynchronous task wait and defaults to 10,800 seconds.

--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.2.13
+version: 0.2.14
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/models/speech2text/_stt_worker.py
+++ b/models/tongyi/models/speech2text/_stt_worker.py
@@ -36,11 +36,16 @@ def main() -> int:
         status_code = getattr(result, "status_code", 200)
         if status_code != 200:
             message = getattr(result, "message", None) or "Unknown DashScope error"
+            code = getattr(result, "code", None) or "Unknown"
+            request_id = getattr(result, "request_id", None) or "Unknown"
             print(
                 json.dumps(
                     {
                         "status": "err",
-                        "data": f"DashScope error: {message} ({status_code})",
+                        "data": (
+                            f"DashScope error: {message} "
+                            f"(status: {status_code}, code: {code}, request_id: {request_id})"
+                        ),
                     }
                 )
             )

--- a/models/tongyi/models/speech2text/fun-asr-flash-2026-06-15.yaml
+++ b/models/tongyi/models/speech2text/fun-asr-flash-2026-06-15.yaml
@@ -3,7 +3,3 @@ model_type: speech2text
 model_properties:
   file_upload_limit: 7
   supported_file_extensions: aac,amr,avi,flac,flv,m4a,mkv,mov,mp3,mp4,mpeg,ogg,opus,wav,webm,wma,wmv
-pricing:
-  input: "0.00022"
-  unit: "0.00001"
-  currency: RMB

--- a/models/tongyi/models/speech2text/fun-asr-flash-2026-06-15.yaml
+++ b/models/tongyi/models/speech2text/fun-asr-flash-2026-06-15.yaml
@@ -1,0 +1,9 @@
+model: fun-asr-flash-2026-06-15
+model_type: speech2text
+model_properties:
+  file_upload_limit: 7
+  supported_file_extensions: aac,amr,avi,flac,flv,m4a,mkv,mov,mp3,mp4,mpeg,ogg,opus,wav,webm,wma,wmv
+pricing:
+  input: "0.00022"
+  unit: "0.00001"
+  currency: RMB

--- a/models/tongyi/models/speech2text/fun-asr.yaml
+++ b/models/tongyi/models/speech2text/fun-asr.yaml
@@ -3,7 +3,3 @@ model_type: speech2text
 model_properties:
   file_upload_limit: 100
   supported_file_extensions: aac,amr,avi,flac,flv,m4a,mkv,mov,mp3,mp4,mpeg,ogg,opus,wav,webm,wma,wmv
-pricing:
-  input: "0.00022"
-  unit: "0.00001"
-  currency: RMB

--- a/models/tongyi/models/speech2text/fun-asr.yaml
+++ b/models/tongyi/models/speech2text/fun-asr.yaml
@@ -1,0 +1,9 @@
+model: fun-asr
+model_type: speech2text
+model_properties:
+  file_upload_limit: 100
+  supported_file_extensions: aac,amr,avi,flac,flv,m4a,mkv,mov,mp3,mp4,mpeg,ogg,opus,wav,webm,wma,wmv
+pricing:
+  input: "0.00022"
+  unit: "0.00001"
+  currency: RMB

--- a/models/tongyi/models/speech2text/speech2text.py
+++ b/models/tongyi/models/speech2text/speech2text.py
@@ -1,17 +1,22 @@
+import base64
 import json
 import logging
+import mimetypes
 import os
 import subprocess
 import sys
 import tempfile
 import uuid
 from pathlib import Path
-from typing import IO, Any, Optional, Tuple
+from typing import IO, Any
 
-from dashscope.audio.asr import Recognition
+import requests
+from dashscope.audio.asr import Recognition, Transcription
+from dashscope.utils.oss_utils import OssUtils
 from dify_plugin import OAICompatSpeech2TextModel
-from models._common import get_ws_base_address
 from pydub import AudioSegment
+
+from models._common import get_http_base_address, get_ws_base_address
 
 from ..constant import BURY_POINT_HEADER
 
@@ -50,7 +55,11 @@ _SUBPROCESS_ENV = "TONGYI_STT_SUBPROCESS"
 _SUBPROCESS_TRUE_VALUES = {"1", "true", "yes", "on"}
 _RECOGNITION_TIMEOUT_ENV = "TONGYI_STT_RECOGNITION_TIMEOUT"
 _DEFAULT_RECOGNITION_TIMEOUT = 120
+_TRANSCRIPTION_TIMEOUT_ENV = "TONGYI_STT_TRANSCRIPTION_TIMEOUT"
+_DEFAULT_TRANSCRIPTION_TIMEOUT = 10_800
 _DASHSCOPE_ASYNC_BRIDGE_PATCHED = False
+_FUN_ASR_MODEL = "fun-asr"
+_FUN_ASR_FLASH_MODEL = "fun-asr-flash-2026-06-15"
 
 
 def _is_subprocess_enabled() -> bool:
@@ -134,7 +143,7 @@ def _patch_dashscope_async_bridge_for_gevent() -> None:
                             message_queue.put((True, None, None))
                             break
                         message_queue.put((False, None, obj))
-                    except BaseException as ex:  # noqa: E722
+                    except BaseException as ex:
                         dashscope_logger.exception(ex)
                         message_queue.put((True, ex, None))
                         break
@@ -161,15 +170,55 @@ def _patch_dashscope_async_bridge_for_gevent() -> None:
     _DASHSCOPE_ASYNC_BRIDGE_PATCHED = True
 
 
-def _get_recognition_timeout() -> int:
-    value = os.getenv(_RECOGNITION_TIMEOUT_ENV)
+def _get_timeout(env_name: str, default: int) -> int:
+    value = os.getenv(env_name)
     if not value:
-        return _DEFAULT_RECOGNITION_TIMEOUT
+        return default
     try:
         seconds = int(value)
     except (TypeError, ValueError):
-        return _DEFAULT_RECOGNITION_TIMEOUT
-    return seconds if seconds > 0 else _DEFAULT_RECOGNITION_TIMEOUT
+        return default
+    return seconds if seconds > 0 else default
+
+
+def _get_recognition_timeout() -> int:
+    return _get_timeout(_RECOGNITION_TIMEOUT_ENV, _DEFAULT_RECOGNITION_TIMEOUT)
+
+
+def _get_transcription_timeout() -> int:
+    return _get_timeout(_TRANSCRIPTION_TIMEOUT_ENV, _DEFAULT_TRANSCRIPTION_TIMEOUT)
+
+
+def _parse_json_response(response) -> dict:
+    try:
+        data = response.json()
+    except ValueError as ex:
+        body = response.text[:500]
+        raise ValueError(
+            f"DashScope returned invalid JSON ({response.status_code}): {body}"
+        ) from ex
+
+    if not isinstance(data, dict):
+        raise TypeError("DashScope returned invalid JSON: expected an object")
+    if response.status_code != 200:
+        code = data.get("code") or response.status_code
+        message = data.get("message") or response.text or "Unknown DashScope error"
+        request_id = data.get("request_id")
+        request_suffix = f", request_id: {request_id}" if request_id else ""
+        raise ValueError(f"DashScope error {code}: {message}{request_suffix}")
+    return data
+
+
+def _raise_for_dashscope_error(response) -> None:
+    status_code = getattr(response, "status_code", 200)
+    if status_code == 200:
+        return
+    message = getattr(response, "message", None) or "Unknown DashScope error"
+    code = getattr(response, "code", None)
+    request_id = getattr(response, "request_id", None)
+    code_suffix = f", code: {code}" if code else ""
+    request_suffix = f", request_id: {request_id}" if request_id else ""
+    raise ValueError(f"DashScope error: {message} ({status_code}{code_suffix}{request_suffix})")
 
 
 def _run_recognition_in_subprocess(
@@ -178,10 +227,10 @@ def _run_recognition_in_subprocess(
     audio_format: str,
     sample_rate: int,
     api_key: str,
-    base_address: Optional[str],
+    base_address: str | None,
     headers: dict,
-    timeout: Optional[int] = None,
-) -> Tuple[str, Any]:
+    timeout: int | None = None,
+) -> tuple[str, Any]:
     if timeout is None:
         timeout = _get_recognition_timeout()
 
@@ -241,7 +290,7 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
     """
 
     def _invoke(
-        self, model: str, credentials: dict, file: IO[bytes], user: Optional[str] = None
+        self, model: str, credentials: dict, file: IO[bytes], user: str | None = None
     ) -> str:
         """
         Invoke speech2text model
@@ -254,17 +303,26 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
         """
         file_path = None
         try:
-            ws_base_address = get_ws_base_address(credentials)
             file.seek(0)
             audio_format = self.get_audio_type(file)
             if audio_format == "unknown":
                 raise ValueError("Unsupported audio format")
-            audio = AudioSegment.from_file(file, format=audio_format)
-            sample_rate = audio.frame_rate
             file.seek(0)
             file_path = self.write_bytes_to_temp_file(file, audio_format)
             api_key = credentials["dashscope_api_key"]
 
+            if model == _FUN_ASR_MODEL:
+                return self._invoke_fun_asr(
+                    model, file_path, api_key, get_http_base_address(credentials)
+                )
+            if model == _FUN_ASR_FLASH_MODEL:
+                return self._invoke_fun_asr_flash(
+                    model, file_path, audio_format, api_key, get_http_base_address(credentials)
+                )
+
+            audio = AudioSegment.from_file(file_path, format=audio_format)
+            sample_rate = audio.frame_rate
+            ws_base_address = get_ws_base_address(credentials)
             if _is_subprocess_enabled():
                 headers = dict(BURY_POINT_HEADER) if BURY_POINT_HEADER else {}
                 status, data = _run_recognition_in_subprocess(
@@ -293,6 +351,7 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
                     api_key=api_key,
                     base_address=ws_base_address,
                 )
+                _raise_for_dashscope_error(result)
                 sentence_list = result.get_sentence()
 
             if not sentence_list:
@@ -310,6 +369,117 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
                     os.remove(file_path)
                 except OSError:
                     pass
+
+    def _invoke_fun_asr_flash(
+        self, model: str, file_path: str, audio_format: str, api_key: str, base_address: str
+    ) -> str:
+        mime_type = (
+            {"mp3": "audio/mpeg", "wav": "audio/wav"}.get(audio_format)
+            or mimetypes.guess_type(file_path)[0]
+            or "application/octet-stream"
+        )
+        audio_data = base64.b64encode(Path(file_path).read_bytes()).decode()
+        response = requests.post(
+            f"{base_address}/services/aigc/multimodal-generation/generation",
+            headers={
+                **BURY_POINT_HEADER,
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "X-DashScope-SSE": "disable",
+            },
+            json={
+                "model": model,
+                "input": {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_audio",
+                                    "input_audio": {
+                                        "data": f"data:{mime_type};base64,{audio_data}"
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "parameters": {"format": audio_format},
+            },
+            timeout=(10, _get_recognition_timeout()),
+        )
+        data = _parse_json_response(response)
+        text = (data.get("output") or {}).get("text")
+        if not isinstance(text, str):
+            raise TypeError(
+                "DashScope returned an invalid Fun-ASR-Flash response: missing output.text"
+            )
+        return text
+
+    def _invoke_fun_asr(self, model: str, file_path: str, api_key: str, base_address: str) -> str:
+        # ponytail: the official temporary upload is non-production (100 QPS and
+        # a one-hour SDK upload timeout); accept public-URL input before adding OSS credentials.
+        oss_url, _ = OssUtils.upload(
+            model=model,
+            file_path=file_path,
+            api_key=api_key,
+            base_address=base_address,
+            headers=BURY_POINT_HEADER,
+        )
+        submit_response = Transcription.async_call(
+            model=model,
+            file_urls=[oss_url],
+            api_key=api_key,
+            base_address=base_address,
+            headers={**BURY_POINT_HEADER, "X-DashScope-OssResourceResolve": "enable"},
+        )
+        _raise_for_dashscope_error(submit_response)
+        task_id = (submit_response.output or {}).get("task_id")
+        if not task_id:
+            raise ValueError("DashScope returned an invalid Fun-ASR response: missing task_id")
+
+        task_response = Transcription.wait(
+            task_id,
+            api_key=api_key,
+            base_address=base_address,
+            headers=BURY_POINT_HEADER,
+            wait_timeout=_get_transcription_timeout(),
+        )
+        _raise_for_dashscope_error(task_response)
+        output = task_response.output or {}
+        task_status = output.get("task_status")
+
+        results = output.get("results") or []
+        result = results[0] if results else {}
+        if result.get("subtask_status") != "SUCCEEDED":
+            code = result.get("code") or output.get("code") or task_status or "Unknown"
+            message = (
+                result.get("message") or output.get("message") or "Fun-ASR transcription failed"
+            )
+            request_id = task_response.request_id
+            request_suffix = f", request_id: {request_id}" if request_id else ""
+            raise ValueError(f"DashScope error {code}: {message}{request_suffix}")
+
+        transcription_url = result.get("transcription_url")
+        if not transcription_url:
+            raise ValueError(
+                "DashScope returned an invalid Fun-ASR response: missing transcription_url"
+            )
+        transcription = _parse_json_response(
+            requests.get(transcription_url, timeout=(10, _get_recognition_timeout()))
+        )
+        transcripts = transcription.get("transcripts")
+        if not isinstance(transcripts, list):
+            raise TypeError("DashScope returned an invalid Fun-ASR result: missing transcripts")
+
+        texts = []
+        for transcript in transcripts:
+            text = transcript.get("text") if isinstance(transcript, dict) else None
+            if not isinstance(text, str):
+                raise TypeError("DashScope returned an invalid Fun-ASR transcript")
+            if text:
+                texts.append(text)
+        return "\n".join(texts)
 
     def write_bytes_to_temp_file(self, file: IO[bytes], file_extension: str) -> str:
         temp_dir = tempfile.gettempdir()

--- a/models/tongyi/models/speech2text/speech2text.py
+++ b/models/tongyi/models/speech2text/speech2text.py
@@ -55,8 +55,6 @@ _SUBPROCESS_ENV = "TONGYI_STT_SUBPROCESS"
 _SUBPROCESS_TRUE_VALUES = {"1", "true", "yes", "on"}
 _RECOGNITION_TIMEOUT_ENV = "TONGYI_STT_RECOGNITION_TIMEOUT"
 _DEFAULT_RECOGNITION_TIMEOUT = 120
-_TRANSCRIPTION_TIMEOUT_ENV = "TONGYI_STT_TRANSCRIPTION_TIMEOUT"
-_DEFAULT_TRANSCRIPTION_TIMEOUT = 10_800
 _DASHSCOPE_ASYNC_BRIDGE_PATCHED = False
 _FUN_ASR_MODEL = "fun-asr"
 _FUN_ASR_FLASH_MODEL = "fun-asr-flash-2026-06-15"
@@ -170,23 +168,15 @@ def _patch_dashscope_async_bridge_for_gevent() -> None:
     _DASHSCOPE_ASYNC_BRIDGE_PATCHED = True
 
 
-def _get_timeout(env_name: str, default: int) -> int:
-    value = os.getenv(env_name)
+def _get_recognition_timeout() -> int:
+    value = os.getenv(_RECOGNITION_TIMEOUT_ENV)
     if not value:
-        return default
+        return _DEFAULT_RECOGNITION_TIMEOUT
     try:
         seconds = int(value)
     except (TypeError, ValueError):
-        return default
-    return seconds if seconds > 0 else default
-
-
-def _get_recognition_timeout() -> int:
-    return _get_timeout(_RECOGNITION_TIMEOUT_ENV, _DEFAULT_RECOGNITION_TIMEOUT)
-
-
-def _get_transcription_timeout() -> int:
-    return _get_timeout(_TRANSCRIPTION_TIMEOUT_ENV, _DEFAULT_TRANSCRIPTION_TIMEOUT)
+        return _DEFAULT_RECOGNITION_TIMEOUT
+    return seconds if seconds > 0 else _DEFAULT_RECOGNITION_TIMEOUT
 
 
 def _parse_json_response(response) -> dict:
@@ -210,15 +200,11 @@ def _parse_json_response(response) -> dict:
 
 
 def _raise_for_dashscope_error(response) -> None:
-    status_code = getattr(response, "status_code", 200)
-    if status_code == 200:
-        return
-    message = getattr(response, "message", None) or "Unknown DashScope error"
-    code = getattr(response, "code", None)
-    request_id = getattr(response, "request_id", None)
-    code_suffix = f", code: {code}" if code else ""
-    request_suffix = f", request_id: {request_id}" if request_id else ""
-    raise ValueError(f"DashScope error: {message} ({status_code}{code_suffix}{request_suffix})")
+    if response.status_code != 200:
+        raise ValueError(
+            f"DashScope error: {response.message or 'Unknown DashScope error'} "
+            f"({response.status_code}, code: {response.code}, request_id: {response.request_id})"
+        )
 
 
 def _run_recognition_in_subprocess(
@@ -443,7 +429,7 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
             api_key=api_key,
             base_address=base_address,
             headers=BURY_POINT_HEADER,
-            wait_timeout=_get_transcription_timeout(),
+            wait_timeout=10_800,
         )
         _raise_for_dashscope_error(task_response)
         output = task_response.output or {}

--- a/models/tongyi/models/speech2text/speech2text.py
+++ b/models/tongyi/models/speech2text/speech2text.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 import uuid
 from pathlib import Path
 from typing import IO, Any
@@ -14,22 +15,14 @@ import requests
 from dashscope.audio.asr import Recognition, Transcription
 from dashscope.utils.oss_utils import OssUtils
 from dify_plugin import OAICompatSpeech2TextModel
-from pydub import AudioSegment
-
 from models._common import get_http_base_address, get_ws_base_address
+from pydub import AudioSegment
 
 from ..constant import BURY_POINT_HEADER
 
 logger = logging.getLogger(__name__)
 
-_AUDIO_MAGIC = [
-    (0, b"fLaC", "flac"),
-    (0, b"ID3", "mp3"),
-    (0, b"OggS", "ogg"),
-    (0, b"\x1a\x45\xdf\xa3", "webm"),
-    (4, b"ftyp", "m4a"),
-    (0, b"#!AMR", "amr"),
-]
+_AUDIO_MAGIC = [(0, b"fLaC", "flac"), (0, b"ID3", "mp3"), (0, b"#!AMR", "amr")]
 _RIFF_SUBTYPE = {(8, b"WAVE"): "wav", (8, b"AVI "): "avi"}
 _AUDIO_FORMATS_FALLBACK = [
     "wav",
@@ -55,9 +48,13 @@ _SUBPROCESS_ENV = "TONGYI_STT_SUBPROCESS"
 _SUBPROCESS_TRUE_VALUES = {"1", "true", "yes", "on"}
 _RECOGNITION_TIMEOUT_ENV = "TONGYI_STT_RECOGNITION_TIMEOUT"
 _DEFAULT_RECOGNITION_TIMEOUT = 120
+_HTTP_TIMEOUT = (10, 600)
+_RETRY_BACKOFFS = (1, 3)
 _DASHSCOPE_ASYNC_BRIDGE_PATCHED = False
 _FUN_ASR_MODEL = "fun-asr"
 _FUN_ASR_FLASH_MODEL = "fun-asr-flash-2026-06-15"
+_FUN_ASR_FLASH_MAX_FILE_SIZE = 7 * 1024 * 1024
+_FUN_ASR_TASK_TIMEOUT = 3 * 60 * 60
 
 
 def _is_subprocess_enabled() -> bool:
@@ -179,31 +176,99 @@ def _get_recognition_timeout() -> int:
     return seconds if seconds > 0 else _DEFAULT_RECOGNITION_TIMEOUT
 
 
+def _format_dashscope_error(status: Any, code: Any, message: Any, request_id: Any) -> str:
+    return (
+        f"DashScope error: {message or 'Unknown DashScope error'} "
+        f"(status: {status or 'Unknown'}, code: {code or 'Unknown'}, "
+        f"request_id: {request_id or 'Unknown'})"
+    )
+
+
+def _read_ebml_vint(data: bytes, offset: int) -> tuple[int, int] | None:
+    if offset >= len(data) or data[offset] == 0:
+        return None
+    length = 1
+    marker = 0x80
+    while (data[offset] & marker) == 0:
+        marker >>= 1
+        length += 1
+    if length > 8 or offset + length > len(data):
+        return None
+    value = data[offset] & (marker - 1)
+    for byte in data[offset + 1 : offset + length]:
+        value = (value << 8) | byte
+    return value, length
+
+
+def _get_ebml_format(data: bytes) -> str | None:
+    header_size = _read_ebml_vint(data, 4)
+    if header_size is None:
+        return None
+    size, size_length = header_size
+    offset = 4 + size_length
+    end = offset + size
+    if end > len(data):
+        return None
+    while offset < end:
+        element_start = offset
+        element_id = _read_ebml_vint(data, offset)
+        if element_id is None:
+            return None
+        _, id_length = element_id
+        offset += id_length
+        element_size = _read_ebml_vint(data, offset)
+        if element_size is None:
+            return None
+        value_size, value_size_length = element_size
+        offset += value_size_length
+        value_end = offset + value_size
+        if value_end > end:
+            return None
+        if data[element_start : element_start + id_length] == b"\x42\x82":
+            doctype = data[offset:value_end].rstrip(b"\0")
+            return {b"webm": "webm", b"matroska": "mkv"}.get(doctype)
+        offset = value_end
+    return None
+
+
 def _parse_json_response(response) -> dict:
     try:
         data = response.json()
     except ValueError as ex:
         body = response.text[:500]
+        headers = getattr(response, "headers", {}) or {}
+        request_id = headers.get("x-request-id") or headers.get("x-oss-request-id")
         raise ValueError(
-            f"DashScope returned invalid JSON ({response.status_code}): {body}"
+            _format_dashscope_error(response.status_code, "InvalidJSONResponse", body, request_id)
         ) from ex
 
     if not isinstance(data, dict):
         raise TypeError("DashScope returned invalid JSON: expected an object")
     if response.status_code != 200:
-        code = data.get("code") or response.status_code
-        message = data.get("message") or response.text or "Unknown DashScope error"
-        request_id = data.get("request_id")
-        request_suffix = f", request_id: {request_id}" if request_id else ""
-        raise ValueError(f"DashScope error {code}: {message}{request_suffix}")
+        headers = getattr(response, "headers", {}) or {}
+        request_id = (
+            data.get("request_id") or headers.get("x-request-id") or headers.get("x-oss-request-id")
+        )
+        raise ValueError(
+            _format_dashscope_error(
+                response.status_code,
+                data.get("code"),
+                data.get("message") or response.text,
+                request_id,
+            )
+        )
     return data
 
 
 def _raise_for_dashscope_error(response) -> None:
     if response.status_code != 200:
         raise ValueError(
-            f"DashScope error: {response.message or 'Unknown DashScope error'} "
-            f"({response.status_code}, code: {response.code}, request_id: {response.request_id})"
+            _format_dashscope_error(
+                response.status_code,
+                getattr(response, "code", None),
+                getattr(response, "message", None),
+                getattr(response, "request_id", None),
+            )
         )
 
 
@@ -347,6 +412,8 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
                 for sentence in sentence_list
             ]
             return "\n".join(sentence_ans)
+        except requests.exceptions.RequestException:
+            raise
         except Exception as ex:
             raise ValueError(f"[TongyiSpeech2TextModel] {ex}") from ex
         finally:
@@ -359,6 +426,8 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
     def _invoke_fun_asr_flash(
         self, model: str, file_path: str, audio_format: str, api_key: str, base_address: str
     ) -> str:
+        if os.path.getsize(file_path) > _FUN_ASR_FLASH_MAX_FILE_SIZE:
+            raise ValueError("Fun-ASR-Flash audio must not exceed 7 MB before Base64 encoding")
         mime_type = (
             {"mp3": "audio/mpeg", "wav": "audio/wav"}.get(audio_format)
             or mimetypes.guess_type(file_path)[0]
@@ -392,7 +461,7 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
                 },
                 "parameters": {"format": audio_format},
             },
-            timeout=(10, _get_recognition_timeout()),
+            timeout=_HTTP_TIMEOUT,
         )
         data = _parse_json_response(response)
         text = (data.get("output") or {}).get("text")
@@ -403,8 +472,8 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
         return text
 
     def _invoke_fun_asr(self, model: str, file_path: str, api_key: str, base_address: str) -> str:
-        # ponytail: the official temporary upload is non-production (100 QPS and
-        # a one-hour SDK upload timeout); accept public-URL input before adding OSS credentials.
+        # ponytail: official temporary uploads are non-production; accept a stable
+        # public URL before adding OSS credentials to this byte-only Dify interface.
         oss_url, _ = OssUtils.upload(
             model=model,
             file_path=file_path,
@@ -412,25 +481,39 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
             base_address=base_address,
             headers=BURY_POINT_HEADER,
         )
-        submit_response = Transcription.async_call(
-            model=model,
-            file_urls=[oss_url],
-            api_key=api_key,
-            base_address=base_address,
-            headers={**BURY_POINT_HEADER, "X-DashScope-OssResourceResolve": "enable"},
+        submit_data = _parse_json_response(
+            requests.post(
+                f"{base_address}/services/audio/asr/transcription",
+                headers={
+                    **BURY_POINT_HEADER,
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                    "X-DashScope-Async": "enable",
+                    "X-DashScope-OssResourceResolve": "enable",
+                },
+                json={"model": model, "input": {"file_urls": [oss_url]}, "parameters": {}},
+                timeout=_HTTP_TIMEOUT,
+            )
         )
-        _raise_for_dashscope_error(submit_response)
-        task_id = (submit_response.output or {}).get("task_id")
+        task_id = (submit_data.get("output") or {}).get("task_id")
         if not task_id:
             raise ValueError("DashScope returned an invalid Fun-ASR response: missing task_id")
 
-        task_response = Transcription.wait(
-            task_id,
-            api_key=api_key,
-            base_address=base_address,
-            headers=BURY_POINT_HEADER,
-            wait_timeout=10_800,
-        )
+        deadline = time.monotonic() + _FUN_ASR_TASK_TIMEOUT
+        for backoff in (*_RETRY_BACKOFFS, None):
+            try:
+                task_response = Transcription.wait(
+                    task_id,
+                    api_key=api_key,
+                    base_address=base_address,
+                    headers=BURY_POINT_HEADER,
+                    wait_timeout=max(1, deadline - time.monotonic()),
+                )
+                break
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+                if backoff is None or time.monotonic() + backoff >= deadline:
+                    raise
+                time.sleep(backoff)
         _raise_for_dashscope_error(task_response)
         output = task_response.output or {}
         task_status = output.get("task_status")
@@ -442,18 +525,32 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
             message = (
                 result.get("message") or output.get("message") or "Fun-ASR transcription failed"
             )
-            request_id = task_response.request_id
-            request_suffix = f", request_id: {request_id}" if request_id else ""
-            raise ValueError(f"DashScope error {code}: {message}{request_suffix}")
+            raise ValueError(
+                _format_dashscope_error(
+                    result.get("subtask_status") or task_status,
+                    code,
+                    message,
+                    task_response.request_id,
+                )
+            )
 
         transcription_url = result.get("transcription_url")
         if not transcription_url:
             raise ValueError(
                 "DashScope returned an invalid Fun-ASR response: missing transcription_url"
             )
-        transcription = _parse_json_response(
-            requests.get(transcription_url, timeout=(10, _get_recognition_timeout()))
-        )
+        for backoff in (*_RETRY_BACKOFFS, None):
+            try:
+                result_response = requests.get(transcription_url, timeout=_HTTP_TIMEOUT)
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+                if backoff is None:
+                    raise
+            else:
+                if result_response.status_code < 500 or backoff is None:
+                    break
+            if backoff is not None:
+                time.sleep(backoff)
+        transcription = _parse_json_response(result_response)
         transcripts = transcription.get("transcripts")
         if not isinstance(transcripts, list):
             raise TypeError("DashScope returned an invalid Fun-ASR result: missing transcripts")
@@ -481,11 +578,32 @@ class TongyiSpeech2TextModel(OAICompatSpeech2TextModel):
         current_position = file_obj.tell()
         file_obj.seek(0)
         try:
-            header = file_obj.read(12)
+            header = file_obj.read(65536)
             if len(header) >= 12 and header[0:4] == b"RIFF":
                 for (offset, signature), format_name in _RIFF_SUBTYPE.items():
                     if header[offset : offset + len(signature)] == signature:
                         return format_name
+            if header.startswith(b"OggS"):
+                page_segments = header[26] if len(header) > 26 else 0
+                packet_start = 27 + page_segments
+                return "opus" if header[packet_start : packet_start + 8] == b"OpusHead" else "ogg"
+            if header.startswith(b"\x1a\x45\xdf\xa3"):
+                ebml_format = _get_ebml_format(header)
+                if ebml_format:
+                    return ebml_format
+            if header[4:8] == b"ftyp":
+                brand_offset = 16 if header[:4] == b"\0\0\0\1" else 8
+                if len(header) >= brand_offset + 8:
+                    brand = header[brand_offset : brand_offset + 4]
+                    if brand == b"qt  ":
+                        return "mov"
+                    if brand in {b"M4A ", b"M4B ", b"M4P "}:
+                        return "m4a"
+                    name = str(getattr(file_obj, "name", "") or "")
+                    suffix = Path(name).suffix.removeprefix(".").lower()
+                    if suffix in {"m4a", "mp4"}:
+                        return suffix
+                    return "mp4"
             for offset, signature, format_name in _AUDIO_MAGIC:
                 if (
                     len(header) >= offset + len(signature)

--- a/models/tongyi/tests/test_speech2text.py
+++ b/models/tongyi/tests/test_speech2text.py
@@ -50,23 +50,14 @@ def _worker_payload() -> dict:
     }
 
 
-def _http_response(data: dict, status_code: int = 200, text: str = "") -> MagicMock:
-    response = MagicMock(status_code=status_code, text=text)
+def _http_response(data: dict, status_code: int = 200) -> MagicMock:
+    response = MagicMock(status_code=status_code)
     response.json.return_value = data
     return response
 
 
-def _sdk_response(
-    output: dict | None,
-    *,
-    status_code: int = 200,
-    code: str | None = None,
-    message: str | None = None,
-    request_id: str = "request-id",
-) -> MagicMock:
-    return MagicMock(
-        status_code=status_code, code=code, message=message, request_id=request_id, output=output
-    )
+def _sdk_response(output: dict | None, request_id: str = "request-id") -> MagicMock:
+    return MagicMock(status_code=200, request_id=request_id, output=output)
 
 
 def test_get_audio_type_prefers_magic_bytes_without_decoding() -> None:
@@ -176,15 +167,9 @@ def test_invoke_raises_dashscope_status_error() -> None:
 
 
 def test_invoke_fun_asr_flash_uses_http_base64() -> None:
-    response = _http_response({"output": {"text": "hello flash"}, "request_id": "request-2"})
+    response = _http_response({"output": {"text": "hello flash"}})
 
-    with (
-        patch("models.speech2text.speech2text.requests.post", return_value=response) as post,
-        patch(
-            "models.speech2text.speech2text.AudioSegment.from_file",
-            side_effect=AssertionError("Fun-ASR-Flash should not decode audio locally"),
-        ),
-    ):
+    with patch("models.speech2text.speech2text.requests.post", return_value=response) as post:
         text = _model()._invoke(
             model="fun-asr-flash-2026-06-15",
             credentials={"dashscope_api_key": "test-key", "use_international_endpoint": "true"},
@@ -236,23 +221,20 @@ def test_invoke_fun_asr_flash_preserves_http_error() -> None:
 
 
 def test_invoke_fun_asr_uploads_waits_and_downloads() -> None:
-    submit_response = _sdk_response({"task_status": "PENDING", "task_id": "task-1"})
+    submit_response = _sdk_response({"task_id": "task-1"})
     task_response = _sdk_response(
         {
-            "task_status": "SUCCEEDED",
             "results": [
                 {
                     "subtask_status": "SUCCEEDED",
                     "transcription_url": "https://example.com/result.json",
                 }
-            ],
-        },
-        request_id="request-3",
+            ]
+        }
     )
     transcription_response = _http_response({"transcripts": [{"text": "hello"}, {"text": "world"}]})
 
     with (
-        patch.dict(os.environ, {"TONGYI_STT_TRANSCRIPTION_TIMEOUT": "7200"}),
         patch(
             "models.speech2text.speech2text.OssUtils.upload",
             return_value=("oss://temporary/audio.wav", {}),
@@ -286,8 +268,7 @@ def test_invoke_fun_asr_uploads_waits_and_downloads() -> None:
     assert wait.call_args.args == ("task-1",)
     assert wait.call_args.kwargs["api_key"] == "test-key"
     assert wait.call_args.kwargs["base_address"] == "https://dashscope-intl.aliyuncs.com/api/v1"
-    assert wait.call_args.kwargs["wait_timeout"] == 7200
-    get.assert_called_once()
+    assert wait.call_args.kwargs["wait_timeout"] == 10_800
     assert get.call_args.args[0] == "https://example.com/result.json"
 
 

--- a/models/tongyi/tests/test_speech2text.py
+++ b/models/tongyi/tests/test_speech2text.py
@@ -1,9 +1,11 @@
 import json
 import os
 import sys
-from io import BytesIO, StringIO
 from collections.abc import AsyncIterator
+from io import BytesIO, StringIO
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -48,6 +50,25 @@ def _worker_payload() -> dict:
     }
 
 
+def _http_response(data: dict, status_code: int = 200, text: str = "") -> MagicMock:
+    response = MagicMock(status_code=status_code, text=text)
+    response.json.return_value = data
+    return response
+
+
+def _sdk_response(
+    output: dict | None,
+    *,
+    status_code: int = 200,
+    code: str | None = None,
+    message: str | None = None,
+    request_id: str = "request-id",
+) -> MagicMock:
+    return MagicMock(
+        status_code=status_code, code=code, message=message, request_id=request_id, output=output
+    )
+
+
 def test_get_audio_type_prefers_magic_bytes_without_decoding() -> None:
     file_obj = _named_bytes(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 16, "temp.mp3")
     file_obj.seek(5)
@@ -76,6 +97,7 @@ def test_invoke_reuses_detected_audio_format_for_decoding() -> None:
     file_obj = _named_bytes(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 16, "upload.mp3")
     audio = MagicMock(frame_rate=16000)
     result = MagicMock()
+    result.status_code = 200
     result.get_sentence.return_value = [{"text": "hello"}]
     recognition = MagicMock()
     recognition.call.return_value = result
@@ -102,6 +124,7 @@ def test_invoke_normalizes_non_dict_sentences() -> None:
     file_obj = _named_bytes(b"RIFF\x24\x00\x00\x00WAVE" + b"\x00" * 16, "upload.wav")
     audio = MagicMock(frame_rate=16000)
     result = MagicMock()
+    result.status_code = 200
     result.get_sentence.return_value = ["hello", {"text": "world"}]
     recognition = MagicMock()
     recognition.call.return_value = result
@@ -119,9 +142,214 @@ def test_invoke_normalizes_non_dict_sentences() -> None:
                 )
 
 
+def test_invoke_raises_dashscope_status_error() -> None:
+    result = MagicMock(
+        status_code=400,
+        code="InvalidModel",
+        message="Model not available in this region",
+        request_id="request-1",
+    )
+    recognition = MagicMock()
+    recognition.call.return_value = result
+
+    with (
+        patch.dict(os.environ, {"TONGYI_STT_SUBPROCESS": "false"}),
+        patch(
+            "models.speech2text.speech2text.AudioSegment.from_file",
+            return_value=MagicMock(frame_rate=16000),
+        ),
+        patch("models.speech2text.speech2text.Recognition", return_value=recognition),
+        patch("models.speech2text.speech2text._patch_dashscope_async_bridge_for_gevent"),
+        pytest.raises(ValueError) as exc_info,
+    ):
+        _model()._invoke(
+            model="paraformer-realtime-v1",
+            credentials={"dashscope_api_key": "test-key"},
+            file=_wav_file(),
+        )
+
+    message = str(exc_info.value)
+    assert "Model not available in this region" in message
+    assert "InvalidModel" in message
+    assert "request-1" in message
+    result.get_sentence.assert_not_called()
+
+
+def test_invoke_fun_asr_flash_uses_http_base64() -> None:
+    response = _http_response({"output": {"text": "hello flash"}, "request_id": "request-2"})
+
+    with (
+        patch("models.speech2text.speech2text.requests.post", return_value=response) as post,
+        patch(
+            "models.speech2text.speech2text.AudioSegment.from_file",
+            side_effect=AssertionError("Fun-ASR-Flash should not decode audio locally"),
+        ),
+    ):
+        text = _model()._invoke(
+            model="fun-asr-flash-2026-06-15",
+            credentials={"dashscope_api_key": "test-key", "use_international_endpoint": "true"},
+            file=_wav_file(),
+        )
+
+    assert text == "hello flash"
+    assert (
+        post.call_args.args[0]
+        == "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation"
+    )
+    payload = post.call_args.kwargs["json"]
+    headers = post.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer test-key"
+    assert headers["X-DashScope-SSE"] == "disable"
+    assert payload["model"] == "fun-asr-flash-2026-06-15"
+    assert payload["parameters"] == {"format": "wav"}
+    assert payload["input"]["messages"][0]["role"] == "user"
+    assert payload["input"]["messages"][0]["content"][0]["type"] == "input_audio"
+    assert payload["input"]["messages"][0]["content"][0]["input_audio"]["data"].startswith(
+        "data:audio/wav;base64,"
+    )
+
+
+def test_invoke_fun_asr_flash_preserves_http_error() -> None:
+    response = _http_response(
+        {
+            "code": "InvalidParameter",
+            "message": "The audio format is invalid.",
+            "request_id": "request-flash-error",
+        },
+        status_code=400,
+    )
+
+    with (
+        patch("models.speech2text.speech2text.requests.post", return_value=response),
+        pytest.raises(ValueError) as exc_info,
+    ):
+        _model()._invoke(
+            model="fun-asr-flash-2026-06-15",
+            credentials={"dashscope_api_key": "test-key"},
+            file=_wav_file(),
+        )
+
+    error = str(exc_info.value)
+    assert "InvalidParameter" in error
+    assert "The audio format is invalid." in error
+    assert "request-flash-error" in error
+
+
+def test_invoke_fun_asr_uploads_waits_and_downloads() -> None:
+    submit_response = _sdk_response({"task_status": "PENDING", "task_id": "task-1"})
+    task_response = _sdk_response(
+        {
+            "task_status": "SUCCEEDED",
+            "results": [
+                {
+                    "subtask_status": "SUCCEEDED",
+                    "transcription_url": "https://example.com/result.json",
+                }
+            ],
+        },
+        request_id="request-3",
+    )
+    transcription_response = _http_response({"transcripts": [{"text": "hello"}, {"text": "world"}]})
+
+    with (
+        patch.dict(os.environ, {"TONGYI_STT_TRANSCRIPTION_TIMEOUT": "7200"}),
+        patch(
+            "models.speech2text.speech2text.OssUtils.upload",
+            return_value=("oss://temporary/audio.wav", {}),
+        ) as upload,
+        patch(
+            "models.speech2text.speech2text.Transcription.async_call", return_value=submit_response
+        ) as async_call,
+        patch(
+            "models.speech2text.speech2text.Transcription.wait", return_value=task_response
+        ) as wait,
+        patch(
+            "models.speech2text.speech2text.requests.get", return_value=transcription_response
+        ) as get,
+    ):
+        text = _model()._invoke(
+            model="fun-asr",
+            credentials={"dashscope_api_key": "test-key", "use_international_endpoint": "true"},
+            file=_wav_file(),
+        )
+
+    assert text == "hello\nworld"
+    assert upload.call_args.kwargs["model"] == "fun-asr"
+    assert upload.call_args.kwargs["api_key"] == "test-key"
+    assert upload.call_args.kwargs["base_address"] == ("https://dashscope-intl.aliyuncs.com/api/v1")
+    assert async_call.call_args.kwargs["file_urls"] == ["oss://temporary/audio.wav"]
+    assert async_call.call_args.kwargs["api_key"] == "test-key"
+    assert async_call.call_args.kwargs["base_address"] == (
+        "https://dashscope-intl.aliyuncs.com/api/v1"
+    )
+    assert async_call.call_args.kwargs["headers"]["X-DashScope-OssResourceResolve"] == "enable"
+    assert wait.call_args.args == ("task-1",)
+    assert wait.call_args.kwargs["api_key"] == "test-key"
+    assert wait.call_args.kwargs["base_address"] == "https://dashscope-intl.aliyuncs.com/api/v1"
+    assert wait.call_args.kwargs["wait_timeout"] == 7200
+    get.assert_called_once()
+    assert get.call_args.args[0] == "https://example.com/result.json"
+
+
+@pytest.mark.parametrize(
+    ("output", "request_id", "expected"),
+    [
+        (
+            {
+                "task_status": "SUCCEEDED",
+                "results": [
+                    {
+                        "subtask_status": "FAILED",
+                        "code": "InvalidFile.DownloadFailed",
+                        "message": "The audio file cannot be downloaded.",
+                    }
+                ],
+            },
+            "request-4",
+            ("InvalidFile.DownloadFailed", "The audio file cannot be downloaded."),
+        ),
+        (
+            {
+                "task_status": "FAILED",
+                "code": "InternalError",
+                "message": "The transcription task failed.",
+            },
+            "request-5",
+            ("InternalError", "The transcription task failed."),
+        ),
+    ],
+    ids=("subtask", "task"),
+)
+def test_invoke_fun_asr_preserves_errors(
+    output: dict, request_id: str, expected: tuple[str, str]
+) -> None:
+    submit_response = _sdk_response({"task_id": "task-error"})
+    task_response = _sdk_response(output, request_id=request_id)
+    with (
+        patch(
+            "models.speech2text.speech2text.OssUtils.upload",
+            return_value=("oss://temporary/audio.wav", {}),
+        ),
+        patch(
+            "models.speech2text.speech2text.Transcription.async_call", return_value=submit_response
+        ),
+        patch("models.speech2text.speech2text.Transcription.wait", return_value=task_response),
+        pytest.raises(ValueError) as exc_info,
+    ):
+        _model()._invoke(
+            model="fun-asr", credentials={"dashscope_api_key": "test-key"}, file=_wav_file()
+        )
+
+    message = str(exc_info.value)
+    assert expected[0] in message
+    assert expected[1] in message
+    assert request_id in message
+
+
 def test_invoke_patches_dashscope_async_bridge_by_default(monkeypatch) -> None:
     audio = MagicMock(frame_rate=16000)
     result = MagicMock()
+    result.status_code = 200
     result.get_sentence.return_value = [{"text": "hello"}]
     recognition = MagicMock()
     recognition.call.return_value = result
@@ -149,6 +377,7 @@ def test_invoke_patches_dashscope_async_bridge_by_default(monkeypatch) -> None:
 
 def test_dashscope_async_bridge_patch_yields_results() -> None:
     import dashscope.common.utils as dashscope_utils
+
     from models.speech2text import speech2text as st2
 
     async def stream() -> AsyncIterator[str]:
@@ -234,7 +463,7 @@ def test_run_recognition_in_subprocess_returns_error_for_missing_file() -> None:
 
 
 def test_worker_keeps_library_stdout_out_of_json(monkeypatch) -> None:
-    import dashscope.audio.asr as asr
+    from dashscope.audio import asr
 
     class FakeResult:
         status_code = 200
@@ -261,7 +490,7 @@ def test_worker_keeps_library_stdout_out_of_json(monkeypatch) -> None:
 
 
 def test_worker_returns_dashscope_status_error(monkeypatch) -> None:
-    import dashscope.audio.asr as asr
+    from dashscope.audio import asr
 
     class FakeResult:
         status_code = 400

--- a/models/tongyi/tests/test_speech2text.py
+++ b/models/tongyi/tests/test_speech2text.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import os
 import sys
@@ -6,6 +7,8 @@ from io import BytesIO, StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
+from dashscope.api_entities import dashscope_response
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -50,14 +53,23 @@ def _worker_payload() -> dict:
     }
 
 
-def _http_response(data: dict, status_code: int = 200) -> MagicMock:
-    response = MagicMock(status_code=status_code)
-    response.json.return_value = data
+def _http_response(data: dict | str, status_code: int = 200) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = (data if isinstance(data, str) else json.dumps(data)).encode()
+    response.headers["Content-Type"] = "application/json"
     return response
 
 
-def _sdk_response(output: dict | None, request_id: str = "request-id") -> MagicMock:
-    return MagicMock(status_code=200, request_id=request_id, output=output)
+def _sdk_response(
+    output: dict | None, request_id: str = "request-id"
+) -> dashscope_response.TranscriptionResponse:
+    output = {"task_id": "task-1", "task_status": "SUCCEEDED", **(output or {})}
+    return dashscope_response.TranscriptionResponse.from_api_response(
+        dashscope_response.DashScopeAPIResponse(
+            status_code=200, request_id=request_id, output=output, headers={}
+        )
+    )
 
 
 def test_get_audio_type_prefers_magic_bytes_without_decoding() -> None:
@@ -74,14 +86,31 @@ def test_get_audio_type_prefers_magic_bytes_without_decoding() -> None:
     assert file_obj.tell() == 5
 
 
-def test_get_audio_type_uses_magic_bytes_before_misleading_filename() -> None:
-    file_obj = _named_bytes(b"ID3\x04\x00\x00\x00\x00\x00\x21" + b"\x00" * 16, "upload.wav")
+@pytest.mark.parametrize(
+    ("data", "name", "expected"),
+    [
+        (b"ID3" + b"\0" * 40, "upload.wav", "mp3"),
+        (b"\0\0\0\x18ftypM4A " + b"\0" * 12, "upload.wav", "m4a"),
+        (b"\0\0\0\x01ftyp" + b"\0" * 7 + b"\x18M4A " + b"\0" * 4, "upload.wav", "m4a"),
+        (b"\0\0\0\x18ftypisom" + b"\0" * 12, "upload.wav", "mp4"),
+        (b"\0\0\0\x18ftypisom" + b"\0" * 12, "upload.m4a", "m4a"),
+        (b"\0\0\0\x18ftypqt  " + b"\0" * 12, "upload.wav", "mov"),
+        (b"\x1a\x45\xdf\xa3\x87\x42\x82\x84webm", "upload.wav", "webm"),
+        (b"\x1a\x45\xdf\xa3\x8b\x42\x82\x88matroska", "upload.wav", "mkv"),
+        (b"OggS" + b"\0" * 22 + b"\x01\x08OpusHead", "upload.wav", "opus"),
+        (b"OggS" + b"\0" * 22 + b"\x01\x07\x01vorbis", "upload.wav", "ogg"),
+    ],
+)
+def test_get_audio_type_uses_container_metadata_before_filename(
+    data: bytes, name: str, expected: str
+) -> None:
+    file_obj = _named_bytes(data, name)
 
     with patch(
         "models.speech2text.speech2text.AudioSegment.from_file",
         side_effect=AssertionError("magic-byte detection should not decode audio"),
     ):
-        assert _model().get_audio_type(file_obj) == "mp3"
+        assert _model().get_audio_type(file_obj) == expected
 
 
 def test_invoke_reuses_detected_audio_format_for_decoding() -> None:
@@ -160,6 +189,7 @@ def test_invoke_raises_dashscope_status_error() -> None:
         )
 
     message = str(exc_info.value)
+    assert "status: 400" in message
     assert "Model not available in this region" in message
     assert "InvalidModel" in message
     assert "request-1" in message
@@ -168,12 +198,14 @@ def test_invoke_raises_dashscope_status_error() -> None:
 
 def test_invoke_fun_asr_flash_uses_http_base64() -> None:
     response = _http_response({"output": {"text": "hello flash"}})
+    audio_file = _wav_file()
+    audio_bytes = audio_file.getvalue()
 
     with patch("models.speech2text.speech2text.requests.post", return_value=response) as post:
         text = _model()._invoke(
             model="fun-asr-flash-2026-06-15",
             credentials={"dashscope_api_key": "test-key", "use_international_endpoint": "true"},
-            file=_wav_file(),
+            file=audio_file,
         )
 
     assert text == "hello flash"
@@ -189,9 +221,11 @@ def test_invoke_fun_asr_flash_uses_http_base64() -> None:
     assert payload["parameters"] == {"format": "wav"}
     assert payload["input"]["messages"][0]["role"] == "user"
     assert payload["input"]["messages"][0]["content"][0]["type"] == "input_audio"
-    assert payload["input"]["messages"][0]["content"][0]["input_audio"]["data"].startswith(
-        "data:audio/wav;base64,"
-    )
+    data_uri = payload["input"]["messages"][0]["content"][0]["input_audio"]["data"]
+    prefix, encoded = data_uri.split(",", 1)
+    assert prefix == "data:audio/wav;base64"
+    assert base64.b64decode(encoded) == audio_bytes
+    assert post.call_args.kwargs["timeout"] == (10, 600)
 
 
 def test_invoke_fun_asr_flash_preserves_http_error() -> None:
@@ -215,13 +249,99 @@ def test_invoke_fun_asr_flash_preserves_http_error() -> None:
         )
 
     error = str(exc_info.value)
+    assert "status: 400" in error
     assert "InvalidParameter" in error
     assert "The audio format is invalid." in error
     assert "request-flash-error" in error
 
 
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (_http_response("upstream failure", status_code=502), "InvalidJSONResponse"),
+        (_http_response({"output": {}}), "missing output.text"),
+    ],
+)
+def test_invoke_fun_asr_flash_rejects_malformed_responses(
+    response: requests.Response, expected: str
+) -> None:
+    with (
+        patch("models.speech2text.speech2text.requests.post", return_value=response),
+        pytest.raises(ValueError, match=expected),
+    ):
+        _model()._invoke(
+            model="fun-asr-flash-2026-06-15",
+            credentials={"dashscope_api_key": "test-key"},
+            file=_wav_file(),
+        )
+
+
+def test_invoke_fun_asr_flash_validates_7_mib_boundary_before_encoding() -> None:
+    header = b"RIFF\x24\x00\x00\x00WAVE"
+    limit = 7 * 1024 * 1024
+    oversized = _named_bytes(header + b"\0" * (limit + 1 - len(header)), "large.wav")
+
+    with (
+        patch(
+            "models.speech2text.speech2text.Path.read_bytes",
+            side_effect=AssertionError("oversized audio must not be read for encoding"),
+        ) as read_bytes,
+        patch(
+            "models.speech2text.speech2text.base64.b64encode",
+            side_effect=AssertionError("oversized audio must not be encoded"),
+        ) as encode,
+        patch("models.speech2text.speech2text.requests.post") as post,
+        pytest.raises(ValueError, match="must not exceed 7 MB"),
+    ):
+        _model()._invoke(
+            model="fun-asr-flash-2026-06-15",
+            credentials={"dashscope_api_key": "test-key"},
+            file=oversized,
+        )
+
+    read_bytes.assert_not_called()
+    encode.assert_not_called()
+    post.assert_not_called()
+
+    allowed = _named_bytes(header + b"\0" * (limit - len(header)), "maximum.wav")
+    response = _http_response({"output": {"text": "accepted"}})
+    with (
+        patch(
+            "models.speech2text.speech2text.Path.read_bytes", return_value=b"audio"
+        ) as read_bytes,
+        patch("models.speech2text.speech2text.requests.post", return_value=response),
+    ):
+        assert (
+            _model()._invoke(
+                model="fun-asr-flash-2026-06-15",
+                credentials={"dashscope_api_key": "test-key"},
+                file=allowed,
+            )
+            == "accepted"
+        )
+
+    read_bytes.assert_called_once()
+
+
+def test_invoke_preserves_http_transport_errors() -> None:
+    error = requests.exceptions.ReadTimeout("timed out")
+    with (
+        patch("models.speech2text.speech2text.requests.post", side_effect=error),
+        pytest.raises(requests.exceptions.ReadTimeout) as exc_info,
+    ):
+        _model()._invoke(
+            model="fun-asr-flash-2026-06-15",
+            credentials={"dashscope_api_key": "test-key"},
+            file=_wav_file(),
+        )
+
+    assert exc_info.value is error
+
+
 def test_invoke_fun_asr_uploads_waits_and_downloads() -> None:
-    submit_response = _sdk_response({"task_id": "task-1"})
+    submit_response = _http_response(
+        {"output": {"task_id": "task-1", "task_status": "PENDING"}, "request_id": "submit-request"}
+    )
     task_response = _sdk_response(
         {
             "results": [
@@ -232,6 +352,9 @@ def test_invoke_fun_asr_uploads_waits_and_downloads() -> None:
             ]
         }
     )
+    unavailable_response = _http_response(
+        {"code": "ServiceUnavailable", "message": "try again"}, status_code=503
+    )
     transcription_response = _http_response({"transcripts": [{"text": "hello"}, {"text": "world"}]})
 
     with (
@@ -239,15 +362,17 @@ def test_invoke_fun_asr_uploads_waits_and_downloads() -> None:
             "models.speech2text.speech2text.OssUtils.upload",
             return_value=("oss://temporary/audio.wav", {}),
         ) as upload,
+        patch("models.speech2text.speech2text.requests.post", return_value=submit_response) as post,
         patch(
-            "models.speech2text.speech2text.Transcription.async_call", return_value=submit_response
-        ) as async_call,
-        patch(
-            "models.speech2text.speech2text.Transcription.wait", return_value=task_response
+            "models.speech2text.speech2text.Transcription.wait",
+            side_effect=[requests.exceptions.ReadTimeout("poll timed out"), task_response],
         ) as wait,
         patch(
-            "models.speech2text.speech2text.requests.get", return_value=transcription_response
+            "models.speech2text.speech2text.requests.get",
+            side_effect=[unavailable_response, unavailable_response, transcription_response],
         ) as get,
+        patch("models.speech2text.speech2text.time.sleep") as sleep,
+        patch("models.speech2text.speech2text.time.monotonic", return_value=0),
     ):
         text = _model()._invoke(
             model="fun-asr",
@@ -259,17 +384,32 @@ def test_invoke_fun_asr_uploads_waits_and_downloads() -> None:
     assert upload.call_args.kwargs["model"] == "fun-asr"
     assert upload.call_args.kwargs["api_key"] == "test-key"
     assert upload.call_args.kwargs["base_address"] == ("https://dashscope-intl.aliyuncs.com/api/v1")
-    assert async_call.call_args.kwargs["file_urls"] == ["oss://temporary/audio.wav"]
-    assert async_call.call_args.kwargs["api_key"] == "test-key"
-    assert async_call.call_args.kwargs["base_address"] == (
-        "https://dashscope-intl.aliyuncs.com/api/v1"
+    assert (
+        post.call_args.args[0]
+        == "https://dashscope-intl.aliyuncs.com/api/v1/services/audio/asr/transcription"
     )
-    assert async_call.call_args.kwargs["headers"]["X-DashScope-OssResourceResolve"] == "enable"
+    assert post.call_args.kwargs["json"] == {
+        "model": "fun-asr",
+        "input": {"file_urls": ["oss://temporary/audio.wav"]},
+        "parameters": {},
+    }
+    submit_headers = post.call_args.kwargs["headers"]
+    assert submit_headers["Authorization"] == "Bearer test-key"
+    assert submit_headers["Content-Type"] == "application/json"
+    assert submit_headers["X-DashScope-Async"] == "enable"
+    assert submit_headers["X-DashScope-OssResourceResolve"] == "enable"
+    assert post.call_args.kwargs["timeout"] == (10, 600)
     assert wait.call_args.args == ("task-1",)
     assert wait.call_args.kwargs["api_key"] == "test-key"
     assert wait.call_args.kwargs["base_address"] == "https://dashscope-intl.aliyuncs.com/api/v1"
     assert wait.call_args.kwargs["wait_timeout"] == 10_800
-    assert get.call_args.args[0] == "https://example.com/result.json"
+    upload.assert_called_once()
+    post.assert_called_once()
+    assert wait.call_count == 2
+    assert get.call_count == 3
+    assert all(call.args[0] == "https://example.com/result.json" for call in get.call_args_list)
+    assert all(call.kwargs["timeout"] == (10, 600) for call in get.call_args_list)
+    assert [call.args[0] for call in sleep.call_args_list] == [1, 1, 3]
 
 
 @pytest.mark.parametrize(
@@ -304,16 +444,19 @@ def test_invoke_fun_asr_uploads_waits_and_downloads() -> None:
 def test_invoke_fun_asr_preserves_errors(
     output: dict, request_id: str, expected: tuple[str, str]
 ) -> None:
-    submit_response = _sdk_response({"task_id": "task-error"})
+    submit_response = _http_response(
+        {
+            "output": {"task_id": "task-error", "task_status": "PENDING"},
+            "request_id": "submit-request",
+        }
+    )
     task_response = _sdk_response(output, request_id=request_id)
     with (
         patch(
             "models.speech2text.speech2text.OssUtils.upload",
             return_value=("oss://temporary/audio.wav", {}),
         ),
-        patch(
-            "models.speech2text.speech2text.Transcription.async_call", return_value=submit_response
-        ),
+        patch("models.speech2text.speech2text.requests.post", return_value=submit_response),
         patch("models.speech2text.speech2text.Transcription.wait", return_value=task_response),
         pytest.raises(ValueError) as exc_info,
     ):
@@ -322,6 +465,7 @@ def test_invoke_fun_asr_preserves_errors(
         )
 
     message = str(exc_info.value)
+    assert "status: FAILED" in message
     assert expected[0] in message
     assert expected[1] in message
     assert request_id in message
@@ -358,7 +502,6 @@ def test_invoke_patches_dashscope_async_bridge_by_default(monkeypatch) -> None:
 
 def test_dashscope_async_bridge_patch_yields_results() -> None:
     import dashscope.common.utils as dashscope_utils
-
     from models.speech2text import speech2text as st2
 
     async def stream() -> AsyncIterator[str]:
@@ -475,7 +618,9 @@ def test_worker_returns_dashscope_status_error(monkeypatch) -> None:
 
     class FakeResult:
         status_code = 400
+        code = "InvalidModel"
         message = "invalid audio"
+        request_id = "request-1"
 
         def get_sentence(self):
             raise AssertionError("API errors should be returned before reading sentences")
@@ -494,5 +639,8 @@ def test_worker_returns_dashscope_status_error(monkeypatch) -> None:
 
     assert exit_code == 0
     assert data["status"] == "err"
-    assert "DashScope error: invalid audio (400)" == data["data"]
+    assert "status: 400" in data["data"]
+    assert "code: InvalidModel" in data["data"]
+    assert "invalid audio" in data["data"]
+    assert "request_id: request-1" in data["data"]
     assert stderr == ""


### PR DESCRIPTION
## Summary

Fixes #3726.

Tongyi speech-to-text currently exposes only `paraformer-realtime-v1` and `paraformer-realtime-v2`.

Those models use the realtime WebSocket API and are unavailable for customers whose Alibaba Cloud Model Studio region exposes the non-realtime Fun-ASR models instead.

The existing recognition path also reads `get_sentence()` without checking the DashScope response status, so model and region errors become empty transcripts.

This change:

- Adds predefined schemas for `fun-asr` and `fun-asr-flash-2026-06-15`.
- Preserves DashScope status, error code, message, and request ID before reading realtime recognition results.
- Submits `fun-asr` through the documented asynchronous REST API, then polls the same task ID and downloads its signed result.
- Invokes `fun-asr-flash-2026-06-15` through its documented synchronous HTTP Base64 contract and parses `output.text`.
- Retries only idempotent task polling and result downloads on network timeouts or transient 5xx responses.
- Keeps the non-idempotent submission and synchronous inference POST requests single-attempt to avoid duplicate tasks and billing.
- Distinguishes Ogg/Opus, WebM/Matroska, and M4A/MP4/MOV containers before sending `parameters.format`.
- Supports the existing China and international DashScope endpoints without changing Paraformer behavior.
- Uses a 7 MiB raw upload limit for Fun-ASR-Flash so the encoded Data URI remains below the API-specific 10 MB limit.
- Bumps the Tongyi plugin from 0.2.13 to 0.2.14.

## Protocol Verification

The request and response contracts were checked against the official [Fun-ASR asynchronous HTTP API](https://help.aliyun.com/en/model-studio/fun-asr-recorded-speech-recognition-http-api) and [Fun-ASR-Flash HTTP API](https://help.aliyun.com/en/model-studio/non-real-time-speech-recognition-for-fun-asr-flash).

Alibaba documents both models for Beijing and Singapore and states that the existing shared DashScope domains remain functional in the [regional endpoint guide](https://help.aliyun.com/en/model-studio/regions).

Unauthenticated probes of the international Fun-ASR submit, Fun-ASR-Flash submit, and temporary upload routes all reached the expected authentication layer and returned structured `401 InvalidApiKey` responses containing `code`, `message`, and `request_id`.

Fun-ASR requires a URL while Dify supplies audio bytes, so this implementation uses DashScope temporary OSS upload with `X-DashScope-OssResourceResolve`.

Alibaba documents temporary upload as unsuitable for production or high-concurrency use and recommends stable OSS storage in the [temporary upload guide](https://help.aliyun.com/en/model-studio/get-temporary-file-url).

## Release Notes

Adds `fun-asr` and `fun-asr-flash-2026-06-15` speech-to-text models to Tongyi and surfaces DashScope model, region, transport, and audio errors instead of returning an empty transcript.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not available.

The predefined model registry and invocation contracts are covered by automated tests.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (audio)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (speech-to-text error handling)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` from 0.2.13 to 0.2.14.
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`.

The second box remains unchecked because Tongyi already declares `dify_plugin>=0.9.0`, which is outside the stale range in this template and is unchanged by this PR.

## Testing

- [ ] Local deployment.
- [ ] SaaS deployment.

Automated verification completed in the Tongyi plugin environment:

- `uv run pytest -q tests/test_speech2text.py`: 30 passed.
- `uv run pytest -q`: 110 passed and 80 credential-dependent live tests skipped.
- Black check at the repository's 100-character line length passes for all changed Python files.
- Ruff import and undefined-name checks pass for all changed Python files.
- All four speech-to-text model YAML files pass the installed Dify model schema.
- `python -m compileall` and `git diff --check` pass.

A billable DashScope call was not run because no customer-region API key was available in the workspace.
