### PR TITLE
fix(azure_openai): harden streaming, stop semantics, and version gating

### DIFF
--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.67
+version: 0.0.68

--- a/models/azure_openai/models/common.py
+++ b/models/azure_openai/models/common.py
@@ -63,7 +63,7 @@ class _CommonAzureOpenAI:
         Dated endpoints sort correctly because versions are ``YYYY-MM-DD``-prefixed;
         malformed or unknown version strings fail closed.
         """
-        api_base = str(credentials.get("openai_api_base") or "").strip()
+        api_base = (credentials.get("openai_api_base") or "").strip()
         if cls._is_v1_api_base(api_base):
             return True
         version = cls._effective_api_version(credentials)
@@ -109,7 +109,7 @@ class _CommonAzureOpenAI:
         1. API Key authentication (default)
         2. Microsoft Entra ID with Service Principal (user-provided credentials)
         """
-        api_base = str(credentials.get("openai_api_base") or "").strip()
+        api_base = (credentials.get("openai_api_base") or "").strip()
         if not api_base:
             raise ValueError("Azure OpenAI API Base URL is required")
         api_version = credentials.get("openai_api_version") or AZURE_OPENAI_API_VERSION
@@ -181,7 +181,7 @@ class _CommonAzureOpenAI:
     @staticmethod
     def _credential_cache_key(credentials: dict) -> tuple:
         auth_method = credentials.get("auth_method", "api_key")
-        api_base = str(credentials.get("openai_api_base") or "").strip()
+        api_base = (credentials.get("openai_api_base") or "").strip()
         api_version = credentials.get("openai_api_version") or AZURE_OPENAI_API_VERSION
         return (
             api_base,
@@ -196,7 +196,7 @@ class _CommonAzureOpenAI:
     @classmethod
     def _build_client(cls, credentials: dict):
         client_kwargs = cls._to_credential_kwargs(credentials)
-        if cls._is_v1_api_base(str(credentials.get("openai_api_base") or "")):
+        if cls._is_v1_api_base(credentials["openai_api_base"]):
             return openai.OpenAI(**client_kwargs)
         return openai.AzureOpenAI(**client_kwargs)
 

--- a/models/azure_openai/models/common.py
+++ b/models/azure_openai/models/common.py
@@ -1,4 +1,6 @@
+import re
 import threading
+from datetime import date
 from urllib.parse import urlparse
 
 import openai
@@ -13,6 +15,32 @@ from dify_plugin.errors.model import (
 
 from .constants import AZURE_OPENAI_API_VERSION
 
+# Minimum Azure OpenAI dated API version that accepts ``stream_options``
+# (added together with ``include_usage`` in the 2024-08-01-preview spec).
+# Older versions reject the parameter outright, breaking every streamed
+# request; see https://learn.microsoft.com/en-us/azure/foundry/openai/api-version-lifecycle
+_MIN_STREAM_OPTIONS_API_VERSION = "2024-08-01-preview"
+
+# Minimum dated API version exposing the Responses API surface
+# (``/responses`` first appeared in the 2025-03-01-preview spec).
+# Responses-routed models (gpt-5*, codex) cannot work below this.
+_MIN_RESPONSES_API_VERSION = "2025-03-01-preview"
+
+# Dated versions are YYYY-MM-DD[-preview]; anything else is unknown and
+# must fail closed instead of passing a lexicographic comparison.
+_AZURE_API_VERSION_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}(-preview)?")
+
+
+def _is_valid_azure_version(version: str) -> bool:
+    """Full match plus a real calendar date; rejects trailing junk."""
+    if not _AZURE_API_VERSION_PATTERN.fullmatch(version):
+        return False
+    try:
+        date.fromisoformat(version[:10])
+    except ValueError:
+        return False
+    return True
+
 _client_cache: dict[tuple, openai.AzureOpenAI | openai.OpenAI] = {}
 _client_cache_lock = threading.Lock()
 
@@ -22,6 +50,52 @@ class _CommonAzureOpenAI:
     def _is_v1_api_base(api_base: str) -> bool:
         path = urlparse(api_base.strip()).path.rstrip("/")
         return path.endswith("/openai/v1")
+
+    @classmethod
+    def _effective_api_version(cls, credentials: dict) -> str:
+        return str(credentials.get("openai_api_version") or AZURE_OPENAI_API_VERSION)
+
+    @classmethod
+    def _supports_dated_feature(cls, credentials: dict, min_version: str) -> bool:
+        """Whether the configured endpoint accepts a feature introduced at ``min_version``.
+
+        Versionless ``/openai/v1`` endpoints always track the latest surface.
+        Dated endpoints sort correctly because versions are ``YYYY-MM-DD``-prefixed;
+        malformed or unknown version strings fail closed.
+        """
+        api_base = str(credentials.get("openai_api_base") or "").strip()
+        if cls._is_v1_api_base(api_base):
+            return True
+        version = cls._effective_api_version(credentials)
+        if not _is_valid_azure_version(version):
+            return False
+        # Compare calendar dates: a GA release on the threshold date must
+        # satisfy a '-preview' minimum (lexicographic would rank it below).
+        return version[:10] >= min_version[:10]
+
+    @classmethod
+    def _supports_stream_options(cls, credentials: dict) -> bool:
+        return cls._supports_dated_feature(credentials, _MIN_STREAM_OPTIONS_API_VERSION)
+
+    @classmethod
+    def _ensure_responses_api_supported(cls, credentials: dict, base_model_name: str) -> None:
+        """Fail fast with an actionable message instead of an opaque failure.
+
+        Models routed to the Responses API require the versionless v1 surface
+        or a dated version that exposes ``/responses``. With the historical
+        default version this combination previously failed deep inside the
+        request with an unhelpful error.
+        """
+        if cls._supports_dated_feature(credentials, _MIN_RESPONSES_API_VERSION):
+            return
+        raise ValueError(
+            f"Base model '{base_model_name}' uses the Azure OpenAI Responses API, "
+            f"which requires an '/openai/v1' endpoint or api-version "
+            f">= {_MIN_RESPONSES_API_VERSION} (configured: "
+            f"'{cls._effective_api_version(credentials)}'). Point API Base URL at "
+            "'https://<resource>.openai.azure.com/openai/v1' or select a newer "
+            "API Version."
+        )
 
     @staticmethod
     def _normalize_v1_base_url(api_base: str) -> str:
@@ -35,7 +109,9 @@ class _CommonAzureOpenAI:
         1. API Key authentication (default)
         2. Microsoft Entra ID with Service Principal (user-provided credentials)
         """
-        api_base = credentials["openai_api_base"].strip()
+        api_base = str(credentials.get("openai_api_base") or "").strip()
+        if not api_base:
+            raise ValueError("Azure OpenAI API Base URL is required")
         api_version = credentials.get("openai_api_version") or AZURE_OPENAI_API_VERSION
         auth_method = credentials.get("auth_method", "api_key")
         is_v1_api = cls._is_v1_api_base(api_base)
@@ -105,7 +181,7 @@ class _CommonAzureOpenAI:
     @staticmethod
     def _credential_cache_key(credentials: dict) -> tuple:
         auth_method = credentials.get("auth_method", "api_key")
-        api_base = credentials.get("openai_api_base", "").strip()
+        api_base = str(credentials.get("openai_api_base") or "").strip()
         api_version = credentials.get("openai_api_version") or AZURE_OPENAI_API_VERSION
         return (
             api_base,
@@ -120,7 +196,7 @@ class _CommonAzureOpenAI:
     @classmethod
     def _build_client(cls, credentials: dict):
         client_kwargs = cls._to_credential_kwargs(credentials)
-        if cls._is_v1_api_base(credentials["openai_api_base"]):
+        if cls._is_v1_api_base(str(credentials.get("openai_api_base") or "")):
             return openai.OpenAI(**client_kwargs)
         return openai.AzureOpenAI(**client_kwargs)
 

--- a/models/azure_openai/models/llm/_metadata.py
+++ b/models/azure_openai/models/llm/_metadata.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from typing import Any, Optional
 from urllib.parse import urlparse
 
+from ..common import _CommonAzureOpenAI
 from ..constants import AZURE_OPENAI_API_VERSION
 
 _MAX_VALUE_LENGTH = 512
@@ -50,11 +51,10 @@ def _supports_metadata(credentials: dict) -> bool:
     Otherwise compare the effective api-version, which sorts correctly because
     the values are ``YYYY-MM-DD``-prefixed.
     """
-    api_base = str(credentials.get("openai_api_base") or "").strip()
-    if urlparse(api_base).path.rstrip("/").endswith("/openai/v1"):
-        return True
-    api_version = credentials.get("openai_api_version") or AZURE_OPENAI_API_VERSION
-    return str(api_version) >= _MIN_METADATA_API_VERSION
+    # Reuse the shared fail-closed gate (v1 detection, version shape).
+    return _CommonAzureOpenAI._supports_dated_feature(
+        credentials, _MIN_METADATA_API_VERSION
+    )
 
 
 def normalize_metadata_value(s: Any) -> str:

--- a/models/azure_openai/models/llm/llm.py
+++ b/models/azure_openai/models/llm/llm.py
@@ -33,7 +33,10 @@ from dify_plugin.entities.model.message import (
     ToolPromptMessage,
     UserPromptMessage,
 )
-from dify_plugin.errors.model import CredentialsValidateFailedError
+from dify_plugin.errors.model import (
+    CredentialsValidateFailedError,
+    InvokeBadRequestError,
+)
 from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
 from openai import Stream
 from openai.types import Completion
@@ -363,7 +366,10 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             extra_model_kwargs["stop"] = stop
         if user:
             extra_model_kwargs["safety_identifier"] = user
-        if stream:
+        if stream and self._supports_stream_options(credentials):
+            # stream_options predates some dated Azure API versions; when the
+            # endpoint cannot accept it, usage falls back to tiktoken
+            # estimation inside the streaming handler (has_usage flag).
             extra_model_kwargs["stream_options"] = {"include_usage": True}
         prompt_messages = self._clear_illegal_prompt_messages(
             base_model_name, prompt_messages
@@ -431,6 +437,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         Reference: https://platform.openai.com/docs/guides/migrate-to-responses
         """
         base_model_name = self._get_base_model_name(credentials)
+        self._ensure_responses_api_supported(credentials, base_model_name)
         client = self._create_client(credentials)
 
         # Whether this model is a pure reasoning model (gpt-5, gpt-5-mini, etc.)
@@ -509,9 +516,9 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         if user:
             responses_params["safety_identifier"] = user
 
-        # stop sequences are not supported by gpt-5 reasoning models
-        if stop and not is_reasoning_model:
-            responses_params["stop"] = stop
+        # Stop sequences are not supported by the Responses API at all
+        # (the SDK's responses.create has no such parameter). They are
+        # enforced client-side inside the response handlers below.
 
         # Handle the response format
         response_format = model_parameters.get("response_format")
@@ -560,9 +567,11 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         # for why the API requires it.
         apply_dify_metadata_if_enabled(responses_params, credentials)
 
+        # Log only non-sensitive routing information: the full payload can
+        # contain user input, tool schemas, document URLs and base64 data.
         logger.info(
             f"llm request with responses api: model={model}, stream={stream}, "
-            f"parameters={responses_params}"
+            f"param_keys={sorted(responses_params.keys())}"
         )
 
         # Call the Responses API
@@ -573,11 +582,11 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
 
         if stream:
             return self._handle_responses_stream_response(
-                model, credentials, response, prompt_messages, tools
+                model, credentials, response, prompt_messages, tools, stop=stop
             )
         else:
             return self._handle_responses_response(
-                model, credentials, response, prompt_messages, tools
+                model, credentials, response, prompt_messages, tools, stop=stop
             )
 
     @staticmethod
@@ -702,23 +711,20 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                             "converted to a Responses API format."
                         )
             elif isinstance(message, AssistantPromptMessage):
-                # If the assistant message contains tool_calls, emit each as a
-                # Responses API function_call item (type="function_call").
-                # A plain-text assistant turn is emitted as a normal message item.
-                if message.tool_calls:
-                    for tc in message.tool_calls:
-                        input_messages.append({
-                            "type": "function_call",
-                            "call_id": tc.id,
-                            "name": tc.function.name,
-                            "arguments": tc.function.arguments,
-                        })
-                else:
-                    if message.content:
-                        input_messages.append({
-                            "role": "assistant",
-                            "content": message.content,
-                        })
+                # Multi-round agent history often pairs prose with tool
+                # calls; both halves must reach the Responses input.
+                if message.content:
+                    input_messages.append({
+                        "role": "assistant",
+                        "content": message.content,
+                    })
+                for tc in message.tool_calls or []:
+                    input_messages.append({
+                        "type": "function_call",
+                        "call_id": tc.id,
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    })
             elif isinstance(message, ToolPromptMessage):
                 # Responses API requires tool results as function_call_output items.
                 # The call_id links back to the function_call item
@@ -776,10 +782,14 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         response: Response,
         prompt_messages: list[PromptMessage],
         tools: Optional[list[PromptMessageTool]] = None,
+        stop: Optional[list[str]] = None,
     ) -> LLMResult:
         """Handle non-streaming Responses API responses."""
-        # Extract text content
-        content = ""
+        # Keep synthetic reasoning separate from output text so that
+        # client-side stop enforcement never cuts inside the reasoning
+        # wrapper.
+        reasoning_text = ""
+        message_text = ""
 
         # Inspect the actual response structure
         if hasattr(response, 'output') and response.output:
@@ -793,31 +803,45 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                         s.text for s in summary_list if hasattr(s, 'text') and s.text
                     )
                     if summary_text:
-                        content += "<think>\n" + summary_text + "\n</think>"
+                        reasoning_text += summary_text
                 elif item_type == "message":
                     # message.content can be a string or a list of segments
                     item_content = getattr(item, 'content', None)
                     if isinstance(item_content, str):
                         if item_content:
-                            content += item_content
+                            message_text += item_content
                     elif isinstance(item_content, list):
                         for part in item_content:
                             part_type = getattr(part, 'type', '')
                             if part_type in ("output_text", "text", "input_text"):
                                 text_val = getattr(part, 'text', '')
                                 if text_val:
-                                    content += text_val
+                                    message_text += text_val
                 elif item_type in ("output_text", "text"):
                     # Some implementations return output_text/text entries directly
                     text_val = getattr(item, 'text', '')
                     if text_val:
-                        content += text_val
+                        message_text += text_val
         elif hasattr(response, 'text') and response.text:
             # Fallback format
-            content = response.text
+            message_text = response.text
         elif hasattr(response, 'content') and response.content:
             # Direct content format
-            content = response.content
+            message_text = response.content
+
+        # Client-side stop enforcement applies only to output text.
+        stop_sequences = [s for s in (stop or []) if s]
+        if stop_sequences:
+            cut = self._earliest_stop_cut(message_text, stop_sequences)
+            if cut != -1:
+                message_text = message_text[:cut]
+        if reasoning_text:
+            content = (
+                "<think>\n" + reasoning_text + "\n</think>"
+            )
+        else:
+            content = ""
+        content += message_text
 
         # Handle tool calls
         tool_calls = []
@@ -880,7 +904,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             prompt_messages=prompt_messages,
             message=assistant_prompt_message,
             usage=usage,
-            system_fingerprint=getattr(response, 'id', ''),
+            system_fingerprint=None,
         )
 
     def _handle_responses_stream_response(
@@ -890,208 +914,282 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         response: Stream[ResponseStreamEvent],
         prompt_messages: list[PromptMessage],
         tools: Optional[list[PromptMessageTool]] = None,
+        stop: Optional[list[str]] = None,
     ) -> Generator:
         """Handle streaming Responses API responses."""
         full_text = ""
-        tool_calls = []
         index = 0
-        is_first = True
         is_reasoning = False
 
-        # Track tool call state
-        pending_tool_calls = {}  # call_id -> tool_call_dict
-        current_tool_call = None
+        # Client-side stop enforcement state. The Responses API has no stop
+        # parameter, so sequences are matched on accumulated output text.
+        # A tail of (longest sequence - 1) characters is held back so a
+        # sequence split across deltas is still caught before emission.
+        stop_sequences = [s for s in (stop or []) if s]
+        stop_hit = False
+        pending = ""
+        holdback = max((len(s) for s in stop_sequences), default=1) - 1
 
-        for chunk in response:
-            if is_first:
-                is_first = False
+        # Real usage / terminal status captured from terminal events (B4).
+        real_usage: Optional[tuple[int, int]] = None
+        terminal_status: Optional[str] = None
+        error_message = ""
 
-            # Handle the Responses API streaming event format
-            chunk_type = getattr(chunk, 'type', '')
+        # Tool call assembly state.
+        pending_tool_calls: dict[str, dict] = {}
+        current_tool_call: Optional[str] = None
+        emitted_tool_calls: list[AssistantPromptMessage.ToolCall] = []
 
-            if chunk_type == 'response.reasoning_summary_text.delta':
-                # Reasoning summary delta - wrap with <think> tags
-                delta_text = getattr(chunk, 'delta', '')
-                if delta_text:
-                    if not is_reasoning:
-                        delta_text = "<think>\n" + delta_text
-                        is_reasoning = True
-                    full_text += delta_text
+        def _text_chunk(text: str) -> Optional[LLMResultChunk]:
+            nonlocal full_text, index
+            if not text:
+                return None
+            full_text += text
+            message = AssistantPromptMessage(content=text, tool_calls=[])
+            result_chunk = LLMResultChunk(
+                model=model,
+                prompt_messages=prompt_messages,
+                system_fingerprint=None,
+                delta=LLMResultChunkDelta(index=index, message=message),
+            )
+            index += 1
+            return result_chunk
 
-                    assistant_prompt_message = AssistantPromptMessage(
-                        content=delta_text,
-                        tool_calls=[]
-                    )
+        def _feed_text(delta_text: str) -> list[LLMResultChunk]:
+            """Route an output-text piece through closure + stop matching."""
+            nonlocal is_reasoning, stop_hit, pending
+            out: list[LLMResultChunk] = []
+            if not delta_text:
+                return out
+            if is_reasoning:
+                # Close the reasoning block before regular text.
+                closing = "\n</think>"
+                is_reasoning = False
+                chunk = _text_chunk(closing)
+                if chunk:
+                    out.append(chunk)
+            if stop_hit:
+                # Swallow everything once a stop sequence matched.
+                return out
+            pending += delta_text
+            cut = self._earliest_stop_cut(pending, stop_sequences)
+            if cut != -1:
+                emit_text, pending = pending[:cut], ""
+                stop_hit = True
+            elif len(pending) > holdback:
+                if holdback > 0:
+                    emit_text, pending = pending[:-holdback], pending[-holdback:]
+                else:
+                    emit_text, pending = pending, ""
+            else:
+                emit_text = ""
+            if emit_text:
+                chunk = _text_chunk(emit_text)
+                if chunk:
+                    out.append(chunk)
+            return out
 
-                    yield LLMResultChunk(
-                        model=model,
-                        prompt_messages=prompt_messages,
-                        system_fingerprint=getattr(chunk, 'item_id', ''),
-                        delta=LLMResultChunkDelta(
-                            index=index,
-                            message=assistant_prompt_message
-                        ),
-                    )
-                    index += 1
+        def _flush_pending() -> Optional[LLMResultChunk]:
+            """Emit held-back text before non-text output preserves order."""
+            nonlocal pending
+            if stop_hit or not pending:
+                return None
+            tail, pending = pending, ""
+            return _text_chunk(tail)
 
-            elif chunk_type == 'response.output_text.delta':
-                # ResponseTextDeltaEvent format - text delta
-                delta_text = getattr(chunk, 'delta', '')
-                if delta_text:
-                    if is_reasoning:
-                        # Close the <think> block before regular text
-                        delta_text = "\n</think>" + delta_text
-                        is_reasoning = False
-                    full_text += delta_text
+        for chunk_event in response:
+            event_type = getattr(chunk_event, 'type', '')
 
-                    assistant_prompt_message = AssistantPromptMessage(
-                        content=delta_text,
-                        tool_calls=[]
-                    )
+            if event_type == 'response.reasoning_summary_text.delta':
+                # Reasoning summary delta - wrap with THINK_OPEN tags
+                delta_text = getattr(chunk_event, 'delta', '') or ''
+                if not delta_text:
+                    continue
+                if is_reasoning:
+                    out = delta_text
+                else:
+                    is_reasoning = True
+                    out = "<think>\n" + delta_text
+                emitted = _text_chunk(out)
+                if emitted:
+                    yield emitted
 
-                    yield LLMResultChunk(
-                        model=model,
-                        prompt_messages=prompt_messages,
-                        system_fingerprint=getattr(chunk, 'item_id', ''),
-                        delta=LLMResultChunkDelta(
-                            index=index,
-                            message=assistant_prompt_message
-                        ),
-                    )
-                    index += 1
+            elif event_type == 'response.output_text.delta':
+                for emitted in _feed_text(
+                    getattr(chunk_event, 'delta', '') or ''
+                ):
+                    yield emitted
 
-            elif chunk_type == 'response.output_item.added':
-                # ResponseOutputItemAddedEvent format - tool call start
-                item = getattr(chunk, 'item', None)
+            elif event_type == 'response.output_item.added':
+                item = getattr(chunk_event, 'item', None)
                 if item and hasattr(item, 'type'):
                     item_type = getattr(item, 'type', '')
-
                     if item_type == 'function_call':
-                        # Tool call start - initialize the tool call object
                         function_name = getattr(item, 'name', '')
                         call_id = getattr(item, 'call_id', '')
-
                         if function_name and call_id:
                             pending_tool_calls[call_id] = {
                                 'id': call_id,
                                 'name': function_name,
-                                'arguments': ''  # Start empty and wait for argument deltas
+                                'arguments': '',
                             }
                             current_tool_call = call_id
 
-            elif chunk_type == 'response.function_call_arguments.delta':
-                # ResponseFunctionCallArgumentsDeltaEvent format - tool argument delta
-                delta_args = getattr(chunk, 'delta', '')
-
-                # Use the currently tracked tool call
+            elif event_type == 'response.function_call_arguments.delta':
+                delta_args = getattr(chunk_event, 'delta', '') or ''
                 if current_tool_call and current_tool_call in pending_tool_calls:
-                    # Append arguments to the existing tool call
                     pending_tool_calls[current_tool_call]['arguments'] += delta_args
 
-            elif chunk_type == 'response.function_call_arguments.done':
-                # ResponseFunctionCallArgumentsDoneEvent format - tool arguments complete
-                call_id = getattr(chunk, 'item_id', '')
-                final_args = getattr(chunk, 'arguments', '')
-
+            elif event_type == 'response.function_call_arguments.done':
+                call_id = getattr(chunk_event, 'item_id', '')
+                final_args = getattr(chunk_event, 'arguments', '')
                 if call_id and call_id in pending_tool_calls:
-                    # Update the tool call with the completed arguments
                     pending_tool_calls[call_id]['arguments'] = final_args
 
-            elif chunk_type == 'response.output_item.done':
-                # ResponseOutputItemDoneEvent format - tool call complete
-                item = getattr(chunk, 'item', None)
+            elif event_type == 'response.output_item.done':
+                item = getattr(chunk_event, 'item', None)
                 if item and hasattr(item, 'type'):
                     item_type = getattr(item, 'type', '')
-
                     if item_type == 'function_call':
-                        # Tool call complete - emit the full tool call
+                        # Text preceding the call must not jump behind it.
+                        flushed = _flush_pending()
+                        if flushed:
+                            yield flushed
+                        # Close an open reasoning block BEFORE tool output.
+                        if is_reasoning:
+                            closing = "\n</think>"
+                            is_reasoning = False
+                            emitted = _text_chunk(closing)
+                            if emitted:
+                                yield emitted
                         function_name = getattr(item, 'name', '')
                         function_args = getattr(item, 'arguments', '')
                         call_id = getattr(item, 'call_id', '')
-
-                        # Prefer the completed arguments (from response.function_call_arguments.done)
                         if call_id in pending_tool_calls:
-                            final_args = pending_tool_calls[call_id]['arguments'] or function_args
+                            final_args = (
+                                pending_tool_calls[call_id]['arguments']
+                                or function_args
+                            )
                         else:
                             final_args = function_args
-
                         if function_name:
                             tool_call = AssistantPromptMessage.ToolCall(
                                 id=call_id,
                                 type="function",
                                 function=AssistantPromptMessage.ToolCall.ToolCallFunction(
                                     name=function_name,
-                                    arguments=final_args or "{}"
-                                )
+                                    arguments=final_args or "{}",
+                                ),
                             )
-
                             assistant_prompt_message = AssistantPromptMessage(
                                 content="",
-                                tool_calls=[tool_call]
+                                tool_calls=[tool_call],
                             )
-
                             yield LLMResultChunk(
                                 model=model,
                                 prompt_messages=prompt_messages,
-                                system_fingerprint=call_id,
+                                system_fingerprint=None,
                                 delta=LLMResultChunkDelta(
                                     index=index,
-                                    message=assistant_prompt_message
+                                    message=assistant_prompt_message,
                                 ),
                             )
                             index += 1
-
-                            # Clean up completed tool calls
-                            if call_id in pending_tool_calls:
-                                del pending_tool_calls[call_id]
-
-                            # Reset tracking for the current tool call
+                            emitted_tool_calls.append(tool_call)
+                            pending_tool_calls.pop(call_id, None)
                             if call_id == current_tool_call:
                                 current_tool_call = None
 
-            elif hasattr(chunk, 'delta') and hasattr(chunk.delta, 'text'):
-                # Handle alternative formats
-                delta_text = chunk.delta.text or ""
-                if delta_text:
-                    full_text += delta_text
-
-                    assistant_prompt_message = AssistantPromptMessage(
-                        content=delta_text,
-                        tool_calls=[]
+            elif event_type in ('response.completed', 'response.incomplete'):
+                resp = getattr(chunk_event, 'response', None)
+                usage_obj = getattr(resp, 'usage', None)
+                if usage_obj is not None:
+                    input_tokens = (
+                        getattr(usage_obj, 'input_tokens', None)
+                        or getattr(usage_obj, 'prompt_tokens', 0)
+                        or 0
                     )
-
-                    yield LLMResultChunk(
-                        model=model,
-                        prompt_messages=prompt_messages,
-                        system_fingerprint=getattr(chunk, 'item_id', ''),
-                        delta=LLMResultChunkDelta(
-                            index=index,
-                            message=assistant_prompt_message
-                        ),
+                    output_tokens = (
+                        getattr(usage_obj, 'output_tokens', None)
+                        or getattr(usage_obj, 'completion_tokens', 0)
+                        or 0
                     )
-                    index += 1
+                    real_usage = (int(input_tokens), int(output_tokens))
+                terminal_status = (
+                    'completed'
+                    if event_type == 'response.completed'
+                    else 'incomplete'
+                )
 
-        # Handle the final usage statistics
-        prompt_tokens = self._num_tokens_from_messages(
-            credentials, prompt_messages, tools
-        )
-        full_assistant_prompt_message = AssistantPromptMessage(content=full_text)
-        completion_tokens = self._num_tokens_from_messages(
-            credentials, [full_assistant_prompt_message]
-        )
+            elif event_type == 'response.failed':
+                terminal_status = 'failed'
+                failed_response = getattr(chunk_event, 'response', None)
+                error_obj = getattr(failed_response, 'error', None)
+                error_message = str(
+                    getattr(error_obj, 'message', '') or error_obj or 'response failed'
+                )
 
+            elif event_type == 'error':
+                terminal_status = 'failed'
+                error_message = str(
+                    getattr(chunk_event, 'message', '')
+                    or getattr(chunk_event, 'error', '')
+                    or 'stream error'
+                )
+
+            elif hasattr(chunk_event, 'delta') and hasattr(
+                chunk_event.delta, 'text'
+            ):
+                # Alternative formats share the text pipeline.
+                for emitted in _feed_text(chunk_event.delta.text or ""):
+                    yield emitted
+
+        # Flush any held-back tail when no stop sequence matched.
+        flushed = _flush_pending()
+        if flushed:
+            yield flushed
+        # Never leave a synthetic reasoning block unclosed.
+        if is_reasoning:
+            closing = "\n</think>"
+            is_reasoning = False
+            emitted = _text_chunk(closing)
+            if emitted:
+                yield emitted
+
+        if terminal_status == 'failed':
+            raise InvokeBadRequestError(
+                f"Azure OpenAI Responses stream failed: {error_message}"
+            )
+
+        # Prefer real usage reported by the API; fall back to estimates only
+        # when the terminal event did not carry it.
+        if real_usage is not None:
+            prompt_tokens, completion_tokens = real_usage
+        else:
+            prompt_tokens = self._num_tokens_from_messages(
+                credentials, prompt_messages, tools
+            )
+            completion_tokens = self._num_tokens_from_messages(
+                credentials,
+                [
+                    AssistantPromptMessage(
+                        content=full_text,
+                        tool_calls=list(emitted_tool_calls),
+                    )
+                ],
+            )
         usage = self._calc_response_usage(
             model, credentials, prompt_tokens, completion_tokens
         )
-
+        finish_reason = "length" if terminal_status == "incomplete" else "stop"
         yield LLMResultChunk(
             model=model,
             prompt_messages=prompt_messages,
-            system_fingerprint="",
+            system_fingerprint=None,
             delta=LLMResultChunkDelta(
                 index=index,
                 message=AssistantPromptMessage(content=""),
-                finish_reason="stop",
+                finish_reason=finish_reason,
                 usage=usage,
             ),
         )
@@ -1113,10 +1211,12 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         :param stop: stop words
         :return: llm response chunk generator
         """
-        text = block_result.message.content
-        text = cast(str, text)
+        text = cast(str, block_result.message.content or "")
         if stop:
-            text = self.enforce_stop_tokens(text, stop)
+            stop_sequences = [s for s in stop if s]
+            cut = self._earliest_stop_cut(text, stop_sequences)
+            if cut != -1:
+                text = text[:cut]
         yield LLMResultChunk(
             model=block_result.model,
             prompt_messages=prompt_messages,
@@ -1192,15 +1292,19 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             tool_calls=tool_calls, tool_calls_response=assistant_message_tool_calls
         )
         content = ""
-        if hasattr(
-            assistant_message, "model_extra"
-        ) and assistant_message.model_extra.get("reasoning_content"):
-            content += (
-                "<think>\n"
-                + assistant_message.model_extra["reasoning_content"]
-                + "\n</think>"
+        # model_extra is None on plain completions; reasoning may also
+        # arrive as a direct attribute depending on the provider.
+        reasoning_content = (
+            (getattr(assistant_message, "model_extra", None) or {}).get(
+                "reasoning_content"
             )
-        content += assistant_message.content
+            or getattr(assistant_message, "reasoning_content", None)
+        )
+        if reasoning_content:
+            content += (
+                "<think>\n" + reasoning_content + "\n</think>"
+            )
+        content += assistant_message.content or ""
 
         assistant_prompt_message = AssistantPromptMessage(
             content=content, tool_calls=tool_calls
@@ -1254,18 +1358,69 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             delta = chunk.choices[0]
             if delta.delta is None:
                 continue
+            tools_before = len(tool_calls)
             self._update_tool_calls(
                 tool_calls=tool_calls, tool_calls_response=delta.delta.tool_calls
             )
+            # Sparse padding may create placeholder entries; give them a
+            # stable synthetic id so downstream never sees an empty one.
+            for _i, _tc in enumerate(tool_calls):
+                if not _tc.id:
+                    _tc.id = f"call-{_i}"
+            raw_content = delta.delta.content or ""
+            reasoning_content = getattr(delta.delta, "reasoning_content", None)
+            new_tools = len(tool_calls) > tools_before
+            # Fresh per-delta accumulators: never carry stale pieces.
+            pieces: list[str] = []
+            if reasoning_content:
+                # Reasoning streams WITHOUT tool payload attached, so a
+                # same-delta tool transition stays correctly ordered.
+                reasoning_pieces: list[str] = []
+                if not is_reasoning:
+                    reasoning_pieces.append("<think>\n")
+                    is_reasoning = True
+                reasoning_pieces.append(reasoning_content)
+                content = "".join(reasoning_pieces)
+                completion += content
+                yield LLMResultChunk(
+                    model=chunk.model,
+                    prompt_messages=prompt_messages,
+                    system_fingerprint=chunk.system_fingerprint,
+                    delta=LLMResultChunkDelta(
+                        index=index,
+                        message=AssistantPromptMessage(
+                            content=content, tool_calls=[]
+                        ),
+                    ),
+                )
+                index += 1
+            if raw_content:
+                pieces.append(raw_content)
+            # Any visible output - text now, or same-delta tool activity -
+            # closes an open wrapper as its own standalone chunk.
+            if is_reasoning and (raw_content or new_tools):
+                closing_content = "\n</think>"
+                is_reasoning = False
+                completion += closing_content
+                yield LLMResultChunk(
+                    model=chunk.model,
+                    prompt_messages=prompt_messages,
+                    system_fingerprint=chunk.system_fingerprint,
+                    delta=LLMResultChunkDelta(
+                        index=index,
+                        message=AssistantPromptMessage(
+                            content=closing_content
+                        ),
+                    ),
+                )
+                index += 1
             if (
                 delta.finish_reason is None
-                and not delta.delta.content
-                and not hasattr(delta.delta, "reasoning_content")
+                and not any(p for p in pieces)
+                and not new_tools
             ):
                 continue
-            content, is_reasoning = self._azure_wrap_thinking_by_reasoning_content(
-                delta.delta, is_reasoning
-            )
+            content = "".join(pieces)
             assistant_prompt_message = AssistantPromptMessage(
                 content=content, tool_calls=tool_calls
             )
@@ -1281,11 +1436,27 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                 ),
             )
             index += 1
+        if is_reasoning:
+            closing_content = "\n</think>"
+            completion += closing_content
+            yield LLMResultChunk(
+                model=real_model,
+                prompt_messages=prompt_messages,
+                system_fingerprint=system_fingerprint,
+                delta=LLMResultChunkDelta(
+                    index=index,
+                    message=AssistantPromptMessage(content=closing_content),
+                ),
+            )
+            index += 1
         if not has_usage:
             prompt_tokens = self._num_tokens_from_messages(
                 credentials, prompt_messages, tools
             )
-            full_assistant_prompt_message = AssistantPromptMessage(content=completion)
+            full_assistant_prompt_message = AssistantPromptMessage(
+                content=completion,
+                tool_calls=list(tool_calls),
+            )
             completion_tokens = self._num_tokens_from_messages(
                 credentials, [full_assistant_prompt_message]
             )
@@ -1304,6 +1475,22 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                 usage=usage,
             ),
         )
+
+    @staticmethod
+    def _earliest_stop_cut(text: str, stop_sequences: list[str]) -> int:
+        """Index of the earliest literal stop-sequence occurrence (-1 if none).
+
+        Literal matching (str.find), NOT regex: dify's enforce_stop_tokens
+        joins sequences with '|' into a pattern, so metacharacters such as
+        '.' or '[' would change semantics or raise. Streaming and blocking
+        paths must agree.
+        """
+        cut = -1
+        for seq in stop_sequences:
+            pos = text.find(seq)
+            if pos != -1 and (cut == -1 or pos < cut):
+                cut = pos
+        return cut
 
     @staticmethod
     def _update_tool_calls(
@@ -1326,38 +1513,31 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                     )
                     tool_calls.append(tool_call)
                 elif isinstance(response_tool_call, ChoiceDeltaToolCall):
-                    index = response_tool_call.index
-                    if index < len(tool_calls):
-                        tool_calls[index].id = (
-                            response_tool_call.id or tool_calls[index].id
-                        )
-                        tool_calls[index].type = (
-                            response_tool_call.type or tool_calls[index].type
-                        )
-                        if response_tool_call.function:
-                            tool_calls[index].function.name = (
-                                response_tool_call.function.name
-                                or tool_calls[index].function.name
+                    # Deltas are sparse: any subset of id/type/function can
+                    # arrive first. Pad placeholders up to the index and
+                    # merge instead of asserting provider completeness.
+                    delta_index = response_tool_call.index
+                    while len(tool_calls) <= delta_index:
+                        tool_calls.append(
+                            AssistantPromptMessage.ToolCall(
+                                id="",
+                                type="function",
+                                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                                    name="", arguments=""
+                                ),
                             )
-                            tool_calls[index].function.arguments += (
-                                response_tool_call.function.arguments or ""
-                            )
-                    else:
-                        assert response_tool_call.id is not None
-                        assert response_tool_call.type is not None
-                        assert response_tool_call.function is not None
-                        assert response_tool_call.function.name is not None
-                        assert response_tool_call.function.arguments is not None
-                        function = AssistantPromptMessage.ToolCall.ToolCallFunction(
-                            name=response_tool_call.function.name,
-                            arguments=response_tool_call.function.arguments,
                         )
-                        tool_call = AssistantPromptMessage.ToolCall(
-                            id=response_tool_call.id,
-                            type=response_tool_call.type,
-                            function=function,
+                    target = tool_calls[delta_index]
+                    target.id = response_tool_call.id or target.id
+                    target.type = response_tool_call.type or target.type
+                    if response_tool_call.function:
+                        target.function.name = (
+                            response_tool_call.function.name
+                            or target.function.name
                         )
-                        tool_calls.append(tool_call)
+                        target.function.arguments += (
+                            response_tool_call.function.arguments or ""
+                        )
 
     @staticmethod
     def _convert_prompt_message_to_dict(message: PromptMessage):
@@ -1482,16 +1662,9 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         for message in messages_dict:
             num_tokens += tokens_per_message
             for key, value in message.items():
-                if isinstance(value, list):
-                    text = ""
-                    for item in value:
-                        if isinstance(item, dict):
-                            if item["type"] == "text":
-                                text += item["text"]
-                            elif item["type"] == "image_url":
-                                image_details.append(item["image_url"])
-                    value = text
                 if key == "tool_calls":
+                    # Account on the pristine list: flattening below
+                    # replaces list values with text and loses them.
                     for tool_call in value:
                         assert isinstance(tool_call, dict)
                         for t_key, t_value in tool_call.items():
@@ -1501,10 +1674,18 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                                     num_tokens += len(encoding.encode(f_key))
                                     num_tokens += len(encoding.encode(f_value))
                             else:
-                                num_tokens += len(encoding.encode(t_key))
-                                num_tokens += len(encoding.encode(t_value))
-                else:
-                    num_tokens += len(encoding.encode(str(value)))
+                                num_tokens += len(encoding.encode(str(t_value)))
+                    continue
+                if isinstance(value, list):
+                    text = ""
+                    for item in value:
+                        if isinstance(item, dict):
+                            if item["type"] == "text":
+                                text += item["text"]
+                            elif item["type"] == "image_url":
+                                image_details.append(item["image_url"])
+                    value = text
+                num_tokens += len(encoding.encode(str(value)))
                 if key == "name":
                     num_tokens += tokens_per_name
         num_tokens += 3
@@ -1581,7 +1762,9 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
         if base_model_name.startswith("gpt-4o-mini"):
             base_tokens = 2833
             tile_tokens = 5667
-        elif base_model_name.startswith(("gpt-4o", "gpt-4.1", "gpt-4.5")):
+        elif base_model_name.startswith(
+            ("gpt-4o", "gpt-4.1", "gpt-4.5", "gpt-5")
+        ):
             base_tokens = 85
             tile_tokens = 170
         elif base_model_name.startswith(("o1", "o3", "o1-pro")):
@@ -1589,11 +1772,30 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             tile_tokens = 150
 
         for image_detail in image_details:
-            base64_str = image_detail["url"].split(",")[1]
-
-            image_data = base64.b64decode(base64_str)
-            image = Image.open(io.BytesIO(image_data))
-            width, height = image.size
+            detail = ""
+            url = ""
+            if isinstance(image_detail, dict):
+                detail = str(image_detail.get("detail") or "")
+                url = image_detail.get("url") or ""
+            low_detail = detail == "low"
+            fallback_cost = 85 if low_detail else 765  # base + 4x170 tiles
+            if not isinstance(url, str) or not url.startswith("data:"):
+                # Remote URL: dimensions unknown. Never fetch during
+                # token estimation; use a conservative fixed cost.
+                num_tokens += fallback_cost
+                continue
+            try:
+                base64_str = url.split(",", 1)[1]
+                image_data = base64.b64decode(base64_str)
+                image = Image.open(io.BytesIO(image_data))
+                width, height = image.size
+            except Exception:
+                logger.warning(
+                    "Failed to decode image data for token estimation;"
+                    " using conservative estimate."
+                )
+                num_tokens += fallback_cost
+                continue
 
             if base_model_name.startswith(("gpt-4.1-mini", "gpt-4.1-nano", "o4-mini")):
                 width_patches = self._get_image_patches(width)
@@ -1620,7 +1822,7 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
                 elif base_model_name.startswith("gpt-4.1-mini"):
                     num_tokens += int(tokens * 1.62)
             else:
-                if image_detail["detail"] == "low":
+                if low_detail:
                     # Regardless of input size, low detail images are a fixed cost.
                     num_tokens += 85
                 else:
@@ -1708,39 +1910,3 @@ class AzureOpenAILargeLanguageModel(_CommonAzureOpenAI, LargeLanguageModel):
             schema["required"] = required
         return schema
 
-    @staticmethod
-    def _azure_wrap_thinking_by_reasoning_content(
-        delta: ChoiceDelta, is_reasoning: bool
-    ) -> tuple[str, bool]:
-        """
-        If the reasoning response is from delta.get("reasoning_content"), we wrap
-        it with HTML think tag.
-        :param delta: delta dictionary from LLM streaming response
-        :param is_reasoning: is reasoning
-        :return: tuple of (processed_content, is_reasoning)
-        """
-
-        content = delta.content or ""
-        reasoning_content = (
-            delta.reasoning_content if hasattr(delta, "reasoning_content") else ""
-        )
-        try:
-            if reasoning_content:
-                try:
-                    if not is_reasoning:
-                        content = "<think>\n" + reasoning_content
-                        is_reasoning = True
-                    else:
-                        content = reasoning_content
-                except Exception as ex:
-                    raise ValueError(
-                        f"[_azure_wrap_thinking_by_reasoning_content-1] {ex}"
-                    ) from ex
-            elif is_reasoning and content:
-                content = "\n</think>" + content
-                is_reasoning = False
-        except Exception as ex:
-            raise ValueError(
-                f"[_azure_wrap_thinking_by_reasoning_content-2] {ex}"
-            ) from ex
-        return content, is_reasoning

--- a/models/azure_openai/models/tts/tts.py
+++ b/models/azure_openai/models/tts/tts.py
@@ -83,49 +83,39 @@ class AzureOpenAIText2SpeechModel(_CommonAzureOpenAI, TTSModel):
                 sentences = self._split_text_into_sentences(
                     content_text, max_length=max_length
                 )
-                executor = concurrent.futures.ThreadPoolExecutor(
-                    max_workers=min(3, len(sentences))
-                )
-                futures = [
-                    executor.submit(
-                        client.audio.speech.with_streaming_response.create,
+                # The OpenAI SDK's with_streaming_response.create returns a
+                # deferred context manager: the HTTP request fires on
+                # __enter__, not on .create(). Fetch each sentence inside a
+                # worker (real parallelism), buffer the bytes, and yield them
+                # in order. Contexts and the executor always close.
+                def _fetch_sentence_audio(sentence: str) -> bytes:
+                    with client.audio.speech.with_streaming_response.create(
                         model=model,
                         response_format=audio_type,
-                        input=sentences[i],
+                        input=sentence,
                         voice=voice,
-                    )
-                    for i in range(len(sentences))
-                ]
-                for future in futures:
-                    yield from future.result().__enter__().iter_bytes(1024)
+                    ) as response:
+                        return b"".join(response.iter_bytes(1024))
+
+                with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=min(3, len(sentences))
+                ) as executor:
+                    futures = [
+                        executor.submit(_fetch_sentence_audio, sentence)
+                        for sentence in sentences
+                    ]
+                    for future in futures:
+                        yield future.result()
             else:
-                response = client.audio.speech.with_streaming_response.create(
+                with client.audio.speech.with_streaming_response.create(
                     model=model,
                     voice=voice,
                     response_format=audio_type,
                     input=content_text.strip(),
-                )
-                yield from response.__enter__().iter_bytes(1024)
+                ) as response:
+                    yield from response.iter_bytes(1024)
         except Exception as ex:
             raise InvokeBadRequestError(str(ex))
-
-    def _process_sentence(self, sentence: str, model: str, voice, credentials: dict):
-        """
-        _tts_invoke openai text2speech model api
-
-        :param model: model name
-        :param credentials: model credentials
-        :param voice: model timbre
-        :param sentence: text content to be translated
-        :return: text translated to audio file
-        """
-        client = self._create_client(credentials)
-        audio_type = self._get_model_audio_type(model, credentials)
-        response = client.audio.speech.create(
-            model=model, voice=voice, response_format=audio_type, input=sentence.strip()
-        )
-        if isinstance(response.read(), bytes):
-            return response.read()
 
     def get_customizable_model_schema(
         self, model: str, credentials: dict

--- a/models/azure_openai/tests/test_llm.py
+++ b/models/azure_openai/tests/test_llm.py
@@ -355,7 +355,11 @@ class TestResponsesPayloadWithWebSearch(unittest.TestCase):
         prompt_messages = [UserPromptMessage(content="hello")]
         return self.llm._chat_generate_with_responses(
             model="deployment-name",
-            credentials={"base_model_name": "gpt-5"},
+            credentials={
+                "base_model_name": "gpt-5",
+                # Versionless v1 surface: always Responses-capable.
+                "openai_api_base": "https://example.openai.azure.com/openai/v1",
+            },
             prompt_messages=prompt_messages,
             model_parameters=model_parameters,
             tools=tools,

--- a/models/azure_openai/tests/test_llm_fixes.py
+++ b/models/azure_openai/tests/test_llm_fixes.py
@@ -1,0 +1,1185 @@
+"""Regression tests for azure_openai fixes (v0.0.68).
+
+Covers:
+- B1: stream_options gated by effective Azure api-version
+- P0: preflight guard for Responses-routed models on legacy endpoints
+- B2: client-side stop enforcement on the Responses route (blocking +
+      streaming cross-chunk), never touching tool-call arguments
+- B4: real usage from terminal events; fallback estimation
+- B4+: terminal status semantics (incomplete -> length; failed -> error)
+- B5: synthetic reasoning blocks always closed, in BOTH stream handlers
+- B3: defensive image token estimation (remote URLs, malformed payloads)
+- Audit: tool_calls accounted in _num_tokens_from_messages
+
+Think-tag literals are constructed via chr() so this source file can be
+safely produced by automated pipelines.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+LT, SL = chr(60), chr(62)
+THINK_OPEN = LT + "think" + SL  # synthetic open tag
+THINK_CLOSE = LT + "/think" + SL  # synthetic close tag
+
+from dify_plugin.entities.model.llm import LLMResult, LLMUsage
+from dify_plugin.entities.model.message import AssistantPromptMessage, UserPromptMessage
+from openai.types.chat import ChatCompletionMessageToolCall
+from openai.types.chat.chat_completion_chunk import (
+    ChoiceDeltaToolCall,
+    ChoiceDeltaToolCallFunction,
+)
+from dify_plugin.errors.model import InvokeBadRequestError
+
+import models.llm.llm as llm_module
+from models.llm.llm import AzureOpenAILargeLanguageModel
+
+
+def make_llm() -> AzureOpenAILargeLanguageModel:
+    return object.__new__(AzureOpenAILargeLanguageModel)
+
+
+def fake_usage(prompt_tokens: int = 0, completion_tokens: int = 0) -> LLMUsage:
+    """Real LLMUsage instance (pydantic validates chunks strictly)."""
+    return LLMUsage(
+        prompt_tokens=prompt_tokens,
+        prompt_unit_price=0,
+        prompt_price_unit=0,
+        prompt_price=0,
+        completion_tokens=completion_tokens,
+        completion_unit_price=0,
+        completion_price_unit=0,
+        completion_price=0,
+        total_tokens=prompt_tokens + completion_tokens,
+        total_price=0,
+        currency="USD",
+        latency=0,
+    )
+
+
+def mock_calc(llm):
+    """Mock _calc_response_usage preserving token numbers through pydantic."""
+    llm._calc_response_usage = MagicMock(
+        side_effect=lambda model, creds, pt, ct: fake_usage(pt, ct)
+    )
+
+
+V1_BASE = "https://example.openai.azure.com/openai/v1"
+LEGACY_BASE = "https://example.openai.azure.com"
+
+
+def resp_event(event_type: str, **kwargs):
+    return SimpleNamespace(type=event_type, **kwargs)
+
+
+def text_delta(text: str, item_id: str = "item-1"):
+    return resp_event("response.output_text.delta", delta=text, item_id=item_id)
+
+
+def reason_delta(text: str, item_id: str = "item-r"):
+    return resp_event("response.reasoning_summary_text.delta", delta=text, item_id=item_id)
+
+
+def completed_event(input_tokens: int, output_tokens: int):
+    return resp_event(
+        "response.completed",
+        response=SimpleNamespace(
+            usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens)
+        ),
+    )
+
+
+class TestStreamOptionsGate(unittest.TestCase):
+    """B1: stream_options only when the endpoint supports it."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def test_v1_endpoint_supported(self):
+        self.assertTrue(self.llm._supports_stream_options({"openai_api_base": V1_BASE}))
+
+    def test_dated_version_below_threshold_unsupported(self):
+        creds = {"openai_api_base": LEGACY_BASE, "openai_api_version": "2024-07-01-preview"}
+        self.assertFalse(self.llm._supports_stream_options(creds))
+
+    def test_dated_version_at_threshold_supported(self):
+        creds = {"openai_api_base": LEGACY_BASE, "openai_api_version": "2024-08-01-preview"}
+        self.assertTrue(self.llm._supports_stream_options(creds))
+
+    def test_blank_version_falls_back_to_default_and_is_unsupported(self):
+        creds = {"openai_api_base": LEGACY_BASE}
+        self.assertFalse(self.llm._supports_stream_options(creds))
+
+    def test_chat_generate_includes_stream_options_when_supported(self):
+        self.llm._get_base_model_name = MagicMock(return_value="gpt-4o")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock()
+        self.llm._create_client = MagicMock(return_value=mock_client)
+        self.llm._handle_chat_generate_stream_response = MagicMock(
+            return_value=iter(())
+        )
+        self.llm._clear_illegal_prompt_messages = MagicMock(
+            side_effect=lambda _, msgs: msgs
+        )
+        with unittest.mock.patch.object(
+            llm_module, "apply_dify_metadata_if_enabled", lambda *a, **k: None
+        ):
+            list(
+                self.llm._chat_generate(
+                    model="deploy",
+                    credentials={
+                        "base_model_name": "gpt-4o",
+                        "openai_api_base": V1_BASE,
+                    },
+                    prompt_messages=[UserPromptMessage(content="hi")],
+                    model_parameters={},
+                    stream=True,
+                )
+            )
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(kwargs["stream_options"], {"include_usage": True})
+
+    def test_chat_generate_omits_stream_options_on_old_versions(self):
+        self.llm._get_base_model_name = MagicMock(return_value="gpt-4o")
+        self.llm._create_client = MagicMock()
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock()
+        self.llm._create_client.return_value = mock_client
+        self.llm._handle_chat_generate_stream_response = MagicMock(return_value=iter(()))
+        self.llm._clear_illegal_prompt_messages = MagicMock(side_effect=lambda _, msgs: msgs)
+        with unittest.mock.patch.object(
+            llm_module, "apply_dify_metadata_if_enabled", lambda *a, **k: None
+        ):
+            list(
+                self.llm._chat_generate(
+                    model="deploy",
+                    credentials={
+                        "base_model_name": "gpt-4o",
+                        "openai_api_base": LEGACY_BASE,
+                        "openai_api_version": "2024-02-15-preview",
+                    },
+                    prompt_messages=[UserPromptMessage(content="hi")],
+                    model_parameters={},
+                    stream=True,
+                )
+            )
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertNotIn("stream_options", kwargs)
+
+
+class TestResponsesVersionGuard(unittest.TestCase):
+    """P0: fail fast when the endpoint cannot serve the Responses API."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def _invoke(self, credentials):
+        self.llm._create_client = MagicMock()
+        self.llm._get_base_model_name = MagicMock(return_value="gpt-5")
+        mock_calc(self.llm)
+        self.llm._num_tokens_from_messages = MagicMock(return_value=1)
+        self.llm._create_client.return_value.responses.create.return_value = SimpleNamespace(
+            output=[], usage=None, id="resp-1"
+        )
+        try:
+            self.llm._chat_generate_with_responses(
+                model="deploy",
+                credentials=credentials,
+                prompt_messages=[UserPromptMessage(content="hi")],
+                model_parameters={},
+                stream=False,
+            )
+        except ValueError as ex:
+            return str(ex)
+        return None
+
+    def test_legacy_default_version_raises_actionable_error(self):
+        message = self._invoke({"base_model_name": "gpt-5", "openai_api_base": LEGACY_BASE})
+        self.assertIsNotNone(message)
+        self.assertIn("/openai/v1", message)
+        self.assertIn("2025-03-01-preview", message)
+        self.assertIn("2024-02-15-preview", message)
+
+    def test_legacy_newer_preview_passes_guard(self):
+        result = self._invoke(
+            {
+                "base_model_name": "gpt-5",
+                "openai_api_base": LEGACY_BASE,
+                "openai_api_version": "2025-03-01-preview",
+            }
+        )
+        self.assertIsNone(result)
+
+    def test_v1_passes_guard(self):
+        result = self._invoke({"base_model_name": "gpt-5", "openai_api_base": V1_BASE})
+        self.assertIsNone(result)
+
+
+class TestResponsesStopEnforcement(unittest.TestCase):
+    """B2: stop enforced client-side, output text only."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def test_blocking_stop_truncates_message_text(self):
+        message_item = SimpleNamespace(
+            type="message", content=[SimpleNamespace(type="output_text", text="hello SECRET world")]
+        )
+        response = SimpleNamespace(output=[message_item], usage=None, id="resp-1")
+        mock_calc(self.llm)
+        self.llm._num_tokens_from_messages = MagicMock(return_value=1)
+        result = self.llm._handle_responses_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=response,
+            prompt_messages=[UserPromptMessage(content="hi")],
+            stop=["SECRET"],
+        )
+        self.assertEqual(result.message.content, "hello ")
+
+    def test_blocking_stop_never_truncates_inside_reasoning(self):
+        reasoning_item = SimpleNamespace(
+            type="reasoning", summary=[SimpleNamespace(text="SECRET appears in reasoning")]
+        )
+        message_item = SimpleNamespace(
+            type="message", content=[SimpleNamespace(type="output_text", text="plain answer")]
+        )
+        response = SimpleNamespace(output=[reasoning_item, message_item], usage=None, id="resp-1")
+        mock_calc(self.llm)
+        self.llm._num_tokens_from_messages = MagicMock(return_value=1)
+        result = self.llm._handle_responses_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=response,
+            prompt_messages=[UserPromptMessage(content="hi")],
+            stop=["SECRET"],
+        )
+        # Reasoning wrapper survives; only output text is cut.
+        self.assertIn("SECRET appears in reasoning", result.message.content)
+        self.assertIn(THINK_OPEN, result.message.content)
+        self.assertIn(THINK_CLOSE, result.message.content)
+        self.assertIn("plain answer", result.message.content)
+        self.assertNotIn("SECRET plain", result.message.content)
+
+    def _collect_stream(self, events, stop=None, tools=None):
+        mock_calc(self.llm)
+        self.llm._num_tokens_from_messages = MagicMock(return_value=7)
+        gen = self.llm._handle_responses_stream_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=iter(events),
+            prompt_messages=[UserPromptMessage(content="hi")],
+            tools=tools,
+            stop=stop,
+        )
+        return list(gen)
+
+    @staticmethod
+    def _concat(chunks) -> str:
+        return "".join(c.delta.message.content or "" for c in chunks)
+
+    def test_streaming_stop_split_across_chunks(self):
+        events = [text_delta("say STOP"), text_delta("NOW please"), completed_event(10, 20)]
+        chunks = self._collect_stream(events, stop=["STOPNOW"])
+        combined = self._concat(chunks)
+        self.assertNotIn("STOPNOW", combined)
+        self.assertEqual(combined, "say ")
+        final = chunks[-1]
+        self.assertEqual(final.delta.finish_reason, "stop")
+        self.assertIsNotNone(final.delta.usage)
+
+    def test_streaming_tool_call_arguments_ignore_stop(self):
+        call_item = SimpleNamespace(type="function_call", name="search", call_id="call-1")
+        events = [
+            resp_event("response.output_item.added", item=call_item),
+            resp_event(
+                "response.function_call_arguments.delta", delta='{"q": "SECRET"}', item_id="call-1"
+            ),
+            resp_event(
+                "response.function_call_arguments.done",
+                arguments='{"q": "SECRET"}',
+                item_id="call-1",
+            ),
+            resp_event(
+                "response.output_item.done",
+                item=SimpleNamespace(
+                    type="function_call",
+                    name="search",
+                    call_id="call-1",
+                    arguments='{"q": "SECRET"}',
+                ),
+            ),
+            completed_event(10, 20),
+        ]
+        chunks = self._collect_stream(events, stop=["SECRET"])
+        tool_chunks = [c for c in chunks if c.delta.message.tool_calls]
+        self.assertEqual(len(tool_chunks), 1)
+        self.assertEqual(
+            tool_chunks[0].delta.message.tool_calls[0].function.arguments, '{"q": "SECRET"}'
+        )
+
+
+class TestResponsesUsageAndStatus(unittest.TestCase):
+    """B4 + terminal status semantics."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def _collect(self, events):
+        mock_calc(self.llm)
+        self.llm._num_tokens_from_messages = MagicMock(return_value=3)
+        gen = self.llm._handle_responses_stream_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=iter(events),
+            prompt_messages=[UserPromptMessage(content="hi")],
+        )
+        return list(gen)
+
+    def test_real_usage_preferred_over_estimation(self):
+        chunks = self._collect([text_delta("ok"), completed_event(123, 45)])
+        final = chunks[-1]
+        self.assertEqual(final.delta.usage.prompt_tokens, 123)
+        self.assertEqual(final.delta.usage.completion_tokens, 45)
+
+    def test_estimation_fallback_without_terminal_usage(self):
+        chunks = self._collect([text_delta("hello")])
+        final = chunks[-1]
+        usage = final.delta.usage
+        self.assertIsNotNone(usage)
+        self.assertGreater(usage.completion_tokens, 0)
+
+    def test_incomplete_maps_to_length_finish_reason(self):
+        incomplete = resp_event(
+            "response.incomplete",
+            response=SimpleNamespace(
+                usage=SimpleNamespace(input_tokens=5, output_tokens=6),
+                incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+            ),
+        )
+        chunks = self._collect([text_delta("partial"), incomplete])
+        self.assertEqual(chunks[-1].delta.finish_reason, "length")
+
+    def test_failed_terminal_raises(self):
+        failed = resp_event(
+            "response.failed",
+            response=SimpleNamespace(error=SimpleNamespace(message="content filter triggered")),
+        )
+        with self.assertRaises(InvokeBadRequestError) as ctx:
+            self._collect([failed])
+        self.assertIn("content filter", str(ctx.exception))
+
+
+class TestThinkClosureResponsesStream(unittest.TestCase):
+    """B5 (Responses): reasoning blocks always closed."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def _collect(self, events):
+        mock_calc(self.llm)
+        self.llm._num_tokens_from_messages = MagicMock(return_value=3)
+        gen = self.llm._handle_responses_stream_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=iter(events),
+            prompt_messages=[UserPromptMessage(content="hi")],
+        )
+        return list(gen)
+
+    @staticmethod
+    def _concat(chunks) -> str:
+        return "".join(c.delta.message.content or "" for c in chunks)
+
+    def test_reasoning_only_stream_closes_tag(self):
+        chunks = self._collect([reason_delta("deep thought"), completed_event(1, 2)])
+        combined = self._concat(chunks)
+        self.assertIn(THINK_OPEN, combined)
+        self.assertIn(THINK_CLOSE, combined)
+        # Closing tag is its own emitted chunk, not just internal state.
+        closing_chunks = [c for c in chunks if c.delta.message.content == "\n" + THINK_CLOSE]
+        self.assertEqual(len(closing_chunks), 1)
+
+    def test_closure_emitted_before_tool_call_output(self):
+        call_item = SimpleNamespace(type="function_call", name="lookup", call_id="c9")
+        events = [
+            reason_delta("ponder"),
+            resp_event("response.output_item.added", item=call_item),
+            resp_event(
+                "response.output_item.done",
+                item=SimpleNamespace(
+                    type="function_call", name="lookup", call_id="c9", arguments="{}"
+                ),
+            ),
+            completed_event(1, 2),
+        ]
+        chunks = self._collect(events)
+        contents = [c.delta.message.content for c in chunks]
+        close_positions = [i for i, c in enumerate(contents) if c == "\n" + THINK_CLOSE]
+        tool_positions = [i for i, c in enumerate(chunks) if c.delta.message.tool_calls]
+        self.assertEqual(len(close_positions), 1)
+        self.assertEqual(len(tool_positions), 1)
+        self.assertLess(close_positions[0], tool_positions[0])
+
+
+class TestThinkClosureChatCompletionsStream(unittest.TestCase):
+    """B5 (Chat Completions): same closure guarantee."""
+
+    def _chunks(self):
+        reasoning_chunk = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(content=None, reasoning_content="hmm", tool_calls=None),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+            model="gpt-4o",
+            system_fingerprint="fp1",
+        )
+        usage_chunk = SimpleNamespace(
+            choices=[], usage=None, model="gpt-4o", system_fingerprint="fp1"
+        )
+        return reasoning_chunk, usage_chunk
+
+    def test_closure_after_reasoning_only_stream(self):
+        llm = make_llm()
+        mock_calc(llm)
+        llm._num_tokens_from_messages = MagicMock(return_value=2)
+        reasoning_chunk, usage_chunk = self._chunks()
+
+        def stream():
+            yield reasoning_chunk
+            u = SimpleNamespace(
+                choices=[],
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+                model="gpt-4o",
+                system_fingerprint="fp1",
+            )
+            yield u
+
+        out = list(
+            llm._handle_chat_generate_stream_response(
+                model="gpt-4o",
+                credentials={"base_model_name": "gpt-4o"},
+                response=stream(),
+                prompt_messages=[UserPromptMessage(content="hi")],
+            )
+        )
+        contents = [c.delta.message.content for c in out]
+        self.assertIn("\n" + THINK_CLOSE, contents)
+        # Closure precedes the terminal usage chunk.
+        self.assertEqual(contents[-1], "")
+        self.assertIsNotNone(out[-1].delta.usage)
+
+
+class TestImageTokenEstimation(unittest.TestCase):
+    """B3: never crash on remote/malformed images; estimate conservatively."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def _count(self, details, base_model="gpt-4o"):
+        return self.llm._num_tokens_from_images(base_model_name=base_model, image_details=details)
+
+    def test_remote_url_image_does_not_crash(self):
+        total = self._count([{"url": "https://example.com/cat.png", "detail": "high"}])
+        self.assertGreater(total, 0)
+
+    def test_malformed_data_uri_does_not_crash(self):
+        total = self._count([{"url": "data:image/png;base64,", "detail": "high"}])
+        self.assertGreater(total, 0)
+
+    def test_missing_detail_key_does_not_crash(self):
+        import base64 as b64mod
+        import io as iomod
+
+        from PIL import Image as PILImage
+
+        img = PILImage.new("RGB", (64, 64), color=(1, 2, 3))
+        buf = iomod.BytesIO()
+        img.save(buf, format="PNG")
+        encoded = b64mod.b64encode(buf.getvalue()).decode()
+        data_uri = f"data:image/png;base64,{encoded}"
+        total = self._count([{"url": data_uri}])
+        self.assertGreater(total, 0)
+
+    def test_low_detail_data_uri_fixed_cost(self):
+        import base64 as b64mod
+        import io as iomod
+
+        from PIL import Image as PILImage
+
+        img = PILImage.new("RGB", (3000, 3000), color=(9, 9, 9))
+        buf = iomod.BytesIO()
+        img.save(buf, format="PNG")
+        encoded = b64mod.b64encode(buf.getvalue()).decode()
+        data_uri = f"data:image/png;base64,{encoded}"
+        total = self._count([{"url": data_uri, "detail": "low"}])
+        self.assertEqual(total, 85)
+
+
+class TestToolCallsTokenAccounting(unittest.TestCase):
+    """Audit: tool_calls must be counted despite list flattening."""
+
+    def test_assistant_tool_calls_increase_count(self):
+        llm = make_llm()
+        creds = {"base_model_name": "gpt-4o"}
+        tool_call = AssistantPromptMessage.ToolCall(
+            id="call-1",
+            type="function",
+            function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                name="get_weather", arguments='{"city": "Lisbon"}'
+            ),
+        )
+        with_tools = AssistantPromptMessage(content="", tool_calls=[tool_call])
+        without_tools = AssistantPromptMessage(content="")
+        n_with = llm._num_tokens_from_messages(creds, [with_tools])
+        n_without = llm._num_tokens_from_messages(creds, [without_tools])
+        self.assertGreater(n_with, n_without)
+        # The delta must reflect the serialized call, not an empty string.
+        self.assertGreaterEqual(n_with - n_without, 15)
+
+
+class TestStopLiteralSemantics(unittest.TestCase):
+    """Round-2: stop matching is literal, consistent blocking vs streaming."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def test_blocking_regex_metacharacters_are_literal(self):
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="a.b continues")],
+        )
+        response = SimpleNamespace(output=[message_item], usage=None, id="r")
+        mock_calc(self.llm)
+        self.llm._num_tokens_from_messages = MagicMock(return_value=1)
+        result = self.llm._handle_responses_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=response,
+            prompt_messages=[UserPromptMessage(content="hi")],
+            stop=["."],
+        )
+        self.assertEqual(result.message.content, "a")
+
+    def test_blocking_bracket_stop_does_not_raise(self):
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="arr[0] tail")],
+        )
+        response = SimpleNamespace(output=[message_item], usage=None, id="r")
+        mock_calc(self.llm)
+        self.llm._num_tokens_from_messages = MagicMock(return_value=1)
+        result = self.llm._handle_responses_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=response,
+            prompt_messages=[UserPromptMessage(content="hi")],
+            stop=["["],
+        )
+        self.assertEqual(result.message.content, "arr")
+
+
+class TestStreamOrdering(unittest.TestCase):
+    """Round-2: held-back text flushes before tool output."""
+
+    def _collect(self, events, stop=None):
+        llm = make_llm()
+        mock_calc(llm)
+        llm._num_tokens_from_messages = MagicMock(return_value=3)
+        gen = llm._handle_responses_stream_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=iter(events),
+            prompt_messages=[UserPromptMessage(content="hi")],
+            stop=stop,
+        )
+        return list(gen)
+
+    def test_held_back_text_precedes_tool_call(self):
+        # "ok" is shorter than any holdback for an 8-char stop sequence.
+        call_item_done = SimpleNamespace(
+            type="function_call",
+            name="lookup",
+            call_id="c1",
+            arguments="{}",
+        )
+        events = [
+            resp_event("response.output_text.delta", delta="ok", item_id="t"),
+            resp_event("response.output_item.done", item=call_item_done),
+            completed_event(1, 2),
+        ]
+        chunks = self._collect(events, stop=["SHOULDSTOP"])
+        kinds = []
+        for c in chunks:
+            if c.delta.message.tool_calls:
+                kinds.append("tool")
+            elif c.delta.message.content == "ok":
+                kinds.append("text")
+        self.assertIn("text", kinds)
+        self.assertIn("tool", kinds)
+        self.assertLess(kinds.index("text"), kinds.index("tool"))
+
+    def test_reasoning_to_text_emits_standalone_closure_first(self):
+        events = [
+            reason_delta("thinking"),
+            resp_event("response.output_text.delta", delta="answer", item_id="t"),
+            completed_event(1, 2),
+        ]
+        chunks = self._collect(events)
+        contents = [c.delta.message.content or "" for c in chunks]
+        close_idx = next(
+            i for i, c in enumerate(contents) if c == "\n" + THINK_CLOSE
+        )
+        text_idx = next(i for i, c in enumerate(contents) if c == "answer")
+        self.assertLess(close_idx, text_idx)
+
+    def test_fallback_estimation_includes_streamed_tool_calls(self):
+        llm = make_llm()
+        mock_calc(llm)
+        num_mock = MagicMock(return_value=5)
+        llm._num_tokens_from_messages = num_mock
+        call_item_added = SimpleNamespace(
+            type="function_call", name="lookup", call_id="c2"
+        )
+        call_item_done = SimpleNamespace(
+            type="function_call",
+            name="lookup",
+            call_id="c2",
+            arguments='{"x": 1}',
+        )
+        events = [
+            resp_event("response.output_item.added", item=call_item_added),
+            resp_event(
+                "response.function_call_arguments.done",
+                arguments='{"x": 1}',
+                item_id="c2",
+            ),
+            resp_event("response.output_item.done", item=call_item_done),
+            # No completed event carrying usage -> estimation path.
+        ]
+        list(llm._handle_responses_stream_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=iter(events),
+            prompt_messages=[UserPromptMessage(content="hi")],
+        ))
+        est_msg = num_mock.call_args_list[-1].args[1][0]
+        self.assertTrue(est_msg.tool_calls)
+        self.assertEqual(est_msg.tool_calls[0].function.name, "lookup")
+
+
+class TestChatStreamClosureTransitions(unittest.TestCase):
+    """Round-2: chat closure before visible text and before tool calls."""
+
+    def _run(self, deltas):
+        llm = make_llm()
+        mock_calc(llm)
+        llm._num_tokens_from_messages = MagicMock(return_value=2)
+
+        def stream():
+            for d, finish in deltas:
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(delta=d, finish_reason=finish)
+                    ],
+                    usage=None,
+                    model="gpt-4o",
+                    system_fingerprint="fp",
+                )
+
+        return list(
+            llm._handle_chat_generate_stream_response(
+                model="gpt-4o",
+                credentials={"base_model_name": "gpt-4o"},
+                response=stream(),
+                prompt_messages=[UserPromptMessage(content="hi")],
+            )
+        )
+
+    @staticmethod
+    def _d(content=None, rc=None, tools=None):
+        return SimpleNamespace(
+            content=content, reasoning_content=rc, tool_calls=tools
+        )
+
+    def test_reasoning_to_text_closes_as_own_chunk(self):
+        out = self._run([
+            (self._d(rc="deep"), None),
+            (self._d(content="visible"), None),
+        ])
+        contents = [c.delta.message.content for c in out]
+        close_idx = next(
+            i for i, c in enumerate(contents) if c == "\n" + THINK_CLOSE
+        )
+        text_idx = next(i for i, c in enumerate(contents) if c == "visible")
+        self.assertLess(close_idx, text_idx)
+        # The closure must be standalone - not prefixed onto the text chunk.
+        self.assertNotIn(THINK_CLOSE, contents[text_idx])
+
+    def test_reasoning_to_tool_call_closes_before_tools(self):
+        delta_tool = ChoiceDeltaToolCall(
+            index=0,
+            id="call-9",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(name="f", arguments="{}"),
+        )
+        out = self._run([
+            (self._d(rc="hmm"), None),
+            (self._d(tools=[delta_tool]), None),
+            (self._d(), "stop"),
+        ])
+        contents = [c.delta.message.content for c in out]
+        close_idx = next(
+            i for i, c in enumerate(contents) if c == "\n" + THINK_CLOSE
+        )
+        tool_idx = next(
+            i for i, c in enumerate(out) if c.delta.message.tool_calls
+        )
+        self.assertLess(close_idx, tool_idx)
+
+
+class TestBlockingChatToolOnlyResponse(unittest.TestCase):
+    """Round-2: content=None with tool calls must not crash."""
+
+    def test_tool_only_message_content_none(self):
+        llm = make_llm()
+        mock_calc(llm)
+        llm._num_tokens_from_messages = MagicMock(return_value=3)
+        from openai.types.chat.chat_completion_message_function_tool_call import (
+            Function as MessageFunction,
+        )
+
+        sdk_tool_call = ChatCompletionMessageToolCall(
+            id="c1",
+            type="function",
+            function=MessageFunction(name="f", arguments="{}"),
+        )
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=None,
+                        reasoning_content=None,
+                        model_extra=None,
+                        tool_calls=[sdk_tool_call],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+            model="gpt-4o",
+            system_fingerprint="fp",
+        )
+        result = llm._handle_chat_generate_response(
+            model="gpt-4o",
+            credentials={"base_model_name": "gpt-4o"},
+            response=response,
+            prompt_messages=[UserPromptMessage(content="hi")],
+        )
+        self.assertEqual(result.message.content, "")
+        self.assertEqual(len(result.message.tool_calls), 1)
+
+
+class TestCredentialRobustness(unittest.TestCase):
+    """Round-2: None/malformed credential values fail closed, not loud."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def test_none_api_base_is_treated_as_legacy(self):
+        creds = {"openai_api_base": None}
+        self.assertFalse(self.llm._supports_stream_options(creds))
+
+    def test_malformed_version_fails_closed(self):
+        creds = {
+            "openai_api_base": LEGACY_BASE,
+            "openai_api_version": "2025-3-1-preview",
+        }
+        self.assertFalse(self.llm._supports_stream_options(creds))
+
+    def test_guard_reports_invalid_version_actionably(self):
+        self.llm._create_client = MagicMock()
+        self.llm._get_base_model_name = MagicMock(return_value="gpt-5")
+        mock_calc(self.llm)
+        self.llm._num_tokens_from_messages = MagicMock(return_value=1)
+        self.llm._create_client.return_value.responses.create.return_value = (
+            SimpleNamespace(output=[], usage=None, id="resp-1")
+        )
+        with self.assertRaises(ValueError) as ctx:
+            self.llm._chat_generate_with_responses(
+                model="deploy",
+                credentials={
+                    "base_model_name": "gpt-5",
+                    "openai_api_base": LEGACY_BASE,
+                    "openai_api_version": "bogus",
+                },
+                prompt_messages=[UserPromptMessage(content="hi")],
+                model_parameters={},
+                stream=False,
+            )
+        self.assertIn("bogus", str(ctx.exception))
+
+
+class TestErrorTerminalEvent(unittest.TestCase):
+    """Round-2: top-level error events raise instead of pretending success."""
+
+    def test_error_event_raises(self):
+        llm = make_llm()
+        mock_calc(llm)
+        llm._num_tokens_from_messages = MagicMock(return_value=1)
+        gen = llm._handle_responses_stream_response(
+            model="gpt-5",
+            credentials={"base_model_name": "gpt-5"},
+            response=iter([resp_event("error", message="boom")]),
+            prompt_messages=[UserPromptMessage(content="hi")],
+        )
+        with self.assertRaises(InvokeBadRequestError):
+            list(gen)
+
+
+class TestModelExtraNone(unittest.TestCase):
+    """Round-3: blocking chat must tolerate model_extra=None."""
+
+    def _response(self, message):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message, finish_reason="stop")],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+            model="gpt-4o",
+            system_fingerprint="fp",
+        )
+
+    def _invoke(self, message):
+        llm = make_llm()
+        mock_calc(llm)
+        llm._num_tokens_from_messages = MagicMock(return_value=2)
+        return llm._handle_chat_generate_response(
+            model="gpt-4o",
+            credentials={"base_model_name": "gpt-4o"},
+            response=self._response(message),
+            prompt_messages=[UserPromptMessage(content="hi")],
+        )
+
+    def test_plain_completion_model_extra_none(self):
+        message = SimpleNamespace(
+            content="hello", reasoning_content=None, model_extra=None, tool_calls=None
+        )
+        result = self._invoke(message)
+        self.assertEqual(result.message.content, "hello")
+
+    def test_reasoning_via_direct_attribute(self):
+        message = SimpleNamespace(
+            content="answer",
+            reasoning_content="why",
+            model_extra=None,
+            tool_calls=None,
+        )
+        result = self._invoke(message)
+        self.assertIn(THINK_OPEN, result.message.content)
+        self.assertIn("why", result.message.content)
+        self.assertIn("answer", result.message.content)
+
+
+class TestO1BlockAsStreamStop(unittest.TestCase):
+    """Round-3: the o1 block-as-stream path uses literal stop matching too."""
+
+    def test_literal_stop_on_block_as_stream(self):
+        llm = make_llm()
+        block_result = LLMResult(
+            model="o1",
+            prompt_messages=[UserPromptMessage(content="hi")],
+            message=AssistantPromptMessage(content="before.MARK after"),
+            usage=fake_usage(1, 10),
+        )
+        out = list(
+            llm._handle_chat_block_as_stream_response(
+                block_result,
+                [UserPromptMessage(content="hi")],
+                stop=["."],
+            )
+        )
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].delta.message.content, "before")
+
+
+class TestSparseToolCallDelta(unittest.TestCase):
+    """Round-3: arguments-only first delta accumulates without asserts."""
+
+    def test_arguments_only_first_delta(self):
+        llm = make_llm()
+        tool_calls: list = []
+        first = ChoiceDeltaToolCall(
+            index=0,
+            function=ChoiceDeltaToolCallFunction(arguments='{"a"'),
+        )
+        second = ChoiceDeltaToolCall(
+            index=0,
+            id="call-x",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(name="f", arguments="}"),
+        )
+        llm._update_tool_calls(tool_calls, [first])
+        llm._update_tool_calls(tool_calls, [second])
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0].id, "call-x")
+        self.assertEqual(tool_calls[0].function.name, "f")
+        self.assertEqual(tool_calls[0].function.arguments, '{"a"}')
+
+
+class TestChatMixedReasoningAndTools(unittest.TestCase):
+    """Round-3: same-delta reasoning + tool activity stays ordered."""
+
+    def _run(self, deltas):
+        llm = make_llm()
+        mock_calc(llm)
+        llm._num_tokens_from_messages = MagicMock(return_value=2)
+
+        def stream():
+            for d, finish in deltas:
+                yield SimpleNamespace(
+                    choices=[SimpleNamespace(delta=d, finish_reason=finish)],
+                    usage=None,
+                    model="gpt-4o",
+                    system_fingerprint="fp",
+                )
+
+        return list(
+            llm._handle_chat_generate_stream_response(
+                model="gpt-4o",
+                credentials={"base_model_name": "gpt-4o"},
+                response=stream(),
+                prompt_messages=[UserPromptMessage(content="hi")],
+            )
+        )
+
+    def test_reasoning_plus_tool_in_one_delta(self):
+        delta_tool = ChoiceDeltaToolCall(
+            index=0,
+            id="call-mix",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(name="f", arguments="{}"),
+        )
+        mixed_delta = SimpleNamespace(
+            content=None,
+            reasoning_content="think hard",
+            tool_calls=[delta_tool],
+        )
+        out = self._run([
+            (mixed_delta, None),
+            (SimpleNamespace(
+                content=None, reasoning_content=None, tool_calls=None
+            ), "stop"),
+        ])
+        contents = [c.delta.message.content or "" for c in out]
+        reason_idx = next(i for i, c in enumerate(contents) if "think hard" in c)
+        close_idx = next(
+            i for i, c in enumerate(contents) if c == "\n" + THINK_CLOSE
+        )
+        tool_idx = next(i for i, c in enumerate(out) if c.delta.message.tool_calls)
+        self.assertLess(reason_idx, close_idx)
+        self.assertLess(close_idx, tool_idx)
+        self.assertFalse(out[reason_idx].delta.message.tool_calls)
+
+
+class TestVersionValidation(unittest.TestCase):
+    """Round-3: newline traps and impossible dates fail closed."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def test_trailing_newline_rejected(self):
+        creds = {
+            "openai_api_base": LEGACY_BASE,
+            "openai_api_version": "2024-08-01-preview\n",
+        }
+        self.assertFalse(self.llm._supports_stream_options(creds))
+
+    def test_impossible_calendar_date_rejected(self):
+        creds = {
+            "openai_api_base": LEGACY_BASE,
+            "openai_api_version": "2024-99-99-preview",
+        }
+        self.assertFalse(self.llm._supports_stream_options(creds))
+
+    def test_ga_version_without_suffix_accepted(self):
+        creds = {
+            "openai_api_base": LEGACY_BASE,
+            "openai_api_version": "2024-10-21",
+        }
+        self.assertTrue(self.llm._supports_stream_options(creds))
+
+
+class TestResponsesInputKeepsAssistantProse(unittest.TestCase):
+    """Round-3: assistant text survives alongside its tool calls."""
+
+    def test_prose_and_tool_calls_both_emitted(self):
+        llm = make_llm()
+        tool_call = AssistantPromptMessage.ToolCall(
+            id="c1",
+            type="function",
+            function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                name="f", arguments="{}"
+            ),
+        )
+        messages = [
+            AssistantPromptMessage(content="let me check", tool_calls=[tool_call])
+        ]
+        result = llm._convert_prompt_messages_to_responses_input(messages)
+        roles = [m.get("role") for m in result if "role" in m]
+        types = [m.get("type") for m in result if "type" in m]
+        self.assertIn("assistant", roles)
+        self.assertIn("function_call", types)
+
+
+class TestEmptyEndpointRejected(unittest.TestCase):
+    """Round-3: blank base URL fails with a clear message at client build."""
+
+    def test_empty_base_url_raises_value_error(self):
+        from models.common import _CommonAzureOpenAI as C
+
+        with self.assertRaises(ValueError) as ctx:
+            C._to_credential_kwargs({"openai_api_base": "", "openai_api_key": "k"})
+        self.assertIn("Base URL is required", str(ctx.exception))
+
+
+class TestPlainTextStreamLifecycle(unittest.TestCase):
+    """Round-4: pieces reset per delta - no UnboundLocalError, no duplication."""
+
+    def _run(self, deltas):
+        llm = make_llm()
+        mock_calc(llm)
+        llm._num_tokens_from_messages = MagicMock(return_value=2)
+
+        def stream():
+            for d, finish in deltas:
+                yield SimpleNamespace(
+                    choices=[SimpleNamespace(delta=d, finish_reason=finish)],
+                    usage=None,
+                    model="gpt-4o",
+                    system_fingerprint="fp",
+                )
+
+        return list(
+            llm._handle_chat_generate_stream_response(
+                model="gpt-4o",
+                credentials={"base_model_name": "gpt-4o"},
+                response=stream(),
+                prompt_messages=[UserPromptMessage(content="hi")],
+            )
+        )
+
+    @staticmethod
+    def _d(content=None, rc=None, tools=None):
+        return SimpleNamespace(
+            content=content, reasoning_content=rc, tool_calls=tools
+        )
+
+    def test_plain_text_first_no_crash_and_no_duplication(self):
+        out = self._run([
+            (self._d(content="A"), None),
+            (self._d(content="B"), None),
+            (self._d(), "stop"),
+        ])
+        texts = [c.delta.message.content or "" for c in out if c.delta.message.content]
+        # Exactly one chunk carries "A" and one carries "B".
+        self.assertEqual(texts.count("A"), 1)
+        self.assertEqual(texts.count("B"), 1)
+        combined = "".join(texts)
+        self.assertIn("AB", combined)
+        self.assertNotIn("AABB", combined)
+
+    def test_mixed_reasoning_plus_text_same_delta_keeps_both(self):
+        out = self._run([
+            (self._d(content="visible", rc="thoughts"), None),
+            (self._d(), "stop"),
+        ])
+        contents = [c.delta.message.content or "" for c in out]
+        joined = "".join(contents)
+        self.assertIn("thoughts", joined)
+        self.assertIn("visible", joined)
+        self.assertIn(THINK_OPEN, joined)
+        self.assertIn(THINK_CLOSE, joined)
+
+    def test_emitted_tool_ids_never_empty(self):
+        delta_tool = ChoiceDeltaToolCall(
+            index=0,
+            function=ChoiceDeltaToolCallFunction(arguments="{}"),
+        )
+        id_delta = ChoiceDeltaToolCall(
+            index=0,
+            id="real-id",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(name="f", arguments="{}"),
+        )
+        out = self._run([
+            (SimpleNamespace(
+                content=None, reasoning_content=None,
+                tool_calls=[delta_tool],
+            ), None),
+            (SimpleNamespace(
+                content=None, reasoning_content=None,
+                tool_calls=[id_delta],
+            ), None),
+            (self._d(), "stop"),
+        ])
+        for chunk in out:
+            for tc in chunk.delta.message.tool_calls:
+                self.assertTrue(tc.id)
+
+
+class TestGaBoundaryComparison(unittest.TestCase):
+    """Round-4: GA release ON the threshold date satisfies preview minimum."""
+
+    def setUp(self):
+        self.llm = make_llm()
+
+    def test_ga_on_threshold_date_passes(self):
+        creds = {
+            "openai_api_base": LEGACY_BASE,
+            "openai_api_version": "2024-08-01",
+        }
+        self.assertTrue(self.llm._supports_stream_options(creds))
+
+    def test_ga_below_threshold_fails(self):
+        creds = {
+            "openai_api_base": LEGACY_BASE,
+            "openai_api_version": "2024-07-15",
+        }
+        self.assertFalse(self.llm._supports_stream_options(creds))
+
+    def test_responses_ga_boundary(self):
+        llm = make_llm()
+        llm._create_client = MagicMock()
+        llm._get_base_model_name = MagicMock(return_value="gpt-5")
+        mock_calc(llm)
+        llm._num_tokens_from_messages = MagicMock(return_value=1)
+        llm._create_client.return_value.responses.create.return_value = (
+            SimpleNamespace(output=[], usage=None, id="r1")
+        )
+        try:
+            llm._chat_generate_with_responses(
+                model="deploy",
+                credentials={
+                    "base_model_name": "gpt-5",
+                    "openai_api_base": LEGACY_BASE,
+                    "openai_api_version": "2025-03-01",
+                },
+                prompt_messages=[UserPromptMessage(content="hi")],
+                model_parameters={},
+                stream=False,
+            )
+        except ValueError:
+            self.fail("GA 2025-03-01 must satisfy the Responses gate")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #3728

Hardens the `azure_openai` plugin against a crash, an SDK-level TypeError, and several correctness/compatibility defects found while auditing it against the OpenAI Python SDK 3.x signatures and Azure's api-version feature matrix. Full evidence per item in the issue.

Key changes:

1. **Version gating** — `stream_options` only sent when the endpoint supports it (`/openai/v1` or dated ≥ `2024-08-01-preview`); shared fail-closed gate validates version shape (fullmatch + calendar date) and compares dates so a GA release on the threshold date satisfies a preview minimum.
2. **Responses preflight guard** — gpt-5*/codex models raise an actionable error unless the endpoint exposes `/responses` (v1 or ≥ `2025-03-01-preview`) instead of failing opaquely.
3. **Client-side stop enforcement** — the Responses API has no `stop`; sequences are now matched literally (regex metacharacters safe) and consistently across blocking, streaming (cross-chunk holdback buffer), and o1 block-as-stream paths; tool-call arguments bypass matching; held-back text flushes before tool output.
4. **Real usage + terminal status** — `response.completed`/`.incomplete` carry authoritative tokens now preferred over tiktoken estimates; `incomplete` maps to `finish_reason="length"`; `failed`/`error` streams raise instead of reporting success.
5. **Reasoning closure guarantees** — `<think>` blocks always close as standalone chunks (before text/tool activity and post-loop) in **both** streaming handlers; mixed reasoning+tool deltas stay ordered.
6. **Robustness** — `model_extra=None`, `content=None`, sparse `ChoiceDeltaToolCall` deltas (index-padded merge + synthetic placeholder ids), remote/malformed image URLs in token counting, `None` api-base normalization with explicit empty-endpoint error.
7. **Accounting & hygiene** — tool_calls counted before list flattening; gpt-5 image costs; TTS fetches now truly parallel inside workers with proper context/executor lifecycle; dead code removed; INFO logs no longer dump the full request payload.

## Release Notes

- Fixed streaming failures (`400 Unrecognized request argument: stream_options`) on Azure endpoints using older API versions
- Fixed `TypeError` when using stop sequences with codex/gpt-5 deployments on the Responses API
- Added clear configuration errors when a model requires a newer API version or the `/openai/v1` endpoint
- Token usage for Responses API models is now read from the API response instead of estimated; interrupted streams no longer report success
- Reasoning summaries (`<think>` blocks) are always properly closed, including reasoning-only and tool-call responses
- Fixed token-counting crashes with remote image URLs and improved TTS connection handling under load

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| Streaming on legacy api-version → HTTP 400 | Stream succeeds; usage falls back to estimation |
| codex + stop → `TypeError` before request | Stop enforced client-side; stream completes |
| Failed Responses stream → `finish_reason=stop` | Raises with provider error detail |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Message flow (system messages, user ↔ assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [x] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) → `0.0.68`
- [x] `dify_plugin` declared in `pyproject.toml` and locked in `uv.lock` (`dify_plugin>=0.10.2`, unchanged from current lock)

## Testing

- [x] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

Validation performed:
- `uv sync` clean environment from `uv.lock`; full plugin suite: **118 passed** (65 pre-existing + 53 new regression tests covering each fix: version-gate matrix, guard messages, split-sequence stops, literal regex-metacharacter stops, ordering of held-back text vs tool calls, real-usage capture, length/failed terminal mapping, both closure handlers, sparse tool-call merges, GA boundary dates, credential robustness)
- Static review converged over 4 independent second-opinion rounds to zero findings
