### PR TITLE
feat(azure_openai): modernize fallback api-version to 2025-04-01-preview

### DIFF
--- a/models/azure_openai/manifest.yaml
+++ b/models/azure_openai/manifest.yaml
@@ -24,4 +24,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.68
+version: 0.0.69

--- a/models/azure_openai/models/constants.py
+++ b/models/azure_openai/models/constants.py
@@ -15,7 +15,7 @@ from dify_plugin.entities.model import (
 from dify_plugin.entities.model.llm import LLMMode
 from pydantic import BaseModel
 
-AZURE_OPENAI_API_VERSION = "2024-02-15-preview"
+AZURE_OPENAI_API_VERSION = "2025-04-01-preview"
 
 AZURE_DEFAULT_PARAM_SEED_HELP = I18nObject(
     zh_hans="如果指定，模型将尽最大努力进行确定性采样，使得重复的具有相同种子和参数的请求应该返回相同的结果。不能保证确定性，"

--- a/models/azure_openai/models/llm/_metadata.py
+++ b/models/azure_openai/models/llm/_metadata.py
@@ -27,19 +27,17 @@ respected rather than overwritten.
 from __future__ import annotations
 
 from typing import Any, Optional
-from urllib.parse import urlparse
 
 from ..common import _CommonAzureOpenAI
-from ..constants import AZURE_OPENAI_API_VERSION
 
 _MAX_VALUE_LENGTH = 512
 
 # Stored Completions, and with it the ``metadata`` field, is only available
 # from this api-version onward. Older versions reject the request outright, so
 # telemetry is skipped rather than allowed to break generation. The dropdown in
-# provider/azure_openai.yaml still offers versions as old as 2023-12-01-preview
-# and AZURE_OPENAI_API_VERSION is older than this, so the check is load-bearing
-# rather than theoretical.
+# provider/azure_openai.yaml still offers versions older than this and users
+# may pin them explicitly, so the check is load-bearing rather than
+# theoretical (the fallback default itself is newer since 0.0.69).
 _MIN_METADATA_API_VERSION = "2024-10-01-preview"
 
 

--- a/models/azure_openai/provider/azure_openai.yaml
+++ b/models/azure_openai/provider/azure_openai.yaml
@@ -103,8 +103,8 @@ model_credential_schema:
         en_US: API Version
         zh_Hans: API 版本
       help:
-        en_US: Optional when your API Base URL already ends with /openai/v1. Non-v1 Azure endpoints will fall back to the default API version if left empty.
-        zh_Hans: 当 API Base URL 已经以 /openai/v1 结尾时，此项可留空。非 v1 的 Azure endpoint 若留空，会自动回退到默认 API 版本。
+        en_US: Optional when your API Base URL already ends with /openai/v1. Non-v1 Azure endpoints fall back to the default API version (2025-04-01-preview) if left empty. Older dated versions are deprecated by Azure and no longer support modern models (gpt-5/codex require the Responses API, available from 2025-03-01-preview); prefer the versionless /openai/v1 endpoint. Upgrading this plugin changes the effective version for configurations that leave this field empty; if your Azure resource or gateway (e.g. API Management) does not serve 2025-04-01-preview, pin an explicitly supported version below.
+        zh_Hans: 当 API Base URL 已经以 /openai/v1 结尾时，此项可留空。非 v1 的 Azure endpoint 若留空，会使用默认 API 版本（2025-04-01-preview）。Azure 已弃用较旧的日期版本——现代模型（gpt-5/codex 需要自 2025-03-01-preview 起可用的 Responses API）无法在旧版本上运行；建议优先使用无版本的 /openai/v1 端点。注意：升级本插件会改变留空此字段的配置所实际使用的版本；如果您的 Azure 资源或网关（如 API Management）不支持 2025-04-01-preview，请在下方显式选择受支持的版本。
       options:
         - label:
             en_US: 2025-04-01-preview

--- a/models/azure_openai/tests/test_llm_fixes.py
+++ b/models/azure_openai/tests/test_llm_fixes.py
@@ -113,9 +113,16 @@ class TestStreamOptionsGate(unittest.TestCase):
         creds = {"openai_api_base": LEGACY_BASE, "openai_api_version": "2024-08-01-preview"}
         self.assertTrue(self.llm._supports_stream_options(creds))
 
-    def test_blank_version_falls_back_to_default_and_is_unsupported(self):
+    def test_blank_version_falls_back_to_modern_default_and_is_supported(self):
+        # Since 0.0.69 the fallback default is 2025-04-01-preview, which
+        # supports stream_options; explicitly old versions stay unsupported.
         creds = {"openai_api_base": LEGACY_BASE}
-        self.assertFalse(self.llm._supports_stream_options(creds))
+        self.assertTrue(self.llm._supports_stream_options(creds))
+        creds_old = {
+            "openai_api_base": LEGACY_BASE,
+            "openai_api_version": "2024-02-15-preview",
+        }
+        self.assertFalse(self.llm._supports_stream_options(creds_old))
 
     def test_chat_generate_includes_stream_options_when_supported(self):
         self.llm._get_base_model_name = MagicMock(return_value="gpt-4o")
@@ -200,12 +207,23 @@ class TestResponsesVersionGuard(unittest.TestCase):
             return str(ex)
         return None
 
-    def test_legacy_default_version_raises_actionable_error(self):
-        message = self._invoke({"base_model_name": "gpt-5", "openai_api_base": LEGACY_BASE})
+    def test_explicit_pre_responses_version_raises_actionable_error(self):
+        message = self._invoke(
+            {
+                "base_model_name": "gpt-5",
+                "openai_api_base": LEGACY_BASE,
+                "openai_api_version": "2024-02-15-preview",
+            }
+        )
         self.assertIsNotNone(message)
         self.assertIn("/openai/v1", message)
         self.assertIn("2025-03-01-preview", message)
         self.assertIn("2024-02-15-preview", message)
+
+    def test_blank_version_uses_modern_default_and_passes_guard(self):
+        # Since 0.0.69 the fallback default satisfies the Responses gate.
+        result = self._invoke({"base_model_name": "gpt-5", "openai_api_base": LEGACY_BASE})
+        self.assertIsNone(result)
 
     def test_legacy_newer_preview_passes_guard(self):
         result = self._invoke(
@@ -796,9 +814,11 @@ class TestCredentialRobustness(unittest.TestCase):
     def setUp(self):
         self.llm = make_llm()
 
-    def test_none_api_base_is_treated_as_legacy(self):
+    def test_none_api_base_falls_back_to_default_version_gate(self):
+        # Missing base URL behaves like a dated endpoint evaluated against
+        # the fallback default (modern since 0.0.69).
         creds = {"openai_api_base": None}
-        self.assertFalse(self.llm._supports_stream_options(creds))
+        self.assertTrue(self.llm._supports_stream_options(creds))
 
     def test_malformed_version_fails_closed(self):
         creds = {

--- a/models/azure_openai/tests/test_metadata.py
+++ b/models/azure_openai/tests/test_metadata.py
@@ -85,8 +85,9 @@ def test_apply_no_op_when_credential_disabled():
 
 
 # Metadata requires an api-version that supports Stored Completions. The
-# plugin's fallback default predates it, so the enabled-path tests have to be
-# explicit about the version, exactly as a working deployment must be.
+# enabled-path fixtures pin the version explicitly for determinism,
+# exactly as a deployment relying on a dated endpoint must (the plugin's
+# fallback default also satisfies the gate since 0.0.69).
 ENABLED = {
     "enable_request_metadata": "enabled",
     "openai_api_version": "2025-04-01-preview",
@@ -140,15 +141,26 @@ def test_apply_skipped_when_api_version_predates_stored_completions(monkeypatch)
     assert "store" not in target
 
 
-def test_apply_skipped_when_api_version_left_empty(monkeypatch):
-    # openai_api_version is optional, and the fallback default also predates
-    # Stored Completions, so an empty value must be treated as unsupported.
+def test_apply_attaches_when_api_version_left_empty(monkeypatch):
+    # Since 0.0.69 the fallback default (2025-04-01-preview) postdates
+    # Stored Completions, so an empty value now supports metadata even on a
+    # dated endpoint; an explicitly old version must still be skipped above.
     import dify_plugin
 
     monkeypatch.setattr(dify_plugin, "get_current_session", lambda: _FakeSession())
     target: dict = {}
-    apply_dify_metadata_if_enabled(target, {"enable_request_metadata": "enabled"})
-    assert "metadata" not in target
+    apply_dify_metadata_if_enabled(
+        target,
+        {
+            "enable_request_metadata": "enabled",
+            "openai_api_base": "https://example.openai.azure.com",
+        },
+    )
+    assert target["metadata"] == {
+        "dify_app_id": "550e8400-e29b-41d4-a716-446655440000",
+        "dify_source": "dify",
+    }
+    assert target["store"] is True
 
 
 def test_apply_allowed_on_versionless_v1_endpoint(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #3730

> Rebased to a single commit on top of current `main` (which now includes the #3729 hardening). Review this PR for the **default api-version decision** only.

Bumps the plugin's fallback `AZURE_OPENAI_API_VERSION` from the deprecated `2024-02-15-preview` to `2025-04-01-preview` (already the newest dropdown option), so configurations that leave API Version empty get a surface that supports:

- `stream_options`/`include_usage` (since `2024-08-01-preview`)
- stored-completions `metadata`/`store` opt-in (since `2024-10-01-preview`)
- structured outputs GA
- Responses-routed models — gpt-5*/codex require `/responses`, available from `2025-03-01-preview`

The credential help text now documents Azure's deprecation of old dated versions, recommends the versionless `/openai/v1` endpoint, and carries an explicit migration warning: if your Azure resource or gateway (e.g. API Management) does not serve `2025-04-01-preview`, pin an explicitly supported version below.

## Release Notes

- Default API version for deployments leaving "API Version" empty is now `2025-04-01-preview` (was `2024-02-15-preview`), enabling modern models and features without extra configuration
- Added an upgrade notice for gateways/API Management that do not yet serve the newer preview version — pin an explicit version there

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| Blank version + gpt-5 deployment → opaque failure | Works out of the box; guard only fires for explicitly old versions |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Message flow (system messages, user ↔ assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [x] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) → `0.0.69`
- [x] `dify_plugin` declared in `pyproject.toml` and locked in `uv.lock` (unchanged)

## Testing

- [x] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

Validation performed:
- Full suite **119 passed** (4 tests reworked from old-default semantics to new-default with explicit legacy negatives retained; blank-version metadata test strengthened to full-dict assertion on a dated endpoint)
- Blank-version behavior verified across all three feature gates (stream_options / metadata-store / Responses)
- Static second-opinion review converged to zero findings over 2 rounds
