### PR TITLE
fix(gemini): price 3.6 Flash at the introductory rate, not the 2027 rate

### DIFF
--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.6
+version: 0.9.7

--- a/models/gemini/models/llm/gemini-3.6-flash.yaml
+++ b/models/gemini/models/llm/gemini-3.6-flash.yaml
@@ -155,8 +155,9 @@ parameter_rules:
   - name: json_schema
     use_template: json_schema
 # https://ai.google.dev/gemini-api/docs/pricing#gemini-3.6-flash
+# Introductory pricing applies through 2026-12-31.
 pricing:
-  input: '1.50'
-  output: '7.50'
+  input: '0.75'
+  output: '3.75'
   unit: '0.000001'
   currency: USD

--- a/models/gemini/models/tests/test_model_schema.py
+++ b/models/gemini/models/tests/test_model_schema.py
@@ -14,9 +14,14 @@ from models.llm.model_schema import (
 LLM_SCHEMA_DIR = Path(__file__).parents[1] / "llm"
 LATEST_FLASH_MODELS = (
     ("gemini-3.7-flash", "Medium", Decimal("0.75"), Decimal("3.75")),
-    ("gemini-3.6-flash", "Medium", Decimal("1.50"), Decimal("7.50")),
+    ("gemini-3.6-flash", "Medium", Decimal("0.75"), Decimal("3.75")),
     ("gemini-3.5-flash-lite", "Minimal", Decimal("0.30"), Decimal("2.50")),
 )
+
+# 3.6 and 3.7 Flash are published on one introductory rate card: $0.75 in /
+# $3.75 out per 1M tokens through 2026-12-31, doubling on 2027-01-01.
+# https://ai.google.dev/gemini-api/docs/pricing
+INTRODUCTORY_FLASH_MODELS = ("gemini-3.6-flash", "gemini-3.7-flash")
 
 
 def _load_llm_model_schemas() -> list[AIModelEntity]:
@@ -106,6 +111,22 @@ def test_latest_flash_model_contract(
     assert schema.pricing.output == output_price
     assert schema.pricing.unit == Decimal("0.000001")
     assert schema.pricing.currency == "USD"
+
+
+def test_introductory_flash_models_share_one_rate_card():
+    # The two models on the introductory schedule move together: same price
+    # today, same doubling on 2027-01-01. Pinning them to each other rather
+    # than only to literals means one of them cannot quietly carry the
+    # post-promotion number while the other still carries the current one.
+    llm = GoogleLargeLanguageModel(_load_llm_model_schemas())
+    pricings = []
+    for model in INTRODUCTORY_FLASH_MODELS:
+        schema = llm.get_model_schema(model)
+        assert schema is not None, model
+        assert schema.pricing is not None, model
+        pricings.append((schema.pricing.input, schema.pricing.output))
+
+    assert len(set(pricings)) == 1, dict(zip(INTRODUCTORY_FLASH_MODELS, pricings))
 
 
 def test_latest_flash_models_are_first_in_display_order():


### PR DESCRIPTION
## Summary

`gemini-3.6-flash` is priced at **$1.50 in / $7.50 out** per 1M tokens. That is the rate
Google's page says takes effect **on 2027-01-01**. Through 2026-12-31 the model is on
introductory pricing at **$0.75 / $3.75** — so every 3.6 Flash call Dify reports today costs
**2x what it should**.

Source: https://ai.google.dev/gemini-api/docs/pricing — "Gemini 3.6 Flash … $0.75 through
December 31, 2026 … $1.50 starting January 1, 2027", same for output at $3.75 → $7.50.

The plugin already has the right answer one file over. `gemini-3.7-flash` is on the identical
schedule and carries the current number, with the reason written down:

```yaml
# https://ai.google.dev/gemini-api/docs/pricing#gemini-3.7-flash
# Introductory pricing applies through 2026-12-31.
pricing:
  input: '0.75'
  output: '3.75'
```

`gemini-3.6-flash.yaml` has the same first comment line and not the second one.

| model | in / out today | Google publishes today | from 2027-01-01 |
| --- | --- | --- | --- |
| `gemini-3.7-flash` | 0.75 / 3.75 | 0.75 / 3.75 | 1.50 / 7.50 |
| `gemini-3.6-flash` | **1.50 / 7.50** | **0.75 / 3.75** | 1.50 / 7.50 |

This is the kind of wrong number that stops being wrong on its own: on 2027-01-01 the file
becomes correct and the four months of over-reported cost leave no trace.

### Test

`test_latest_flash_model_contract` already pins 3.6 Flash's price — at `Decimal("1.50")` /
`Decimal("7.50")`. So the wrong number was asserted, not merely present. That literal is
updated, and I added one assertion that ties the two introductory-priced models to each other
instead of only to literals:

```python
def test_introductory_flash_models_share_one_rate_card():
    # ... one of them cannot quietly carry the post-promotion number while
    # the other still carries the current one.
    assert len(set(pricings)) == 1, dict(zip(INTRODUCTORY_FLASH_MODELS, pricings))
```

Reverting only the YAML fails exactly those two assertions and nothing else, and the failure
message prints both rate cards:

```
AssertionError: {'gemini-3.6-flash': (Decimal('1.50'), Decimal('7.50')),
                 'gemini-3.7-flash': (Decimal('0.75'), Decimal('3.75'))}
2 failed, 6 passed
```

### Not changed here

`gemini-flash-latest` and `gemini-flash-lite-latest` look stale in a way I can't fix without
knowing what the aliases resolve to today — filed separately rather than guessed at.
`vertex_ai` has no 3.6/3.7 Flash entries, so it is unaffected.

## Release Notes

Fixed Gemini 3.6 Flash pricing: it was set to the standard rate that begins 2027-01-01
($1.50 / $7.50 per 1M tokens) instead of the introductory rate in effect through 2026-12-31
($0.75 / $3.75), which made reported cost for that model twice the actual amount.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

No UI change — the diff is a price literal and its test. The before/after is the table above.

## LLM Plugin Checklist

- [x] New models / model parameter fixes

No other area is touched: the change is `pricing.input` / `pricing.output` in one model YAML
plus the test that pins them. Message flow, tool calls, multimodal I/O and token counting are
untouched.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.9.6 → 0.9.7
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` —
      unchanged by this PR (the plugin declares `dify-plugin>=0.10.0`; `uv.lock` is untouched)

## Testing

- [x] Local deployment — Dify version: 1.7.0

```
uv sync --all-groups --frozen --python 3.12
python -m pytest models/tests/  →  210 passed, 32 skipped
python -m pytest tests/         →   24 passed, 21 skipped
ruff check models/tests/test_model_schema.py  →  All checks passed
```

Skips are the `live` tests that require `GEMINI_API_KEY`.
