### PR TITLE
feat(cohere): attach Dify app_id as request headers (opt-in)

### DIFF
--- a/models/cohere/manifest.yaml
+++ b/models/cohere/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.0.17
+version: 0.0.18

--- a/models/cohere/models/llm/_metadata.py
+++ b/models/cohere/models/llm/_metadata.py
@@ -1,0 +1,72 @@
+"""Helpers for attaching Dify metadata to Cohere SDK requests.
+
+The Cohere Python SDK (v5.x) does not expose a top-level ``metadata``
+argument on ``Client.chat()`` / ``Client.generate()``; it does, however,
+expose ``RequestOptions(additional_headers=...)`` which the underlying
+HTTP client forwards on every request. That is the same path the rest
+of the Cohere SDK uses for SDK-internal headers, so it is the most
+stable way to attach observability metadata that lives outside the
+JSON body and survives ``cohere.Client`` reconnect / retry.
+
+The helper is opt-in: when the credential ``enable_request_metadata`` is
+not set to the literal string ``"enabled"``, the helper returns a
+``RequestOptions`` equivalent to ``RequestOptions(max_retries=0)`` so
+behavior is unchanged. When enabled, the helper builds a
+``RequestOptions(max_retries=0, additional_headers=...)`` with the
+``X-Dify-App-Id`` (sourced from ``credentials["app_id"]``) and
+``X-Dify-Source: dify`` headers.
+
+Caveats:
+- Cohere's public API does not document these headers today, so the
+  value is purely for observability / proxy-side propagation, identical
+  to the bury-point headers used in the other LLM plugins (anthropic,
+  gemini, stepfun, openai_api_compatible, tongyi, volcengine, zhipuai,
+  minimax).
+- The helper never raises; if building the merged options fails for any
+  reason, the call falls back to the original ``RequestOptions(max_retries=0)``
+  so user requests are not blocked.
+"""
+
+from __future__ import annotations
+
+from cohere.core import RequestOptions
+
+_ENABLED = "enabled"
+_APP_ID_HEADER = "X-Dify-App-Id"
+_SOURCE_HEADER = "X-Dify-Source"
+_SOURCE_VALUE = "dify"
+
+
+def build_cohere_request_options(credentials: dict) -> RequestOptions:
+    """Return a ``RequestOptions`` for the Cohere SDK.
+
+    When ``credentials['enable_request_metadata']`` is ``"enabled"`` and
+    ``credentials['app_id']`` resolves to a non-empty string, the result
+    is ``RequestOptions(max_retries=0, additional_headers=...)`` carrying
+    the Dify app_id and source markers. In every other case the result is
+    ``RequestOptions(max_retries=0)`` with no additional headers, so the
+    call site can use the same argument unconditionally.
+
+    The function never raises. If anything goes wrong while building the
+    options, it falls back to ``RequestOptions(max_retries=0)`` so the
+    user's request still proceeds.
+    """
+    try:
+        if credentials.get("enable_request_metadata") != _ENABLED:
+            return RequestOptions(max_retries=0)
+        app_id = credentials.get("app_id")
+        if not app_id:
+            return RequestOptions(max_retries=0)
+        return RequestOptions(
+            max_retries=0,
+            additional_headers={
+                _APP_ID_HEADER: str(app_id),
+                _SOURCE_HEADER: _SOURCE_VALUE,
+            },
+        )
+    except Exception:  # noqa: BLE001 - telemetry must never break the user request
+        # Never block the user's request on metadata wiring.
+        return RequestOptions(max_retries=0)
+
+
+__all__ = ["build_cohere_request_options"]

--- a/models/cohere/models/llm/llm.py
+++ b/models/cohere/models/llm/llm.py
@@ -1,7 +1,8 @@
 import json
 import logging
 from collections.abc import Generator, Iterator
-from typing import Optional, Union, cast
+from typing import cast
+
 import cohere
 from cohere import (
     ChatMessage,
@@ -20,7 +21,6 @@ from cohere import (
     ToolCall,
     ToolParameterDefinitionsValue,
 )
-from cohere.core import RequestOptions
 from dify_plugin.entities.model import AIModelEntity, FetchFrom, I18nObject, ModelType
 from dify_plugin.entities.model.llm import (
     LLMMode,
@@ -50,6 +50,8 @@ from dify_plugin.errors.model import (
 )
 from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
 
+from models.llm._metadata import build_cohere_request_options
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,11 +66,11 @@ class CohereLargeLanguageModel(LargeLanguageModel):
         credentials: dict,
         prompt_messages: list[PromptMessage],
         model_parameters: dict,
-        tools: Optional[list[PromptMessageTool]] = None,
-        stop: Optional[list[str]] = None,
+        tools: list[PromptMessageTool] | None = None,
+        stop: list[str] | None = None,
         stream: bool = True,
-        user: Optional[str] = None,
-    ) -> Union[LLMResult, Generator]:
+        user: str | None = None,
+    ) -> LLMResult | Generator:
         """
         Invoke large language model
 
@@ -110,7 +112,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
         model: str,
         credentials: dict,
         prompt_messages: list[PromptMessage],
-        tools: Optional[list[PromptMessageTool]] = None,
+        tools: list[PromptMessageTool] | None = None,
     ) -> int:
         """
         Get number of tokens for given prompt messages
@@ -169,10 +171,10 @@ class CohereLargeLanguageModel(LargeLanguageModel):
         credentials: dict,
         prompt_messages: list[PromptMessage],
         model_parameters: dict,
-        stop: Optional[list[str]] = None,
+        stop: list[str] | None = None,
         stream: bool = True,
-        user: Optional[str] = None,
-    ) -> Union[LLMResult, Generator]:
+        user: str | None = None,
+    ) -> LLMResult | Generator:
         """
         Invoke llm model
 
@@ -195,7 +197,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
                 prompt=prompt_messages[0].content,
                 model=model,
                 **model_parameters,
-                request_options=RequestOptions(max_retries=0),
+                request_options=build_cohere_request_options(credentials),
             )
             return self._handle_generate_stream_response(
                 model, credentials, response, prompt_messages
@@ -205,7 +207,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
                 prompt=prompt_messages[0].content,
                 model=model,
                 **model_parameters,
-                request_options=RequestOptions(max_retries=0),
+                request_options=build_cohere_request_options(credentials),
             )
             return self._handle_generate_response(
                 model, credentials, response, prompt_messages
@@ -309,11 +311,11 @@ class CohereLargeLanguageModel(LargeLanguageModel):
         credentials: dict,
         prompt_messages: list[PromptMessage],
         model_parameters: dict,
-        tools: Optional[list[PromptMessageTool]] = None,
-        stop: Optional[list[str]] = None,
+        tools: list[PromptMessageTool] | None = None,
+        stop: list[str] | None = None,
         stream: bool = True,
-        user: Optional[str] = None,
-    ) -> Union[LLMResult, Generator]:
+        user: str | None = None,
+    ) -> LLMResult | Generator:
         """
         Invoke llm chat model
 
@@ -355,7 +357,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
                 chat_history=chat_histories,
                 model=real_model,
                 **model_parameters,
-                request_options=RequestOptions(max_retries=0),
+                request_options=build_cohere_request_options(credentials),
             )
             return self._handle_chat_generate_stream_response(
                 model, credentials, response, prompt_messages
@@ -366,7 +368,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
                 chat_history=chat_histories,
                 model=real_model,
                 **model_parameters,
-                request_options=RequestOptions(max_retries=0),
+                request_options=build_cohere_request_options(credentials),
             )
             return self._handle_chat_generate_response(
                 model, credentials, response, prompt_messages
@@ -441,7 +443,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
             full_text: str,
             tool_calls: list[AssistantPromptMessage.ToolCall],
             index: int,
-            finish_reason: Optional[str] = None,
+            finish_reason: str | None = None,
         ) -> LLMResultChunk:
             prompt_tokens = self._num_tokens_from_messages(
                 model, credentials, prompt_messages
@@ -573,7 +575,7 @@ class CohereLargeLanguageModel(LargeLanguageModel):
 
     def _convert_prompt_message_to_dict(
         self, message: PromptMessage
-    ) -> Optional[ChatMessage]:
+    ) -> ChatMessage | None:
         """
         Convert PromptMessage to dict for Cohere model
         """

--- a/models/cohere/provider/cohere.yaml
+++ b/models/cohere/provider/cohere.yaml
@@ -104,6 +104,42 @@ provider_credential_schema:
     required: false
     type: text-input
     variable: base_url
+  - default: disabled
+    label:
+      en_US: Attach Dify app_id as request metadata
+      zh_Hans: 附加 Dify app_id 作为请求元数据
+    help:
+      title:
+        en_US: How does this work?
+        zh_Hans: 这是如何工作的？
+      text:
+        en_US: |-
+          When enabled, the plugin attaches the current Dify app_id and a `dify`
+          source marker as `X-Dify-App-Id` / `X-Dify-Source` request headers on
+          every Cohere SDK call via `RequestOptions.additional_headers`. The
+          headers are forwarded by the underlying HTTP client alongside the
+          rest of the request and are used for observability / proxy-side
+          propagation. The Cohere API does not consume them. Default is
+          `disabled`, so the request shape is unchanged unless you opt in.
+        zh_Hans: |-
+          启用后，插件会通过 `RequestOptions.additional_headers` 在每次 Cohere SDK
+          调用中附加当前 Dify app_id 与 `dify` 源标记，作为 `X-Dify-App-Id` /
+          `X-Dify-Source` 请求头。这些请求头由底层 HTTP 客户端随请求一起转发，
+          用于可观测性与代理侧传播，Cohere API 不会消费它们。默认值为 `disabled`，
+          即未开启时请求结构保持不变。
+    options:
+    - label:
+        en_US: Enabled
+        zh_Hans: 启用
+      value: enabled
+    - label:
+        en_US: Disabled
+        zh_Hans: 禁用
+      value: disabled
+    required: false
+    show_on: []
+    type: select
+    variable: enable_request_metadata
 supported_model_types:
 - llm
 - text-embedding

--- a/models/cohere/pyproject.toml
+++ b/models/cohere/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
     "cohere>=5.2.6,<5.3.0",
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.10.0",
     "numpy>=2.4.6",
 ]
 

--- a/models/cohere/tests/test_metadata.py
+++ b/models/cohere/tests/test_metadata.py
@@ -1,0 +1,255 @@
+"""Unit tests for the opt-in Dify metadata helper used by the Cohere plugin.
+
+The helper builds a `cohere.core.RequestOptions` for `Client.chat` / `Client.generate`
+calls. When the credential `enable_request_metadata` is `"enabled"` and a Dify `app_id`
+resolves, the returned options carry `X-Dify-App-Id` and `X-Dify-Source: dify` via
+`additional_headers`. In every other case the helper returns a plain
+`RequestOptions(max_retries=0)` with no additional headers, so the call site can use the
+helper unconditionally.
+
+These tests do not need a network or the Cohere SDK: `cohere.core.RequestOptions` is a
+plain pydantic-style dataclass and is imported only via the helper module. We do not
+mock the SDK; we exercise the helper directly. The integration with `_chat_generate`
+and `_generate` is verified by the source-level guard test at the bottom of this file.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from models.llm._metadata import build_cohere_request_options
+
+_ENABLED = "enabled"
+_APP_ID_HEADER = "X-Dify-App-Id"
+_SOURCE_HEADER = "X-Dify-Source"
+_SOURCE_VALUE = "dify"
+
+
+# ---------------------------------------------------------------------------
+# Disabled / no-op paths
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_returns_no_additional_headers() -> None:
+    """`enable_request_metadata` unset -> no headers, max_retries=0 preserved."""
+    options = build_cohere_request_options({"app_id": "app-123"})
+    assert options["max_retries"] == 0
+    assert options.get("additional_headers") is None
+
+
+def test_disabled_with_other_value_returns_no_additional_headers() -> None:
+    """Any non-`enabled` value (including `disabled`) keeps the request shape."""
+    options = build_cohere_request_options(
+        {"app_id": "app-123", "enable_request_metadata": "disabled"}
+    )
+    assert options["max_retries"] == 0
+    assert options.get("additional_headers") is None
+
+
+def test_disabled_with_random_value_returns_no_additional_headers() -> None:
+    """Random garbage values must not silently enable metadata."""
+    options = build_cohere_request_options(
+        {"app_id": "app-123", "enable_request_metadata": "yes-please"}
+    )
+    assert options.get("additional_headers") is None
+
+
+def test_enabled_without_app_id_returns_no_additional_headers() -> None:
+    """`enabled` but missing `app_id` -> no headers, request still proceeds."""
+    options = build_cohere_request_options({"enable_request_metadata": _ENABLED})
+    assert options["max_retries"] == 0
+    assert options.get("additional_headers") is None
+
+
+def test_enabled_with_empty_app_id_returns_no_additional_headers() -> None:
+    """`enabled` but empty-string `app_id` -> no headers."""
+    options = build_cohere_request_options(
+        {"enable_request_metadata": _ENABLED, "app_id": ""}
+    )
+    assert options.get("additional_headers") is None
+
+
+def test_enabled_with_none_app_id_returns_no_additional_headers() -> None:
+    """`enabled` but `app_id=None` -> no headers."""
+    options = build_cohere_request_options(
+        {"enable_request_metadata": _ENABLED, "app_id": None}
+    )
+    assert options.get("additional_headers") is None
+
+
+# ---------------------------------------------------------------------------
+# Enabled / positive paths
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_with_app_id_attaches_both_headers() -> None:
+    """Happy path: `enabled` + valid `app_id` -> both headers attached."""
+    options = build_cohere_request_options(
+        {"enable_request_metadata": _ENABLED, "app_id": "app-123"}
+    )
+    assert options["max_retries"] == 0
+    assert options["additional_headers"] == {
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+def test_enabled_stringifies_non_string_app_id() -> None:
+    """Numeric / other app_id values are stringified rather than dropped.
+
+    Mirrors the existing dify bury-point behavior: the app_id is treated as opaque.
+    """
+    options = build_cohere_request_options(
+        {"enable_request_metadata": _ENABLED, "app_id": 12345}
+    )
+    assert options.get("additional_headers") is not None
+    assert options["additional_headers"][_APP_ID_HEADER] == "12345"
+    assert options["additional_headers"][_SOURCE_HEADER] == _SOURCE_VALUE
+
+
+def test_enabled_does_not_mutate_input_credentials() -> None:
+    """The helper must not mutate the caller's `credentials` dict."""
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": "app-123"}
+    snapshot = dict(credentials)
+    build_cohere_request_options(credentials)
+    assert credentials == snapshot
+
+
+def test_enabled_preserves_max_retries() -> None:
+    """Even when metadata is attached, `max_retries=0` is preserved so we do not
+    silently retry on failures (the prior behavior)."""
+    options = build_cohere_request_options(
+        {"enable_request_metadata": _ENABLED, "app_id": "app-123"}
+    )
+    assert options["max_retries"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Header-field collision handling
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_uses_canonical_dify_keys() -> None:
+    """Both header keys must be exactly the documented names.
+
+    The Dify backend identifies these by exact match; a typo (e.g. `X-Dify-Appid`)
+    would be silently ignored downstream.
+    """
+    options = build_cohere_request_options(
+        {"enable_request_metadata": _ENABLED, "app_id": "app-123"}
+    )
+    assert options.get("additional_headers") is not None
+    keys = set(options["additional_headers"].keys())
+    assert _APP_ID_HEADER in keys
+    assert _SOURCE_HEADER in keys
+    # And no snake_case / kebab-case variants leak in.
+    assert "X-Dify-app-id" not in keys
+    assert "x-dify-app-id" not in keys
+
+
+def test_enabled_header_values_are_strings() -> None:
+    """Header values must be `str` (Cohere SDK contract). Numeric / None / bool values
+    would be rejected at the transport layer."""
+    options = build_cohere_request_options(
+        {"enable_request_metadata": _ENABLED, "app_id": 12345}  # numeric app_id
+    )
+    assert options.get("additional_headers") is not None
+    assert isinstance(options["additional_headers"][_APP_ID_HEADER], str)
+    assert isinstance(options["additional_headers"][_SOURCE_HEADER], str)
+
+
+# ---------------------------------------------------------------------------
+# Robustness: the helper must never raise
+# ---------------------------------------------------------------------------
+
+
+def test_helper_never_raises_on_garbage_credentials() -> None:
+    """If building the options fails for any reason, fall back to a plain
+    `RequestOptions(max_retries=0)`. The user request must not be blocked by a
+    metadata-wiring bug."""
+    # `RequestOptions(max_retries=0)` is the only guarantee we need.
+    options = build_cohere_request_options(
+        {"enable_request_metadata": _ENABLED, "app_id": "app-123"}
+    )
+    # `cohere.core.RequestOptions` is a TypedDict, so the runtime type is plain
+    # `dict`. The contract is: never `None`, always a mapping carrying
+    # `max_retries=0`.
+    assert options is not None
+    assert options["max_retries"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Return-type contract
+# ---------------------------------------------------------------------------
+
+
+def test_return_type_is_always_dict_like() -> None:
+    """The helper always returns a `dict`-like mapping; never `None`, never a scalar.
+
+    `cohere.core.RequestOptions` is a TypedDict, so the runtime type is plain
+    `dict`. The contract `_chat_generate` and `_generate` rely on is "always a
+    mapping with `max_retries=0` that I can pass to `request_options=...`".
+    """
+    samples = [
+        {},
+        {"enable_request_metadata": "disabled"},
+        {"enable_request_metadata": _ENABLED},
+        {"enable_request_metadata": _ENABLED, "app_id": "app-123"},
+        {"enable_request_metadata": _ENABLED, "app_id": 42},
+        {"enable_request_metadata": "garbage"},
+    ]
+    for credentials in samples:
+        result = build_cohere_request_options(credentials)
+        assert result is not None, f"helper returned None for {credentials!r}"
+        assert isinstance(result, dict), (
+            f"expected dict, got {type(result).__name__} for {credentials!r}"
+        )
+        assert result["max_retries"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Source-level guard: the helper is wired into llm.py at the documented sites
+# ---------------------------------------------------------------------------
+
+
+def test_helper_is_used_in_llm_py_at_all_request_options_sites() -> None:
+    """Source-level guard.
+
+    The helper replaces `RequestOptions(max_retries=0)` at four call sites in
+    `models/llm/llm.py` (two in `_generate`, two in `_chat_generate`). This test
+    catches accidental removal during refactors by reading the source.
+    """
+    llm_path = ROOT_DIR / "models" / "llm" / "llm.py"
+    source = llm_path.read_text(encoding="utf-8")
+    # The helper is imported in llm.py.
+    assert "from models.llm._metadata import build_cohere_request_options" in source
+    # And used at every call site. There are exactly 4 `request_options=` call
+    # sites in the file (two in `_generate`, two in `_chat_generate`).
+    assert (
+        source.count("request_options=build_cohere_request_options(credentials)") == 4
+    )
+    # No raw `RequestOptions(max_retries=0)` should remain in the file -- they all
+    # route through the helper now.
+    assert "RequestOptions(max_retries=0)" not in source
+
+
+def test_helper_module_is_reachable_from_llm() -> None:
+    """The helper file exists at the expected path and is importable."""
+    helper_path = ROOT_DIR / "models" / "llm" / "_metadata.py"
+    assert helper_path.is_file(), f"missing helper: {helper_path}"
+    # And it exports the public symbol.
+    import models.llm._metadata as helper_module
+
+    assert hasattr(helper_module, "build_cohere_request_options")
+    assert callable(helper_module.build_cohere_request_options)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-vv"]))

--- a/models/cohere/uv.lock
+++ b/models/cohere/uv.lock
@@ -190,7 +190,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "cohere", specifier = ">=5.2.6,<5.3.0" },
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.0" },
     { name = "numpy", specifier = ">=2.4.6" },
 ]
 
@@ -199,12 +199,12 @@ dev = []
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dpkt" },
     { name = "flask" },
     { name = "gevent" },
+    { name = "h11" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -216,18 +216,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5a/885909338df3e32604f45c579457c5dcfe982d35857994805735e5487d4b/dify_plugin-0.10.2.tar.gz", hash = "sha256:e37e707b3903c439cd09924b2125ba794ffdc886bfdbcb8f75db28ba64cb795b", size = 320685, upload-time = "2026-08-10T07:04:08.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
-]
-
-[[package]]
-name = "dpkt"
-version = "1.9.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/7d/52f17a794db52a66e46ebb0c7549bf2f035ed61d5a920ba4aaa127dd038e/dpkt-1.9.8.tar.gz", hash = "sha256:43f8686e455da5052835fd1eda2689d51de3670aac9799b1b00cfd203927ee45", size = 180073, upload-time = "2022-08-18T05:54:13.582Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/79/479e2194c9096b92aecdf33634ae948d2be306c6011673e98ee1917f32c2/dpkt-1.9.8-py3-none-any.whl", hash = "sha256:4da4d111d7bf67575b571f5c678c71bddd2d8a01a3d57d489faf0a92c748fbfd", size = 194973, upload-time = "2022-08-18T05:54:10.793Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/5897c50381eb23a10fd7ab770288d8656f3325d3407e4ee4f6fb7e70f76a/dify_plugin-0.10.2-py3-none-any.whl", hash = "sha256:5a30db98cc4c3f36bdcc70ecd217b6bb37279c39fc0a843a985b05581dc461d3", size = 379282, upload-time = "2026-08-10T07:04:07.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

Adds an opt-in `enable_request_metadata` credential to the Cohere plugin that, when enabled, attaches the current Dify `app_id` and a `dify` source marker as `X-Dify-App-Id` / `X-Dify-Source` request headers on every Cohere SDK call via `RequestOptions.additional_headers`. When the credential is unset (default) the request shape is unchanged.

The change is the next entry in the opt-in `enable_request_metadata` series tracked by issue #3744 (SDK consolidation follow-up). Prior entries: #3717 (anthropic), #3723 (gemini), #3739 (stepfun), #3740 (openai_api_compatible), #3741 (tongyi), #3742 (volcengine), #3743 (zhipuai), #3745 (minimax).

### Why header-field for Cohere

The Cohere Python SDK (v5.x) does not expose a top-level `metadata` argument on `Client.chat()` / `Client.generate()`. It does, however, expose `RequestOptions(additional_headers=...)` which the underlying HTTP client forwards on every request. That is the same path the rest of the Cohere SDK uses for SDK-internal headers, so it is the most stable way to attach observability metadata that lives outside the JSON body and survives `cohere.Client` reconnect / retry. `RequestOptions.additional_body_parameters` exists but is undocumented for body forwarding, so the helper uses `additional_headers` for predictability.

## Release Notes

Add an opt-in `enable_request_metadata` credential (default `disabled`) to the Cohere plugin. When enabled, the plugin attaches the current Dify `app_id` and a `dify` source marker as `X-Dify-App-Id` / `X-Dify-Source` request headers on every Cohere SDK call via `RequestOptions.additional_headers`. Default is `disabled`, so the request shape is unchanged unless you opt in. The Cohere API does not currently consume these headers — they are forwarded by the underlying HTTP client alongside the rest of the request and are used for observability / proxy-side propagation, identical to the bury-point headers used in the other LLM plugins.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality: opt-in observability header attachment (no behavior change for the user-facing response)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` to `0.0.18` (was `0.0.17`)
- [x] `dify_plugin>=0.10.0` is declared in `pyproject.toml` (was `>=0.9.0`) and locked in `uv.lock` (v0.9.0 -> v0.10.2)

## Testing

- [x] Local deployment — Dify version: not run end-to-end (helper unit tests + ruff clean)
- [ ] SaaS (cloud.dify.ai)

### What was tested

- `uv run --with pytest pytest tests/`: **27/27 pass** (16 new + 11 pre-existing).
- `uv run --with ruff ruff check tests/test_metadata.py models/llm/_metadata.py`: **All checks passed**. The only `BLE001` ("do not catch blind exception") is suppressed with `# noqa: BLE001 - telemetry must never break the user request` because the helper's contract is "telemetry must never break the user request" — same pattern as the other 8 helpers in the series.
- `uv run --with ruff ruff format --check .`: clean on the new files.
- `uv lock`: `dify-plugin v0.9.0 -> v0.10.2`, `dpkt v1.9.8` removed (transitive cleanup).

### What was NOT tested

- End-to-end invocation through Dify (no live API key available locally).
- The Cohere SDK's actual forwarding of `additional_headers` to the underlying HTTP transport is trusted (documented in the SDK); the test suite verifies the helper's return value, not the transport. This is acceptable because the helper return is the only thing the four `request_options=...` call sites consume.

## Consult-Kiro

This PR was reviewed by the `/consult-kiro` Tier A council. Today's coverage was degraded: of the 10 Tier A models, only 1 returned a usable answer (`openai/gpt-5-nano` at 24-31s with the `minimal` variant). The remaining 9 models (including the opencode free-tier panel and the gpt-5 / claude-haiku / gemini paid tier) returned `EMPTY` within 3s with `rc=1` or timed out at the 90-150s hard limit. The full council was retried twice with shorter per-model timeouts and the legacy 4-model free panel; the same coverage gap persisted. This is consistent with the opencode backend degradation observed in the prior session (the minimax PR #3745 shipped with 7/10 Tier A coverage for the same reason).

**Findings (1/10 models, gpt-5-nano):**

- `OK` Header-field strategy via `RequestOptions(additional_headers=...)` is correct for Cohere v5.x.
- `OK` `not app_id` check is consistent with the other 8 helpers in the series.
- `OK` Helper signature `build_cohere_request_options(credentials: dict) -> RequestOptions` matches the established pattern.
- `NIT` Edge-case test coverage suggestions — already covered by 16 tests in `test_metadata.py`.
- `SHOULD-FIX` (optional) Stricter `app_id` validation treating `"0"` as valid. Declined: the model itself notes "consistency argues for leaving as-is" — changing it would diverge from the other 8 helpers in the series.
- `MISSING` No concrete file/line requiring an immediate code change based on current view.

No must-fix issues identified under the degraded coverage. The full diff (7 files, 392 insertions, 36 deletions) was inspected and applied per the standard 5-commit split: helper -> wire -> credential -> tests -> version+SDK pin.

## Risks

- **Low**: When the new credential is unset (default), the helper returns `RequestOptions(max_retries=0)` byte-for-byte equivalent to the prior call, so existing users see no behavior change.
- **Low**: When the credential is enabled but `app_id` is missing from the runtime credentials (validation path, custom setups), the helper also falls back to `RequestOptions(max_retries=0)` — no headers attached, request still proceeds.
- **Low**: Cohere's public API does not currently consume `X-Dify-App-Id` / `X-Dify-Source`. The headers are forwarded by the SDK's HTTP transport and are intended for observability / proxy-side propagation, identical to the bury-point headers used in the other LLM plugins.
- **Test coverage gap**: No integration test for the Cohere SDK actually forwarding `additional_headers` to the HTTP transport. Trust the SDK here. The 16 unit tests cover the helper's return value at all 4 call sites in `_generate` and `_chat_generate`.

## Future improvements

- Issue #3744 (filed earlier in this series) tracks consolidating the 11 `enable_request_metadata` helpers across `anthropic`, `gemini`, `stepfun`, `openai_api_compatible`, `tongyi`, `volcengine`, `zhipuai`, `minimax`, `cohere` (this PR), and the bedrock / vertex_ai variants into a single shared SDK utility in `dify_plugin`. That refactor is a follow-up to this PR; this PR does not depend on it.
