### PR TITLE
fix(openai_api_compatible): stop forcing language and prompt on speech2text

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.64
+version: 0.0.65
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/speech2text/speech2text.py
+++ b/models/openai_api_compatible/models/speech2text/speech2text.py
@@ -28,11 +28,26 @@ class OpenAISpeech2TextModel(OAICompatSpeech2TextModel):
             endpoint_url += "/"
         endpoint_url = urljoin(endpoint_url, "audio/transcriptions")
 
-        language = credentials.get("language", "en")
-        prompt = credentials.get("initial_prompt", "convert the audio to text")
-        payload = {"model": credentials.get("endpoint_model_name", model), "language": language, "prompt": prompt}
+        payload = {"model": credentials.get("endpoint_model_name", model)}
+        # `language` and `prompt` are optional in the OpenAI transcription API and both
+        # change the output, so only forward them when the user actually configured one.
+        # Sending a hardcoded default made every request claim a language the server may
+        # not support, and injected an unrelated English instruction as the decoder prompt.
+        language = credentials.get("language")
+        if language:
+            payload["language"] = language
+        prompt = credentials.get("initial_prompt")
+        if prompt:
+            payload["prompt"] = prompt
+
         files = [("file", file)]
-        response = requests.post(endpoint_url, headers=headers, data=payload, files=files)  # noqa: S113
+        response = requests.post(
+            endpoint_url,
+            headers=headers,
+            data=payload,
+            files=files,
+            timeout=(10, 300),
+        )
 
         if response.status_code != 200:
             raise InvokeBadRequestError(response.text)

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -45,32 +45,14 @@ model_credential_schema:
       label:
         en_US: Language
         zh_Hans: 语言
-      type: select
-      default: zh
+      type: text-input
       required: false
       show_on:
         - variable: __model_type
           value: speech2text
       placeholder:
-        zh_Hans: 模型支持的语言，例如 zh,en
-        en_US: The language supported by the model, e.g. zh,en
-      options:
-        - value: zh
-          label:
-            en_US: zh-Hans
-            zh_Hans: 中文
-        - value: en
-          label:
-            en_US: en-US
-            zh_Hans: 英文
-        - value: ja
-          label:
-            en_US: ja-JP
-            zh_Hans: 日语
-        - value: ko
-          label:
-            en_US: ko-KR
-            zh_Hans: 韩语
+        zh_Hans: ISO-639-1 语言代码，例如 zh、en、ru；留空则由模型自动检测
+        en_US: ISO-639-1 language code, e.g. zh, en, ru. Leave empty to let the model auto-detect.
     - variable: initial_prompt
       label:
         en_US: Initial Prompt

--- a/models/openai_api_compatible/tests/test_speech2text_language.py
+++ b/models/openai_api_compatible/tests/test_speech2text_language.py
@@ -1,0 +1,83 @@
+"""Regression tests for the speech2text `language` and `initial_prompt` handling.
+
+The plugin used to force both fields into every transcription request:
+`language` fell back to a hardcoded value and the credential schema only
+offered `zh`, `en`, `ja` and `ko`, while `prompt` fell back to the literal
+string "convert the audio to text". Both are optional in the OpenAI
+transcription API, so an OpenAI-compatible server that serves any other
+language could not be used at all, and the injected decoder prompt biased
+the transcript.
+
+These tests drive the model directly so we can capture the form payload the
+implementation actually sends, without needing a real transcription server.
+"""
+
+import io
+from unittest.mock import MagicMock, patch
+
+from models.speech2text.speech2text import OpenAISpeech2TextModel
+
+
+def _captured_payload(mock_post):
+    """Extract the form data passed to requests.post from the mock call."""
+    assert mock_post.call_count == 1
+    _args, kwargs = mock_post.call_args
+    return kwargs.get("data") or {}
+
+
+def _credentials(**overrides):
+    creds = {
+        "endpoint_url": "https://asr.example.com/v1",
+        "api_key": "",
+        "endpoint_model_name": "whisper-1",
+    }
+    creds.update(overrides)
+    return creds
+
+
+def _invoke(credentials):
+    model = OpenAISpeech2TextModel(model_schemas=[])
+    with patch("models.speech2text.speech2text.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=200, json=lambda: {"text": "ok"})
+        model._invoke(
+            model="whisper-1",
+            credentials=credentials,
+            file=io.BytesIO(b"RIFF"),
+        )
+    return mock_post
+
+
+def test_language_is_omitted_when_not_configured():
+    payload = _captured_payload(_invoke(_credentials()))
+    assert "language" not in payload, (
+        f"An unconfigured language must let the server auto-detect; payload={payload!r}"
+    )
+
+
+def test_prompt_is_omitted_when_not_configured():
+    payload = _captured_payload(_invoke(_credentials()))
+    assert "prompt" not in payload, (
+        f"An unconfigured initial prompt must not bias the transcript; payload={payload!r}"
+    )
+
+
+def test_language_outside_the_former_option_list_is_forwarded():
+    payload = _captured_payload(_invoke(_credentials(language="ru")))
+    assert payload.get("language") == "ru", (
+        f"Any ISO-639-1 code must reach the server, not just zh/en/ja/ko; payload={payload!r}"
+    )
+
+
+def test_configured_prompt_is_forwarded():
+    payload = _captured_payload(_invoke(_credentials(initial_prompt="Kubernetes, kubectl")))
+    assert payload.get("prompt") == "Kubernetes, kubectl", (
+        f"A configured initial prompt must reach the server; payload={payload!r}"
+    )
+
+
+def test_request_has_a_timeout():
+    mock_post = _invoke(_credentials())
+    _args, kwargs = mock_post.call_args
+    assert kwargs.get("timeout") is not None, (
+        "A stalled transcription server must not hang the worker thread forever"
+    )


### PR DESCRIPTION
Fixes #3749.

The `openai_api_compatible` speech2text implementation put `language` and `prompt` into every transcription request whether or not the user configured them, and the credential schema only let `language` be one of `zh`, `en`, `ja`, `ko`. Together that made the plugin unusable with any OpenAI-compatible ASR server serving a language outside those four — which is a problem for the one plugin whose purpose is connecting arbitrary self-hosted servers.

Both parameters are optional in `POST /audio/transcriptions`: omitting `language` requests auto-detection, and `prompt` is a decoder hint that biases the transcript's vocabulary and style. The SDK base class `OAICompatSpeech2TextModel` sends neither; this override reintroduced them.

### Changes

**`provider/openai_api_compatible.yaml`** — `language` becomes a free-form `text-input` for an ISO-639-1 code instead of a four-option `select`, and loses the `zh` default. It stays `required: false`. The placeholder now describes the field accurately; the previous one was already phrased for free text, which a `select` never renders anyway.

**`models/speech2text/speech2text.py`** — `language` and `prompt` are added to the payload only when configured.

Also restores the request timeout the override had dropped. The base class uses `timeout=(10, 300)`; this call had none and carried a `# noqa: S113` to silence the linter about it, so a server that accepts the connection and then stalls would hang the worker thread indefinitely. That `noqa` is no longer needed.

**`manifest.yaml`** — version bump to 0.0.65.

### Compatibility

Existing credentials keep working. A stored `language: "zh"` is a valid value for a text input, so previously configured models continue to send exactly what they sent before. Users who never touched the field stop sending `language=en` and `prompt="convert the audio to text"` — which is the fix.

### Tests

`tests/test_speech2text_language.py` drives the model with `requests.post` patched and asserts on the form payload actually sent:

- `language` is absent when unconfigured
- `prompt` is absent when unconfigured
- a code outside the former option list (`ru`) reaches the server
- a configured prompt reaches the server
- the request carries a timeout

Three of the five fail against the current implementation; the other two guard behaviour that already worked. The plugin's full suite passes: 62 tests.
