### PR TITLE
fix(gemini): update -latest alias pricing per Google changelog (#3737)

### DIFF
--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.8
+version: 0.9.9

--- a/models/gemini/models/llm/gemini-flash-latest.yaml
+++ b/models/gemini/models/llm/gemini-flash-latest.yaml
@@ -143,10 +143,11 @@ parameter_rules:
       zh_Hans: 模型单次输出的最大 tokens 数。
   - name: json_schema
     use_template: json_schema
-# https://ai.google.dev/gemini-api/docs/pricing#gemini-3-flash-preview
+# https://ai.google.dev/gemini-api/docs/changelog (gemini-flash-latest → gemini-3.5-flash as of 2026-08-13)
+# https://ai.google.dev/gemini-api/docs/pricing#gemini-3.5-flash
 pricing:
   # prompts <= 200k tokens
-  input: '0.5'
-  output: '3.00'
+  input: '1.50'
+  output: '9.00'
   unit: '0.000001'
   currency: USD

--- a/models/gemini/models/llm/gemini-flash-lite-latest.yaml
+++ b/models/gemini/models/llm/gemini-flash-lite-latest.yaml
@@ -100,8 +100,10 @@ parameter_rules:
       ja_JP: Gemini にコードを使って複雑なタスクを解決させましょう。
   - name: json_schema
     use_template: json_schema
+# https://ai.google.dev/gemini-api/docs/changelog (gemini-3.5-flash-lite GA as of 2026-07-21)
+# https://ai.google.dev/gemini-api/docs/pricing#gemini-3.5-flash-lite
 pricing:
-  input: '0.10'
-  output: '0.40'
+  input: '0.30'
+  output: '2.50'
   unit: '0.000001'
   currency: USD


### PR DESCRIPTION
"Closes #3737\n\n## Problem\nThe pricing in the Gemini plugin for the `-latest` aliases was stale:\n- `gemini-flash-latest.yaml` listed $0.50 / $3.00 (matches the older `gemini-3-flash-preview`)\n- `gemini-flash-lite-latest.yaml` listed $0.10 / $0.40 (matches the older `gemini-3-flash-lite-preview`)\n\nBecause Google rotates these aliases to point at newer models, cost calculations in Dify for users selecting `gemini-flash-latest` / `gemini-flash-lite-latest` were wildly inaccurate (under-counting tokens in most cases).\n\n## Fix\nRe-verified the latest alias targets and prices against the official Google docs (last updated 2026-09-04):\n- https://ai.google.dev/gemini-api/docs/changelog\n- https://ai.google.dev/gemini-api/docs/pricing\n\n| Alias | Current target (per changelog) | Pricing (per 1M tokens, USD) |\n| --- | --- | --- |\n| `gemini-flash-latest` | `gemini-3.5-flash` (GA, switched from `gemini-3-flash-preview`) | input $1.50 / output $9.00 |\n| `gemini-flash-lite-latest` | `gemini-3.5-flash-lite` (GA, switched from `gemini-3.1-flash-lite-preview`) | input $0.30 / output $2.50 |\n\nBoth files now reference the official changelog and pricing docs in a code comment so future rotations are easier to spot.\n\n## Diff scope\nThis branch contains exactly three changes under `models/gemini/`:\n1. `models/gemini/models/llm/gemini-flash-latest.yaml` \u2014 pricing block (input/output).\n2. `models/gemini/models/llm/gemini-flash-lite-latest.yaml` \u2014 pricing block (input/output).\n3. `models/gemini/manifest.yaml` \u2014 top-level version bump 0.9.8 \u2192 0.9.9.\n\nNo dify_extractor changes, no empty `models/gemini/_position.yaml`.\n\n## Verification\n- YAML parses cleanly with PyYAML `safe_load`.\n- Plugin model discovery is unaffected \u2014 only the `pricing` block was touched.\n- Pricing entries re-verified against the current Google pricing page (which lists both `gemini-3.5-flash` and `gemini-3.5-flash-lite` Standard tier tables) and the changelog, which says:\n  > Released `gemini-3.5-flash`, the generally available (GA) version of Gemini 3.5 Flash, ... This is now the model behind `gemini-flash-latest`.\n  > Released `gemini-3.6 Flash` and `gemini-3.5 Flash-Lite` (GA) ... `gemini-3.5-flash-lite`: Offers a low-latency, highly cost-effective subagent option.\n\n## Release Notes\n- `gemini-flash-latest` (`models/llm/gemini-flash-latest.yaml`): pricing block updated to match the current alias target `gemini-3.5-flash` (input $1.50 / output $9.00 per 1M tokens). The previous $0.50 / $3.00 was the older `gemini-3-flash-preview` price and under-counted token costs for users selecting the `-latest` alias.\n- `gemini-flash-lite-latest` (`models/llm/gemini-flash-lite-latest.yaml`): pricing block updated to match the current alias target `gemini-3.5-flash-lite` (input $0.30 / output $2.50 per 1M tokens). The previous $0.10 / $0.40 was the older preview price.\n- Both files now include a code comment pointing at the Google changelog and pricing docs so future alias rotations are easier to spot.\n- Bumps the gemini plugin from 0.9.8 \u2192 0.9.9.\n\nRefs: https://ai.google.dev/gemini-api/docs/changelog, https://ai.google.dev/gemini-api/docs/pricing\n"