### PR TITLE
fix(bedrock): enable and wire up vision input for GPT-5.6 models

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.81
+version: 0.0.82
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -2104,7 +2104,16 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         return provide_token(region=region)
 
     def _build_responses_api_input(self, prompt_messages: list[PromptMessage]) -> list[dict]:
-        """Convert Dify prompt messages to OpenAI Responses API input format."""
+        """Convert Dify prompt messages to OpenAI Responses API input format.
+
+        Text-only user messages keep a plain-string ``content``. Multimodal
+        user messages are converted to a Responses API content-item list so
+        images (vision) are forwarded to the model instead of being silently
+        dropped. GPT-5.6/5.5/5.4 on the bedrock-mantle endpoint expose the
+        OpenAI Responses API, so image parts use the ``input_image`` content
+        type — mirrors the reference implementation in models/openai
+        (responses.py).
+        """
         result = []
         for message in prompt_messages:
             if isinstance(message, SystemPromptMessage):
@@ -2113,14 +2122,48 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                 if isinstance(message.content, str):
                     content = message.content
                 else:
-                    content = " ".join(
-                        c.data for c in message.content
-                        if c.type == PromptMessageContentType.TEXT
-                    )
+                    content = self._convert_responses_api_user_content(message.content)
                 result.append({"role": "user", "content": content})
             elif isinstance(message, AssistantPromptMessage):
                 result.append({"role": "assistant", "content": message.content or ""})
         return result
+
+    @staticmethod
+    def _convert_responses_api_user_content(contents: list) -> list[dict]:
+        """Convert a multimodal user-message content list into OpenAI Responses
+        API input content items.
+
+        Text -> ``{"type": "input_text", "text": ...}``
+        Image -> ``{"type": "input_image", "image_url": <data uri or url>, "detail": ...}``
+
+        ``ImagePromptMessageContent.data`` returns the source URL when present,
+        otherwise a ``data:<mime>;base64,<data>`` URI — both are accepted by the
+        Responses API ``image_url`` field.
+
+        :raises InvokeBadRequestError: for an image part with neither a url nor
+            base64 data, or for a content type the mantle GPT-5.x models cannot
+            accept (audio/video/document).
+        """
+        items: list[dict] = []
+        for content in contents:
+            if content.type == PromptMessageContentType.TEXT:
+                content = cast(TextPromptMessageContent, content)
+                items.append({"type": "input_text", "text": content.data})
+            elif content.type == PromptMessageContentType.IMAGE:
+                content = cast(ImagePromptMessageContent, content)
+                if not content.url and not content.base64_data:
+                    raise InvokeBadRequestError("Image input must include a url or base64 data")
+                items.append({
+                    "type": "input_image",
+                    "image_url": content.data,
+                    "detail": content.detail.value,
+                })
+            else:
+                raise InvokeBadRequestError(
+                    f"Unsupported content type '{content.type}' for GPT-5.x on the "
+                    "bedrock-mantle endpoint; only text and image inputs are supported."
+                )
+        return items
 
     def _generate_with_responses_api(
         self,

--- a/models/bedrock/models/llm/openai.yaml
+++ b/models/bedrock/models/llm/openai.yaml
@@ -5,6 +5,7 @@ icon: icon_s_en.svg
 model_type: llm
 features:
   - agent-thought
+  - vision
   - tool-call
   - stream-tool-call
 model_properties:

--- a/models/bedrock/tests/test_mantle_responses_api.py
+++ b/models/bedrock/tests/test_mantle_responses_api.py
@@ -286,12 +286,13 @@ class TestBuildResponsesApiInput:
         )
         assert result == [{"role": "user", "content": "hi"}]
 
-    def test_user_multimodal_message_joins_text_and_skips_non_text(self) -> None:
-        # The mantle path is text-only: text pieces are space-joined in order,
-        # any non-text content (here: an image between two text pieces) is
-        # dropped rather than raising.
+    def test_user_multimodal_message_forwards_text_and_image_parts(self) -> None:
+        # Vision: a multimodal user message becomes a Responses API
+        # content-item list; the image is forwarded as an ``input_image``
+        # (previously it was silently dropped, which broke vision on the
+        # mantle path — issue: GPT-5.6 vision greyed out / non-functional).
         image = ImagePromptMessageContent(
-            data="aGk=", format="png", mime_type="image/png", detail="low"
+            base64_data="aGk=", format="png", mime_type="image/png", detail="low"
         )
         result = BedrockLLM._build_responses_api_input(
             _make_instance(),
@@ -305,7 +306,54 @@ class TestBuildResponsesApiInput:
                 )
             ],
         )
-        assert result == [{"role": "user", "content": "look at this"}]
+        assert result == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "look at"},
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,aGk=",
+                        "detail": "low",
+                    },
+                    {"type": "input_text", "text": "this"},
+                ],
+            }
+        ]
+
+    def test_user_image_via_url_is_forwarded_as_image_url(self) -> None:
+        # When the image is provided as a URL, ``.data`` returns the URL as-is
+        # and it is forwarded unchanged; ``detail`` is carried through.
+        image = ImagePromptMessageContent(
+            url="https://example.com/cat.png",
+            format="png",
+            mime_type="image/png",
+            detail="high",
+        )
+        result = BedrockLLM._build_responses_api_input(
+            _make_instance(), [UserPromptMessage(content=[image])]
+        )
+        assert result == [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.com/cat.png",
+                        "detail": "high",
+                    }
+                ],
+            }
+        ]
+
+    def test_image_without_url_or_base64_raises_bad_request(self) -> None:
+        # An image part carrying neither a url nor base64 data cannot be sent;
+        # surface a clear bad-request rather than silently dropping it.
+        image = ImagePromptMessageContent(format="png", mime_type="image/png")
+        with pytest.raises(llm_mod.InvokeBadRequestError, match="url or base64"):
+            BedrockLLM._build_responses_api_input(
+                _make_instance(), [UserPromptMessage(content=[image])]
+            )
 
     def test_assistant_message_and_none_content(self) -> None:
         result = BedrockLLM._build_responses_api_input(


### PR DESCRIPTION
## Summary

When a **GPT-5.6** variant (Sol / Terra / Luna) is selected under the **Amazon Bedrock → OpenAI** model, the **Vision** capability is greyed out in the Dify UI, and even if it could be turned on, images sent to the model are silently dropped. This PR makes vision both selectable and actually functional for the GPT-5.6 (bedrock-mantle) models.

**Root cause — two independent issues:**

1. **UI toggle greyed out.** The model registered in Dify is the predefined entry `models/llm/openai.yaml`, and Dify derives the capability toggles from that file's `features` list. It listed only `agent-thought`, `tool-call`, `stream-tool-call` — no `vision`. The per‑variant files under `models/llm/model_configurations/` (e.g. `gpt-5-6-sol.yaml`) *do* declare `vision`, but those files are only read for **pricing** (`_get_model_specific_pricing` reads their `pricing` key); Dify never sees their `features`, so they have no effect on the UI.

2. **Images silently dropped at invocation.** GPT‑5.6/5.5/5.4 are served via the **bedrock‑mantle** endpoint using the OpenAI **Responses API** (`_generate_with_responses_api`). Its input builder `_build_responses_api_input` only extracted text parts from multimodal messages and discarded image parts — so even with the toggle on, no image ever reached the model.

**Fix:**

- `models/llm/openai.yaml`: add `vision` to `features` (un‑greys the toggle).
- `models/llm/llm.py`: convert multimodal user messages into Responses API content items via a new helper `_convert_responses_api_user_content` — text → `input_text`, image → `input_image` with `image_url` (data‑URI or URL from `ImagePromptMessageContent.data`) and `detail`. Raises `InvokeBadRequestError` for an image with neither url nor base64 data, and for content types the mantle models can't accept. Format mirrors the existing `models/openai` Responses implementation.
- `tests/test_mantle_responses_api.py`: the old test pinned the buggy "drop image" behavior; replaced with cases asserting base64 and URL images are forwarded, plus a missing‑data error case.
- `manifest.yaml`: bump top‑level `version` `0.0.81` → `0.0.82`.

**Scope / blast radius:** only the 5 bedrock‑mantle GPT‑5.x model IDs (`openai.gpt-5.6-sol/-terra/-luna`, `openai.gpt-5.5`, `openai.gpt-5.4`) reach the changed code path (guarded by `_is_bedrock_mantle_model` in `_invoke`). Converse‑path models — Claude, Nova, Meta, Mistral, Cohere, DeepSeek, Qwen, and GPT‑OSS 20B/120B — are unchanged.

## Release Notes

GPT‑5.6 (Sol / Terra / Luna) now supports image (vision) input. Previously the Vision toggle was disabled in the UI and images were not sent to the model. GPT‑OSS and non‑OpenAI Bedrock models are unaffected.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!-- Local UI verification with a GPT-5.6 variant; before = Vision greyed out, after = Vision selectable and image is read by the model. -->

| Before | After |
| ------ | ----- |
| Vision toggle greyed out for GPT-5.6 | Vision selectable; uploaded image is read by the model |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — `0.0.81` → `0.0.82`
- [x] `dify_plugin` is declared in `pyproject.toml` and locked in `uv.lock` (this plugin tracks `dify_plugin>=0.10.0`)

## Testing

- [x] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

Verification performed:
- Full bedrock unit-test suite: **186 passed** (`uv run --frozen pytest`), including the updated mantle Responses API input tests.
- Plugin packaged with the Dify CLI (`bedrock-0.0.82.difypkg`) and installed into a local Dify for functional checks: the Vision toggle is selectable for GPT‑5.6 variants and uploaded images are read by the model.
