### PR TITLE
feat(paddleocr): align with latest official API

### DIFF
--- a/tools/paddleocr/README.md
+++ b/tools/paddleocr/README.md
@@ -34,11 +34,25 @@ The `file` input supports Dify uploaded image/PDF files directly and submits the
 
 | Tool | Supported models |
 | --- | --- |
-| Text Recognition | `PP-OCRv5` (default), `PP-OCRv5-latin`, `PP-OCRv6` |
+| Text Recognition | `PP-OCRv6` (default), `PP-OCRv5`, `PP-OCRv5-latin` |
 | Document Parsing | `PP-StructureV3` |
 | Large Model Document Parsing | `PaddleOCR-VL-1.6` (default), `PaddleOCR-VL-1.5`, `PaddleOCR-VL` |
 
 All tools accept an optional PDF page range such as `2,4-6`. Both document parsing tools can skip Markdown image resources when they are not needed and can return an additional DOCX file alongside the Markdown and JSON results.
+
+The document parsing tools also expose the official layout score threshold, bounding-box expansion ratio, and overlapping-box merge mode (`large`, `small`, or `union`). All three tools accept an optional **Advanced API Options (JSON)** value that is merged into the official API `optionalPayload`. This supports per-class layout settings, PaddleOCR-VL `vlmExtraArgs`, and newly introduced hosted API options without changing the transport contract. Advanced values override named options; transport-level fields such as `file`, `model`, and `pageRanges` are rejected.
+
+For example, the following advanced value applies per-class layout thresholds and PaddleOCR-VL resolution controls:
+
+```json
+{
+  "layoutThreshold": {"0": 0.45, "2": 0.48},
+  "vlmExtraArgs": {
+    "ocr_min_pixels": 3136,
+    "ocr_max_pixels": 4014080
+  }
+}
+```
 
 See the [PaddleOCR official API documentation](https://www.paddleocr.ai/latest/en/version3.x/inference_deployment/serving/paddleocr_official_api/cli.html) for the hosted service model matrix and request behavior.
 

--- a/tools/paddleocr/manifest.yaml
+++ b/tools/paddleocr/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.2.10
+version: 0.3.0
 type: plugin
 author: langgenius
 name: paddleocr

--- a/tools/paddleocr/provider/paddleocr.py
+++ b/tools/paddleocr/provider/paddleocr.py
@@ -2,33 +2,33 @@ from typing import Any
 
 from dify_plugin import ToolProvider
 from dify_plugin.errors.tool import ToolProviderCredentialValidationError
-
-from tools.document_parsing import DocumentParsingTool
-from tools.document_parsing_vl import DocumentParsingVlTool
-from tools.text_recognition import TextRecognitionTool
-from tools.utils import call_paddleocr_api, get_api_client_config
+from tools.document_parsing import DocumentParsingTool  # noqa: F401
+from tools.document_parsing_vl import DocumentParsingVlTool  # noqa: F401
+from tools.text_recognition import TextRecognitionTool  # noqa: F401
+from tools.utils import DEFAULT_OCR_MODEL, call_paddleocr_api, get_api_client_config
 
 
 class PaddleocrProvider(ToolProvider):
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
-        if "aistudio_access_token" not in credentials:
-            raise ToolProviderCredentialValidationError(
-                "AI Studio access token must be provided"
-            )
+        access_token = credentials.get("aistudio_access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
+            raise ToolProviderCredentialValidationError("AI Studio access token must be provided")
 
         # Get base_url (optional, uses SDK default if not provided)
         base_url = credentials.get("base_url")
 
         # Test with OCR (works for all models)
-        test_file = "https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/general_ocr_002.png"
+        test_file = (
+            "https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/general_ocr_002.png"
+        )
 
         try:
             client_config = get_api_client_config(
-                access_token=credentials["aistudio_access_token"],
+                access_token=access_token,
                 base_url=base_url,
             )
             call_paddleocr_api(
-                model="PP-OCRv5",
+                model=DEFAULT_OCR_MODEL,
                 file_url=test_file,
                 file_path=None,
                 options={},
@@ -36,6 +36,4 @@ class PaddleocrProvider(ToolProvider):
                 is_document_parsing=False,
             )
         except Exception as e:
-            raise ToolProviderCredentialValidationError(
-                f"Validation failed: {e}"
-            ) from e
+            raise ToolProviderCredentialValidationError(f"Validation failed: {e}") from e

--- a/tools/paddleocr/tests/test_file_input.py
+++ b/tools/paddleocr/tests/test_file_input.py
@@ -11,7 +11,9 @@ PLUGIN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if PLUGIN_DIR not in sys.path:
     sys.path.insert(0, PLUGIN_DIR)
 
+from dify_plugin.errors.tool import ToolProviderCredentialValidationError  # noqa: E402
 from dify_plugin.file.file import File, FileType  # noqa: E402
+from provider.paddleocr import PaddleocrProvider  # noqa: E402
 from tools.document_parsing import (  # noqa: E402
     DocumentParsingTool,
     build_pp_structure_v3_options,
@@ -24,9 +26,16 @@ from tools.text_recognition import TextRecognitionTool, build_ocr_options  # noq
 from tools.utils import (  # noqa: E402
     DOCX_MIME_TYPE,
     _parse_doc_parsing_result,
+    _poll_job,
+    _response_data,
     _submit_job,
+    download_image_from_url,
+    extract_base_url,
+    get_api_client_config,
     iter_docx_exports,
     normalize_file_input,
+    replace_markdown_image_paths,
+    validate_model,
 )
 
 
@@ -170,6 +179,75 @@ def test_option_builders_preserve_official_camel_case_keys():
     ) == {"useLayoutDetection": True}
 
 
+def test_extra_options_override_named_options_and_support_structured_values():
+    assert build_pp_structure_v3_options(
+        {
+            "layoutThreshold": 0.5,
+            "layoutMergeBboxesMode": "large",
+            "extraOptions": json.dumps(
+                {
+                    "layoutThreshold": {"0": 0.45},
+                    "layoutUnclipRatio": [1.2, 1.5],
+                    "layoutMergeBboxesMode": {"0": "small"},
+                }
+            ),
+        }
+    ) == {
+        "layoutThreshold": {"0": 0.45},
+        "layoutUnclipRatio": [1.2, 1.5],
+        "layoutMergeBboxesMode": {"0": "small"},
+    }
+
+    assert build_paddleocr_vl_options(
+        {
+            "extraOptions": {
+                "vlmExtraArgs": {"ocr_min_pixels": 3136},
+            }
+        }
+    ) == {"vlmExtraArgs": {"ocr_min_pixels": 3136}}
+
+
+@pytest.mark.parametrize("value", ["not-json", "[]", "1"])
+def test_extra_options_reject_invalid_or_non_object_json(value):
+    with pytest.raises(RuntimeError, match="extraOptions"):
+        build_ocr_options({"extraOptions": value})
+
+
+@pytest.mark.parametrize("reserved_key", ["file", "fileUrl", "model", "pageRanges", "batchId"])
+def test_extra_options_reject_transport_fields(reserved_key):
+    with pytest.raises(RuntimeError, match="transport-level"):
+        build_ocr_options({"extraOptions": json.dumps({reserved_key: "value"})})
+
+
+@pytest.mark.parametrize(
+    ("parameters", "message"),
+    [
+        ({"layoutThreshold": 1.1}, "layoutThreshold"),
+        ({"layoutUnclipRatio": 0}, "layoutUnclipRatio"),
+        ({"layoutMergeBboxesMode": "invalid"}, "layoutMergeBboxesMode"),
+    ],
+)
+def test_layout_option_validation(parameters, message):
+    with pytest.raises(RuntimeError, match=message):
+        build_pp_structure_v3_options(parameters)
+
+
+@pytest.mark.parametrize(
+    ("parameters", "message"),
+    [
+        ({"topP": 0}, "topP"),
+        ({"temperature": -0.1}, "temperature"),
+        ({"repetitionPenalty": 0}, "repetitionPenalty"),
+        ({"minPixels": 0}, "minPixels"),
+        ({"minPixels": 200, "maxPixels": 100}, "minPixels cannot"),
+        ({"extraOptions": '{"vlmExtraArgs": []}'}, "vlmExtraArgs"),
+    ],
+)
+def test_vl_option_validation(parameters, message):
+    with pytest.raises(RuntimeError, match=message):
+        build_paddleocr_vl_options(parameters)
+
+
 def test_submit_url_sends_page_ranges_at_job_level(monkeypatch):
     response = MagicMock(status_code=200)
     response.json.return_value = {"data": {"jobId": "job-url"}}
@@ -215,6 +293,109 @@ def test_submit_file_sends_page_ranges_as_multipart_field(monkeypatch, tmp_path)
     request_data = post.call_args.kwargs["data"]
     assert request_data["pageRanges"] == "1-3"
     assert json.loads(request_data["optionalPayload"]) == {"returnMarkdownImages": False}
+
+
+def test_base_url_accepts_full_jobs_endpoint_and_gateway_prefix():
+    assert extract_base_url("https://paddleocr.aistudio-app.com/api/v2/ocr/jobs/") == (
+        "https://paddleocr.aistudio-app.com"
+    )
+    assert extract_base_url("https://example.com/gateway/api/v2/ocr/jobs") == (
+        "https://example.com/gateway"
+    )
+    assert get_api_client_config(
+        " token ", base_url="https://example.com/gateway/api/v2/ocr/jobs"
+    ) == {
+        "token": "token",
+        "base_url": "https://example.com/gateway",
+        "headers": {
+            "Authorization": "Bearer token",
+            "Client-Platform": "dify",
+        },
+    }
+
+
+@pytest.mark.parametrize("token", ["", "   ", None])
+def test_api_client_rejects_empty_access_token(token):
+    with pytest.raises(RuntimeError, match="access token must be provided"):
+        get_api_client_config(token)
+
+
+def test_response_data_rejects_nonzero_api_code():
+    response = MagicMock(status_code=200, text="")
+    response.json.return_value = {"code": 17, "data": {"errorMsg": "quota exhausted"}}
+
+    with pytest.raises(RuntimeError, match=r"code 17.*quota exhausted"):
+        _response_data(response, operation="Job submission")
+
+
+def test_response_data_preserves_legacy_flat_payload():
+    response = MagicMock(status_code=200, text="")
+    response.json.return_value = {"jobId": "legacy-job"}
+
+    assert _response_data(response, operation="Job submission") == {"jobId": "legacy-job"}
+
+
+def test_model_validation_rejects_cross_task_and_unknown_models():
+    validate_model("PP-OCRv6", is_document_parsing=False)
+    validate_model("PaddleOCR-VL-1.6", is_document_parsing=True)
+
+    with pytest.raises(RuntimeError, match="Unsupported OCR model"):
+        validate_model("PaddleOCR-VL-1.6", is_document_parsing=False)
+    with pytest.raises(RuntimeError, match="Unsupported document parsing model"):
+        validate_model("HPD-Parsing", is_document_parsing=True)
+
+
+def test_poll_rejects_unknown_job_state(monkeypatch):
+    response = MagicMock(status_code=200, text="")
+    response.json.return_value = {"code": 0, "data": {"state": "paused"}}
+    monkeypatch.setattr("requests.get", MagicMock(return_value=response))
+
+    with pytest.raises(RuntimeError, match="Unknown or missing job state"):
+        _poll_job("job-id", "https://example.com", {}, max_wait_time=1)
+
+
+@pytest.mark.parametrize(
+    "result_field",
+    [
+        {"resultUrl": {"jsonUrl": "https://example.com/result.jsonl"}},
+        {"resultJsonUrl": "https://example.com/result.jsonl"},
+    ],
+)
+def test_poll_accepts_current_and_legacy_result_urls(monkeypatch, result_field):
+    status_response = MagicMock(status_code=200, text="")
+    status_response.json.return_value = {
+        "code": 0,
+        "data": {"state": "done", **result_field},
+    }
+    result_response = MagicMock(
+        status_code=200,
+        text='{"result": {"ocrResults": []}}\n',
+    )
+    get = MagicMock(side_effect=[status_response, result_response])
+    monkeypatch.setattr("requests.get", get)
+
+    jsonl_data, status_data = _poll_job("job-id", "https://example.com", {}, max_wait_time=1)
+
+    assert jsonl_data == [{"result": {"ocrResults": []}}]
+    assert status_data["state"] == "done"
+    result_response.raise_for_status.assert_called_once_with()
+
+
+def test_image_download_checks_http_status(monkeypatch):
+    response = MagicMock(content=b"image")
+    get = MagicMock(return_value=response)
+    monkeypatch.setattr("requests.get", get)
+
+    assert download_image_from_url("https://example.com/image.png") == b"image"
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_failed_markdown_image_is_replaced_with_placeholder():
+    markdown = '<p>Before</p><img src="images/chart.jpg"><p>After</p>'
+
+    assert replace_markdown_image_paths(markdown, {}, ["images/chart.jpg"]) == (
+        "<p>Before</p>[Image unavailable]<p>After</p>"
+    )
 
 
 def test_document_result_parser_preserves_exports():
@@ -367,7 +548,7 @@ def test_text_recognition_sends_normalized_file_to_api(monkeypatch):
     # HTTP API receives file_path (temp file), not base64 directly
     assert "file_path" in captured["kwargs"]
     assert captured["kwargs"]["file_path"] == "temp_file.png"
-    assert captured["kwargs"]["model"] == "PP-OCRv5"
+    assert captured["kwargs"]["model"] == "PP-OCRv6"
     assert captured["kwargs"]["is_document_parsing"] is False
     assert captured["cleanup"] == ("temp_file.png", True)
 
@@ -512,11 +693,36 @@ def test_text_recognition_yaml_exposes_all_official_models():
     parameters = {parameter["name"]: parameter for parameter in tool_yaml["parameters"]}
     model = parameters["model"]
 
-    assert model["default"] == "PP-OCRv5"
+    assert model["default"] == "PP-OCRv6"
     assert [option["value"] for option in model["options"]] == [
         "PP-OCRv5",
         "PP-OCRv5-latin",
         "PP-OCRv6",
+    ]
+
+
+@pytest.mark.parametrize(
+    "tool_name", ["text_recognition", "document_parsing", "document_parsing_vl"]
+)
+def test_yaml_exposes_advanced_api_options(tool_name):
+    tool_yaml = load_tool_yaml(tool_name)
+    parameters = {parameter["name"]: parameter for parameter in tool_yaml["parameters"]}
+
+    assert parameters["extraOptions"]["type"] == "string"
+    assert parameters["extraOptions"]["required"] is False
+
+
+@pytest.mark.parametrize("tool_name", ["document_parsing", "document_parsing_vl"])
+def test_document_yaml_exposes_layout_controls(tool_name):
+    tool_yaml = load_tool_yaml(tool_name)
+    parameters = {parameter["name"]: parameter for parameter in tool_yaml["parameters"]}
+
+    assert parameters["layoutThreshold"]["type"] == "number"
+    assert parameters["layoutUnclipRatio"]["type"] == "number"
+    assert [option["value"] for option in parameters["layoutMergeBboxesMode"]["options"]] == [
+        "large",
+        "small",
+        "union",
     ]
 
 
@@ -537,4 +743,25 @@ def test_manifest_version_is_bumped():
     with open(os.path.join(PLUGIN_DIR, "manifest.yaml"), encoding="utf-8") as manifest_file:
         manifest = yaml.safe_load(manifest_file)
 
-    assert manifest["version"] == "0.2.10"
+    assert manifest["version"] == "0.3.0"
+
+
+def test_provider_validation_uses_latest_default_model(monkeypatch):
+    captured = {}
+
+    def fake_call(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("provider.paddleocr.call_paddleocr_api", fake_call)
+    provider = object.__new__(PaddleocrProvider)
+    provider._validate_credentials({"aistudio_access_token": "token"})
+
+    assert captured["model"] == "PP-OCRv6"
+    assert captured["is_document_parsing"] is False
+
+
+@pytest.mark.parametrize("token", ["", "   ", None])
+def test_provider_validation_rejects_empty_token(token):
+    provider = object.__new__(PaddleocrProvider)
+    with pytest.raises(ToolProviderCredentialValidationError, match="must be provided"):
+        provider._validate_credentials({"aistudio_access_token": token})

--- a/tools/paddleocr/tests/test_file_input.py
+++ b/tools/paddleocr/tests/test_file_input.py
@@ -409,6 +409,19 @@ def test_failed_markdown_image_is_replaced_with_placeholder():
     )
 
 
+def test_markdown_image_replacement_does_not_change_non_image_content():
+    upload_response = MagicMock(preview_url="https://example.com/preview.png")
+    markdown = (
+        '<img src="images/chart.jpg">\n<a src="images/chart.jpg">link</a>\n`src="images/chart.jpg"`'
+    )
+
+    assert replace_markdown_image_paths(markdown, {"images/chart.jpg": upload_response}) == (
+        '<img src="https://example.com/preview.png">\n'
+        '<a src="images/chart.jpg">link</a>\n'
+        '`src="images/chart.jpg"`'
+    )
+
+
 def test_document_markdown_uploads_each_image_once(monkeypatch):
     monkeypatch.setattr("tools.utils.download_image_from_url", lambda _url: b"image")
     upload_response = MagicMock(preview_url="https://example.com/preview.png")

--- a/tools/paddleocr/tests/test_file_input.py
+++ b/tools/paddleocr/tests/test_file_input.py
@@ -34,6 +34,7 @@ from tools.utils import (  # noqa: E402
     get_api_client_config,
     iter_docx_exports,
     normalize_file_input,
+    render_document_markdown,
     replace_markdown_image_paths,
     validate_model,
 )
@@ -396,6 +397,64 @@ def test_failed_markdown_image_is_replaced_with_placeholder():
     assert replace_markdown_image_paths(markdown, {}, ["images/chart.jpg"]) == (
         "<p>Before</p>[Image unavailable]<p>After</p>"
     )
+
+
+def test_document_markdown_uploads_each_image_once(monkeypatch):
+    monkeypatch.setattr("tools.utils.download_image_from_url", lambda _url: b"image")
+    upload_response = MagicMock(preview_url="https://example.com/preview.png")
+    tool = MagicMock()
+    tool.session.file.upload.return_value = upload_response
+    result = {
+        "pages": [
+            {
+                "markdown_text": '<img src="images/chart.jpg">',
+                "markdown_images": {"images/chart.jpg": "https://example.com/chart.jpg"},
+            },
+            {
+                "markdown_text": '<img src="images/chart.jpg">',
+                "markdown_images": {"images/chart.jpg": "https://example.com/chart.jpg"},
+            },
+        ]
+    }
+
+    markdown = render_document_markdown(
+        result,
+        tool,
+        image_filename_prefix="paddleocr_image",
+    )
+
+    assert markdown == (
+        '<img src="https://example.com/preview.png">\n\n<img src="https://example.com/preview.png">'
+    )
+    tool.session.file.upload.assert_called_once_with(
+        "paddleocr_image_0.jpg", b"image", "image/jpeg"
+    )
+
+
+def test_document_markdown_degrades_only_failed_image(monkeypatch):
+    def fail_download(_url):
+        raise RuntimeError("download failed")
+
+    monkeypatch.setattr("tools.utils.download_image_from_url", fail_download)
+    warning_logger = MagicMock()
+    result = {
+        "pages": [
+            {
+                "markdown_text": '<p>Parsed</p><img src="images/chart.jpg">',
+                "markdown_images": {"images/chart.jpg": "https://example.com/chart.jpg"},
+            }
+        ]
+    }
+
+    markdown = render_document_markdown(
+        result,
+        MagicMock(),
+        image_filename_prefix="paddleocr_image",
+        warning_logger=warning_logger,
+    )
+
+    assert markdown == "<p>Parsed</p>[Image unavailable]"
+    warning_logger.warning.assert_called_once()
 
 
 def test_document_result_parser_preserves_exports():

--- a/tools/paddleocr/tests/test_file_input.py
+++ b/tools/paddleocr/tests/test_file_input.py
@@ -214,6 +214,15 @@ def test_extra_options_reject_invalid_or_non_object_json(value):
         build_ocr_options({"extraOptions": value})
 
 
+@pytest.mark.parametrize(
+    "value",
+    ['{"temperature": NaN}', '{"temperature": Infinity}', {"temperature": float("nan")}],
+)
+def test_extra_options_reject_non_finite_numbers(value):
+    with pytest.raises(RuntimeError, match="valid JSON values"):
+        build_ocr_options({"extraOptions": value})
+
+
 @pytest.mark.parametrize("reserved_key", ["file", "fileUrl", "model", "pageRanges", "batchId"])
 def test_extra_options_reject_transport_fields(reserved_key):
     with pytest.raises(RuntimeError, match="transport-level"):
@@ -225,6 +234,7 @@ def test_extra_options_reject_transport_fields(reserved_key):
     [
         ({"layoutThreshold": 1.1}, "layoutThreshold"),
         ({"layoutUnclipRatio": 0}, "layoutUnclipRatio"),
+        ({"layoutUnclipRatio": {"0": [1.2, 1.5]}}, "layoutUnclipRatio"),
         ({"layoutMergeBboxesMode": "invalid"}, "layoutMergeBboxesMode"),
     ],
 )

--- a/tools/paddleocr/tools/document_parsing.py
+++ b/tools/paddleocr/tools/document_parsing.py
@@ -7,39 +7,24 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 from tools.utils import (
     DEFAULT_DOCUMENT_MODEL,
     DOCX_MIME_TYPE,
-    EXTRA_OPTIONS_PARAMETER,
+    build_optional_payload,
     call_paddleocr_api,
     cleanup_temp_file,
-    download_image_from_url,
     get_api_client_config,
     iter_docx_exports,
-    merge_extra_options,
     normalize_file_input,
-    replace_markdown_image_paths,
+    render_document_markdown,
     validate_layout_options,
 )
 
-_SKIP_KEYS = {"file", "fileType", "model", "pageRanges", EXTRA_OPTIONS_PARAMETER}
 logger = logging.getLogger(__name__)
 
 
 def build_pp_structure_v3_options(params: dict[str, Any]) -> dict[str, Any]:
     """Build the camelCase optional payload expected by the HTTP API."""
-    options_dict = {}
-    for api_name, value in params.items():
-        if value is None or api_name in _SKIP_KEYS:
-            continue
-        if api_name == "markdownIgnoreLabels" and isinstance(value, str):
-            value = [label.strip() for label in value.split(",") if label.strip()]
-        if api_name == "outputFormats":
-            if value in ("", "none"):
-                continue
-            if isinstance(value, str):
-                value = [value]
-        options_dict[api_name] = value
-    merge_extra_options(options_dict, params.get(EXTRA_OPTIONS_PARAMETER))
-    validate_layout_options(options_dict)
-    return options_dict
+    options = build_optional_payload(params)
+    validate_layout_options(options)
+    return options
 
 
 class DocumentParsingTool(Tool):
@@ -93,43 +78,13 @@ class DocumentParsingTool(Tool):
                     page_ranges=page_ranges,
                 )
 
-            # Process images from result
-            images = []
-            image_path_map = {}
-            failed_images = []
-
-            for page in result["pages"]:
-                if page["markdown_images"]:
-                    image_dict = page["markdown_images"]
-                    if image_dict:
-                        for image_path, image_url in image_dict.items():
-                            if image_path in image_path_map:
-                                continue
-                            try:
-                                image_bytes = download_image_from_url(image_url)
-                                file_name = f"paddleocr_image_{len(images)}.jpg"
-                                upload_response = self.session.file.upload(
-                                    file_name, image_bytes, "image/jpeg"
-                                )
-                                images.append(upload_response)
-                                image_path_map[image_path] = upload_response
-                                if not upload_response.preview_url:
-                                    failed_images.append(image_path)
-                            except Exception as e:
-                                logger.warning(f"Failed to process image {image_path}: {e}")
-                                failed_images.append(image_path)
-
-            # Build markdown with image replacement
-            markdown_text_list = []
-            for page in result["pages"]:
-                markdown_text = page["markdown_text"]
-                if markdown_text is not None:
-                    markdown_text = replace_markdown_image_paths(
-                        markdown_text, image_path_map, failed_images
-                    )
-                    markdown_text_list.append(markdown_text)
-
-            yield self.create_text_message("\n\n".join(markdown_text_list))
+            markdown_text = render_document_markdown(
+                result,
+                self,
+                image_filename_prefix="paddleocr_image",
+                warning_logger=logger,
+            )
+            yield self.create_text_message(markdown_text)
 
             for filename, document_bytes in iter_docx_exports(
                 result,

--- a/tools/paddleocr/tools/document_parsing.py
+++ b/tools/paddleocr/tools/document_parsing.py
@@ -4,17 +4,22 @@ from typing import Any
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
-
 from tools.utils import (
+    DEFAULT_DOCUMENT_MODEL,
     DOCX_MIME_TYPE,
+    EXTRA_OPTIONS_PARAMETER,
     call_paddleocr_api,
     cleanup_temp_file,
+    download_image_from_url,
     get_api_client_config,
     iter_docx_exports,
+    merge_extra_options,
     normalize_file_input,
+    replace_markdown_image_paths,
+    validate_layout_options,
 )
 
-_SKIP_KEYS = {"file", "fileType", "model", "pageRanges"}
+_SKIP_KEYS = {"file", "fileType", "model", "pageRanges", EXTRA_OPTIONS_PARAMETER}
 logger = logging.getLogger(__name__)
 
 
@@ -32,23 +37,26 @@ def build_pp_structure_v3_options(params: dict[str, Any]) -> dict[str, Any]:
             if isinstance(value, str):
                 value = [value]
         options_dict[api_name] = value
+    merge_extra_options(options_dict, params.get(EXTRA_OPTIONS_PARAMETER))
+    validate_layout_options(options_dict)
     return options_dict
 
 
 class DocumentParsingTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         """Invoke the PaddleOCR API to parse the document images."""
-        if "aistudio_access_token" not in self.runtime.credentials:
+        access_token = self.runtime.credentials.get("aistudio_access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
             raise RuntimeError(
-                "The AI Studio access token is not configured or invalid. Please provide it in the plugin settings."
+                "The AI Studio access token is not configured or invalid. "
+                "Please provide it in the plugin settings."
             )
-        access_token = self.runtime.credentials["aistudio_access_token"]
 
         # Get base_url (optional, uses default if not provided)
         base_url = self.runtime.credentials.get("base_url")
 
         # Normalize file input - returns (input_value, is_temp_file, file_type_code)
-        file_input, is_temp_file, file_type_code = normalize_file_input(
+        file_input, is_temp_file, _file_type_code = normalize_file_input(
             tool_parameters.get("file"), tool_parameters.get("fileType")
         )
 
@@ -60,7 +68,7 @@ class DocumentParsingTool(Tool):
             client_config = get_api_client_config(access_token, base_url=base_url)
 
             # Get model selection
-            model = tool_parameters.get("model") or "PP-StructureV3"
+            model = tool_parameters.get("model") or DEFAULT_DOCUMENT_MODEL
             page_ranges = tool_parameters.get("pageRanges")
 
             # Call API
@@ -98,9 +106,7 @@ class DocumentParsingTool(Tool):
                             if image_path in image_path_map:
                                 continue
                             try:
-                                import requests
-
-                                image_bytes = requests.get(image_url, timeout=(10, 600)).content
+                                image_bytes = download_image_from_url(image_url)
                                 file_name = f"paddleocr_image_{len(images)}.jpg"
                                 upload_response = self.session.file.upload(
                                     file_name, image_bytes, "image/jpeg"
@@ -118,17 +124,9 @@ class DocumentParsingTool(Tool):
             for page in result["pages"]:
                 markdown_text = page["markdown_text"]
                 if markdown_text is not None:
-                    # Replace image paths with uploaded URLs
-                    for image_path, upload_response in image_path_map.items():
-                        if upload_response.preview_url:
-                            markdown_text = markdown_text.replace(
-                                f'src="{image_path}"',
-                                f'src="{upload_response.preview_url}"',
-                            )
-                        else:
-                            markdown_text = markdown_text.replace(
-                                f'src="{image_path}"', 'src="[Image unavailable]"'
-                            )
+                    markdown_text = replace_markdown_image_paths(
+                        markdown_text, image_path_map, failed_images
+                    )
                     markdown_text_list.append(markdown_text)
 
             yield self.create_text_message("\n\n".join(markdown_text_list))

--- a/tools/paddleocr/tools/document_parsing.yaml
+++ b/tools/paddleocr/tools/document_parsing.yaml
@@ -194,6 +194,52 @@ parameters:
       zh_Hans: 是否对版面检测结果进行 NMS。
     llm_description: Whether to perform NMS on layout detection results.
     form: llm
+  - name: layoutThreshold
+    type: number
+    required: false
+    label:
+      en_US: Layout Detection Score Threshold
+      zh_Hans: 版面检测得分阈值
+    human_description:
+      en_US: Optional score threshold from 0 to 1 for filtering layout detections. Use Advanced API Options for per-class thresholds.
+      zh_Hans: 可选的版面检测过滤阈值，取值范围为 0 到 1。按类别设置阈值时请使用高级 API 参数。
+    llm_description: Optional layout detection score threshold from 0 to 1. Use extraOptions for per-class thresholds.
+    form: llm
+  - name: layoutUnclipRatio
+    type: number
+    required: false
+    label:
+      en_US: Layout Bounding Box Expansion Ratio
+      zh_Hans: 版面检测框扩张比例
+    human_description:
+      en_US: Optional positive expansion ratio for layout bounding boxes. Use Advanced API Options for directional or per-class values.
+      zh_Hans: 可选的版面检测框正数扩张比例。设置横纵向或按类别的值时请使用高级 API 参数。
+    llm_description: Optional positive expansion ratio for layout bounding boxes. Use extraOptions for arrays or per-class values.
+    form: llm
+  - name: layoutMergeBboxesMode
+    type: select
+    required: false
+    options:
+      - label:
+          en_US: Keep Larger Boxes
+          zh_Hans: 保留较大框
+        value: large
+      - label:
+          en_US: Keep Smaller Boxes
+          zh_Hans: 保留较小框
+        value: small
+      - label:
+          en_US: Keep All Boxes
+          zh_Hans: 保留全部框
+        value: union
+    label:
+      en_US: Layout Bounding Box Merge Mode
+      zh_Hans: 版面检测框合并模式
+    human_description:
+      en_US: Controls how overlapping layout boxes are filtered. Use Advanced API Options for per-class modes.
+      zh_Hans: 控制如何过滤相互重叠的版面检测框。按类别设置模式时请使用高级 API 参数。
+    llm_description: Layout bounding box merge mode. Use extraOptions for per-class modes.
+    form: llm
   - name: textDetLimitSideLen
     type: number
     required: false
@@ -503,6 +549,17 @@ parameters:
       en_US: Whether or not to return visualization results.
       zh_Hans: 是否返回可视化结果。
     llm_description: Whether or not to return visualization results.
+    form: llm
+  - name: extraOptions
+    type: string
+    required: false
+    label:
+      en_US: Advanced API Options (JSON)
+      zh_Hans: 高级 API 参数（JSON）
+    human_description:
+      en_US: Optional JSON object merged into the official API optional payload. Values here override named options and can provide per-class layout controls. Transport-level fields are not allowed.
+      zh_Hans: 可选 JSON 对象，将合并到官方 API 的 optional payload 中。同名值会覆盖具名参数，并可提供按类别的版面控制。不允许包含传输层字段。
+    llm_description: Optional JSON object of advanced PaddleOCR API options. Values override named options. Do not include transport-level fields.
     form: llm
 output_schema:
     type: object

--- a/tools/paddleocr/tools/document_parsing_vl.py
+++ b/tools/paddleocr/tools/document_parsing_vl.py
@@ -7,43 +7,26 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 from tools.utils import (
     DEFAULT_VL_MODEL,
     DOCX_MIME_TYPE,
-    EXTRA_OPTIONS_PARAMETER,
+    build_optional_payload,
     call_paddleocr_api,
     cleanup_temp_file,
-    download_image_from_url,
     get_api_client_config,
     iter_docx_exports,
-    merge_extra_options,
     normalize_file_input,
-    replace_markdown_image_paths,
+    render_document_markdown,
     validate_layout_options,
     validate_vl_options,
 )
 
-_SKIP_KEYS = {"file", "fileType", "model", "pageRanges", EXTRA_OPTIONS_PARAMETER}
 logger = logging.getLogger(__name__)
 
 
 def build_paddleocr_vl_options(params: dict[str, Any]) -> dict[str, Any]:
     """Build the camelCase optional payload expected by the HTTP API."""
-    options_dict = {}
-    for api_name, value in params.items():
-        if value is None or api_name in _SKIP_KEYS:
-            continue
-        if api_name == "promptLabel" and value == "undefined":
-            continue
-        if api_name == "markdownIgnoreLabels" and isinstance(value, str):
-            value = [label.strip() for label in value.split(",") if label.strip()]
-        if api_name == "outputFormats":
-            if value in ("", "none"):
-                continue
-            if isinstance(value, str):
-                value = [value]
-        options_dict[api_name] = value
-    merge_extra_options(options_dict, params.get(EXTRA_OPTIONS_PARAMETER))
-    validate_layout_options(options_dict)
-    validate_vl_options(options_dict)
-    return options_dict
+    options = build_optional_payload(params)
+    validate_layout_options(options)
+    validate_vl_options(options)
+    return options
 
 
 class DocumentParsingVlTool(Tool):
@@ -97,43 +80,13 @@ class DocumentParsingVlTool(Tool):
                     page_ranges=page_ranges,
                 )
 
-            # Process images from result
-            images = []
-            image_path_map = {}
-            failed_images = []
-
-            for page in result["pages"]:
-                if page["markdown_images"]:
-                    image_dict = page["markdown_images"]
-                    if image_dict:
-                        for image_path, image_url in image_dict.items():
-                            if image_path in image_path_map:
-                                continue
-                            try:
-                                image_bytes = download_image_from_url(image_url)
-                                file_name = f"paddleocr_vl_image_{len(images)}.jpg"
-                                upload_response = self.session.file.upload(
-                                    file_name, image_bytes, "image/jpeg"
-                                )
-                                images.append(upload_response)
-                                image_path_map[image_path] = upload_response
-                                if not upload_response.preview_url:
-                                    failed_images.append(image_path)
-                            except Exception as e:
-                                logger.warning(f"Failed to process image {image_path}: {e}")
-                                failed_images.append(image_path)
-
-            # Build markdown with image replacement
-            markdown_text_list = []
-            for page in result["pages"]:
-                markdown_text = page["markdown_text"]
-                if markdown_text is not None:
-                    markdown_text = replace_markdown_image_paths(
-                        markdown_text, image_path_map, failed_images
-                    )
-                    markdown_text_list.append(markdown_text)
-
-            yield self.create_text_message("\n\n".join(markdown_text_list))
+            markdown_text = render_document_markdown(
+                result,
+                self,
+                image_filename_prefix="paddleocr_vl_image",
+                warning_logger=logger,
+            )
+            yield self.create_text_message(markdown_text)
 
             for filename, document_bytes in iter_docx_exports(
                 result,

--- a/tools/paddleocr/tools/document_parsing_vl.py
+++ b/tools/paddleocr/tools/document_parsing_vl.py
@@ -4,17 +4,23 @@ from typing import Any
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
-
 from tools.utils import (
+    DEFAULT_VL_MODEL,
     DOCX_MIME_TYPE,
+    EXTRA_OPTIONS_PARAMETER,
     call_paddleocr_api,
     cleanup_temp_file,
+    download_image_from_url,
     get_api_client_config,
     iter_docx_exports,
+    merge_extra_options,
     normalize_file_input,
+    replace_markdown_image_paths,
+    validate_layout_options,
+    validate_vl_options,
 )
 
-_SKIP_KEYS = {"file", "fileType", "model", "pageRanges"}
+_SKIP_KEYS = {"file", "fileType", "model", "pageRanges", EXTRA_OPTIONS_PARAMETER}
 logger = logging.getLogger(__name__)
 
 
@@ -34,23 +40,27 @@ def build_paddleocr_vl_options(params: dict[str, Any]) -> dict[str, Any]:
             if isinstance(value, str):
                 value = [value]
         options_dict[api_name] = value
+    merge_extra_options(options_dict, params.get(EXTRA_OPTIONS_PARAMETER))
+    validate_layout_options(options_dict)
+    validate_vl_options(options_dict)
     return options_dict
 
 
 class DocumentParsingVlTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         """Invoke the PaddleOCR API to parse the document images using a VLM."""
-        if "aistudio_access_token" not in self.runtime.credentials:
+        access_token = self.runtime.credentials.get("aistudio_access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
             raise RuntimeError(
-                "The AI Studio access token is not configured or invalid. Please provide it in the plugin settings."
+                "The AI Studio access token is not configured or invalid. "
+                "Please provide it in the plugin settings."
             )
-        access_token = self.runtime.credentials["aistudio_access_token"]
 
         # Get base_url (optional, uses default if not provided)
         base_url = self.runtime.credentials.get("base_url")
 
         # Normalize file input - returns (input_value, is_temp_file, file_type_code)
-        file_input, is_temp_file, file_type_code = normalize_file_input(
+        file_input, is_temp_file, _file_type_code = normalize_file_input(
             tool_parameters.get("file"), tool_parameters.get("fileType")
         )
 
@@ -62,7 +72,7 @@ class DocumentParsingVlTool(Tool):
             client_config = get_api_client_config(access_token, base_url=base_url)
 
             # Get model selection
-            model = tool_parameters.get("model") or "PaddleOCR-VL-1.6"
+            model = tool_parameters.get("model") or DEFAULT_VL_MODEL
             page_ranges = tool_parameters.get("pageRanges")
 
             # Call API
@@ -100,9 +110,7 @@ class DocumentParsingVlTool(Tool):
                             if image_path in image_path_map:
                                 continue
                             try:
-                                import requests
-
-                                image_bytes = requests.get(image_url, timeout=(10, 600)).content
+                                image_bytes = download_image_from_url(image_url)
                                 file_name = f"paddleocr_vl_image_{len(images)}.jpg"
                                 upload_response = self.session.file.upload(
                                     file_name, image_bytes, "image/jpeg"
@@ -120,17 +128,9 @@ class DocumentParsingVlTool(Tool):
             for page in result["pages"]:
                 markdown_text = page["markdown_text"]
                 if markdown_text is not None:
-                    # Replace image paths with uploaded URLs
-                    for image_path, upload_response in image_path_map.items():
-                        if upload_response.preview_url:
-                            markdown_text = markdown_text.replace(
-                                f'src="{image_path}"',
-                                f'src="{upload_response.preview_url}"',
-                            )
-                        else:
-                            markdown_text = markdown_text.replace(
-                                f'src="{image_path}"', 'src="[Image unavailable]"'
-                            )
+                    markdown_text = replace_markdown_image_paths(
+                        markdown_text, image_path_map, failed_images
+                    )
                     markdown_text_list.append(markdown_text)
 
             yield self.create_text_message("\n\n".join(markdown_text_list))

--- a/tools/paddleocr/tools/document_parsing_vl.yaml
+++ b/tools/paddleocr/tools/document_parsing_vl.yaml
@@ -165,6 +165,52 @@ parameters:
       zh_Hans: 是否对版面检测结果进行 NMS。
     llm_description: Whether to perform NMS on layout detection results.
     form: llm
+  - name: layoutThreshold
+    type: number
+    required: false
+    label:
+      en_US: Layout Detection Score Threshold
+      zh_Hans: 版面检测得分阈值
+    human_description:
+      en_US: Optional score threshold from 0 to 1 for filtering layout detections. Use Advanced API Options for per-class thresholds.
+      zh_Hans: 可选的版面检测过滤阈值，取值范围为 0 到 1。按类别设置阈值时请使用高级 API 参数。
+    llm_description: Optional layout detection score threshold from 0 to 1. Use extraOptions for per-class thresholds.
+    form: llm
+  - name: layoutUnclipRatio
+    type: number
+    required: false
+    label:
+      en_US: Layout Bounding Box Expansion Ratio
+      zh_Hans: 版面检测框扩张比例
+    human_description:
+      en_US: Optional positive expansion ratio for layout bounding boxes. Use Advanced API Options for directional or per-class values.
+      zh_Hans: 可选的版面检测框正数扩张比例。设置横纵向或按类别的值时请使用高级 API 参数。
+    llm_description: Optional positive expansion ratio for layout bounding boxes. Use extraOptions for arrays or per-class values.
+    form: llm
+  - name: layoutMergeBboxesMode
+    type: select
+    required: false
+    options:
+      - label:
+          en_US: Keep Larger Boxes
+          zh_Hans: 保留较大框
+        value: large
+      - label:
+          en_US: Keep Smaller Boxes
+          zh_Hans: 保留较小框
+        value: small
+      - label:
+          en_US: Keep All Boxes
+          zh_Hans: 保留全部框
+        value: union
+    label:
+      en_US: Layout Bounding Box Merge Mode
+      zh_Hans: 版面检测框合并模式
+    human_description:
+      en_US: Controls how overlapping layout boxes are filtered. Use Advanced API Options for per-class modes.
+      zh_Hans: 控制如何过滤相互重叠的版面检测框。按类别设置模式时请使用高级 API 参数。
+    llm_description: Layout bounding box merge mode. Use extraOptions for per-class modes.
+    form: llm
   - name: layoutShapeMode
     type: select
     required: false
@@ -439,6 +485,17 @@ parameters:
       en_US: Whether or not to return visualization results.
       zh_Hans: 是否返回可视化结果。
     llm_description: Whether or not to return visualization results.
+    form: llm
+  - name: extraOptions
+    type: string
+    required: false
+    label:
+      en_US: Advanced API Options (JSON)
+      zh_Hans: 高级 API 参数（JSON）
+    human_description:
+      en_US: Optional JSON object merged into the official API optional payload. Values here override named options and can provide per-class layout controls or vlmExtraArgs. Transport-level fields are not allowed.
+      zh_Hans: 可选 JSON 对象，将合并到官方 API 的 optional payload 中。同名值会覆盖具名参数，并可提供按类别的版面控制或 vlmExtraArgs。不允许包含传输层字段。
+    llm_description: Optional JSON object of advanced PaddleOCR API options, including vlmExtraArgs. Values override named options. Do not include transport-level fields.
     form: llm
 output_schema:
     type: object

--- a/tools/paddleocr/tools/text_recognition.py
+++ b/tools/paddleocr/tools/text_recognition.py
@@ -5,25 +5,17 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from tools.utils import (
     DEFAULT_OCR_MODEL,
-    EXTRA_OPTIONS_PARAMETER,
+    build_optional_payload,
     call_paddleocr_api,
     cleanup_temp_file,
     get_api_client_config,
-    merge_extra_options,
     normalize_file_input,
 )
-
-_SKIP_KEYS = {"file", "fileType", "model", "pageRanges", EXTRA_OPTIONS_PARAMETER}
 
 
 def build_ocr_options(params: dict[str, Any]) -> dict[str, Any]:
     """Build the camelCase optional payload expected by the HTTP API."""
-    options_dict = {}
-    for api_name, value in params.items():
-        if value is None or api_name in _SKIP_KEYS:
-            continue
-        options_dict[api_name] = value
-    return merge_extra_options(options_dict, params.get(EXTRA_OPTIONS_PARAMETER))
+    return build_optional_payload(params)
 
 
 class TextRecognitionTool(Tool):

--- a/tools/paddleocr/tools/text_recognition.py
+++ b/tools/paddleocr/tools/text_recognition.py
@@ -3,15 +3,17 @@ from typing import Any
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
-
 from tools.utils import (
+    DEFAULT_OCR_MODEL,
+    EXTRA_OPTIONS_PARAMETER,
     call_paddleocr_api,
     cleanup_temp_file,
     get_api_client_config,
+    merge_extra_options,
     normalize_file_input,
 )
 
-_SKIP_KEYS = {"file", "fileType", "model", "pageRanges"}
+_SKIP_KEYS = {"file", "fileType", "model", "pageRanges", EXTRA_OPTIONS_PARAMETER}
 
 
 def build_ocr_options(params: dict[str, Any]) -> dict[str, Any]:
@@ -21,23 +23,24 @@ def build_ocr_options(params: dict[str, Any]) -> dict[str, Any]:
         if value is None or api_name in _SKIP_KEYS:
             continue
         options_dict[api_name] = value
-    return options_dict
+    return merge_extra_options(options_dict, params.get(EXTRA_OPTIONS_PARAMETER))
 
 
 class TextRecognitionTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         """Invoke the PaddleOCR API to recognize the text in the image."""
-        if "aistudio_access_token" not in self.runtime.credentials:
+        access_token = self.runtime.credentials.get("aistudio_access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
             raise RuntimeError(
-                "The AI Studio access token is not configured or invalid. Please provide it in the plugin settings."
+                "The AI Studio access token is not configured or invalid. "
+                "Please provide it in the plugin settings."
             )
-        access_token = self.runtime.credentials["aistudio_access_token"]
 
         # Get base_url (optional, uses default if not provided)
         base_url = self.runtime.credentials.get("base_url")
 
         # Normalize file input - returns (input_value, is_temp_file, file_type_code)
-        file_input, is_temp_file, file_type_code = normalize_file_input(
+        file_input, is_temp_file, _file_type_code = normalize_file_input(
             tool_parameters.get("file"), tool_parameters.get("fileType")
         )
 
@@ -49,7 +52,7 @@ class TextRecognitionTool(Tool):
             client_config = get_api_client_config(access_token, base_url=base_url)
 
             # Get model selection
-            model = tool_parameters.get("model") or "PP-OCRv5"
+            model = tool_parameters.get("model") or DEFAULT_OCR_MODEL
             page_ranges = tool_parameters.get("pageRanges")
 
             # Call API

--- a/tools/paddleocr/tools/text_recognition.yaml
+++ b/tools/paddleocr/tools/text_recognition.yaml
@@ -13,7 +13,7 @@ parameters:
   - name: model
     type: select
     required: false
-    default: PP-OCRv5
+    default: PP-OCRv6
     options:
       - label:
           en_US: PP-OCRv5
@@ -220,6 +220,17 @@ parameters:
       en_US: Whether or not to return visualization results.
       zh_Hans: 是否返回可视化结果。
     llm_description: Whether or not to return visualization results.
+    form: llm
+  - name: extraOptions
+    type: string
+    required: false
+    label:
+      en_US: Advanced API Options (JSON)
+      zh_Hans: 高级 API 参数（JSON）
+    human_description:
+      en_US: Optional JSON object merged into the official API optional payload. Values here override named options. Transport-level fields such as file, model, and pageRanges are not allowed.
+      zh_Hans: 可选 JSON 对象，将合并到官方 API 的 optional payload 中。同名值会覆盖具名参数，且不允许包含 file、model、pageRanges 等传输层字段。
+    llm_description: Optional JSON object of advanced PaddleOCR API options. Values override named options. Do not include file, model, pageRanges, or other transport-level fields.
     form: llm
 extra:
   python:

--- a/tools/paddleocr/tools/utils.py
+++ b/tools/paddleocr/tools/utils.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 from dify_plugin.file.file import File
 from dify_plugin.invocations.file import UploadFileResponse
 
+HTML_IMG_PATTERN = re.compile(r'(<img[^>]*src=")([^"]+)(")')
 FAILED_IMG_TAG_TEMPLATE = r'<img[^>]*src="[^"]*{escaped_path}[^"]*"[^>]*>'
 
 
@@ -356,13 +357,18 @@ def replace_markdown_image_paths(
         len(failed_images),
     )
 
-    # Replace successful images.
+    # Replace successful images without changing matching text outside image tags.
     replaced_count = 0
     for image_path, upload_response in image_path_map.items():
         if upload_response.preview_url:
             original_markdown = markdown
-            markdown = markdown.replace(
-                f'src="{image_path}"', f'src="{upload_response.preview_url}"'
+            markdown = HTML_IMG_PATTERN.sub(
+                lambda match, expected_path=image_path, preview_url=upload_response.preview_url: (
+                    f"{match.group(1)}{preview_url}{match.group(3)}"
+                    if match.group(2) == expected_path
+                    else match.group(0)
+                ),
+                markdown,
             )
             if markdown != original_markdown:
                 replaced_count += 1

--- a/tools/paddleocr/tools/utils.py
+++ b/tools/paddleocr/tools/utils.py
@@ -91,6 +91,11 @@ def merge_extra_options(options: dict[str, Any], raw_extra_options: Any) -> dict
     if not isinstance(extra_options, dict):
         raise RuntimeError("extraOptions must be a JSON object.")
 
+    try:
+        json.dumps(extra_options, allow_nan=False)
+    except (TypeError, ValueError) as e:
+        raise RuntimeError(f"extraOptions must contain only valid JSON values: {e}.") from e
+
     reserved_keys = sorted(RESERVED_EXTRA_OPTION_KEYS.intersection(extra_options))
     if reserved_keys:
         raise RuntimeError(
@@ -186,7 +191,7 @@ def _valid_unclip_ratio(value: Any) -> bool:
     if isinstance(value, (list, tuple)):
         return len(value) == 2 and all(_is_number(item) and item > 0 for item in value)
     if isinstance(value, dict):
-        return bool(value) and all(_valid_unclip_ratio(item) for item in value.values())
+        return bool(value) and all(_is_number(item) and item > 0 for item in value.values())
     return False
 
 

--- a/tools/paddleocr/tools/utils.py
+++ b/tools/paddleocr/tools/utils.py
@@ -5,14 +5,12 @@ import os
 import re
 import tempfile
 import time
-from typing import Any, List, Optional, Tuple
+from typing import Any
 from urllib.parse import urlparse
 
 from dify_plugin.file.file import File
 from dify_plugin.invocations.file import UploadFileResponse
 
-# Pre-compiled regex patterns for performance
-HTML_IMG_PATTERN = re.compile(r'(<img[^>]*src=")([^"]+)(")')
 FAILED_IMG_TAG_TEMPLATE = r'<img[^>]*src="[^"]*{escaped_path}[^"]*"[^>]*>'
 
 
@@ -27,8 +25,6 @@ OCR_MODELS = frozenset({"PP-OCRv5", "PP-OCRv5-latin", "PP-OCRv6"})
 DOCUMENT_MODELS = frozenset(
     {"PP-StructureV3", "PaddleOCR-VL", "PaddleOCR-VL-1.5", "PaddleOCR-VL-1.6"}
 )
-VL_MODELS = frozenset({"PaddleOCR-VL", "PaddleOCR-VL-1.5", "PaddleOCR-VL-1.6"})
-
 EXTRA_OPTIONS_PARAMETER = "extraOptions"
 RESERVED_EXTRA_OPTION_KEYS = frozenset(
     {
@@ -41,6 +37,9 @@ RESERVED_EXTRA_OPTION_KEYS = frozenset(
         "optionalPayload",
         "pageRanges",
     }
+)
+TRANSPORT_PARAMETER_KEYS = frozenset(
+    {"file", "fileType", "model", "pageRanges", EXTRA_OPTIONS_PARAMETER}
 )
 
 
@@ -100,6 +99,25 @@ def merge_extra_options(options: dict[str, Any], raw_extra_options: Any) -> dict
 
     options.update(extra_options)
     return options
+
+
+def build_optional_payload(params: dict[str, Any]) -> dict[str, Any]:
+    """Build the optional payload shared by all hosted API tools."""
+    options = {}
+    for api_name, value in params.items():
+        if value is None or api_name in TRANSPORT_PARAMETER_KEYS:
+            continue
+        if api_name == "promptLabel" and value == "undefined":
+            continue
+        if api_name == "markdownIgnoreLabels" and isinstance(value, str):
+            value = [label.strip() for label in value.split(",") if label.strip()]
+        if api_name == "outputFormats":
+            if value in ("", "none"):
+                continue
+            if isinstance(value, str):
+                value = [value]
+        options[api_name] = value
+    return merge_extra_options(options, params.get(EXTRA_OPTIONS_PARAMETER))
 
 
 def validate_layout_options(options: dict[str, Any]) -> None:
@@ -189,7 +207,7 @@ def convert_file_type(file_type: str | None) -> int | None:
         return None
 
 
-def normalize_file_input(file_value: Any, file_type: str | None) -> Tuple[str, bool, int | None]:
+def normalize_file_input(file_value: Any, file_type: str | None) -> tuple[str, bool, int | None]:
     """Normalize PaddleOCR file input.
 
     Returns:
@@ -300,21 +318,6 @@ def base64_to_temp_file(base64_str: str, suffix: str = ".png") -> str:
         return f.name
 
 
-def bytes_to_temp_file(data: bytes, suffix: str = ".png") -> str:
-    """Save bytes directly to a temporary file (AI reviewer suggestion).
-
-    Args:
-        data: Raw bytes data
-        suffix: File extension suffix
-
-    Returns:
-        Path to the temporary file
-    """
-    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as f:
-        f.write(data)
-        return f.name
-
-
 def cleanup_temp_file(file_path: str, is_temp: bool) -> None:
     """Clean up temporary file if it exists and is marked as temporary.
 
@@ -329,17 +332,10 @@ def cleanup_temp_file(file_path: str, is_temp: bool) -> None:
             logger.warning(f"Failed to clean up temporary file {file_path}: {e}")
 
 
-def extract_image_urls_from_markdown(markdown: str) -> List[str]:
-    """Extract image URLs from markdown"""
-    image_pattern = re.compile(r'<img[^>]*src="([^"]*)"[^>]*>', re.IGNORECASE)
-    matches = image_pattern.findall(markdown)
-    return matches
-
-
 def replace_markdown_image_paths(
     markdown: str,
     image_path_map: dict[str, UploadFileResponse],
-    failed_images: Optional[List[str]] = None,
+    failed_images: list[str] | None = None,
 ) -> str:
     """Replace image paths in HTML img tags with uploaded URLs.
 
@@ -355,18 +351,13 @@ def replace_markdown_image_paths(
         len(failed_images),
     )
 
-    # Replace successful images using pre-compiled regex
+    # Replace successful images.
     replaced_count = 0
     for image_path, upload_response in image_path_map.items():
         if upload_response.preview_url:
             original_markdown = markdown
-            markdown = HTML_IMG_PATTERN.sub(
-                lambda m: (
-                    f"{m.group(1)}{upload_response.preview_url}{m.group(3)}"
-                    if m.group(2) == image_path
-                    else m.group(0)
-                ),
-                markdown,
+            markdown = markdown.replace(
+                f'src="{image_path}"', f'src="{upload_response.preview_url}"'
             )
             if markdown != original_markdown:
                 replaced_count += 1
@@ -391,140 +382,42 @@ def replace_markdown_image_paths(
     return markdown
 
 
-def process_images_from_result(
-    result: dict, tool_instance
-) -> Tuple[
-    List[UploadFileResponse],
-    dict[str, UploadFileResponse],
-    List[str],
-    List[Tuple[bytes, dict]],
-]:
-    """Extract and process images from API result
-
-    Args:
-        result: API response result
-        tool_instance: Tool instance for file operations
-    """
-    images = []
-    image_path_map = {}
-    failed_images = []
-    blob_messages = []
-    image_counter = 0
-
-    logger.debug("Processing images from API result")
-
-    for item in result.get("result", {}).get("layoutParsingResults", []):
-        markdown_data = item.get("markdown", {})
-        if markdown_data:
-            image_dict = markdown_data.get("images", {})
-            if image_dict:
-                logger.debug(
-                    f"Found {len(image_dict)} images to process: {list(image_dict.keys())}"
-                )
-            else:
-                logger.debug("No images found in this markdown item")
-
-            for image_path, image_url in image_dict.items():
-                if image_path in image_path_map:
-                    logger.debug(f"Skipping already processed image: {image_path}")
-                    continue
-
-                logger.debug(f"Processing image: {image_path} -> {image_url}")
-
-                image_processed_successfully = False
-
-                try:
-                    try:
-                        image_bytes = download_image_from_url(image_url)
-                    except Exception as download_error:
-                        logger.warning(
-                            "Failed to download image %s from %s: %s",
-                            image_path,
-                            image_url,
-                            download_error,
-                        )
-                        failed_images.append(image_path)
-                        continue
-
-                    file_name = f"paddleocr_image_{image_counter}.jpg"
-                    logger.debug(f"Uploading image {image_path} as {file_name}")
-
-                    try:
-                        upload_response = tool_instance.session.file.upload(
-                            file_name, image_bytes, "image/jpeg"
-                        )
-                        images.append(upload_response)
-                        image_path_map[image_path] = upload_response
-                        image_counter += 1
-
-                        logger.debug(
-                            "Successfully uploaded image %s, preview_url: %s",
-                            image_path,
-                            upload_response.preview_url,
-                        )
-
-                        if not upload_response.preview_url:
-                            logger.warning(
-                                "No preview URL for uploaded image %s; creating blob fallback",
-                                image_path,
-                            )
-                            blob_messages.append(
-                                (
-                                    image_bytes,
-                                    {"filename": file_name, "mime_type": "image/jpeg"},
-                                )
-                            )
-                            failed_images.append(image_path)
-                        else:
-                            image_processed_successfully = True
-
-                    except Exception as upload_error:
-                        logger.error(f"Failed to upload image {image_path} to dify: {upload_error}")
-                        logger.info(
-                            f"Creating blob message as fallback for failed upload of {image_path}"
-                        )
-                        blob_messages.append(
-                            (
-                                image_bytes,
-                                {"filename": file_name, "mime_type": "image/jpeg"},
-                            )
-                        )
-                        failed_images.append(image_path)
-
-                except Exception as e:
-                    logger.error(f"Unexpected error processing image {image_path}: {e}")
-                    failed_images.append(image_path)
-                    continue
-
-                if image_processed_successfully:
-                    logger.debug(f"Successfully processed image {image_path}")
-
-    logger.info(
-        "Image processing completed - successful: %s, markdown-failed: %s, blob-messages: %s",
-        len(images),
-        len(failed_images),
-        len(blob_messages),
-    )
-    if failed_images:
-        logger.warning(f"Images that failed processing (no URL available): {failed_images}")
-
-    return images, image_path_map, failed_images, blob_messages
-
-
-def get_markdown_from_result(
-    result: dict,
-    image_path_map: Optional[dict[str, UploadFileResponse]] = None,
-    failed_images: Optional[List[str]] = None,
+def render_document_markdown(
+    result: dict[str, Any],
+    tool_instance: Any,
+    *,
+    image_filename_prefix: str,
+    warning_logger: Any | None = None,
 ) -> str:
-    """Extract Markdown and replace image references when mappings are provided."""
-    markdown_text_list = []
-    for item in result.get("result", {}).get("layoutParsingResults", []):
-        markdown_text = item.get("markdown", {}).get("text")
-        if markdown_text is not None:
-            if image_path_map or failed_images:
-                markdown_text = replace_markdown_image_paths(
-                    markdown_text, image_path_map or {}, failed_images
+    """Upload result images and return Markdown with usable image references."""
+    active_logger = warning_logger or logger
+    image_path_map: dict[str, UploadFileResponse] = {}
+    failed_images: list[str] = []
+
+    for page in result.get("pages", []):
+        for image_path, image_url in (page.get("markdown_images") or {}).items():
+            if image_path in image_path_map:
+                continue
+            try:
+                image_bytes = download_image_from_url(image_url)
+                file_name = f"{image_filename_prefix}_{len(image_path_map)}.jpg"
+                upload_response = tool_instance.session.file.upload(
+                    file_name, image_bytes, "image/jpeg"
                 )
+                image_path_map[image_path] = upload_response
+                if not upload_response.preview_url:
+                    failed_images.append(image_path)
+            except Exception as e:
+                active_logger.warning(f"Failed to process image {image_path}: {e}")
+                failed_images.append(image_path)
+
+    markdown_text_list = []
+    for page in result.get("pages", []):
+        markdown_text = page.get("markdown_text")
+        if markdown_text is not None:
+            markdown_text = replace_markdown_image_paths(
+                markdown_text, image_path_map, failed_images
+            )
             markdown_text_list.append(markdown_text)
     return "\n\n".join(markdown_text_list)
 

--- a/tools/paddleocr/tools/utils.py
+++ b/tools/paddleocr/tools/utils.py
@@ -3,8 +3,8 @@ import json
 import logging
 import os
 import re
-import time
 import tempfile
+import time
 from typing import Any, List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -19,6 +19,29 @@ FAILED_IMG_TAG_TEMPLATE = r'<img[^>]*src="[^"]*{escaped_path}[^"]*"[^>]*>'
 logger = logging.getLogger(__name__)
 
 IMAGE_EXTENSIONS = {".bmp", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp"}
+
+DEFAULT_OCR_MODEL = "PP-OCRv6"
+DEFAULT_DOCUMENT_MODEL = "PP-StructureV3"
+DEFAULT_VL_MODEL = "PaddleOCR-VL-1.6"
+OCR_MODELS = frozenset({"PP-OCRv5", "PP-OCRv5-latin", "PP-OCRv6"})
+DOCUMENT_MODELS = frozenset(
+    {"PP-StructureV3", "PaddleOCR-VL", "PaddleOCR-VL-1.5", "PaddleOCR-VL-1.6"}
+)
+VL_MODELS = frozenset({"PaddleOCR-VL", "PaddleOCR-VL-1.5", "PaddleOCR-VL-1.6"})
+
+EXTRA_OPTIONS_PARAMETER = "extraOptions"
+RESERVED_EXTRA_OPTION_KEYS = frozenset(
+    {
+        EXTRA_OPTIONS_PARAMETER,
+        "batchId",
+        "file",
+        "fileType",
+        "fileUrl",
+        "model",
+        "optionalPayload",
+        "pageRanges",
+    }
+)
 
 
 def extract_base_url(api_url: str) -> str:
@@ -35,11 +58,118 @@ def extract_base_url(api_url: str) -> str:
         Base URL without endpoint path
     """
     parsed = urlparse(api_url)
-    # Remove common PaddleOCR endpoints
+    # Remove common PaddleOCR endpoints and the full async jobs path.
     path = parsed.path.rstrip("/")
-    if path in ("", "/ocr", "/layout-parsing", "/paddleocr"):
+    if path.endswith(API_PATH):
+        path = path[: -len(API_PATH)].rstrip("/")
+    elif path in ("", "/ocr", "/layout-parsing", "/paddleocr"):
         path = ""
     return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
+def validate_model(model: str, *, is_document_parsing: bool) -> None:
+    """Validate that a hosted API model belongs to the requested task."""
+    supported_models = DOCUMENT_MODELS if is_document_parsing else OCR_MODELS
+    task_name = "document parsing" if is_document_parsing else "OCR"
+    if model not in supported_models:
+        choices = ", ".join(sorted(supported_models))
+        raise RuntimeError(f"Unsupported {task_name} model '{model}'. Choose from: {choices}.")
+
+
+def merge_extra_options(options: dict[str, Any], raw_extra_options: Any) -> dict[str, Any]:
+    """Merge a JSON object into optionalPayload, matching the official SDK's extra options."""
+    if raw_extra_options is None or raw_extra_options == "":
+        return options
+
+    if isinstance(raw_extra_options, str):
+        try:
+            extra_options = json.loads(raw_extra_options)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"extraOptions must be valid JSON: {e.msg}.") from e
+    else:
+        extra_options = raw_extra_options
+
+    if not isinstance(extra_options, dict):
+        raise RuntimeError("extraOptions must be a JSON object.")
+
+    reserved_keys = sorted(RESERVED_EXTRA_OPTION_KEYS.intersection(extra_options))
+    if reserved_keys:
+        raise RuntimeError(
+            "extraOptions cannot contain transport-level fields: " + ", ".join(reserved_keys) + "."
+        )
+
+    options.update(extra_options)
+    return options
+
+
+def validate_layout_options(options: dict[str, Any]) -> None:
+    """Validate scalar and per-class layout controls accepted by the official API."""
+    threshold = options.get("layoutThreshold")
+    if threshold is not None:
+        values = threshold.values() if isinstance(threshold, dict) else (threshold,)
+        if any(not _is_number(value) or not 0 <= value <= 1 for value in values):
+            raise RuntimeError(
+                "layoutThreshold must be a number from 0 to 1 or an object of such values."
+            )
+
+    unclip_ratio = options.get("layoutUnclipRatio")
+    if unclip_ratio is not None and not _valid_unclip_ratio(unclip_ratio):
+        raise RuntimeError(
+            "layoutUnclipRatio must be a positive number, a two-number array, "
+            "or an object of those values."
+        )
+
+    merge_mode = options.get("layoutMergeBboxesMode")
+    if merge_mode is not None:
+        values = merge_mode.values() if isinstance(merge_mode, dict) else (merge_mode,)
+        if any(value not in {"large", "small", "union"} for value in values):
+            raise RuntimeError(
+                "layoutMergeBboxesMode must be large, small, union, "
+                "or an object using those values."
+            )
+
+
+def validate_vl_options(options: dict[str, Any]) -> None:
+    """Apply the same core PaddleOCR-VL option validation as the official SDK."""
+    top_p = options.get("topP")
+    if top_p is not None and (not _is_number(top_p) or not 0 < top_p <= 1):
+        raise RuntimeError("topP must be greater than 0 and less than or equal to 1.")
+
+    temperature = options.get("temperature")
+    if temperature is not None and (not _is_number(temperature) or temperature < 0):
+        raise RuntimeError("temperature must be greater than or equal to 0.")
+
+    repetition_penalty = options.get("repetitionPenalty")
+    if repetition_penalty is not None and (
+        not _is_number(repetition_penalty) or repetition_penalty <= 0
+    ):
+        raise RuntimeError("repetitionPenalty must be greater than 0.")
+
+    min_pixels = options.get("minPixels")
+    max_pixels = options.get("maxPixels")
+    for name, value in (("minPixels", min_pixels), ("maxPixels", max_pixels)):
+        if value is not None and (not _is_number(value) or value <= 0):
+            raise RuntimeError(f"{name} must be greater than 0.")
+    if min_pixels is not None and max_pixels is not None and min_pixels > max_pixels:
+        raise RuntimeError("minPixels cannot be greater than maxPixels.")
+
+    vlm_extra_args = options.get("vlmExtraArgs")
+    if vlm_extra_args is not None and not isinstance(vlm_extra_args, dict):
+        raise RuntimeError("vlmExtraArgs must be a JSON object.")
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _valid_unclip_ratio(value: Any) -> bool:
+    if _is_number(value):
+        return value > 0
+    if isinstance(value, (list, tuple)):
+        return len(value) == 2 and all(_is_number(item) and item > 0 for item in value)
+    if isinstance(value, dict):
+        return bool(value) and all(_valid_unclip_ratio(item) for item in value.values())
+    return False
 
 
 def convert_file_type(file_type: str | None) -> int | None:
@@ -85,7 +215,7 @@ def normalize_file_input(file_value: Any, file_type: str | None) -> Tuple[str, b
         # Check if it's a URL
         if file_value.startswith(("http://", "https://")):
             return file_value, False, explicit_file_type
-        # Check if it's a file path (AI reviewer suggestion: check file path before base64 validation)
+        # Check file paths before base64 validation.
         if os.path.exists(file_value):
             return file_value, False, explicit_file_type
         # Check if it's base64 (data URL or raw)
@@ -220,7 +350,9 @@ def replace_markdown_image_paths(
         failed_images = []
 
     logger.debug(
-        f"Replacing image paths in markdown - {len(image_path_map)} images available, {len(failed_images)} need placeholder"
+        "Replacing image paths in markdown - %s images available, %s need placeholder",
+        len(image_path_map),
+        len(failed_images),
     )
 
     # Replace successful images using pre-compiled regex
@@ -252,7 +384,9 @@ def replace_markdown_image_paths(
             logger.debug(f"Replaced failed image {failed_path} with placeholder")
 
     logger.debug(
-        f"Markdown replacement completed - {replaced_count} URL replacements, {placeholder_count} placeholders"
+        "Markdown replacement completed - %s URL replacements, %s placeholders",
+        replaced_count,
+        placeholder_count,
     )
     return markdown
 
@@ -304,7 +438,10 @@ def process_images_from_result(
                         image_bytes = download_image_from_url(image_url)
                     except Exception as download_error:
                         logger.warning(
-                            f"Failed to download image {image_path} from {image_url}: {download_error}"
+                            "Failed to download image %s from %s: %s",
+                            image_path,
+                            image_url,
+                            download_error,
                         )
                         failed_images.append(image_path)
                         continue
@@ -321,12 +458,15 @@ def process_images_from_result(
                         image_counter += 1
 
                         logger.debug(
-                            f"Successfully uploaded image {image_path}, preview_url: {upload_response.preview_url}"
+                            "Successfully uploaded image %s, preview_url: %s",
+                            image_path,
+                            upload_response.preview_url,
                         )
 
                         if not upload_response.preview_url:
                             logger.warning(
-                                f"No preview URL for uploaded image {image_path}, creating blob message as fallback"
+                                "No preview URL for uploaded image %s; creating blob fallback",
+                                image_path,
                             )
                             blob_messages.append(
                                 (
@@ -360,7 +500,10 @@ def process_images_from_result(
                     logger.debug(f"Successfully processed image {image_path}")
 
     logger.info(
-        f"Image processing completed - successful: {len(images)}, markdown-failed: {len(failed_images)}, blob-messages: {len(blob_messages)}"
+        "Image processing completed - successful: %s, markdown-failed: %s, blob-messages: %s",
+        len(images),
+        len(failed_images),
+        len(blob_messages),
     )
     if failed_images:
         logger.warning(f"Images that failed processing (no URL available): {failed_images}")
@@ -373,7 +516,7 @@ def get_markdown_from_result(
     image_path_map: Optional[dict[str, UploadFileResponse]] = None,
     failed_images: Optional[List[str]] = None,
 ) -> str:
-    """Extract markdown text from result, replace image references if image path mapping is provided"""
+    """Extract Markdown and replace image references when mappings are provided."""
     markdown_text_list = []
     for item in result.get("result", {}).get("layoutParsingResults", []):
         markdown_text = item.get("markdown", {}).get("text")
@@ -488,6 +631,10 @@ def get_api_client_config(access_token: str, *, base_url: str | None = None) -> 
     Returns:
         Configuration dict with token, base_url, headers
     """
+    if not isinstance(access_token, str) or not access_token.strip():
+        raise RuntimeError("AI Studio access token must be provided.")
+    access_token = access_token.strip()
+
     # If base_url is provided, extract it (in case user passed full API URL)
     if base_url:
         base_url = extract_base_url(base_url)
@@ -502,6 +649,48 @@ def get_api_client_config(access_token: str, *, base_url: str | None = None) -> 
             "Client-Platform": "dify",
         },
     }
+
+
+def _extract_api_message(payload: Any, fallback: str = "") -> str:
+    if not isinstance(payload, dict):
+        return fallback
+    for key in ("msg", "errorMsg", "message", "error"):
+        value = payload.get(key)
+        if value:
+            return str(value)
+    data = payload.get("data")
+    if isinstance(data, dict):
+        return _extract_api_message(data, fallback)
+    return fallback
+
+
+def _response_data(response: Any, *, operation: str) -> dict[str, Any]:
+    """Validate an official API response envelope while accepting the legacy flat form."""
+    try:
+        payload = response.json()
+    except ValueError as e:
+        if not 200 <= response.status_code < 300:
+            raise RuntimeError(
+                f"{operation} failed (HTTP {response.status_code}): {response.text}"
+            ) from e
+        raise RuntimeError(f"{operation} response is not valid JSON: {e}") from e
+
+    message = _extract_api_message(payload, response.text)
+    if not 200 <= response.status_code < 300:
+        raise RuntimeError(f"{operation} failed (HTTP {response.status_code}): {message}")
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{operation} response must be a JSON object.")
+
+    code = payload.get("code", 0)
+    if code not in (0, None):
+        raise RuntimeError(f"{operation} failed (code {code}): {message}")
+
+    data = payload.get("data")
+    if data is None:
+        return payload
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{operation} response field 'data' must be a JSON object.")
+    return data
 
 
 def _submit_job(
@@ -570,22 +759,11 @@ def _submit_job(
     except requests.ConnectionError as e:
         raise RuntimeError(f"Connection failed: {e}") from e
 
-    if not 200 <= resp.status_code < 300:
-        try:
-            payload = resp.json()
-            msg = payload.get("msg") or payload.get("message") or payload.get("error") or resp.text
-        except ValueError:
-            msg = resp.text
-        raise RuntimeError(f"Job submission failed (HTTP {resp.status_code}): {msg}")
-
-    try:
-        payload = resp.json()
-        job_id = payload.get("data", {}).get("jobId") or payload.get("jobId")
-        if not job_id:
-            raise RuntimeError(f"Job ID not found in response: {payload}")
-        return job_id
-    except (ValueError, KeyError) as e:
-        raise RuntimeError(f"Failed to parse job submission response: {e}") from e
+    data = _response_data(resp, operation="Job submission")
+    job_id = data.get("jobId")
+    if not isinstance(job_id, str) or not job_id:
+        raise RuntimeError(f"Job ID not found in response: {data}")
+    return job_id
 
 
 def _poll_job(
@@ -629,32 +807,15 @@ def _poll_job(
         except requests.ConnectionError as e:
             raise RuntimeError(f"Connection failed: {e}") from e
 
-        if not 200 <= resp.status_code < 300:
-            try:
-                payload = resp.json()
-                msg = (
-                    payload.get("msg")
-                    or payload.get("message")
-                    or payload.get("error")
-                    or resp.text
-                )
-            except ValueError:
-                msg = resp.text
-            raise RuntimeError(f"Poll failed (HTTP {resp.status_code}): {msg}")
-
-        try:
-            data = resp.json()
-            state = data.get("data", {}).get("state") or data.get("state")
-        except (ValueError, KeyError) as e:
-            raise RuntimeError(f"Failed to parse poll response: {e}") from e
+        data = _response_data(resp, operation="Job status request")
+        state = data.get("state")
+        if state not in {"pending", "running", "done", "failed"}:
+            raise RuntimeError(f"Unknown or missing job state: {state!r}.")
 
         if state == "done":
             # Get result URL — handle both response formats
-            result_data = data.get("data", {})
-            result_json_url = (
-                result_data.get("resultJsonUrl")
-                or (result_data.get("resultUrl") or {}).get("jsonUrl")
-                or data.get("resultJsonUrl")
+            result_json_url = (data.get("resultUrl") or {}).get("jsonUrl") or data.get(
+                "resultJsonUrl"
             )
             if not result_json_url:
                 raise RuntimeError(f"Result URL not found in response: {data}")
@@ -665,7 +826,7 @@ def _poll_job(
                 resp.raise_for_status()
             except requests.Timeout as e:
                 raise RuntimeError(f"Result download timed out: {e}") from e
-            except requests.ConnectionError as e:
+            except requests.RequestException as e:
                 raise RuntimeError(f"Result download failed: {e}") from e
 
             # Parse JSONL
@@ -682,9 +843,7 @@ def _poll_job(
             return jsonl_data, data
 
         if state == "failed":
-            error_msg = (
-                data.get("data", {}).get("errorMsg") or data.get("errorMsg") or "Unknown error"
-            )
+            error_msg = data.get("errorMsg") or "Unknown error"
             raise RuntimeError(f"Job {job_id} failed: {error_msg}")
 
         # Continue polling
@@ -789,6 +948,8 @@ def call_paddleocr_api(
     Raises:
         RuntimeError: If API call fails
     """
+    validate_model(model, is_document_parsing=is_document_parsing)
+
     job_id = _submit_job(
         model,
         file_url,
@@ -798,7 +959,9 @@ def call_paddleocr_api(
         client_config["headers"],
         page_ranges,
     )
-    jsonl_data, status_data = _poll_job(job_id, client_config["base_url"], client_config["headers"])
+    jsonl_data, _status_data = _poll_job(
+        job_id, client_config["base_url"], client_config["headers"]
+    )
 
     if is_document_parsing:
         return _parse_doc_parsing_result(job_id, jsonl_data)


### PR DESCRIPTION
## Summary

- make `PP-OCRv6` the default OCR model across the tool runtime, schema, and credential validation
- expose current hosted API layout controls plus safe `extraOptions` JSON overrides for advanced and per-class settings
- validate models and PaddleOCR-VL sampling/layout parameters before submission
- accept complete `/api/v2/ocr/jobs` URLs and align response-envelope, state, result URL, and error handling with the official API
- preserve existing text, JSON, image, and DOCX output shapes while improving failed-image fallback behavior
- share optional-payload and document-image rendering logic, and remove obsolete legacy response helpers
- bump the PaddleOCR plugin from `0.2.10` to `0.3.0`

Official references:

- [PaddleOCR official API Python SDK](https://www.paddleocr.ai/latest/en/version3.x/inference_deployment/serving/paddleocr_official_api/python.html)
- [PaddleOCR official API model matrix](https://www.paddleocr.ai/latest/en/version3.x/inference_deployment/serving/paddleocr_official_api/cli.html)
- [PP-StructureV3 options](https://www.paddleocr.ai/latest/en/version3.x/pipeline_usage/PP-StructureV3.html)
- [PaddleOCR-VL options](https://www.paddleocr.ai/latest/en/version3.x/pipeline_usage/PaddleOCR-VL.html)

## Release Notes

Updated PaddleOCR to use PP-OCRv6 by default and added advanced layout controls for the latest hosted API. This release also improves API URL compatibility, parameter validation, error handling, and document image fallbacks while preserving existing output formats.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

Not applicable — this is a tool schema and hosted API integration update validated through automated and live API tests.

| Before | After |
| ------ | ----- |
| PP-OCRv5 default and limited layout controls | PP-OCRv6 default with current layout and advanced API controls |

## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

Not applicable — this is a non-LLM tool plugin.

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

The second checklist item is not applicable to this plugin's current repository baseline: PaddleOCR already declares and locks the newer `dify_plugin>=0.9.0`. This PR intentionally does not downgrade the SDK or change the lockfile.

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)
- [x] Clean Python 3.12 frozen dependency installation and 74 unit tests
- [x] Ruff import/error checks and 100-column format check
- [x] Dify CLI v0.6.10 package build, clean unpacked dependency install, and 74 packaged-plugin tests
- [x] Live official API: PP-OCRv6 local upload, PP-StructureV3 URL input, and PaddleOCR-VL-1.6 URL input
- [x] `git diff --check` and secret scan



