### PR TITLE
feat(ernie_image): align with latest official API

### DIFF
--- a/tools/ernie_image/README.md
+++ b/tools/ernie_image/README.md
@@ -1,22 +1,25 @@
 # ERNIE Image
 
-A Dify tool that generates images with Baidu's ERNIE Image models, served by the
-[AI Studio](https://aistudio.baidu.com) OpenAI-compatible endpoint.
+A Dify tool that generates images with Baidu's ERNIE Image models through the
+[AI Studio](https://aistudio.baidu.com) OpenAI-compatible Images API.
 
 > Localized docs: [简体中文](readme/README_zh_Hans.md) · [日本語](readme/README_ja_JP.md)
 
 ## Samples
 
-Generated with the prompt below, `ernie-image-turbo` at 1280×720:
+Generated with `ernie-image-turbo` at the legacy-compatible 1280×720 size:
 
 ![ERNIE Image Turbo sample, 1280x720](_assets/samples/sample_turbo_1280x720.jpg)
 
 ## Models
 
-| Model | Notes |
-|-------|-------|
-| `ernie-image-turbo` | Faster, lower latency, suitable for drafts and iteration. |
-| `ernie-image` | Higher quality, richer detail. |
+| Model | Official model guidance |
+|-------|-------------------------|
+| `ernie-image-turbo` | Distilled model optimized for speed and aesthetics; typically uses 8 inference steps. This remains the plugin default. |
+| `ernie-image` | SFT model focused on general capability and instruction fidelity; typically uses 50 inference steps. |
+
+The hosted API controls inference settings. The step counts above describe the
+official model releases and are not plugin parameters.
 
 ## Setup
 
@@ -26,13 +29,36 @@ Generated with the prompt below, `ernie-image-turbo` at 1280×720:
 
 ## Parameters
 
-- `prompt` *(required)* – text description of the image.
+- `prompt` *(required)* – text description of the image, up to 2048 characters.
 - `model` – `ernie-image-turbo` (default) or `ernie-image`.
-- `size` – `WxH`, e.g. `1024x1024`, `1024x768`, `768x1024`, `1280x720`,
-  `1792x1024`. Default `1024x1024`.
+- `size` – one of the current official resolutions: `1024x1024`, `848x1264`,
+  `768x1376`, `896x1200`, `1264x848`, `1376x768`, or `1200x896`. Default
+  `1024x1024`; Baidu recommends `1376x768`. Previously exposed resolutions
+  remain accepted by the runtime so saved Dify workflows continue to work.
 - `n` – number of images, 1 to 4. Default `1`.
 - `seed` – optional integer for reproducibility.
 - `watermark` – add a model watermark to the output. Default `false`.
 
-The tool emits each generated image as a blob and returns the structured
-response (URLs and revised prompts) as JSON.
+`n` and `seed` are compatibility extensions of the AI Studio endpoint. The
+current public Qianfan request schema documents `prompt`, `model`, `size`, and
+`watermark`.
+
+The tool emits each successfully downloaded image as a PNG blob and returns a
+JSON summary containing the response `id`, `created`, AI Studio `trace_id`,
+source URLs, and revised prompts. Baidu documents generated URLs as valid for
+24 hours, so use the emitted blobs for durable workflow output.
+
+## Compatibility and validation
+
+- Model, size, prompt length, image count, and integer seed are validated before
+  the request.
+- Both AI Studio (`errorCode` / `errorMsg`) and current OpenAI-compatible
+  (`code` / `message` / `type`) error responses are surfaced.
+- A failed image download only skips that image; other images and the JSON
+  summary are preserved.
+
+## Official references
+
+- [ERNIE-Image official model card](https://aistudio.baidu.com/modelsdetail/46031)
+- [ERNIE-Image-Turbo official model card](https://aistudio.baidu.com/modelsdetail/46030/intro)
+- [ERNIE-Image-Turbo API reference](https://cloud.baidu.com/doc/qianfan-api/s/Imo9g5a6a)

--- a/tools/ernie_image/manifest.yaml
+++ b/tools/ernie_image/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: langgenius
 name: ernie_image

--- a/tools/ernie_image/provider/ernie_image.py
+++ b/tools/ernie_image/provider/ernie_image.py
@@ -6,5 +6,6 @@ from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 
 class ErnieImageProvider(ToolProvider):
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
-        if not (credentials.get("access_token") or "").strip():
+        token = credentials.get("access_token")
+        if not isinstance(token, str) or not token.strip():
             raise ToolProviderCredentialValidationError("Access token is required")

--- a/tools/ernie_image/readme/README_ja_JP.md
+++ b/tools/ernie_image/readme/README_ja_JP.md
@@ -4,14 +4,17 @@
 をご覧ください。
 
 Baidu AI Studio の OpenAI 互換 Images API を呼び出し、**ERNIE Image** と
-**ERNIE Image Turbo** モデルでテキストから画像を生成する Dify ツールです。
+**ERNIE Image Turbo** でテキストから画像を生成する Dify ツールです。
 
 ## モデル
 
-| モデル | 用途 |
-|--------|------|
-| `ernie-image-turbo` | 高速、ドラフトや繰り返し生成に適しています。 |
-| `ernie-image` | 高品質、ディテール重視。 |
+| モデル | 公式モデルガイダンス |
+|--------|------------------------|
+| `ernie-image-turbo` | 速度と美観に最適化された蒸留モデル。通常 8 推論ステップで、プラグインのデフォルトです。 |
+| `ernie-image` | 汎用能力と指示追従性を重視した SFT モデル。通常 50 推論ステップです。 |
+
+推論設定はホスト API が制御します。上記のステップ数は公式モデルの説明であり、
+プラグインのパラメータではありません。
 
 ## セットアップ
 
@@ -21,16 +24,37 @@ Baidu AI Studio の OpenAI 互換 Images API を呼び出し、**ERNIE Image** �
 
 ## パラメータ
 
-- `prompt`（必須）: 生成したい画像のテキスト説明。
+- `prompt`（必須）: 生成したい画像のテキスト説明（最大 2048 文字）。
 - `model`: `ernie-image-turbo`（デフォルト）または `ernie-image`。
-- `size`: `WxH` 形式。例: `1024x1024`、`1024x768`、`768x1024`、
-  `1280x720`、`1792x1024`。デフォルトは `1024x1024`。
+- `size`: 現行の公式解像度 `1024x1024`、`848x1264`、`768x1376`、
+  `896x1200`、`1264x848`、`1376x768`、`1200x896` のいずれか。
+  デフォルトは `1024x1024`、Baidu の推奨は `1376x768` です。既存の
+  Dify ワークフローとの互換性のため、以前公開した解像度も実行時には受け付けます。
 - `n`: 生成枚数（1–4）。デフォルトは `1`。
 - `seed`: 再現可能な出力のための任意の整数シード。
 - `watermark`: 出力にモデル透かしを付けるかどうか。デフォルトは `false`。
 
-出力: 生成画像はそれぞれバイナリ blob として返され、URL と
-`revised_prompt` を含む JSON サマリーが添付されます。
+`n` と `seed` は AI Studio endpoint の互換拡張です。現在公開されている
+Qianfan のリクエスト仕様では `prompt`、`model`、`size`、`watermark` が
+文書化されています。
+
+出力: ダウンロードに成功した画像は PNG blob として返され、レスポンスの
+`id`、`created`、AI Studio の `trace_id`、URL、`revised_prompt` を含む
+JSON サマリーが添付されます。生成 URL の有効期間は公式文書で 24 時間と
+されているため、永続的な出力には blob を使用してください。
+
+## 互換性と検証
+
+- リクエスト前にモデル、解像度、プロンプト長、生成枚数、整数シードを検証します。
+- AI Studio（`errorCode` / `errorMsg`）と現行 OpenAI 互換
+  （`code` / `message` / `type`）のエラー形式に対応します。
+- 1 枚の画像取得に失敗しても、他の画像と JSON サマリーは保持されます。
+
+## 公式リファレンス
+
+- [ERNIE-Image 公式モデルカード](https://aistudio.baidu.com/modelsdetail/46031)
+- [ERNIE-Image-Turbo 公式モデルカード](https://aistudio.baidu.com/modelsdetail/46030/intro)
+- [ERNIE-Image-Turbo API リファレンス](https://cloud.baidu.com/doc/qianfan-api/s/Imo9g5a6a)
 
 ## プライバシー
 

--- a/tools/ernie_image/readme/README_zh_Hans.md
+++ b/tools/ernie_image/readme/README_zh_Hans.md
@@ -2,15 +2,17 @@
 
 本文件提供简体中文说明。英文文档请参见上级目录的 `README.md`。
 
-基于百度飞桨星河社区（AI Studio）OpenAI 兼容接口的文生图工具，支持
-**ERNIE Image** 与 **ERNIE Image Turbo** 两个模型。
+基于百度飞桨星河社区（AI Studio）OpenAI 兼容 Images API 的文生图工具，
+支持 **ERNIE Image** 与 **ERNIE Image Turbo** 两个模型。
 
 ## 模型
 
-| 模型 | 说明 |
-|------|------|
-| `ernie-image-turbo` | 速度更快，适合草图与快速迭代。 |
-| `ernie-image` | 画质更佳，细节更丰富。 |
+| 模型 | 官方模型说明 |
+|------|--------------|
+| `ernie-image-turbo` | 面向速度与美感优化的蒸馏模型，通常使用 8 个推理步骤；为插件默认模型。 |
+| `ernie-image` | 强调通用能力和指令遵循的 SFT 模型，通常使用 50 个推理步骤。 |
+
+推理参数由托管 API 控制，上述步骤数仅说明官方模型版本，并非插件参数。
 
 ## 配置
 
@@ -19,16 +21,35 @@
 
 ## 参数
 
-- `prompt`（必填）：图像的文字描述。
+- `prompt`（必填）：图像的文字描述，最长 2048 个字符。
 - `model`：`ernie-image-turbo`（默认）或 `ernie-image`。
-- `size`：`WxH`，例如 `1024x1024`、`1024x768`、`768x1024`、`1280x720`、
-  `1792x1024`，默认 `1024x1024`。
+- `size`：当前官方分辨率之一：`1024x1024`、`848x1264`、`768x1376`、
+  `896x1200`、`1264x848`、`1376x768` 或 `1200x896`。默认
+  `1024x1024`，百度推荐 `1376x768`。运行时继续接受旧版插件已公开的尺寸，
+  以兼容已有 Dify 工作流。
 - `n`：生成图像数量，1–4，默认 `1`。
 - `seed`：可选随机种子，用于复现结果。
 - `watermark`：是否在输出中添加模型水印，默认 `false`。
 
-输出：每张生成的图像都会以二进制 blob 返回，同时附带一段 JSON
-（包含原始 URL 与 `revised_prompt`）。
+`n` 与 `seed` 是 AI Studio endpoint 的兼容扩展；当前公开的千帆请求文档列出
+`prompt`、`model`、`size` 与 `watermark`。
+
+输出：每张成功下载的图像都会以 PNG blob 返回，同时附带一段 JSON，包含
+响应 `id`、`created`、AI Studio `trace_id`、原始 URL 与 `revised_prompt`。
+百度文档说明生成 URL 的有效期为 24 小时，持久化工作流结果应使用 blob。
+
+## 兼容性与校验
+
+- 请求前校验模型、尺寸、提示词长度、生成数量及整数种子。
+- 同时支持 AI Studio（`errorCode` / `errorMsg`）和当前 OpenAI 兼容
+  （`code` / `message` / `type`）错误格式。
+- 单张图片下载失败只跳过该图片，不影响其他图片与 JSON 摘要。
+
+## 官方资料
+
+- [ERNIE-Image 官方模型卡](https://aistudio.baidu.com/modelsdetail/46031)
+- [ERNIE-Image-Turbo 官方模型卡](https://aistudio.baidu.com/modelsdetail/46030/intro)
+- [ERNIE-Image-Turbo API 文档](https://cloud.baidu.com/doc/qianfan-api/s/Imo9g5a6a)
 
 ## 隐私
 

--- a/tools/ernie_image/tests/test_ernie_image.py
+++ b/tools/ernie_image/tests/test_ernie_image.py
@@ -1,0 +1,173 @@
+import base64
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+PLUGIN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, PLUGIN_DIR)
+
+from dify_plugin.errors.model import InvokeError  # noqa: E402
+from dify_plugin.errors.tool import ToolProviderCredentialValidationError  # noqa: E402
+from provider.ernie_image import ErnieImageProvider  # noqa: E402
+
+from tools.ernie_image import (  # noqa: E402
+    DEFAULT_MODEL,
+    DEFAULT_SIZE,
+    LEGACY_SIZES,
+    OFFICIAL_SIZES,
+    ErnieImageTool,
+    _build_payload,
+    _error_message,
+    _fetch_image,
+)
+
+
+def test_build_payload_uses_compatible_defaults():
+    assert _build_payload({"prompt": "  a cat  "}) == {
+        "model": DEFAULT_MODEL,
+        "prompt": "a cat",
+        "n": 1,
+        "size": DEFAULT_SIZE,
+        "watermark": False,
+    }
+
+
+def test_build_payload_accepts_current_options_and_integer_seed():
+    assert _build_payload(
+        {
+            "prompt": "海边日落",
+            "model": "ernie-image",
+            "size": "1376x768",
+            "n": 2,
+            "seed": "42",
+            "watermark": True,
+        }
+    ) == {
+        "model": "ernie-image",
+        "prompt": "海边日落",
+        "n": 2,
+        "size": "1376x768",
+        "seed": 42,
+        "watermark": True,
+    }
+
+
+@pytest.mark.parametrize("size", sorted(LEGACY_SIZES))
+def test_build_payload_keeps_legacy_sizes_compatible(size):
+    assert _build_payload({"prompt": "a cat", "size": size})["size"] == size
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"prompt": ""}, "Prompt is required"),
+        ({"prompt": "x" * 2049}, "2048"),
+        ({"prompt": "x", "model": "unknown"}, "Unsupported model"),
+        ({"prompt": "x", "size": "512x512"}, "Unsupported size"),
+        ({"prompt": "x", "n": 0}, "between 1 and 4"),
+        ({"prompt": "x", "n": 1.5}, "n must be an integer"),
+        ({"prompt": "x", "seed": "1.5"}, "seed must be an integer"),
+    ],
+)
+def test_build_payload_rejects_invalid_parameters(params, message):
+    with pytest.raises(InvokeError, match=message):
+        _build_payload(params)
+
+
+def test_error_message_accepts_current_and_ai_studio_envelopes():
+    assert _error_message({"errorMsg": "AI Studio error"}, "fallback") == "AI Studio error"
+    assert _error_message({"message": "Current API error"}, "fallback") == "Current API error"
+    assert _error_message({"error": {"message": "Nested error"}}, "fallback") == "Nested error"
+    assert _error_message({}, "fallback") == "fallback"
+
+
+def test_fetch_image_checks_status_and_uses_bounded_timeout(monkeypatch):
+    response = MagicMock(content=b"image")
+    get = MagicMock(return_value=response)
+    monkeypatch.setattr("requests.get", get)
+
+    assert _fetch_image("https://example.com/image.png") == b"image"
+    get.assert_called_once_with("https://example.com/image.png", timeout=(10, 120))
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_image_blob_accepts_base64_and_skips_invalid_content():
+    assert ErnieImageTool._image_blob({"b64_json": base64.b64encode(b"image").decode()}) == b"image"
+    assert ErnieImageTool._image_blob({"b64_json": "not-base64"}) is None
+
+
+def test_invoke_emits_blob_and_current_response_metadata(monkeypatch):
+    response = MagicMock(status_code=200, ok=True, content=b"{}")
+    response.json.return_value = {
+        "id": "image-request-id",
+        "created": 1776827546,
+        "trace_id": "ai-studio-trace",
+        "data": [{"url": "https://example.com/image.png", "revised_prompt": "a cat"}],
+    }
+    post = MagicMock(return_value=response)
+    monkeypatch.setattr("requests.post", post)
+    monkeypatch.setattr("tools.ernie_image._fetch_image", lambda _url: b"image")
+    monkeypatch.setattr(
+        ErnieImageTool,
+        "create_blob_message",
+        lambda self, *, blob, meta: {"blob": blob, "meta": meta},
+    )
+    monkeypatch.setattr(
+        ErnieImageTool,
+        "create_json_message",
+        lambda self, data: {"json": data},
+    )
+
+    tool = ErnieImageTool.from_credentials({"access_token": "  token  "})
+    messages = list(tool._invoke({"prompt": "a cat"}))
+
+    assert messages[0]["blob"] == b"image"
+    assert messages[1]["json"]["id"] == "image-request-id"
+    assert messages[1]["json"]["created"] == 1776827546
+    assert messages[1]["json"]["trace_id"] == "ai-studio-trace"
+    assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer token"
+
+
+def test_invoke_surfaces_current_error_message(monkeypatch):
+    response = MagicMock(status_code=400, ok=False, content=b"{}", text="fallback")
+    response.json.return_value = {
+        "code": "invalid_argument",
+        "message": "Unsupported size",
+        "type": "invalid_request_error",
+    }
+    monkeypatch.setattr("requests.post", MagicMock(return_value=response))
+    tool = ErnieImageTool.from_credentials({"access_token": "token"})
+
+    with pytest.raises(InvokeError, match="Unsupported size"):
+        list(tool._invoke({"prompt": "a cat"}))
+
+
+def test_schema_lists_only_current_official_sizes():
+    with open(os.path.join(PLUGIN_DIR, "tools", "ernie_image.yaml"), encoding="utf-8") as file:
+        tool_schema = yaml.safe_load(file)
+    parameters = {parameter["name"]: parameter for parameter in tool_schema["parameters"]}
+
+    assert parameters["prompt"]["max_length"] == 2048
+    assert parameters["model"]["default"] == DEFAULT_MODEL
+    assert parameters["size"]["default"] == DEFAULT_SIZE
+    assert {option["value"] for option in parameters["size"]["options"]} == OFFICIAL_SIZES
+
+
+def test_manifest_version_is_bumped_without_changing_meta_version():
+    with open(os.path.join(PLUGIN_DIR, "manifest.yaml"), encoding="utf-8") as file:
+        manifest = yaml.safe_load(file)
+
+    assert manifest["version"] == "0.0.4"
+    assert manifest["meta"]["version"] == "0.0.1"
+
+
+@pytest.mark.parametrize("token", [None, "", "   ", 123])
+def test_provider_rejects_missing_or_invalid_token(token):
+    provider = object.__new__(ErnieImageProvider)
+
+    with pytest.raises(ToolProviderCredentialValidationError, match="Access token is required"):
+        provider._validate_credentials({"access_token": token})

--- a/tools/ernie_image/tools/ernie_image.py
+++ b/tools/ernie_image/tools/ernie_image.py
@@ -3,7 +3,6 @@ from collections.abc import Generator
 from typing import Any
 
 import requests
-
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.errors.model import InvokeError
@@ -11,41 +10,94 @@ from dify_plugin.errors.model import InvokeError
 API_URL = "https://aistudio.baidu.com/llm/lmapi/v3/images/generations"
 DEFAULT_MODEL = "ernie-image-turbo"
 DEFAULT_SIZE = "1024x1024"
+MAX_PROMPT_LENGTH = 2048
+SUPPORTED_MODELS = frozenset({"ernie-image", "ernie-image-turbo"})
+OFFICIAL_SIZES = frozenset(
+    {
+        "1024x1024",
+        "848x1264",
+        "768x1376",
+        "896x1200",
+        "1264x848",
+        "1376x768",
+        "1200x896",
+    }
+)
+# Keep existing workflows working while new configurations use the current official size list.
+LEGACY_SIZES = frozenset({"1024x768", "768x1024", "1280x720", "720x1280", "1792x1024", "1024x1792"})
+SUPPORTED_SIZES = OFFICIAL_SIZES | LEGACY_SIZES
+
+
+def _parse_integer(value: Any, name: str) -> int:
+    if isinstance(value, bool) or (isinstance(value, float) and not value.is_integer()):
+        raise InvokeError(f"{name} must be an integer")
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise InvokeError(f"{name} must be an integer") from exc
 
 
 def _build_payload(params: dict[str, Any]) -> dict[str, Any]:
     prompt = (params.get("prompt") or "").strip()
     if not prompt:
         raise InvokeError("Prompt is required")
+    if len(prompt) > MAX_PROMPT_LENGTH:
+        raise InvokeError(f"Prompt must not exceed {MAX_PROMPT_LENGTH} characters")
 
-    n = int(params.get("n") or 1)
+    model = params.get("model") or DEFAULT_MODEL
+    if model not in SUPPORTED_MODELS:
+        raise InvokeError(f"Unsupported model: {model}")
+
+    size = params.get("size") or DEFAULT_SIZE
+    if size not in SUPPORTED_SIZES:
+        raise InvokeError(f"Unsupported size: {size}")
+
+    raw_n = params.get("n")
+    if raw_n is None or raw_n == "":
+        raw_n = 1
+    n = _parse_integer(raw_n, "n")
     if not 1 <= n <= 4:
         raise InvokeError("n must be between 1 and 4")
 
     payload: dict[str, Any] = {
-        "model": params.get("model") or DEFAULT_MODEL,
+        "model": model,
         "prompt": prompt,
         "n": n,
-        "size": params.get("size") or DEFAULT_SIZE,
+        "size": size,
         "watermark": bool(params.get("watermark", False)),
     }
     seed = params.get("seed")
     if seed not in (None, ""):
-        payload["seed"] = int(seed)
+        payload["seed"] = _parse_integer(seed, "seed")
     return payload
 
 
 def _fetch_image(url: str) -> bytes:
-    resp = requests.get(url, timeout=60)
+    resp = requests.get(url, timeout=(10, 120))
     resp.raise_for_status()
     return resp.content
+
+
+def _error_message(body: Any, fallback: str) -> str:
+    if not isinstance(body, dict):
+        return fallback
+    for key in ("errorMsg", "message", "detail"):
+        if body.get(key):
+            return str(body[key])
+    error = body.get("error")
+    if isinstance(error, dict):
+        return _error_message(error, fallback)
+    if error:
+        return str(error)
+    return fallback
 
 
 class ErnieImageTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
         token = (self.runtime.credentials or {}).get("access_token")
-        if not token:
+        if not isinstance(token, str) or not token.strip():
             raise InvokeError("Access token is missing")
+        token = token.strip()
 
         payload = _build_payload(tool_parameters)
 
@@ -66,11 +118,11 @@ class ErnieImageTool(Tool):
             body = resp.json() if resp.content else {}
         except ValueError:
             body = {}
-        if resp.status_code != 200 or "data" not in body:
-            msg = body.get("errorMsg") or body.get("detail") or resp.text
+        items = body.get("data") if isinstance(body, dict) else None
+        if not resp.ok or not isinstance(items, list):
+            msg = _error_message(body, resp.text)
             raise InvokeError(f"ERNIE Image request failed (HTTP {resp.status_code}): {msg}")
 
-        items = body.get("data") or []
         if not items:
             raise InvokeError("ERNIE Image returned no data")
 
@@ -91,6 +143,8 @@ class ErnieImageTool(Tool):
                 "model": payload["model"],
                 "size": payload["size"],
                 "n": payload["n"],
+                "id": body.get("id"),
+                "created": body.get("created"),
                 "trace_id": body.get("trace_id"),
                 "data": [
                     {"url": item.get("url"), "revised_prompt": item.get("revised_prompt")}
@@ -101,11 +155,13 @@ class ErnieImageTool(Tool):
 
     @staticmethod
     def _image_blob(item: dict[str, Any]) -> bytes | None:
+        if not isinstance(item, dict):
+            return None
         try:
             if item.get("b64_json"):
                 return base64.b64decode(item["b64_json"])
             if item.get("url"):
                 return _fetch_image(item["url"])
-        except Exception:
+        except (TypeError, ValueError, requests.RequestException):
             return None
         return None

--- a/tools/ernie_image/tools/ernie_image.yaml
+++ b/tools/ernie_image/tools/ernie_image.yaml
@@ -28,6 +28,7 @@ parameters:
       zh_Hans: 您想要生成的图像的文字描述。
       ja_JP: 生成したい画像の説明文。
     llm_description: Text prompt describing the desired image.
+    max_length: 2048
   - name: model
     type: select
     required: true
@@ -62,24 +63,24 @@ parameters:
       zh_Hans: 尺寸
       ja_JP: サイズ
     human_description:
-      en_US: Output resolution in WxH.
-      zh_Hans: 输出分辨率，宽x高。
-      ja_JP: 出力解像度（幅x高さ）。
+      en_US: Current official output resolution in WxH.
+      zh_Hans: 当前官方支持的输出分辨率，宽x高。
+      ja_JP: 現行の公式出力解像度（幅x高さ）。
     options:
       - value: 1024x1024
         label: { en_US: 1024x1024 (Square), zh_Hans: 1024x1024（方形）, ja_JP: 1024x1024（正方形） }
-      - value: 1024x768
-        label: { en_US: 1024x768 (Landscape 4:3), zh_Hans: 1024x768（横屏 4:3）, ja_JP: 1024x768（横 4:3） }
-      - value: 768x1024
-        label: { en_US: 768x1024 (Portrait 3:4), zh_Hans: 768x1024（竖屏 3:4）, ja_JP: 768x1024（縦 3:4） }
-      - value: 1280x720
-        label: { en_US: 1280x720 (Landscape 16:9), zh_Hans: 1280x720（横屏 16:9）, ja_JP: 1280x720（横 16:9） }
-      - value: 720x1280
-        label: { en_US: 720x1280 (Portrait 9:16), zh_Hans: 720x1280（竖屏 9:16）, ja_JP: 720x1280（縦 9:16） }
-      - value: 1792x1024
-        label: { en_US: 1792x1024 (Wide 7:4), zh_Hans: 1792x1024（宽屏 7:4）, ja_JP: 1792x1024（ワイド 7:4） }
-      - value: 1024x1792
-        label: { en_US: 1024x1792 (Tall 4:7), zh_Hans: 1024x1792（高屏 4:7）, ja_JP: 1024x1792（縦長 4:7） }
+      - value: 848x1264
+        label: { en_US: 848x1264 (Portrait), zh_Hans: 848x1264（竖屏）, ja_JP: 848x1264（縦） }
+      - value: 768x1376
+        label: { en_US: 768x1376 (Portrait), zh_Hans: 768x1376（竖屏）, ja_JP: 768x1376（縦） }
+      - value: 896x1200
+        label: { en_US: 896x1200 (Portrait), zh_Hans: 896x1200（竖屏）, ja_JP: 896x1200（縦） }
+      - value: 1264x848
+        label: { en_US: 1264x848 (Landscape), zh_Hans: 1264x848（横屏）, ja_JP: 1264x848（横） }
+      - value: 1376x768
+        label: { en_US: 1376x768 (Recommended), zh_Hans: 1376x768（推荐）, ja_JP: 1376x768（推奨） }
+      - value: 1200x896
+        label: { en_US: 1200x896 (Landscape), zh_Hans: 1200x896（横屏）, ja_JP: 1200x896（横） }
   - name: n
     type: number
     required: false


### PR DESCRIPTION
## Summary

- align ERNIE Image documentation and tool schema with Baidu's current official model guidance and seven supported resolutions
- keep `ernie-image-turbo` as the compatible default and retain legacy resolutions at runtime for saved Dify workflows
- validate the 2048-character prompt limit, model, size, image count, integer seed, and non-empty token before requests
- support both AI Studio and current OpenAI-compatible error envelopes, add official `id` and `created` response metadata, and preserve per-image download fallback behavior
- add focused tests for payload validation, response compatibility, image handling, credential validation, YAML schema, and manifest version
- bump the ERNIE Image plugin from `0.0.3` to `0.0.4`

Official references:

- [ERNIE-Image official model card](https://aistudio.baidu.com/modelsdetail/46031)
- [ERNIE-Image-Turbo official model card](https://aistudio.baidu.com/modelsdetail/46030/intro)
- [ERNIE-Image-Turbo API reference](https://cloud.baidu.com/doc/qianfan-api/s/Imo9g5a6a)

## Release Notes

Updated ERNIE Image with Baidu's current official resolutions and model guidance. This release adds stricter local parameter validation, supports current API response and error fields, preserves existing workflows through legacy-size compatibility, and expands localized documentation and automated tests.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

Not applicable — this is a tool schema, validation, and API compatibility update verified through automated and live API tests.

| Before | After |
| ------ | ----- |
| Legacy resolution list and limited local validation | Current official resolution list with backward-compatible runtime validation |

## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

Not applicable — this is a non-LLM tool plugin.

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

The second checklist item is not applicable to this plugin's repository baseline: ERNIE Image already declares and locks the newer `dify_plugin>=0.9.0`. This PR intentionally does not downgrade the SDK or modify the dependency lock.

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [ ] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)
- [x] Clean Python 3.12 frozen dependency installation and 26 unit tests
- [x] Ruff import/error checks and 100-column format check
- [x] Dify CLI v0.6.10 package build, cache-free archive verification, clean unpacked dependency install, and 26 packaged-plugin tests
- [x] Live AI Studio API: `ernie-image-turbo` at the official recommended `1376x768`, including image download verification
- [x] `git diff --check` and secret scan
