### PR TITLE
fix(plugins): parse files when Dify already has an event loop

### DIFF
--- a/tools/llama_parse/manifest.yaml
+++ b/tools/llama_parse/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.8
+version: 0.0.9
 type: plugin
 tags:
   - utilities

--- a/tools/llama_parse/pyproject.toml
+++ b/tools/llama_parse/pyproject.toml
@@ -17,3 +17,6 @@ dependencies = [
 # uv run black . -C -l 100 && uv run ruff check --fix
 [dependency-groups]
 dev = []
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tools/llama_parse/tests/test_file_inputs.py
+++ b/tools/llama_parse/tests/test_file_inputs.py
@@ -1,0 +1,45 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from tools.file_inputs import call_sync, file_bytes, file_name, iter_files
+
+
+class FileInputTests(unittest.TestCase):
+    def test_iter_files_wraps_a_single_file(self) -> None:
+        file = SimpleNamespace(filename="a.pdf", blob=b"%PDF")
+        self.assertEqual(iter_files(file), [file])
+
+    def test_iter_files_rejects_empty_list(self) -> None:
+        with self.assertRaisesRegex(ValueError, "File is required"):
+            iter_files([])
+
+    def test_file_bytes_coerces_bytearray_and_memoryview(self) -> None:
+        payload = b"%PDF-1.4"
+        as_bytearray = SimpleNamespace(filename="doc.pdf", blob=bytearray(payload))
+        as_memory = SimpleNamespace(filename="doc.pdf", blob=memoryview(payload))
+        self.assertEqual(file_bytes(as_bytearray), payload)
+        self.assertEqual(file_bytes(as_memory), payload)
+
+    def test_file_bytes_rejects_nested_list_payload(self) -> None:
+        file = SimpleNamespace(filename="doc.pdf", blob=[b"%PDF-a", b"%PDF-b"])
+        with self.assertRaises(ValueError) as ctx:
+            file_bytes(file)
+        self.assertIn("missing binary content", str(ctx.exception))
+
+    def test_file_name_requires_extension_bearing_name(self) -> None:
+        with self.assertRaises(ValueError):
+            file_name(SimpleNamespace(filename=None, name=None, blob=b"x"))
+
+    def test_call_sync_from_running_event_loop(self) -> None:
+        def uses_asyncio_run() -> str:
+            return asyncio.run(asyncio.sleep(0, result="ok"))
+
+        async def invoke_from_loop() -> str:
+            return call_sync(uses_asyncio_run)
+
+        self.assertEqual(asyncio.run(invoke_from_loop()), "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/llama_parse/tools/file_inputs.py
+++ b/tools/llama_parse/tools/file_inputs.py
@@ -1,0 +1,58 @@
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+import nest_asyncio
+
+T = TypeVar("T")
+
+
+def iter_files(files: Any) -> list[Any]:
+    """Normalize the Dify ``files`` parameter to a non-empty list."""
+    if files is None:
+        raise ValueError("File is required")
+    if isinstance(files, list):
+        if not files:
+            raise ValueError("File is required")
+        return files
+    return [files]
+
+
+def file_name(file: Any) -> str:
+    name = getattr(file, "filename", None) or getattr(file, "name", None)
+    if not name:
+        raise ValueError("Each file must have a filename with an extension")
+    return str(name)
+
+
+def file_bytes(file: Any) -> bytes:
+    """Return file contents as ``bytes`` for LlamaParse.
+
+    LlamaParse treats anything that is not ``bytes`` / a buffer / a path string
+    as a type error (``file_path must be a string or a list of strings``).
+    Dify File blobs can be ``bytearray`` or ``memoryview``; coerce those, and
+    fail clearly when the payload is missing or nested.
+    """
+    blob = getattr(file, "blob", None)
+    if isinstance(blob, memoryview):
+        blob = blob.tobytes()
+    elif isinstance(blob, bytearray):
+        blob = bytes(blob)
+    if isinstance(blob, bytes):
+        if not blob:
+            raise ValueError(f"File '{file_name(file)}' is empty")
+        return blob
+    raise ValueError(
+        f"File '{file_name(file)}' is missing binary content. "
+        "LlamaParse needs the file bytes on each File.blob."
+    )
+
+
+def call_sync(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Call a sync function that itself uses ``asyncio.run``.
+
+    The Dify plugin daemon (gevent) may already be inside an event loop.
+    LlamaParse ``load_data`` then raises
+    ``asyncio.run() cannot be called from a running event loop``.
+    """
+    nest_asyncio.apply()
+    return func(*args, **kwargs)

--- a/tools/llama_parse/tools/llama_parse.py
+++ b/tools/llama_parse/tools/llama_parse.py
@@ -10,6 +10,8 @@ from llama_cloud_services import LlamaParse
 from llama_cloud_services.parse.utils import ResultType
 from pydantic import BaseModel
 
+from tools.file_inputs import call_sync, file_bytes, file_name, iter_files
+
 logger = logging.getLogger(__name__)
 
 
@@ -39,7 +41,9 @@ class LlamaParseTool(Tool):
         nest_asyncio.apply()
         if tool_parameters.get("files") is None:
             raise ValueError("File is required")
-        params = ToolParameters(**tool_parameters)
+        params = ToolParameters(
+            **{**tool_parameters, "files": iter_files(tool_parameters["files"])}
+        )
         files = params.files
 
         parser = LlamaParse(
@@ -51,16 +55,18 @@ class LlamaParseTool(Tool):
             ignore_errors=False,
         )
         for file in files:
-            documents = parser.load_data(
-                file_path=file.blob,
-                extra_info={"file_name": file.filename},
+            filename = file_name(file)
+            documents = call_sync(
+                parser.load_data,
+                file_path=file_bytes(file),
+                extra_info={"file_name": filename},
             )
             texts = "---".join([doc.text for doc in documents])
             yield self.create_text_message(texts)
             handled_docs = [
                 {"text": doc.text, "metadata": doc.metadata} for doc in documents
             ]
-            yield self.create_json_message({file.filename: handled_docs})
+            yield self.create_json_message({filename: handled_docs})
             yield self.create_blob_message(
                 texts.encode(),
                 meta={

--- a/tools/llama_parse/tools/llama_parse_advanced.py
+++ b/tools/llama_parse/tools/llama_parse_advanced.py
@@ -13,6 +13,8 @@ from llama_cloud_services import LlamaParse
 from llama_cloud_services.parse.utils import ResultType
 from pydantic import BaseModel
 
+from tools.file_inputs import call_sync, file_bytes, file_name, iter_files
+
 logger = logging.getLogger(__name__)
 
 
@@ -153,7 +155,9 @@ class LlamaParseAdvancedTool(Tool):
         nest_asyncio.apply()
         if tool_parameters.get("files") is None:
             raise ValueError("File is required")
-        params = AdvancedToolParameters(**tool_parameters)
+        params = AdvancedToolParameters(
+            **{**tool_parameters, "files": iter_files(tool_parameters["files"])}
+        )
         files = params.files
 
         # Build parser configuration with advanced features
@@ -180,53 +184,40 @@ class LlamaParseAdvancedTool(Tool):
         parser = LlamaParse(**parser_config)
 
         for file in files:
-            try:
-                # Add timeout and error handling for file access
-                file_size_mb = getattr(file, 'size', 0) / (1024 * 1024)
-                logger.info(f"Processing file: {file.filename} ({file_size_mb:.1f}MB)")
-                
-                # Show warning for very large files
-                if file_size_mb > 50:
-                    logger.warning(f"Processing very large file ({file_size_mb:.1f}MB). This may take several minutes.")
-                    yield self.create_text_message(f"Processing large file ({file_size_mb:.1f}MB). Please be patient...")
-                
-                # Try to access the file content with custom timeout handling
-                try:
-                    file_content = self._get_file_content_with_timeout(file, timeout=300.0)
-                except (httpx.ConnectTimeout, httpx.ReadTimeout, httpx.HTTPStatusError, ValueError) as e:
-                    error_msg = str(e)
-                    logger.error(error_msg)
-                    yield self.create_text_message(error_msg)
-                    continue
-                except Exception as e:
-                    error_msg = f"Unexpected error while accessing file '{file.filename}': {e}"
-                    logger.error(error_msg)
-                    yield self.create_text_message(error_msg)
-                    continue
+            filename = file_name(file)
+            file_size_mb = getattr(file, "size", 0) / (1024 * 1024)
+            logger.info(f"Processing file: {filename} ({file_size_mb:.1f}MB)")
 
-                # Parse the document
-                logger.info(f"Parsing file '{file.filename}' with LlamaParse LLM mode...")
-                documents = parser.load_data(
-                    file_path=file_content,
-                    extra_info={"file_name": file.filename},
+            if file_size_mb > 50:
+                logger.warning(
+                    f"Processing very large file ({file_size_mb:.1f}MB). This may take several minutes."
                 )
-                
-                texts = "---".join([doc.text for doc in documents])
-                yield self.create_text_message(texts)
-                handled_docs = [
-                    {"text": doc.text, "metadata": doc.metadata} for doc in documents
-                ]
-                yield self.create_json_message({file.filename: handled_docs})
-                yield self.create_blob_message(
-                    texts.encode(),
-                    meta={
-                        "mime_type": mime_type_map[params.result_type],
-                    },
+                yield self.create_text_message(
+                    f"Processing large file ({file_size_mb:.1f}MB). Please be patient..."
                 )
-                
-                logger.info(f"Successfully processed file '{file.filename}'")
-                
-            except Exception as e:
-                error_msg = f"Error processing file '{file.filename}': {e}"
-                logger.error(error_msg)
-                yield self.create_text_message(error_msg) 
+
+            try:
+                file_content = file_bytes(file)
+            except ValueError:
+                file_content = self._get_file_content_with_timeout(file, timeout=300.0)
+
+            logger.info(f"Parsing file '{filename}' with LlamaParse LLM mode...")
+            documents = call_sync(
+                parser.load_data,
+                file_path=file_content,
+                extra_info={"file_name": filename},
+            )
+
+            texts = "---".join([doc.text for doc in documents])
+            yield self.create_text_message(texts)
+            handled_docs = [
+                {"text": doc.text, "metadata": doc.metadata} for doc in documents
+            ]
+            yield self.create_json_message({filename: handled_docs})
+            yield self.create_blob_message(
+                texts.encode(),
+                meta={
+                    "mime_type": mime_type_map[params.result_type],
+                },
+            )
+            logger.info(f"Successfully processed file '{filename}'") 

--- a/tools/unstructured/manifest.yaml
+++ b/tools/unstructured/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 type: plugin
 author: langgenius
 name: unstructured

--- a/tools/unstructured/pyproject.toml
+++ b/tools/unstructured/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unstructured"
-version = "0.0.10"
+version = "0.0.11"
 description = "Dify tools for Unstructured Transform and the legacy Partition API"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -10,6 +10,7 @@ dependencies = [
     "dify_plugin>=0.9.0",
     "httpx>=0.28.1",
     "mcp>=1.26.0,<2",
+    "nest-asyncio>=1.6.0",
     "requests>=2.34.2",
     "unstructured-client>=0.44.0",
 ]

--- a/tools/unstructured/tests/test_transform.py
+++ b/tools/unstructured/tests/test_transform.py
@@ -15,6 +15,7 @@ from tools.transform import (
     _get_job_results,
     _require_public_file_url,
     _require_public_https_transfer_url,
+    _run_coroutine,
     _stages,
     _tool_payload,
     _validate_transform_tools,
@@ -542,3 +543,60 @@ def test_partition_rejects_transform_credentials() -> None:
 
     with pytest.raises(ToolProviderCredentialValidationError, match="use Partition"):
         PartitionTool._get_credentials(tool)
+
+
+def test_run_coroutine_from_running_event_loop() -> None:
+    async def ping() -> str:
+        await asyncio.sleep(0)
+        return "ok"
+
+    async def invoke_from_loop() -> str:
+        return _run_coroutine(lambda: ping())
+
+    assert asyncio.run(invoke_from_loop()) == "ok"
+
+
+def test_invoke_from_running_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_transform(self, *, api_url: str, api_key: str, parameters: dict) -> dict:
+        del self, api_url, api_key, parameters
+        asyncio.get_running_loop()
+        return {
+            "job_id": "job-123",
+            "output_ref": "",
+            "filename": "document.md",
+            "mime_type": "text/markdown",
+            "content": b"parsed",
+        }
+
+    monkeypatch.setattr(TransformTool, "_transform", fake_transform)
+
+    tool = object.__new__(TransformTool)
+    tool.runtime = SimpleNamespace(
+        credentials={
+            "server_type": "transform",
+            "api_url": "https://mcp.transform.unstructured.io",
+            "api_key": "test-key",
+        }
+    )
+    tool.create_text_message = lambda text: ("text", text)
+    tool.create_blob_message = lambda content, meta: ("blob", content, meta)
+    tool.create_json_message = lambda obj: ("json", obj)
+    tool.create_variable_message = lambda name, value: ("var", name, value)
+
+    async def invoke_from_loop() -> list:
+        return list(
+            tool._invoke(
+                {
+                    "file": SimpleNamespace(
+                        filename="document.pdf",
+                        mime_type="application/pdf",
+                        blob=b"%PDF",
+                    ),
+                    "output_format": "md",
+                }
+            )
+        )
+
+    messages = asyncio.run(invoke_from_loop())
+    assert ("text", "parsed") in messages
+    assert any(item[0] == "var" and item[1] == "job_id" for item in messages)

--- a/tools/unstructured/tools/transform.py
+++ b/tools/unstructured/tools/transform.py
@@ -3,13 +3,14 @@ import ipaddress
 import json
 import mimetypes
 import socket
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 import httpx
+import nest_asyncio
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.errors.tool import ToolProviderCredentialValidationError
@@ -262,6 +263,17 @@ async def _get_job_results(
             await asyncio.sleep(min(_RESULTS_RETRY_SECONDS, remaining))
 
 
+def _run_coroutine(coro_factory: Callable[[], Any]) -> Any:
+    """Run an async function even when the plugin daemon already has a loop.
+
+    Dify's plugin runtime (gevent) can already be inside an event loop, so
+    ``asyncio.run`` raises ``RuntimeError``. ``nest_asyncio`` is the same
+    workaround LlamaParse uses for this environment.
+    """
+    nest_asyncio.apply()
+    return asyncio.run(coro_factory())
+
+
 def _stages(parameters: dict[str, Any]) -> dict[str, Any]:
     stages: dict[str, Any] = {}
     partition: dict[str, Any] = {}
@@ -301,7 +313,7 @@ class TransformTool(Tool):
             )
         _require_hosted_transform_url(api_url)
         try:
-            asyncio.run(TransformTool._validate_connection(api_url, api_key))
+            _run_coroutine(lambda: TransformTool._validate_connection(api_url, api_key))
         except Exception as exc:
             raise ToolProviderCredentialValidationError(
                 f"Could not connect to Unstructured Transform: {exc}"
@@ -338,8 +350,8 @@ class TransformTool(Tool):
             )
         _require_hosted_transform_url(api_url)
 
-        result = asyncio.run(
-            self._transform(
+        result = _run_coroutine(
+            lambda: self._transform(
                 api_url=api_url,
                 api_key=api_key,
                 parameters=tool_parameters,

--- a/tools/unstructured/uv.lock
+++ b/tools/unstructured/uv.lock
@@ -734,6 +734,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1448,12 +1457,13 @@ wheels = [
 
 [[package]]
 name = "unstructured"
-version = "0.0.10"
+version = "0.0.11"
 source = { virtual = "." }
 dependencies = [
     { name = "dify-plugin" },
     { name = "httpx" },
     { name = "mcp" },
+    { name = "nest-asyncio" },
     { name = "requests" },
     { name = "unstructured-client" },
 ]
@@ -1468,6 +1478,7 @@ requires-dist = [
     { name = "dify-plugin", specifier = ">=0.9.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", specifier = ">=1.26.0,<2" },
+    { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "unstructured-client", specifier = ">=0.44.0" },
 ]


### PR DESCRIPTION
## Summary

Fixes #3732

Knowledge pipelines that pass **multiple files** into LlamaParse fail with a type-confusion error or an async warning, and the plugin often reports success while emitting the error as text. Unstructured Transform hits the same worker constraint: `asyncio.run() cannot be called from a running event loop`.

**LlamaParse 0.0.9**
- Coerce each `File.blob` to `bytes` (`bytearray` / `memoryview` included) so `load_data` is not given a nested list or non-bytes payload
- Wrap `load_data` with `nest_asyncio` so parsing works inside the gevent plugin daemon
- Raise parse/download errors instead of yielding them as successful text output
- Normalize a single file into a list so multi-file source nodes keep working

**Unstructured Transform 0.0.11**
- Run `_transform` / credential checks through `_run_coroutine()`, which applies `nest_asyncio` before `asyncio.run`

## Release Notes

- **Fix**: LlamaParse now accepts multiple knowledge-pipeline files, coerces file bytes, and fails the node when parsing errors instead of returning them as success text.
- **Fix**: Unstructured Transform no longer crashes with `asyncio.run() cannot be called from a running event loop` inside Dify workers.
