### PR TITLE
feat(notion): add fetch_all option to paginate through all database records

### DIFF
--- a/tools/notion/manifest.yaml
+++ b/tools/notion/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.15
+version: 0.1.0
 type: plugin
 author: langgenius
 name: notion

--- a/tools/notion/manifest.yaml
+++ b/tools/notion/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.14
+version: 0.0.15
 type: plugin
 author: langgenius
 name: notion

--- a/tools/notion/tools/query_database.py
+++ b/tools/notion/tools/query_database.py
@@ -8,6 +8,10 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 
 from tools.notion_client import NotionClient
 
+# Safety cap on Notion API calls when fetch_all paginates through a data source
+# (mirrors retrieve_page.py's max_api_calls budget).
+DEFAULT_MAX_API_CALLS = 500
+
 # Conditions whose Notion API value is fixed (not taken from filter_value)
 NO_VALUE_CONDITIONS = {
     "is_empty", "is_not_empty",
@@ -212,6 +216,9 @@ class QueryDatabaseTool(Tool):
         filter_value = tool_parameters.get("filter_value", "")
         limit = int(tool_parameters.get("limit", 10))
         fetch_all = _to_bool(tool_parameters.get("fetch_all", False))
+        max_api_calls = int(tool_parameters.get("max_api_calls") or DEFAULT_MAX_API_CALLS)
+        if max_api_calls < 1:
+            max_api_calls = 1
 
         # Validate parameters
         if not database_id:
@@ -267,17 +274,23 @@ class QueryDatabaseTool(Tool):
                     filter_obj = client.create_simple_text_filter(filter_property, filter_value)
             
             # Query the database
+            truncated = False
             try:
                 if fetch_all:
                     results = []
                     start_cursor = None
+                    api_calls_made = 0
                     while True:
+                        if api_calls_made >= max_api_calls:
+                            truncated = True
+                            break
                         data = client.query_data_source(
                             data_source_id=data_source_id,
                             filter_obj=filter_obj,
                             page_size=100,
                             start_cursor=start_cursor
                         )
+                        api_calls_made += 1
                         results.extend(data.get("results", []))
                         if not data.get("has_more"):
                             break
@@ -396,8 +409,15 @@ class QueryDatabaseTool(Tool):
             # Return results
             filter_msg = f" with filter {filter_property}={filter_value}" if filter_property and filter_value else ""
             summary = f"Found {len(formatted_results)} results in database{filter_msg}"
+            response = {"results": formatted_results}
+            if truncated:
+                summary += f" (truncated: max_api_calls={max_api_calls} reached, more records remain)"
+                response["fetch_truncated"] = True
+                response["fetch_truncated_reason"] = (
+                    f"max_api_calls={max_api_calls} exceeded; increase the limit to fetch the remaining records."
+                )
             yield self.create_text_message(summary)
-            yield self.create_json_message({"results": formatted_results})
+            yield self.create_json_message(response)
             
         except Exception as e:
             yield self.create_text_message(f"Error querying Notion database: {str(e)}")

--- a/tools/notion/tools/query_database.py
+++ b/tools/notion/tools/query_database.py
@@ -211,29 +211,42 @@ class QueryDatabaseTool(Tool):
         filter_property = tool_parameters.get("filter_property", "")
         filter_value = tool_parameters.get("filter_value", "")
         limit = int(tool_parameters.get("limit", 10))
-        
+        fetch_all = _to_bool(tool_parameters.get("fetch_all", False))
+
         # Validate parameters
         if not database_id:
             yield self.create_text_message("Database ID is required.")
             return
-            
+
         try:
             # Get integration token from credentials
             integration_token = self.runtime.credentials.get("integration_token")
             if not integration_token:
                 yield self.create_text_message("Notion Integration Token is required.")
                 return
-                
+
             # Initialize the Notion client
             client = NotionClient(integration_token)
-            
+
+            # Resolve the data source once; reused for schema lookup, filtering, and querying
+            try:
+                data_source_id = client.get_default_data_source_id(database_id)
+            except requests.HTTPError as e:
+                if e.response.status_code == 404:
+                    yield self.create_text_message(f"Database not found or you don't have access to it: {database_id}")
+                else:
+                    yield self.create_text_message(f"Error querying database: {e}")
+                return
+            except ValueError as e:
+                yield self.create_text_message(str(e))
+                return
+
             # Prepare filter if a property is provided (value is optional for is_empty/is_not_empty/relative-date conditions)
             filter_condition = tool_parameters.get("filter_condition", "equals")
             filter_obj = None
             if filter_property and (filter_value or filter_condition in NO_VALUE_CONDITIONS):
                 # Get database schema to determine the property type
                 try:
-                    data_source_id = client.get_default_data_source_id(database_id)
                     data_source = client.retrieve_data_source(data_source_id)
                     properties = data_source.get("properties", {})
 
@@ -255,12 +268,29 @@ class QueryDatabaseTool(Tool):
             
             # Query the database
             try:
-                data = client.query_database(
-                    database_id=database_id,
-                    filter_obj=filter_obj,
-                    page_size=limit
-                )
-                results = data.get("results", [])
+                if fetch_all:
+                    results = []
+                    start_cursor = None
+                    while True:
+                        data = client.query_data_source(
+                            data_source_id=data_source_id,
+                            filter_obj=filter_obj,
+                            page_size=100,
+                            start_cursor=start_cursor
+                        )
+                        results.extend(data.get("results", []))
+                        if not data.get("has_more"):
+                            break
+                        start_cursor = data.get("next_cursor")
+                        if not start_cursor:
+                            break
+                else:
+                    data = client.query_data_source(
+                        data_source_id=data_source_id,
+                        filter_obj=filter_obj,
+                        page_size=limit
+                    )
+                    results = data.get("results", [])
             except requests.HTTPError as e:
                 if e.response.status_code == 404:
                     yield self.create_text_message(f"Database not found or you don't have access to it: {database_id}")

--- a/tools/notion/tools/query_database.yaml
+++ b/tools/notion/tools/query_database.yaml
@@ -148,7 +148,25 @@ parameters:
       pt_BR: Número máximo de registros do banco de dados a retornar
       ja_JP: 返すデータベースレコードの最大数
       zh_Hant: 返回的資料庫記錄最大數量
-    llm_description: The maximum number of database records to return. Default is 10.
+    llm_description: The maximum number of database records to return. Default is 10. Ignored when fetch_all is true.
+    form: llm
+  - name: fetch_all
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Fetch All Records
+      zh_Hans: 获取所有记录
+      pt_BR: Buscar Todos os Registros
+      ja_JP: 全レコードを取得
+      zh_Hant: 取得所有記錄
+    human_description:
+      en_US: If enabled, retrieves every matching record from the database (paginating through Notion's API as needed), ignoring the limit parameter.
+      zh_Hans: 启用后将检索数据库中所有匹配的记录（根据需要对 Notion API 进行分页），并忽略 limit 参数。
+      pt_BR: Se ativado, recupera todos os registros correspondentes do banco de dados (paginando pela API do Notion conforme necessário), ignorando o parâmetro limit.
+      ja_JP: 有効にすると、（必要に応じて Notion API をページングしながら）データベース内の一致するレコードをすべて取得し、limit パラメータは無視されます。
+      zh_Hant: 啟用後將擷取資料庫中所有符合的記錄（依需要對 Notion API 進行分頁），並忽略 limit 參數。
+    llm_description: Set to true to retrieve every matching record in the database instead of stopping at limit. This automatically pages through Notion's API, so it may issue multiple requests for large databases. When true, limit is ignored.
     form: llm
 extra:
   python:

--- a/tools/notion/tools/query_database.yaml
+++ b/tools/notion/tools/query_database.yaml
@@ -168,6 +168,24 @@ parameters:
       zh_Hant: 啟用後將擷取資料庫中所有符合的記錄（依需要對 Notion API 進行分頁），並忽略 limit 參數。
     llm_description: Set to true to retrieve every matching record in the database instead of stopping at limit. This automatically pages through Notion's API, so it may issue multiple requests for large databases. When true, limit is ignored.
     form: llm
+  - name: max_api_calls
+    type: number
+    required: false
+    default: 500
+    label:
+      en_US: Max API Calls
+      zh_Hans: 最大 API 调用次数
+      pt_BR: Máximo de Chamadas de API
+      ja_JP: 最大 API 呼び出し回数
+      zh_Hant: 最大 API 呼叫次數
+    human_description:
+      en_US: "Safety cap on Notion API calls when fetch_all is true (ignored otherwise). Each call returns up to 100 records. When hit, partial results are returned with fetch_truncated=true."
+      zh_Hans: "当 fetch_all 为 true 时，Notion API 调用次数的安全上限（否则忽略）。每次调用最多返回 100 条记录。达到上限时返回部分结果并标记 fetch_truncated=true。"
+      pt_BR: "Limite de segurança para chamadas à API do Notion quando fetch_all é true (ignorado caso contrário). Cada chamada retorna até 100 registros. Ao atingir o limite, resultados parciais são retornados com fetch_truncated=true."
+      ja_JP: "fetch_allがtrueのときにのみ有効な、Notion API呼び出し回数の安全上限（それ以外では無視されます）。1回の呼び出しで最大100件のレコードを返します。上限到達時は部分的な結果をfetch_truncated=true付きで返します。"
+      zh_Hant: "當 fetch_all 為 true 時，Notion API 呼叫次數的安全上限（否則忽略）。每次呼叫最多回傳 100 筆記錄。達到上限時回傳部分結果並標記 fetch_truncated=true。"
+    llm_description: Safety cap on Notion API calls when fetch_all is true (ignored otherwise). Default 500, each call returns up to 100 records (so ~50,000 records max by default). If exceeded, partial results are returned with fetch_truncated=true.
+    form: llm
 extra:
   python:
     source: tools/query_database.py 


### PR DESCRIPTION
## Summary

Query Notion Database was capped at `limit` (default 10) records, with no
way to retrieve the rest of a database. This adds a `fetch_all` option
that pages through Notion's data source query API (has_more/next_cursor)
to return every matching record, independent of `limit`.

## Release Notes

- Added a `fetch_all` option to the Query Notion Database tool. When
  enabled, it retrieves every matching record by paginating through
  Notion's API instead of stopping at `limit`.

## Change Type

- [ ] Documentation / non-plugin change
- [X] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

No screenshots included — this change affects the tool node's JSON output (which records are returned), not a visual UI element. Verified locally that enabling `fetch_all` returns every matching record (tested against a 105-record database) regardless of `limit`.

## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [X] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [X] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [X] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)
