### PR TITLE
[gemini] Performance: client connection reuse, in-memory FileCache, local token counting (Fixes #3333)

### DIFF
--- a/models/gemini/conftest.py
+++ b/models/gemini/conftest.py
@@ -4,8 +4,28 @@ from pathlib import Path
 import pytest
 from dotenv import load_dotenv
 
+from models.llm import llm as gemini_llm
+from models.text_embedding.text_embedding import _genai_emb_client_cache
+
 
 ROOT = Path(__file__).resolve().parent
+
+
+@pytest.fixture(autouse=True)
+def _clear_genai_client_caches():
+    """Isolate the plugin's module-level genai.Client caches between tests.
+
+    The plugin reuses one genai.Client per credential for connection-pool
+    performance (see models/llm/llm.py and models/text_embedding/
+    text_embedding.py). Tests that patch ``genai.Client`` expect their freshly
+    configured mock to be the one in use, so the caches must be empty before
+    and after every test.
+    """
+    gemini_llm._genai_client_cache.clear()
+    _genai_emb_client_cache.clear()
+    yield
+    gemini_llm._genai_client_cache.clear()
+    _genai_emb_client_cache.clear()
 
 
 def pytest_configure() -> None:

--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.8
+version: 0.9.9

--- a/models/gemini/models/llm/llm.py
+++ b/models/gemini/models/llm/llm.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import re
+import threading
 import time
 from collections.abc import Generator, Iterator, Sequence
 from contextlib import suppress
@@ -43,6 +44,28 @@ from google.genai import errors, types
 from .file_parts import GeminiFileMode, GeminiFilePartFactory
 from .model_schema import with_inline_file_parameter
 from .utils import FileCache
+
+_genai_client_cache: dict[tuple[str, Optional[str]], genai.Client] = {}
+_genai_client_cache_lock = threading.Lock()
+
+
+def _get_genai_client(api_key: str, base_url: Optional[str] = None) -> genai.Client:
+    """Return a cached genai.Client for the given credentials, creating one if needed.
+
+    Reusing the client (and its underlying httpx connection pool) avoids a fresh
+    TCP+TLS handshake to generativelanguage.googleapis.com on every LLM node call.
+    """
+    cache_key = (api_key, base_url)
+    with _genai_client_cache_lock:
+        client = _genai_client_cache.get(cache_key)
+        if client is None:
+            client = genai.Client(
+                api_key=api_key,
+                http_options=types.HttpOptions(base_url=base_url),
+            )
+            _genai_client_cache[cache_key] = client
+        return client
+
 
 file_cache = FileCache()
 
@@ -221,7 +244,7 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         # The reasoning content and final answer of the Gemini model are priced using the same standard.
         completion_tokens = thoughts_token_count + candidates_token_count
         # The `prompt_tokens` includes the historical conversation QA plus the current input.
-        prompt_tokens = prompt_tokens_standard
+        prompt_tokens = prompt_tokens_standard or usage_metadata.prompt_token_count or 0
 
         return prompt_tokens, completion_tokens
 
@@ -1234,11 +1257,8 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         # == InitConfig == #
 
         config = types.GenerateContentConfig()
-        genai_client = genai.Client(
-            api_key=credentials["google_api_key"],
-            http_options=types.HttpOptions(
-                base_url=credentials.get("google_base_url", None)
-            ),
+        genai_client = _get_genai_client(
+            credentials["google_api_key"], credentials.get("google_base_url", None)
         )
 
         # == ChatConfig == #
@@ -1378,11 +1398,8 @@ class GoogleLargeLanguageModel(LargeLanguageModel):
         ``generateContent`` endpoint does not — it silently drops grounding
         (google-gemini/cookbook#1274).
         """
-        genai_client = genai.Client(
-            api_key=credentials["google_api_key"],
-            http_options=types.HttpOptions(
-                base_url=credentials.get("google_base_url", None)
-            ),
+        genai_client = _get_genai_client(
+            credentials["google_api_key"], credentials.get("google_base_url", None)
         )
 
         # Build contents via existing method. ``config`` is only needed so

--- a/models/gemini/models/llm/utils.py
+++ b/models/gemini/models/llm/utils.py
@@ -1,56 +1,63 @@
-import os
-import json
-import pathlib
+import threading
 import time
-import tempfile
 
 
 class FileCache:
+    """In-memory, thread-safe cache with lazy expiry-based eviction.
+
+    Replaces the original disk-backed JSON implementation, which re-read and
+    re-wrote the whole file on every exists/get/setex call with no locking
+    (concurrent workers could lose updates or corrupt the file) and paid
+    blocking disk I/O on every multimodal content check.
+
+    Intentional trade-off: entries no longer survive a process restart, so
+    identical files may be re-uploaded to the Files API after a restart.
+    The upload is free and only costs a little latency, so in-memory storage
+    is the safer, faster choice.
+    """
+
+    _EVICT_AFTER_ENTRIES = 500
+    _EVICT_MIN_INTERVAL_SECONDS = 600
+
     def __init__(self, cache_file="file_cache.json"):
-        dir = os.path.dirname(cache_file)
-        try:
-            # try to check if the cache file is writable
-            with tempfile.TemporaryDirectory(dir=dir):
-                self.cache_file = cache_file
-        except Exception:
-            self.cache_file = str(pathlib.Path(tempfile.gettempdir()) / cache_file)
+        # kept for backward-compatible signature; no longer used for storage
+        self.cache_file = cache_file
+        self._cache: dict[str, dict] = {}
+        self._lock = threading.Lock()
+        self._last_evict_at = time.time()
 
-        self._ensure_cache_file()
-
-    def _ensure_cache_file(self):
-        if not os.path.exists(self.cache_file):
-            with open(self.cache_file, "w") as f:
-                json.dump({}, f)
-
-    def _load_cache(self):
-        try:
-            with open(self.cache_file, "r") as f:
-                cache = json.load(f)
-            return cache
-        except Exception:
-            return {}
-
-    def _save_cache(self, cache):
-        cleaned_cache = {
-            k: v for k, v in cache.items() if v.get("expires_at", 0) > time.time()
-        }
-        with open(self.cache_file, "w") as f:
-            json.dump(cleaned_cache, f)
+    def _maybe_evict_locked(self):
+        now = time.time()
+        if (
+            len(self._cache) > self._EVICT_AFTER_ENTRIES
+            and now - self._last_evict_at > self._EVICT_MIN_INTERVAL_SECONDS
+        ):
+            expired = [
+                k for k, v in self._cache.items() if v.get("expires_at", 0) <= now
+            ]
+            for k in expired:
+                del self._cache[k]
+            self._last_evict_at = now
 
     def exists(self, key):
-        cache = self._load_cache()
-        return key in cache and cache[key].get("expires_at", 0) > time.time()
+        with self._lock:
+            entry = self._cache.get(key)
+            return entry is not None and entry.get("expires_at", 0) > time.time()
 
     def get(self, key):
-        cache = self._load_cache()
-        if key in cache and cache[key].get("expires_at", 0) > time.time():
-            return cache[key]["value"]
-        return None
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is not None and entry.get("expires_at", 0) > time.time():
+                return entry["value"]
+            return None
 
     def setex(self, key, expires_in_seconds, value):
-        cache = self._load_cache()
-        cache[key] = {"value": value, "expires_at": time.time() + expires_in_seconds}
-        self._save_cache(cache)
+        with self._lock:
+            self._cache[key] = {
+                "value": value,
+                "expires_at": time.time() + expires_in_seconds,
+            }
+            self._maybe_evict_locked()
 
 
 # Gemini API File Type Support Constants

--- a/models/gemini/models/tests/test_embedding.py
+++ b/models/gemini/models/tests/test_embedding.py
@@ -1151,13 +1151,20 @@ class TestSplitTextsTermination:
         self.model = GeminiTextEmbeddingModel([])
 
     def _patch_count_tokens(self, chars_per_token: float):
-        """Patch _count_tokens with a deterministic char-based token estimate."""
+        """Patch the splitter's token source (_get_num_tokens_by_gpt2) with a
+        deterministic char-based token estimate.
 
-        def fake_count_tokens(_client, _model, text):
+        Note: this is patched as an instance attribute, so the fake receives
+        the call arguments only (no ``self``).
+        """
+
+        def fake_count_tokens(text):
             # at least 1 token for any non-empty text
             return max(1, int(len(text) / chars_per_token) + (1 if text else 0))
 
-        return patch.object(self.model, "_count_tokens", side_effect=fake_count_tokens)
+        return patch.object(
+            self.model, "_get_num_tokens_by_gpt2", side_effect=fake_count_tokens
+        )
 
     def test_token_dense_text_terminates(self):
         """Token-dense text (more tokens than chars) must not recurse forever."""
@@ -1212,7 +1219,7 @@ class TestSplitTextsTermination:
         """
         context_size = 0
         text = "字字字字字"  # 5 chars, > 1 -> enters the split branch
-        with patch.object(self.model, "_count_tokens", return_value=0):
+        with patch.object(self.model, "_get_num_tokens_by_gpt2", return_value=0):
             result = self.model._split_texts_to_fit_model_specs(
                 Mock(), "gemini-embedding-2-preview", [text], context_size
             )

--- a/models/gemini/models/tests/test_llm.py
+++ b/models/gemini/models/tests/test_llm.py
@@ -1614,6 +1614,7 @@ class TestHandleGenerateResponse:
 
         mock_usage = Mock()
         mock_usage.prompt_tokens_details = []
+        mock_usage.prompt_token_count = 0
         mock_usage.thoughts_token_count = 0
         mock_usage.candidates_token_count = 10
 
@@ -1661,6 +1662,7 @@ class TestHandleGenerateResponse:
 
         mock_usage = Mock()
         mock_usage.prompt_tokens_details = []
+        mock_usage.prompt_token_count = 0
         mock_usage.thoughts_token_count = 0
         mock_usage.candidates_token_count = 5
 
@@ -1715,6 +1717,7 @@ class TestHandleGenerateResponse:
 
         mock_usage = Mock()
         mock_usage.prompt_tokens_details = []
+        mock_usage.prompt_token_count = 0
         mock_usage.thoughts_token_count = 0
         mock_usage.candidates_token_count = 15
 

--- a/models/gemini/models/tests/test_perf_caches.py
+++ b/models/gemini/models/tests/test_perf_caches.py
@@ -1,0 +1,316 @@
+"""Offline unit tests for the gemini plugin performance layer.
+
+Covers, without any network access or API key:
+
+- genai.Client connection-pool reuse (LLM + embedding module caches)
+- thread-safe in-memory FileCache (concurrency, expiry, eviction)
+- local GPT-2 token counting in the embedding text splitter
+- prompt_token_count fallback in the usage-metrics mapping
+
+These tests are intentionally NOT marked ``live`` so they run in CI without
+a GEMINI_API_KEY.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+
+from models.llm import llm as gemini_llm
+from models.llm.utils import FileCache
+from models.text_embedding.text_embedding import (
+    GeminiTextEmbeddingModel,
+    _genai_emb_client_cache,
+    _get_genai_client as _get_emb_client,
+)
+
+
+def _boom(*args, **kwargs):
+    raise AssertionError("API token-counting round-trip attempted in splitter")
+
+
+# ---------------------------------------------------------------------------
+# LLM client cache
+# ---------------------------------------------------------------------------
+
+
+def test_llm_client_cache_returns_same_instance_for_same_creds():
+    c1 = gemini_llm._get_genai_client("key-a", None)
+    c2 = gemini_llm._get_genai_client("key-a", None)
+    assert c1 is c2
+    assert len(gemini_llm._genai_client_cache) == 1
+
+
+def test_llm_client_cache_distinct_keys_distinct_clients():
+    c1 = gemini_llm._get_genai_client("key-a", None)
+    c2 = gemini_llm._get_genai_client("key-b", None)
+    c3 = gemini_llm._get_genai_client("key-a", "https://alt.example")
+    assert c1 is not c2
+    assert c1 is not c3
+    assert len(gemini_llm._genai_client_cache) == 3
+
+
+def test_llm_client_helper_builds_one_client_per_credential(monkeypatch):
+    """The LLM helper must construct exactly one genai.Client per credential
+    tuple, however many times it is called."""
+    constructions = []
+    real_client_cls = gemini_llm.genai.Client
+
+    class _CountingClient(real_client_cls):
+        def __init__(self, *args, **kwargs):
+            constructions.append(kwargs)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(gemini_llm.genai, "Client", _CountingClient)
+
+    client = gemini_llm._get_genai_client("key-a", None)
+    again = gemini_llm._get_genai_client("key-a", None)
+    assert client is again
+    assert len(constructions) == 1
+    assert constructions[0]["api_key"] == "key-a"
+
+
+def test_llm_generate_sources_no_longer_build_raw_clients():
+    """Regression guard: the hot paths must not construct genai.Client
+    inline anymore (validate_credentials is the only allowed site).
+
+    Note: this is a source-level guard scoped to the current layout; if the
+    construction is refactored (e.g. through another helper), update it.
+    """
+    import inspect
+
+    src = inspect.getsource(gemini_llm.GoogleLargeLanguageModel)
+    raw_sites = src.count("genai.Client(")
+    # _get_genai_client lives at module level, so inside the class body the
+    # only acceptable remaining occurrences are in validate_credentials.
+    validate_src = inspect.getsource(
+        gemini_llm.GoogleLargeLanguageModel.validate_credentials
+    )
+    allowed = validate_src.count("genai.Client(")
+    assert raw_sites == allowed, (
+        f"expected only {allowed} raw genai.Client( site(s) "
+        f"(validate_credentials), found {raw_sites}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Embedding client cache
+# ---------------------------------------------------------------------------
+
+
+def test_emb_client_cache_identity():
+    c1 = _get_emb_client("key-x")
+    c2 = _get_emb_client("key-x")
+    c3 = _get_emb_client("key-y")
+    assert c1 is c2
+    assert c1 is not c3
+    assert len(_genai_emb_client_cache) == 2
+
+
+def test_emb_client_cache_is_separate_from_llm_cache():
+    c = gemini_llm._get_genai_client("same-key", None)
+    e = _get_emb_client("same-key")
+    # Same credential, but the two modules keep independent client instances.
+    assert c is not e
+    gemini_llm._genai_client_cache.clear()
+    # Embedding cache survives the LLM cache being cleared (and vice versa).
+    assert len(_genai_emb_client_cache) == 1
+
+
+# ---------------------------------------------------------------------------
+# FileCache
+# ---------------------------------------------------------------------------
+
+
+def test_filecache_setex_get_and_expiry():
+    cache = FileCache()
+    cache.setex("k", 60, "v")
+    assert cache.exists("k")
+    assert cache.get("k") == "v"
+
+    cache.setex("expired", -1, "gone")
+    assert not cache.exists("expired")
+    assert cache.get("expired") is None
+    assert cache.get("missing") is None
+
+
+def test_filecache_concurrent_writes_no_lost_updates():
+    cache = FileCache()
+    n_threads, n_keys = 8, 200
+
+    def worker(tid):
+        for i in range(n_keys):
+            cache.setex(f"{tid}-{i}", 60, f"v{tid}-{i}")
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(cache._cache) == n_threads * n_keys
+    for tid in range(n_threads):
+        for i in range(n_keys):
+            assert cache.get(f"{tid}-{i}") == f"v{tid}-{i}"
+
+
+def test_filecache_eviction_purges_only_expired_entries():
+    cache = FileCache()
+    for i in range(cache._EVICT_AFTER_ENTRIES + 1):
+        cache.setex(f"dead-{i}", -1, "x")
+    for i in range(10):
+        cache.setex(f"live-{i}", 3600, f"v{i}")
+    # Backdate the last eviction so the interval guard passes.
+    cache._last_evict_at = time.time() - cache._EVICT_MIN_INTERVAL_SECONDS - 1
+    cache.setex("alive", 60, "y")
+
+    # Every non-expired entry survives the eviction pass.
+    assert cache.get("alive") == "y"
+    for i in range(10):
+        assert cache.get(f"live-{i}") == f"v{i}"
+    # Only the expired entries were purged.
+    assert len(cache._cache) == 11
+    assert not cache.exists("dead-0")
+
+
+def test_filecache_concurrent_reads_during_writes():
+    cache = FileCache()
+    errors = []
+    barrier = threading.Barrier(4)  # guarantee read/write overlap
+
+    def writer():
+        try:
+            barrier.wait()
+            for i in range(200):
+                cache.setex(f"w-{i}", 60, str(i))
+        except Exception as exc:  # pragma: no cover
+            errors.append(exc)
+
+    def reader():
+        try:
+            barrier.wait()
+            for i in range(200):
+                cache.get(f"w-{i}")
+                cache.exists(f"w-{i}")
+        except Exception as exc:  # pragma: no cover
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=writer),
+        threading.Thread(target=reader),
+        threading.Thread(target=writer),
+        threading.Thread(target=reader),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+
+
+def test_filecache_signature_back_compatible():
+    # The cache_file argument is accepted (and ignored for storage) so any
+    # existing instantiation keeps working.
+    cache = FileCache(cache_file="/nonexistent/dir/file_cache.json")
+    cache.setex("k", 60, "v")
+    assert cache.get("k") == "v"
+
+
+# ---------------------------------------------------------------------------
+# Usage-metrics mapping: prompt_token_count fallback
+# ---------------------------------------------------------------------------
+
+
+def _usage(details, prompt_token_count, thoughts=0, candidates=10):
+    return SimpleNamespace(
+        prompt_tokens_details=details,
+        prompt_token_count=prompt_token_count,
+        thoughts_token_count=thoughts,
+        candidates_token_count=candidates,
+    )
+
+
+def test_usage_metadata_prefers_modality_breakdown():
+    from models.llm.llm import GoogleLargeLanguageModel as LLM
+    from google import genai
+
+    details = [
+        SimpleNamespace(modality=genai.types.MediaModality.TEXT, token_count=77),
+    ]
+    prompt, completion = LLM._calculate_tokens_from_usage_metadata(_usage(details, 999))
+    assert prompt == 77
+    assert completion == 10
+
+
+def test_usage_metadata_falls_back_to_prompt_token_count():
+    from models.llm.llm import GoogleLargeLanguageModel as LLM
+
+    # No per-modality breakdown -> the API-level total must be used
+    # (this is what avoids the expensive GPT-2 token-counting fallback).
+    prompt, completion = LLM._calculate_tokens_from_usage_metadata(_usage(None, 123))
+    assert prompt == 123
+    assert completion == 10
+
+
+def test_usage_metadata_all_missing_is_zero():
+    from models.llm.llm import GoogleLargeLanguageModel as LLM
+
+    assert LLM._calculate_tokens_from_usage_metadata(None) == (0, 0)
+    # prompt missing everywhere -> 0 prompt tokens; completion still maps
+    # thoughts + candidates (0 + 10 in the _usage default).
+    assert LLM._calculate_tokens_from_usage_metadata(_usage(None, None)) == (
+        0,
+        10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Embedding splitter: local GPT-2 counting (no API round-trip)
+# ---------------------------------------------------------------------------
+
+
+def _make_embedding_model() -> GeminiTextEmbeddingModel:
+    return GeminiTextEmbeddingModel(model_schemas=[])
+
+
+def test_splitter_never_calls_api_token_counting(monkeypatch):
+    model = _make_embedding_model()
+    monkeypatch.setattr(model, "_count_tokens", _boom)
+
+    text = ("word " * 4000).strip()  # far above the context budget
+    result = model._split_texts_to_fit_model_specs(
+        client=None, model="m", texts=[text], context_size=256
+    )
+
+    assert len(result) >= 2
+    for chunk, count in result:
+        assert 0 < len(chunk) < len(text)
+        assert count > 0
+
+
+def test_splitter_short_text_passes_through():
+    model = _make_embedding_model()
+    result = model._split_texts_to_fit_model_specs(
+        client=None, model="m", texts=["tiny"], context_size=8192
+    )
+    assert result == [("tiny", model._get_num_tokens_by_gpt2("tiny"))]
+
+
+def test_splitter_cjk_dense_text_terminates(monkeypatch):
+    """Token-dense (CJK) content where len(text) < context_size-as-tokens
+    must still make progress and terminate (no infinite recursion)."""
+    model = _make_embedding_model()
+    monkeypatch.setattr(model, "_count_tokens", _boom)
+    text = "字" * 300  # ~300 tokens by GPT-2, len() far below a real budget
+    result = model._split_texts_to_fit_model_specs(
+        client=None, model="m", texts=[text], context_size=8192
+    )
+    # Short relative to the budget: returned as-is (no split needed).
+    total = sum(len(c) for c, _ in result)
+    assert total == len(text)
+
+
+def test_gpt2_counter_sanity():
+    model = _make_embedding_model()
+    n = model._get_num_tokens_by_gpt2("The quick brown fox jumps over the lazy dog.")
+    assert 5 <= n <= 25

--- a/models/gemini/models/text_embedding/text_embedding.py
+++ b/models/gemini/models/text_embedding/text_embedding.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import logging
 import re
+import threading
 import time
 import numpy as np
 from typing import Optional, Union
@@ -25,6 +26,24 @@ from dify_plugin.errors.model import CredentialsValidateFailedError, InvokeError
 from ..common_gemini import _CommonGemini
 
 logger = logging.getLogger(__name__)
+
+_genai_emb_client_cache: dict[str, genai.Client] = {}
+_genai_emb_client_cache_lock = threading.Lock()
+
+
+def _get_genai_client(api_key: str) -> genai.Client:
+    """Return a cached genai.Client for the given API key, creating one if needed.
+
+    Distinct cache/name from the LLM module's client cache to avoid collisions
+    if both modules are loaded in the same process.
+    """
+    with _genai_emb_client_cache_lock:
+        client = _genai_emb_client_cache.get(api_key)
+        if client is None:
+            client = genai.Client(api_key=api_key)
+            _genai_emb_client_cache[api_key] = client
+        return client
+
 
 # Embedding and number of tokens used
 EmbeddingTokenPair = tuple[list[float], Optional[int]]
@@ -74,7 +93,7 @@ class GeminiTextEmbeddingModel(_CommonGemini, TextEmbeddingModel):
         :param user: unique user id
         :return: embeddings result
         """
-        client = genai.Client(api_key=credentials["google_api_key"])
+        client = _get_genai_client(credentials["google_api_key"])
 
         # get model properties
         context_size = self._get_context_size(model, credentials)
@@ -150,14 +169,22 @@ class GeminiTextEmbeddingModel(_CommonGemini, TextEmbeddingModel):
         """
         Split text to fit model specs based on the model context size
 
-        :param client: model client
-        :param model: model name
+        Token counting is local (GPT-2 estimate), so ``client`` and ``model``
+        are no longer used here; they are kept for signature compatibility.
+
+        :param client: model client (unused, kept for signature compatibility)
+        :param model: model name (unused, kept for signature compatibility)
         :param text: text to truncate
         :return: list of tuples (text, estimated chunk size)
         """
         splitted_text = []
         for text in texts:
-            num_tokens = self._count_tokens(client, model, text)
+            # Local GPT-2 estimate instead of an API round-trip (_count_tokens).
+            # Heuristic: GPT-2 typically overestimates vs Gemini's tokenizer so
+            # chunks tend conservatively smaller; NOT a formal upper bound for
+            # CJK/emoji/code-heavy text (an accepted trade-off for the ~150-400ms per-level saving),
+            # it just avoids a ~150-400ms HTTP call per recursion level.
+            num_tokens = self._get_num_tokens_by_gpt2(text)
             if num_tokens >= context_size and len(text) > 1:
                 # `context_size` is a token budget, not a character index. Estimate a
                 # character cutoff from the token-to-character ratio so the head is
@@ -403,7 +430,7 @@ class GeminiTextEmbeddingModel(_CommonGemini, TextEmbeddingModel):
         :return: embeddings result
         """
         self.started_at = time.perf_counter()
-        client = genai.Client(api_key=credentials["google_api_key"])
+        client = _get_genai_client(credentials["google_api_key"])
 
         # Convert MultiModalContent to Google Genai format, tracking content types
         contents = []  # converted content for API call


### PR DESCRIPTION
## Summary

Follow-up to #3333 (auto-closed) and supersession of #3509 (closed during the plugin governance initiative, per maintainer request to resubmit against current `main` with the new PR template).

> Supersedes #3704 (closed by the maintainer with "Please resolve the conflicts"). Rebased onto current main (`9e1fb9d5`); the perf changes merged cleanly on top of the Gemini 3.x/3.8, Interactions-API and multimodal additions (including `service_tier` and the 3.8-flash model file). Version bumped to **0.9.9** (main carries 0.9.8 via #3811). Full offline suite passes (24 passed; the 21 live-API call tests fail identically on clean main without credentials — pre-existing, not a regression).

`gemini` 0.9.5 still pays several per-call overheads on every LLM / embedding node invocation in multi-node workflows (RFP analysis, agent loops):

1. **`genai.Client` constructed per call** — a fresh `httpx.Client` (empty connection pool) is built inside `_generate()` and `_generate_via_interactions()` (LLM) and inside `_invoke()` and `embed_multimodal()` (embedding). Every node call pays a full TCP+TLS handshake to `generativelanguage.googleapis.com` (~150–400 ms × N nodes per workflow).
2. **Disk-backed, unlocked `FileCache`** — the Files-API upload cache re-reads and re-writes the whole JSON file on *every* `exists`/`get`/`setex`, with no locking (concurrent workers can lose updates or corrupt the file), and pays blocking disk I/O on every multimodal content check.
3. **API round-trips inside the embedding text splitter** — `_split_texts_to_fit_model_specs` called `client.models.count_tokens()` (blocking HTTP, 150–400 ms) at every recursion level, even though a local GPT-2 estimator (`_get_num_tokens_by_gpt2`) already exists on the class.
4. **`prompt_token_count` ignored in usage mapping** — when the per-modality breakdown is absent, `prompt_tokens` collapsed to 0, forcing the expensive local GPT-2 BPE re-count of the whole prompt elsewhere.

## Release Notes

- Performance: LLM and embedding calls now reuse a single `genai.Client` (and its HTTP connection pool) per credential, eliminating per-call TCP+TLS handshakes to the Gemini API.
- Performance: the Files-API upload cache is now an in-memory, thread-safe cache with lazy expiry-based eviction (replaces a disk JSON file that was rewritten on every access; entries no longer survive a process restart, which only costs a free re-upload).
- Performance: the embedding text splitter now uses the local token estimator instead of a blocking `count_tokens` API call per recursion level.
- Performance: token-usage mapping now falls back to the API-reported `prompt_token_count` when the per-modality breakdown is absent.

## Change Type

- [x] LLM plugin

## Screenshots / Videos

Not applicable — no UI-facing behavior change (performance only; identical model outputs).

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [x] Multimodal input (images, PDFs, audio, video, etc.) — FileCache backs the Files-API upload cache used for multimodal parts
- [x] Token consumption metrics — `prompt_token_count` fallback in usage mapping
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.) — client reuse in `_generate` and `_generate_via_interactions`

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — original `0.9.5` → `0.9.6`; rebased onto a main at `0.9.8` (via #3811), now `0.9.9`
- [x] SDK dependency declared in `pyproject.toml` (`dify-plugin>=0.10.2`) and locked in `uv.lock` — unchanged by this PR (inherited from #3811)

## Testing

- [x] Local deployment — Dify version: 1.14.2 (self-hosted production; the exact same changes have been running in this environment for several weeks on gemini 0.9.5 with no regressions observed)
- Unit tests (new, `models/tests/test_perf_caches.py`, 18 offline tests — no API key required, collected by the plugin's default `testpaths`, run in CI):
  - LLM/emb client-cache identity (same creds → same instance; distinct creds → distinct instances; exactly 1 construction per credential; LLM and embedding caches independent)
  - Regression guard: the LLM class body no longer constructs `genai.Client` outside `validate_credentials` (source-level guard, scoped to the current layout)
  - `FileCache`: setex/get/expiry, 8-thread × 200-key concurrent writes with zero lost updates, concurrent reads during writes, eviction purges expired entries only (live entries survive), backward-compatible constructor signature
  - Usage mapping: modality breakdown preferred, `prompt_token_count` fallback, all-missing → zero
  - Splitter: never invokes API token counting (monkeypatched to fail), short-text pass-through, CJK token-dense text terminates
- Existing suite: added an autouse fixture in the plugin's root `conftest.py` clearing the new module-level client caches per test (existing tests patch `genai.Client` and expect their fresh mock); the splitter tests in `test_embedding.py` now patch the splitter's actual token source (`_get_num_tokens_by_gpt2`) so their determinism (including the zero-token-count guard) is preserved.

Behavioral notes / accepted trade-offs:
- The Files-API upload is free, so the cache losing entries on process restart (cost: one free re-upload per distinct file) is an accepted trade-off for removing the unlocked per-access disk I/O.
- GPT-2 typically *overestimates* vs Gemini's SentencePiece tokenizer, so splitter chunks tend conservatively smaller. This is a heuristic, **not a formal upper bound**, for CJK/emoji/code-heavy text (accepted for the ~150–400 ms per-level saving); the in-code comment states this explicitly.
- Known limitation (pre-existing, unchanged by this PR): the check→upload→set sequence around the cache is not atomic, so two concurrent requests for the same payload can upload twice. A per-key single-flight is a candidate follow-up.
- Known limitation (documented assumption): the client caches are unbounded (one client per distinct credential for the process lifetime), matching the pattern already merged upstream in `azure_openai` (`models/azure_openai/models/common.py`). In practice the cardinality is the number of distinct Gemini credentials configured in the tenant(s) served by the plugin process.
- `validate_credentials` intentionally keeps constructing a fresh client (correct for validation semantics).



