### PR TITLE
fix(bedrock): resolve inference profiles for 4.5-generation Claude models

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.81
+version: 0.0.82
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -472,6 +472,13 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     model_id = model_ids.resolve_japan_profile_id(model_id, region_name)
                 except ValueError as e:
                     raise InvokeError(str(e))
+            elif model_ids.is_claude45_model(model_id):
+                # 4.5-generation models are profile-only too (us./eu./global.,
+                # no apac.) but never got the Claude 5 treatment. See model_ids.
+                try:
+                    model_id = model_ids.resolve_claude45_profile_id(model_id, cross_region, region_name)
+                except ValueError as e:
+                    raise InvokeError(str(e))
             elif cross_region in ('geographic', 'global'):
                 # Cross-region inference enabled
                 prefer_global = (cross_region == 'global')

--- a/models/bedrock/models/llm/model_ids.py
+++ b/models/bedrock/models/llm/model_ids.py
@@ -280,3 +280,54 @@ def get_claude5_fallback_model_id(profile_model_id):
     base = strip_profile_prefix(profile_model_id)
     prefix = profile_model_id[: len(profile_model_id) - len(base)]
     return f"{prefix}{CLAUDE5_REFUSAL_FALLBACK_BASE_ID}"
+
+
+# 4.5-generation Claude models are INFERENCE_PROFILE-only on Bedrock, same as
+# Claude 5, but never got the Claude 5 treatment (#3675). Live-verified
+# (ap-northeast-1, 2026-08-17): us./eu./global. exist, apac. does not.
+CLAUDE45_PROFILE_PREFIXES = {
+    'anthropic.claude-sonnet-4-5-20250929-v1:0': ('us', 'eu'),
+    'anthropic.claude-haiku-4-5-20251001-v1:0': ('us', 'eu'),
+    'anthropic.claude-opus-4-5-20251101-v1:0': ('us', 'eu'),
+    'anthropic.claude-sonnet-4-6': ('us', 'eu'),
+    'anthropic.claude-opus-4-6-v1': ('us', 'eu'),
+    'anthropic.claude-opus-4-7': ('us', 'eu'),
+    'anthropic.claude-opus-4-8': ('us', 'eu'),
+}
+
+
+def is_claude45_model(model_id):
+    """True if model_id is a bare 4.5-generation Claude base model ID."""
+    return model_id in CLAUDE45_PROFILE_PREFIXES
+
+
+def resolve_claude45_profile_id(model_id, cross_region, region_name):
+    """
+    Resolve the inference profile ID for a 4.5-generation Claude model for
+    the 'global'/'geographic' cross-region options; raise a clear error for
+    'disabled' and for a 'geographic' region with no matching geo profile
+    (mirrors resolve_claude5_profile_id).
+
+    :param model_id: bare base model ID
+    :param cross_region: 'global', 'geographic', or 'disabled'
+    :param region_name: AWS region of the caller
+    :raises ValueError: when the combination cannot be served, with a
+        user-actionable message
+    """
+    allowed = CLAUDE45_PROFILE_PREFIXES[model_id]
+    if cross_region == 'global':
+        return f"global.{model_id}"
+    if cross_region == 'geographic':
+        area = get_region_area(region_name)
+        if area in allowed:
+            return f"{area}.{model_id}"
+        alternative = "'japan' or 'global'" if model_id in JP_PROFILE_MODELS else "'global'"
+        raise ValueError(
+            f"{model_id} has no '{area or region_name}' geographic inference profile. "
+            f"From {region_name} set Cross-Region Inference to {alternative}."
+        )
+    raise ValueError(
+        f"{model_id} can only be invoked through an inference profile. "
+        f"Set Cross-Region Inference to 'global' (recommended) or 'geographic'"
+        + (", or 'japan'." if model_id in JP_PROFILE_MODELS else ".")
+    )

--- a/models/bedrock/tests/test_claude45_model_ids.py
+++ b/models/bedrock/tests/test_claude45_model_ids.py
@@ -1,0 +1,106 @@
+"""Unit tests for the 4.5-generation Claude (Sonnet/Haiku 4.5, Sonnet/Opus 4.6,
+Opus 4.7/4.8) helpers in model_ids.py.
+
+model_ids.py has no third-party imports, so we load it directly by path:
+no dify_plugin or boto3 required.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODEL_IDS_PATH = (
+    Path(__file__).resolve().parent.parent / "models" / "llm" / "model_ids.py"
+)
+_spec = importlib.util.spec_from_file_location("model_ids", _MODEL_IDS_PATH)
+model_ids = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(model_ids)
+
+SONNET46 = "anthropic.claude-sonnet-4-6"
+OPUS46 = "anthropic.claude-opus-4-6-v1"
+TOKYO = "ap-northeast-1"
+
+
+class TestIsClaude45:
+    def test_bare_ids(self):
+        for model_id in model_ids.CLAUDE45_PROFILE_PREFIXES:
+            assert model_ids.is_claude45_model(model_id)
+
+    def test_other_models_are_not_claude45(self):
+        assert not model_ids.is_claude45_model("anthropic.claude-sonnet-4-20250514-v1:0")
+        assert not model_ids.is_claude45_model("anthropic.claude-sonnet-5")
+        assert not model_ids.is_claude45_model("anthropic.claude-3-haiku-20240307-v1:0")
+
+
+class TestResolveProfileId:
+    def test_global_works_from_apac_region(self):
+        # This is the issue's #1 dead end: 'disabled' always fails for these
+        # models, and 'global' is the documented way out.
+        assert (
+            model_ids.resolve_claude45_profile_id(SONNET46, "global", TOKYO)
+            == f"global.{SONNET46}"
+        )
+
+    @pytest.mark.parametrize("region", ["us-east-1", "us-west-2"])
+    def test_geographic_us_regions(self, region):
+        assert (
+            model_ids.resolve_claude45_profile_id(SONNET46, "geographic", region)
+            == f"us.{SONNET46}"
+        )
+
+    @pytest.mark.parametrize("region", ["eu-central-1", "eu-west-1"])
+    def test_geographic_eu_regions(self, region):
+        assert (
+            model_ids.resolve_claude45_profile_id(SONNET46, "geographic", region)
+            == f"eu.{SONNET46}"
+        )
+
+    def test_geographic_apac_region_raises_and_mentions_japan(self):
+        # Issue's #2 dead end: ap-northeast-1 resolves to 'apac', and no
+        # apac. profile exists for this generation. SONNET46 has a jp.
+        # profile, so the error should point at it.
+        with pytest.raises(ValueError, match="japan"):
+            model_ids.resolve_claude45_profile_id(SONNET46, "geographic", TOKYO)
+
+    def test_geographic_apac_region_without_jp_profile_omits_japan(self):
+        # OPUS46 has no jp. profile (not in JP_PROFILE_MODELS): the error
+        # must not suggest an option that will also fail.
+        assert OPUS46 not in model_ids.JP_PROFILE_MODELS
+        with pytest.raises(ValueError) as excinfo:
+            model_ids.resolve_claude45_profile_id(OPUS46, "geographic", TOKYO)
+        assert "japan" not in str(excinfo.value)
+
+    def test_disabled_raises(self):
+        with pytest.raises(ValueError, match="inference profile"):
+            model_ids.resolve_claude45_profile_id(SONNET46, "disabled", TOKYO)
+
+    def test_disabled_from_us_region_also_raises(self):
+        # The bug is generation-wide, not region-specific: on-demand is not
+        # offered anywhere for these models, regardless of the caller's region.
+        with pytest.raises(ValueError, match="inference profile"):
+            model_ids.resolve_claude45_profile_id(SONNET46, "disabled", "us-east-1")
+
+
+class TestExistingBehaviorUnchanged:
+    """Sibling generations must resolve exactly as before this fix."""
+
+    def test_claude5_untouched(self):
+        assert (
+            model_ids.resolve_claude5_profile_id("anthropic.claude-sonnet-5", "global", TOKYO)
+            == "global.anthropic.claude-sonnet-5"
+        )
+
+    def test_claude4_0_not_claude45(self):
+        # Sonnet 4 (2025-05) supports on-demand and an apac. profile; it must
+        # not be swept into the 4.5-generation profile-only handling.
+        assert not model_ids.is_claude45_model("anthropic.claude-sonnet-4-20250514-v1:0")
+
+    def test_japan_cross_region_unaffected(self):
+        # 'japan' is resolved by resolve_japan_profile_id before is_claude45_model
+        # is ever consulted in the dispatch (see llm.py); this test pins the
+        # data these two helpers agree on so a future edit cannot desync them.
+        assert SONNET46 in model_ids.CLAUDE45_PROFILE_PREFIXES
+        assert SONNET46 in model_ids.JP_PROFILE_MODELS
+        assert (
+            model_ids.resolve_japan_profile_id(SONNET46, TOKYO) == f"jp.{SONNET46}"
+        )


### PR DESCRIPTION
## Summary

`_get_model_info` in the Bedrock LLM never learned about the 4.5-generation
Claude models (Sonnet/Haiku 4.5, Sonnet/Opus 4.6, Opus 4.7/4.8). All of
them are INFERENCE_PROFILE-only on Bedrock, exactly like Claude 5, but
only Claude 5 got a dedicated resolver.

Two dead ends result: `disabled` cross-region falls through to the bare
model ID and always fails with `ValidationException`, and `geographic`
from an APAC region (e.g. `ap-northeast-1`) resolves to a nonexistent
`apac.` profile, since none of these models have one.

Root cause confirmed by reading the dispatch at HEAD and by a live
simulation against the current `main` code (below); fix mirrors the
existing `resolve_claude5_profile_id` shape and wires it into the
dispatch, ahead of the generic geographic/global branch so it also
covers `disabled`.

Fixes #3675

## Release Notes

Fixed: 4.5-generation Claude models (Sonnet/Haiku 4.5, Sonnet/Opus 4.6,
Opus 4.7/4.8) on Bedrock now resolve `Global` and `Geographic`
cross-region inference correctly, and `Disabled` (or an unsupported
geographic region) now raises a clear error instead of a raw AWS
`ValidationException`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable: this is a server-side model-ID resolution fix with no UI surface.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user <-> assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`): `0.0.81` to `0.0.82`
- [x] `dify_plugin>=0.10.0` already declared in `pyproject.toml` and locked in `uv.lock`; unchanged by this PR

## Testing

Reproduced both dead ends against unmodified `main` (`36d69cff`) by driving the
plugin's own dispatch logic directly (no live AWS call needed, since the bug
is in ID resolution before the request is built): `disabled` fell through to
the bare model ID, `geographic` from `ap-northeast-1` built the invalid ID
`apac.anthropic.claude-sonnet-4-6`.

New `tests/test_claude45_model_ids.py` (14 tests) pins both fixed dead ends
plus the unaffected paths (`global`, `geographic` from `us-`/`eu-` regions,
`japan`, Claude 5, an ordinary Claude 3 model); 13 of 14 fail on unmodified
`main` and all 14 pass on this branch, verified both ways in a clean
`python:3.12-slim` container.

Full plugin suite (198 tests, including the new ones) run the same way CI's
`pre-pr-check-per-plugin.yaml` `test` job does: packaged with the real
`dify` CLI, extracted the `.difypkg`, `uv sync --all-groups --frozen
--python 3.12`, `uv run --frozen --with pytest pytest`. All 198 pass.

Not checked: a live AWS Bedrock call. The fix only changes which model ID
is built before the request is sent; it does not touch the request itself.

- [ ] Local deployment - Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)
