### PR TITLE
feat(outlook): add Search Events calendar tool

### DIFF
--- a/tools/outlook/README.md
+++ b/tools/outlook/README.md
@@ -18,6 +18,7 @@ Dify's integration with Microsoft Outlook (via Microsoft Graph) for **email and 
 ### Calendar (new in 0.3.0)
 - **List Calendars** — list your calendars.
 - **List Events** — list upcoming events (optionally from a specific calendar).
+- **Search Events** — find events by keyword and/or a date range (new in 0.6.0).
 - **Create Event** — create a meeting/appointment (supports attendees, location and a Teams online meeting).
 - **Get Event** — get a single event by ID.
 - **Update Event** — update fields of an event.

--- a/tools/outlook/manifest.yaml
+++ b/tools/outlook/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.4.0
+version: 0.6.0
 type: plugin
 author: langgenius
 name: outlook

--- a/tools/outlook/provider/outlook.yaml
+++ b/tools/outlook/provider/outlook.yaml
@@ -115,6 +115,7 @@ tools:
   - tools/flag_message.yaml
   - tools/list_calendars.yaml
   - tools/list_events.yaml
+  - tools/search_events.yaml
   - tools/create_event.yaml
   - tools/get_event.yaml
   - tools/update_event.yaml

--- a/tools/outlook/tools/search_events.py
+++ b/tools/outlook/tools/search_events.py
@@ -1,0 +1,143 @@
+from collections.abc import Generator
+from typing import Any
+from datetime import datetime, timedelta, timezone
+import requests
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+GRAPH = "https://graph.microsoft.com/v1.0"
+SELECT = "id,subject,start,end,organizer,location,webLink,bodyPreview"
+
+
+class SearchEventsTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+        """
+        Search calendar events by keyword and/or date range via Microsoft Graph.
+
+        - Date range given  -> calendarView(start, end), ordered by start time.
+        - Keyword only       -> /me/events?$search="query".
+        - Both               -> calendarView for the range, then keyword-filtered
+          client-side (Graph cannot combine $search with a date filter).
+        """
+        try:
+            query = (tool_parameters.get("query") or "").strip()
+            start_date = (tool_parameters.get("start_date") or "").strip()
+            end_date = (tool_parameters.get("end_date") or "").strip()
+            calendar_id = (tool_parameters.get("calendar_id") or "").strip()
+            try:
+                limit = int(tool_parameters.get("limit") or 25)
+            except (TypeError, ValueError):
+                limit = 25
+            if limit < 1 or limit > 100:
+                yield self.create_text_message("Limit must be between 1 and 100.")
+                return
+
+            if not query and not start_date and not end_date:
+                yield self.create_text_message(
+                    "Provide a keyword (query) and/or a date range (start_date/end_date) to search events."
+                )
+                return
+
+            access_token = self.runtime.credentials.get("access_token")
+            if not access_token:
+                yield self.create_text_message("Access token is required in credentials.")
+                return
+
+            headers = {
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            }
+
+            use_range = bool(start_date or end_date)
+            if use_range:
+                start_iso = self._to_iso(start_date, end_of_day=False) or self._now_iso()
+                end_iso = self._to_iso(end_date, end_of_day=True) or self._plus_days_iso(start_iso, 365)
+                base = (
+                    f"{GRAPH}/me/calendars/{calendar_id}/calendarView"
+                    if calendar_id else f"{GRAPH}/me/calendarView"
+                )
+                params = {
+                    "startDateTime": start_iso,
+                    "endDateTime": end_iso,
+                    "$orderby": "start/dateTime",
+                    # Fetch a full page when we still have to keyword-filter client-side.
+                    "$top": 100 if query else limit,
+                    "$select": SELECT,
+                }
+            else:
+                base = f"{GRAPH}/me/calendars/{calendar_id}/events" if calendar_id else f"{GRAPH}/me/events"
+                params = {
+                    "$search": f'"{query}"',
+                    "$top": limit,
+                    "$select": SELECT,
+                }
+                headers["ConsistencyLevel"] = "eventual"  # required for $search
+
+            try:
+                resp = requests.get(base, headers=headers, params=params, timeout=30)
+            except requests.exceptions.RequestException as e:
+                yield self.create_text_message(f"Network error: {str(e)}")
+                return
+
+            if resp.status_code == 401:
+                yield self.create_text_message("Authentication failed. Token may be expired.")
+                return
+            if resp.status_code == 403:
+                yield self.create_text_message("Access denied. Check calendar permissions and admin consent.")
+                return
+            if resp.status_code < 200 or resp.status_code >= 300:
+                yield self.create_text_message(f"API error {resp.status_code}: {resp.text}")
+                return
+
+            events = resp.json().get("value", [])
+
+            # Graph can't combine $search with a date range, so when both are given
+            # we pull the range from calendarView and filter by keyword here.
+            if use_range and query:
+                q = query.lower()
+                events = [
+                    e for e in events
+                    if q in (e.get("subject") or "").lower()
+                    or q in (e.get("bodyPreview") or "").lower()
+                ][:limit]
+
+            if not events:
+                yield self.create_text_message("No matching events found.")
+                return
+
+            lines = []
+            for e in events:
+                start = (e.get("start") or {}).get("dateTime")
+                end = (e.get("end") or {}).get("dateTime")
+                lines.append(f"- {e.get('subject')} [{start} - {end}] (id: {e.get('id')})")
+            yield self.create_text_message(f"Found {len(events)} event(s):\n" + "\n".join(lines))
+            yield self.create_json_message({"total_count": len(events), "events": events})
+
+        except Exception as e:
+            yield self.create_text_message(f"Error: {str(e)}")
+            return
+
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    @staticmethod
+    def _to_iso(value: str, end_of_day: bool) -> str:
+        """Normalize a user date/datetime into an ISO 8601 string Graph accepts."""
+        v = (value or "").strip()
+        if not v:
+            return ""
+        if "T" not in v:  # date only, e.g. 2026-09-01
+            return v + ("T23:59:59Z" if end_of_day else "T00:00:00Z")
+        if v.endswith("Z") or "+" in v:
+            return v
+        return v + "Z"
+
+    @staticmethod
+    def _plus_days_iso(start_iso: str, days: int) -> str:
+        try:
+            base = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
+        except Exception:
+            base = datetime.now(timezone.utc)
+        return (base + timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tools/outlook/tools/search_events.yaml
+++ b/tools/outlook/tools/search_events.yaml
@@ -1,0 +1,98 @@
+identity:
+  name: search_events
+  display_name: Search Events
+  author: Dify
+  label:
+    en_US: Search Events
+    zh_Hans: 搜索事件
+    pt_BR: Pesquisar Eventos
+    ja_JP: イベントを検索
+description:
+  human:
+    en_US: Search calendar events by keyword and/or date range
+    zh_Hans: 按关键词和/或日期范围搜索日历事件
+    pt_BR: Pesquisar eventos de calendário por palavra-chave e/ou intervalo de datas
+    ja_JP: キーワードや日付範囲でカレンダーイベントを検索
+  llm: Search the user's Outlook calendar events using Microsoft Graph. Provide a keyword (matches subject/body) and/or a date range (start_date/end_date). Giving both narrows a date range by keyword.
+parameters:
+  - name: query
+    type: string
+    required: false
+    label:
+      en_US: Keyword
+      zh_Hans: 关键词
+      pt_BR: Palavra-chave
+      ja_JP: キーワード
+    human_description:
+      en_US: Keyword to match against event subject and body
+      zh_Hans: 用于匹配事件标题和正文的关键词
+      pt_BR: Palavra-chave para corresponder ao assunto e corpo do evento
+      ja_JP: イベントの件名・本文に一致させるキーワード
+    llm_description: Keyword to search event subject and body. Optional if a date range is given.
+    form: llm
+  - name: start_date
+    type: string
+    required: false
+    label:
+      en_US: Start Date
+      zh_Hans: 开始日期
+      pt_BR: Data de Início
+      ja_JP: 開始日
+    human_description:
+      en_US: Start of the date range (e.g. 2026-09-01 or 2026-09-01T09:00:00Z)
+      zh_Hans: 日期范围的开始（如 2026-09-01 或 2026-09-01T09:00:00Z）
+      pt_BR: Início do intervalo de datas (ex. 2026-09-01 ou 2026-09-01T09:00:00Z)
+      ja_JP: 日付範囲の開始（例 2026-09-01 または 2026-09-01T09:00:00Z）
+    llm_description: Optional start of the date range, ISO date or datetime. If only start is given, the range extends one year forward.
+    form: llm
+  - name: end_date
+    type: string
+    required: false
+    label:
+      en_US: End Date
+      zh_Hans: 结束日期
+      pt_BR: Data de Fim
+      ja_JP: 終了日
+    human_description:
+      en_US: End of the date range (e.g. 2026-09-30 or 2026-09-30T18:00:00Z)
+      zh_Hans: 日期范围的结束（如 2026-09-30 或 2026-09-30T18:00:00Z）
+      pt_BR: Fim do intervalo de datas (ex. 2026-09-30 ou 2026-09-30T18:00:00Z)
+      ja_JP: 日付範囲の終了（例 2026-09-30 または 2026-09-30T18:00:00Z）
+    llm_description: Optional end of the date range, ISO date or datetime. If only end is given, the range starts from now.
+    form: llm
+  - name: limit
+    type: number
+    required: false
+    default: 25
+    min: 1
+    max: 100
+    label:
+      en_US: Limit
+      zh_Hans: 数量
+      pt_BR: Limite
+      ja_JP: 件数
+    human_description:
+      en_US: Maximum number of events to return
+      zh_Hans: 要返回的最大事件数
+      pt_BR: Número máximo de eventos a retornar
+      ja_JP: 返すイベントの最大数
+    llm_description: Maximum number of events to return, between 1 and 100, default is 25.
+    form: llm
+  - name: calendar_id
+    type: string
+    required: false
+    label:
+      en_US: Calendar ID
+      zh_Hans: 日历 ID
+      pt_BR: ID do Calendário
+      ja_JP: カレンダー ID
+    human_description:
+      en_US: The ID of the calendar to search; defaults to the primary calendar
+      zh_Hans: 要搜索的日历 ID；默认为主日历
+      pt_BR: O ID do calendário a pesquisar; o padrão é o calendário principal
+      ja_JP: 検索するカレンダーの ID。デフォルトはプライマリカレンダー
+    llm_description: The ID of the calendar to search. If omitted, the primary calendar is used.
+    form: llm
+extra:
+  python:
+    source: tools/search_events.py


### PR DESCRIPTION
## Summary

Adds a **Search Events** tool to the Outlook plugin (`tools/outlook`) so agents can find calendar events by keyword and/or date range — complementing the existing List Events tool.

**Behavior**
- **Keyword** (`query`) — matches event subject/body via Microsoft Graph `$search`.
- **Date range** (`start_date` / `end_date`) — uses Graph `calendarView` (handles recurring-event expansion). Accepts ISO dates or datetimes; giving only one bound extends sensibly (start → +1 year; end → from now).
- **Both** — pulls the date range, then keyword-filters client-side, since Graph can't combine `$search` with a date filter.
- Plus `limit` (1–100, default 25) and optional `calendar_id`.

No changes to existing tools; this is purely additive.

## Release Notes

Added a **Search Events** calendar tool: search Outlook calendar events by keyword and/or date range, with an optional result limit and calendar selection.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — `0.4.0` → `0.6.0`
- [x] `dify_plugin` is declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [x] Local deployment — plugin packages and loads; the new tool registers and enumerates.
- [ ] SaaS (cloud.dify.ai)
