### PR TITLE
feat(aihubmix): add new AIHubMix models

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.43
+version: 0.0.44
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/_position.yaml
+++ b/models/aihubmix/models/llm/_position.yaml
@@ -1,3 +1,11 @@
+- glm-5.3-flash
+- gemini-3.7-flash
+- glm-5.3
+- qwen3.8-2.4t-a95b
+- grok-4.6
+- deepseek-v4-pro-0813
+- deepseek-v4-flash-0731
+- qwen3.7-flash
 - gpt-5.6-sol
 - gpt-5.6-luna
 - gpt-5.6-terra

--- a/models/aihubmix/models/llm/deepseek-v4-flash-0731.yaml
+++ b/models/aihubmix/models/llm/deepseek-v4-flash-0731.yaml
@@ -1,0 +1,50 @@
+model: deepseek-v4-flash-0731
+label:
+  en_US: DeepSeek V4 Flash 0731
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 4096
+    min: 1
+    max: 384000
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - low
+      - high
+      - max
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.142'
+  output: '0.284'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/deepseek-v4-pro-0813.yaml
+++ b/models/aihubmix/models/llm/deepseek-v4-pro-0813.yaml
@@ -1,0 +1,50 @@
+model: deepseek-v4-pro-0813
+label:
+  en_US: DeepSeek V4 Pro 0813
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - multi-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 4096
+    min: 1
+    max: 384000
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - low
+      - high
+      - max
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.6918'
+  output: '2.0754'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/gemini-3.7-flash.yaml
+++ b/models/aihubmix/models/llm/gemini-3.7-flash.yaml
@@ -1,0 +1,94 @@
+model: gemini-3.7-flash
+label:
+  en_US: Gemini 3.7 Flash
+model_type: llm
+features:
+  - tool-call
+  - multi-tool-call
+  - agent-thought
+  - vision
+  - stream-tool-call
+  - document
+  - video
+  - audio
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: include_thoughts
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Include thoughts
+      zh_Hans: 返回思考过程
+  - name: media_resolution
+    type: string
+    required: true
+    default: Default
+    options:
+      - Default
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Media resolution
+      zh_Hans: 媒体分辨率
+  - name: thinking_level
+    type: string
+    required: true
+    default: Medium
+    options:
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Thinking level
+      zh_Hans: 思考层级
+  - name: grounding
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Grounding
+      zh_Hans: 事实核查
+  - name: url_context
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: URL context
+      zh_Hans: 链接详情
+  - name: code_execution
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Code execution
+      zh_Hans: 代码执行
+  - name: max_output_tokens
+    use_template: max_tokens
+    type: int
+    required: true
+    default: 65536
+    min: 1
+    max: 65536
+  - name: service_tier
+    type: string
+    required: true
+    default: standard
+    options:
+      - flex
+      - standard
+      - priority
+    label:
+      en_US: Service tier
+      zh_Hans: 服务等级
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '0.75'
+  output: '3.75'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/glm-5.3-flash.yaml
+++ b/models/aihubmix/models/llm/glm-5.3-flash.yaml
@@ -1,0 +1,44 @@
+model: glm-5.3-flash
+label:
+  en_US: GLM 5.3 Flash
+model_type: llm
+features:
+  - vision
+  - video
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    default: 65536
+    min: 1
+    max: 128000
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: max
+    options:
+      - low
+      - high
+      - max
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '0.11268'
+  output: '0.39438'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/glm-5.3.yaml
+++ b/models/aihubmix/models/llm/glm-5.3.yaml
@@ -1,0 +1,42 @@
+model: glm-5.3
+label:
+  en_US: GLM 5.3
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: max_tokens
+    use_template: max_tokens
+    default: 65536
+    min: 1
+    max: 128000
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: max
+    options:
+      - low
+      - high
+      - max
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '1.1268'
+  output: '3.9438'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/grok-4.6.yaml
+++ b/models/aihubmix/models/llm/grok-4.6.yaml
@@ -1,0 +1,51 @@
+model: grok-4.6
+label:
+  en_US: Grok 4.6
+model_type: llm
+features:
+  - vision
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 500000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    default: 1.0
+    min: 0.0
+    max: 2.0
+  - name: top_p
+    use_template: top_p
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    default: high
+    options:
+      - low
+      - medium
+      - high
+      - xhigh
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '2'
+  output: '6'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/qwen3-vl-235b-a22b-instruct.yaml
+++ b/models/aihubmix/models/llm/qwen3-vl-235b-a22b-instruct.yaml
@@ -11,7 +11,7 @@ features:
   - video
 model_properties:
   mode: chat
-  context_size: 131072
+  context_size: 131000
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -27,7 +27,7 @@ parameter_rules:
     type: int
     default: 8192
     min: 1
-    max: 32768
+    max: 33000
     help:
       zh_Hans: 用于指定模型在生成内容时token的最大数量，它定义了生成的上限，但不保证每次都会生成到这个数量。
       en_US: It is used to specify the maximum number of tokens when the model generates content. It defines the upper limit of generation, but does not guarantee that this number will be generated every time.

--- a/models/aihubmix/models/llm/qwen3.7-flash.yaml
+++ b/models/aihubmix/models/llm/qwen3.7-flash.yaml
@@ -1,0 +1,70 @@
+model: qwen3.7-flash
+label:
+  en_US: Qwen3.7 Flash
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 991000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    type: float
+    default: 0.3
+    min: 0.0
+    max: 2.0
+  - name: max_completion_tokens
+    use_template: max_tokens
+    type: int
+    default: 8192
+    min: 1
+    max: 64000
+  - name: top_p
+    use_template: top_p
+    type: float
+    default: 0.8
+    min: 0.1
+    max: 0.9
+  - name: top_k
+    type: int
+    min: 0
+    max: 99
+  - name: seed
+    type: int
+    required: false
+    default: 1234
+  - name: repetition_penalty
+    type: float
+    required: false
+    default: 1.1
+  - name: enable_search
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 联网搜索
+      en_US: Web Search
+  - name: enable_thinking
+    type: boolean
+    required: false
+    default: false
+    label:
+      zh_Hans: 深度思考
+      en_US: Deep Thinking
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: '0.0282'
+  output: '0.1128'
+  unit: '0.000001'
+  currency: USD

--- a/models/aihubmix/models/llm/qwen3.8-2.4t-a95b.yaml
+++ b/models/aihubmix/models/llm/qwen3.8-2.4t-a95b.yaml
@@ -1,0 +1,50 @@
+model: qwen3.8-2.4t-a95b
+label:
+  en_US: Qwen3.8 2.4T A95B
+model_type: llm
+features:
+  - vision
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 262000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+  - name: top_p
+    use_template: top_p
+  - name: max_tokens
+    use_template: max_tokens
+    default: 4096
+    min: 1
+    max: 262000
+  - name: reasoning_effort
+    label:
+      zh_Hans: 推理强度
+      en_US: Reasoning Effort
+    type: string
+    required: false
+    options:
+      - low
+      - medium
+      - xhigh
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    required: false
+    options:
+      - text
+      - json_object
+      - json_schema
+  - name: json_schema
+    use_template: json_schema
+pricing:
+  input: '2'
+  output: '6'
+  unit: '0.000001'
+  currency: USD


### PR DESCRIPTION
## Summary

Add eight newly available AIHubMix LLM models to the official Dify AIHubMix plugin and align the existing Qwen3-VL limits with the current model facts. This is backward-compatible and keeps existing models unchanged.

## Release Notes

- Add Gemini 3.7 Flash, DeepSeek V4 Flash 0731, DeepSeek V4 Pro 0813, Grok 4.6, Qwen3.8 2.4T A95B, Qwen3.7 Flash, GLM 5.3, and GLM 5.3 Flash.
- Update the plugin version to 0.0.44.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin
- [x] LLM plugin

## Screenshots / Videos

Not applicable; this change adds model metadata and parameter configuration.

## LLM Plugin Checklist

- [x] Message flow
- [x] Other LLM functionality (reasoning / model parameter paths)
- [x] New models / model parameter fixes

## Version

- [x] Bumped top-level version in manifest.yaml
- [x] Existing dify_plugin dependency and uv.lock remain unchanged

## Testing

- [x] Local deployment — Dify version: 1.16.1
- [ ] SaaS (cloud.dify.ai)

Validation completed:

- `pytest models/aihubmix/tests -q`: 6 passed
- Python compileall and staged diff checks passed
- Local Dify plugin package import succeeded (`0.0.42 -> 0.0.44`)
- Dify model list increased from 246 to 254; all eight new models were searchable
- Dify UI smoke calls succeeded for GLM 5.3 Flash and DeepSeek V4 Pro 0813 via the AIHubMix provider