### PR TITLE
fix(self_refine_agent): repair tool invocation and feed results back

### DIFF
--- a/agent-strategies/self_refine_agent/manifest.yaml
+++ b/agent-strategies/self_refine_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 type: plugin
 author: "langgenius"
 name: "self_refine_agent"

--- a/agent-strategies/self_refine_agent/strategies/self_refine.py
+++ b/agent-strategies/self_refine_agent/strategies/self_refine.py
@@ -14,12 +14,11 @@ from dify_plugin.entities.model.message import (
     ToolPromptMessage,
     UserPromptMessage
 )
-from dify_plugin.entities.tool import ToolInvokeMessage, ToolProviderType
+from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.interfaces.agent import (
     AgentModelConfig,
     AgentStrategy,
-    ToolEntity,
-    ToolInvokeMeta
+    ToolEntity
 )
 from pydantic import BaseModel, Field
 
@@ -279,66 +278,42 @@ class SelfRefineStrategy(AgentStrategy):
         )
 
         # Prepare tools
-        prompt_tools = self._init_prompt_tools(params.tools) if params.tools else []
+        prompt_tools = self._init_prompt_tools(params.tools)
+        has_tools = bool(params.tools)
 
-        # Invoke LLM
-        yield self.create_log_message(
-            label=f"Invoking {params.model.model}",
-            data={},
-            status=ToolInvokeMessage.LogMessage.LogStatus.START
-        )
-
+        # One execution attempt is itself a loop: the model may call tools, read
+        # the observations and then continue. `maximum_iterations` bounds the
+        # number of model calls so a model that keeps calling tools cannot spin
+        # forever.
+        max_rounds = max(1, params.maximum_iterations) if has_tools else 1
+        metadata = ExecutionMetadata()
+        final_output = ""
+        observations: list[str] = []
         started_at = time.perf_counter()
 
-        try:
-            chunks = self.session.model.llm.invoke(
-                model_config=model_config,
-                prompt_messages=prompt_messages,
-                stream=stream,
-                tools=prompt_tools,
-                stop=[]
+        for round_number in range(1, max_rounds + 1):
+            yield self.create_log_message(
+                label=f"Invoking {params.model.model}",
+                data={"round": round_number},
+                status=ToolInvokeMessage.LogMessage.LogStatus.START
             )
 
-            # Collect response
-            response_text = ""
-            tool_calls: list[tuple[str, str, dict[str, Any]]] = []
-            usage: Optional[LLMUsage] = None
+            try:
+                chunks = self.session.model.llm.invoke(
+                    model_config=model_config,
+                    prompt_messages=prompt_messages,
+                    stream=stream,
+                    tools=prompt_tools,
+                    stop=[]
+                )
 
-            if stream and isinstance(chunks, Generator):
-                for chunk in chunks:
-                    if chunk.delta and chunk.delta.message and chunk.delta.message.content:
-                        response_text += chunk.delta.message.get_text_content()
+                response_text, tool_calls, usage = self._collect_response(chunks, stream)
 
-                    if chunk.delta and chunk.delta.message and chunk.delta.message.tool_calls:
-                        for tool_call in chunk.delta.message.tool_calls:
-                            if tool_call.function:
-                                tool_calls.append((
-                                    tool_call.id or "",
-                                    tool_call.function.name,
-                                    json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
-                                ))
+            except Exception as e:
+                logger.error(f"LLM invocation failed: {e}")
+                raise
 
-                    if chunk.delta and chunk.delta.usage:
-                        usage = chunk.delta.usage
-            else:
-                result = chunks if isinstance(chunks, LLMResult) else next(chunks)
-                if result.message and result.message.content:
-                    response_text = result.message.get_text_content()
-
-                if result.message and result.message.tool_calls:
-                    for tool_call in result.message.tool_calls:
-                        if tool_call.function:
-                            tool_calls.append((
-                                tool_call.id or "",
-                                tool_call.function.name,
-                                json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
-                            ))
-
-                usage = result.usage
-
-            elapsed_time = time.perf_counter() - started_at
-            metadata = ExecutionMetadata.from_llm_usage(usage)
-            metadata.latency = elapsed_time
+            self._accumulate_usage(metadata, usage)
 
             yield self.create_log_message(
                 label=f"{params.model.model} Response",
@@ -349,42 +324,147 @@ class SelfRefineStrategy(AgentStrategy):
                 status=ToolInvokeMessage.LogMessage.LogStatus.SUCCESS
             )
 
-            # Execute tool calls if any
-            final_output = response_text
+            if response_text:
+                final_output = response_text
 
-            if tool_calls and params.tools:
-                tool_results = yield from self._execute_tools(
-                    tool_calls=tool_calls,
-                    tools=params.tools
+            if not tool_calls or not has_tools:
+                break
+
+            # Same rule as the official cot_agent: on the last of several rounds
+            # there is no round left to consume the observations, so stop instead
+            # of running tools whose results would be discarded.
+            if round_number == max_rounds and max_rounds > 1:
+                logger.warning(f"Hit maximum_iterations={max_rounds} with tool calls still pending")
+                yield self.create_log_message(
+                    label="Maximum Iterations Reached",
+                    data={"maximum_iterations": max_rounds},
+                    status=ToolInvokeMessage.LogMessage.LogStatus.ERROR
+                )
+                break
+
+            # Record what the model asked for, then hand the observations back to
+            # it. Without this the model never sees any tool output.
+            prompt_messages.append(
+                AssistantPromptMessage(
+                    content=response_text,
+                    tool_calls=[
+                        AssistantPromptMessage.ToolCall(
+                            id=call_id,
+                            type="function",
+                            function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                                name=tool_name,
+                                arguments=json.dumps(tool_params, ensure_ascii=False)
+                            )
+                        )
+                        for call_id, tool_name, tool_params in tool_calls
+                    ]
+                )
+            )
+
+            observations = yield from self._execute_tools(
+                tool_calls=tool_calls,
+                tools=params.tools or []
+            )
+
+            for (call_id, tool_name, _), observation in zip(tool_calls, observations):
+                prompt_messages.append(
+                    ToolPromptMessage(
+                        content=observation,
+                        tool_call_id=call_id,
+                        name=tool_name
+                    )
                 )
 
-                # Append tool results to output
-                if tool_results:
-                    final_output += "\n\n[Tool Results]\n" + "\n".join(tool_results)
+        # With maximum_iterations=1 the model never gets a round to summarise the
+        # observations, so surface them rather than returning an empty answer.
+        if not final_output and observations:
+            final_output = "\n".join(observations)
 
-            return {
-                "output": final_output,
-                "metadata": metadata
-            }
+        metadata.latency = time.perf_counter() - started_at
 
-        except Exception as e:
-            logger.error(f"LLM invocation failed: {e}")
-            raise
+        return {
+            "output": final_output,
+            "metadata": metadata
+        }
+
+    def _collect_response(
+        self,
+        chunks: Generator[LLMResultChunk, None, None] | LLMResult,
+        stream: bool
+    ) -> tuple[str, list[tuple[str, str, dict[str, Any]]], Optional[LLMUsage]]:
+        """Collect text, tool calls and usage from a streaming or blocking result"""
+
+        response_text = ""
+        tool_calls: list[tuple[str, str, dict[str, Any]]] = []
+        usage: Optional[LLMUsage] = None
+
+        if stream and isinstance(chunks, Generator):
+            for chunk in chunks:
+                if chunk.delta and chunk.delta.message and chunk.delta.message.content:
+                    response_text += chunk.delta.message.get_text_content()
+
+                if chunk.delta and chunk.delta.message and chunk.delta.message.tool_calls:
+                    tool_calls.extend(self._parse_tool_calls(chunk.delta.message.tool_calls))
+
+                if chunk.delta and chunk.delta.usage:
+                    usage = chunk.delta.usage
+        else:
+            result = chunks if isinstance(chunks, LLMResult) else next(chunks)
+            if result.message and result.message.content:
+                response_text = result.message.get_text_content()
+
+            if result.message and result.message.tool_calls:
+                tool_calls.extend(self._parse_tool_calls(result.message.tool_calls))
+
+            usage = result.usage
+
+        return response_text, tool_calls, usage
+
+    @staticmethod
+    def _parse_tool_calls(
+        raw_tool_calls: list[AssistantPromptMessage.ToolCall]
+    ) -> list[tuple[str, str, dict[str, Any]]]:
+        """Flatten SDK tool calls into (call_id, tool_name, parameters) tuples"""
+
+        return [
+            (
+                tool_call.id or "",
+                tool_call.function.name,
+                json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
+            )
+            for tool_call in raw_tool_calls
+            if tool_call.function
+        ]
+
+    @staticmethod
+    def _accumulate_usage(metadata: ExecutionMetadata, usage: Optional[LLMUsage]) -> None:
+        """Add one round of usage into the attempt totals"""
+
+        round_usage = ExecutionMetadata.from_llm_usage(usage)
+        metadata.total_tokens += round_usage.total_tokens
+        metadata.prompt_tokens += round_usage.prompt_tokens
+        metadata.completion_tokens += round_usage.completion_tokens
+        metadata.total_price += round_usage.total_price
+        metadata.currency = round_usage.currency or metadata.currency
 
     def _execute_tools(
         self,
         tool_calls: list[tuple[str, str, dict[str, Any]]],
         tools: list[ToolEntity]
     ) -> Generator[AgentInvokeMessage, None, list[str]]:
-        """Execute tool calls and return results"""
+        """Execute tool calls and return one observation per call, in call order.
+
+        The caller relies on the positional pairing with `tool_calls`, so every
+        call contributes exactly one entry - failures included.
+        """
 
         tool_instances = {tool.identity.name: tool for tool in tools}
         results = []
 
-        for tool_call_id, tool_name, tool_params in tool_calls:
+        for _tool_call_id, tool_name, tool_params in tool_calls:
             if tool_name not in tool_instances:
                 logger.warning(f"Tool {tool_name} not found")
-                results.append(f"{tool_name}: Tool not found")
+                results.append("Tool not found")
                 continue
 
             tool = tool_instances[tool_name]
@@ -397,19 +477,21 @@ class SelfRefineStrategy(AgentStrategy):
 
             try:
                 tool_result = self.session.tool.invoke(
+                    provider_type=tool.provider_type,
                     provider=tool.identity.provider,
                     tool_name=tool_name,
-                    parameters=tool_params
+                    parameters=tool_params,
+                    credential_id=tool.credential_id
                 )
 
                 result_text = ""
                 for message in tool_result:
-                    if message.type == ToolInvokeMessage.MessageType.TEXT:
-                        result_text += message.message
-                    elif message.type == ToolInvokeMessage.MessageType.JSON:
-                        result_text += json.dumps(message.message)
+                    if isinstance(message.message, ToolInvokeMessage.TextMessage):
+                        result_text += message.message.text
+                    elif isinstance(message.message, ToolInvokeMessage.JsonMessage):
+                        result_text += json.dumps(message.message.json_object, ensure_ascii=False)
 
-                results.append(f"{tool_name}: {result_text}")
+                results.append(result_text or "The tool returned no textual output.")
 
                 yield self.create_log_message(
                     label=f"Tool {tool_name} Complete",
@@ -419,7 +501,7 @@ class SelfRefineStrategy(AgentStrategy):
 
             except Exception as e:
                 logger.error(f"Tool {tool_name} failed: {e}")
-                results.append(f"{tool_name}: Error - {str(e)}")
+                results.append(f"Error - {str(e)}")
 
                 yield self.create_log_message(
                     label=f"Tool {tool_name} Failed",
@@ -495,21 +577,3 @@ class SelfRefineStrategy(AgentStrategy):
                 issues=SELF_REFINE_TEMPLATES["fallback_critique"],
                 score=50
             )
-
-    def _init_prompt_tools(self, tools: list[ToolEntity] | None) -> list[ToolInvokeMeta]:
-        """Convert ToolEntity to ToolInvokeMeta for LLM invocation"""
-        if not tools:
-            return []
-
-        prompt_tools = []
-        for tool in tools:
-            prompt_tools.append(
-                ToolInvokeMeta(
-                    provider_type=tool.identity.provider_type or ToolProviderType.BUILT_IN,
-                    provider=tool.identity.provider,
-                    tool_name=tool.identity.name,
-                    tool_parameters=tool.runtime_parameters or {}
-                )
-            )
-
-        return prompt_tools

--- a/agent-strategies/self_refine_agent/tests/test_self_refine.py
+++ b/agent-strategies/self_refine_agent/tests/test_self_refine.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PLUGIN_ROOT))
 
+from dify_plugin.entities import I18nObject
 from dify_plugin.entities.model import AIModelEntity, ModelFeature, ModelType
 from dify_plugin.entities.model.llm import (
     LLMResult,
@@ -15,9 +16,21 @@ from dify_plugin.entities.model.llm import (
 )
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
+    PromptMessageTool,
     TextPromptMessageContent,
+    ToolPromptMessage,
 )
-from dify_plugin.interfaces.agent import AgentModelConfig
+from dify_plugin.entities.tool import (
+    ToolDescription,
+    ToolInvokeMessage,
+    ToolParameter,
+    ToolProviderType,
+)
+from dify_plugin.interfaces.agent import (
+    AgentModelConfig,
+    AgentToolIdentity,
+    ToolEntity,
+)
 
 from strategies.self_refine import SelfRefineParams, SelfRefineStrategy
 
@@ -28,11 +41,72 @@ def _list_content_message(text: str) -> AssistantPromptMessage:
     )
 
 
-def _params(model: AgentModelConfig) -> SelfRefineParams:
+def _tool_entity() -> ToolEntity:
+    return ToolEntity(
+        identity=AgentToolIdentity(
+            author="tester",
+            name="search",
+            label=I18nObject(en_US="Search"),
+            provider="tavily",
+        ),
+        parameters=[
+            ToolParameter(
+                name="query",
+                label=I18nObject(en_US="Query"),
+                human_description=I18nObject(en_US="What to search for"),
+                type=ToolParameter.ToolParameterType.STRING,
+                form=ToolParameter.ToolParameterForm.LLM,
+                llm_description="the search query",
+                required=True,
+            )
+        ],
+        description=ToolDescription(
+            human=I18nObject(en_US="Search the web"),
+            llm="Search the web",
+        ),
+        provider_type=ToolProviderType.BUILT_IN,
+        credential_id="credential-1",
+    )
+
+
+def _params(
+    model: AgentModelConfig,
+    tools: list[ToolEntity] | None = None,
+    maximum_iterations: int = 5,
+) -> SelfRefineParams:
     return SelfRefineParams(
         query="hello",
         instruction="answer briefly",
         model=model,
+        tools=tools,
+        maximum_iterations=maximum_iterations,
+    )
+
+
+def _tool_call_result(name: str = "search") -> LLMResult:
+    return LLMResult(
+        model="gpt-4o",
+        message=AssistantPromptMessage(
+            content="",
+            tool_calls=[
+                AssistantPromptMessage.ToolCall(
+                    id="call-1",
+                    type="function",
+                    function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                        name=name,
+                        arguments='{"query": "meaning of life"}',
+                    ),
+                )
+            ],
+        ),
+        usage=LLMUsage.empty_usage(),
+    )
+
+
+def _text_tool_message(text: str) -> ToolInvokeMessage:
+    return ToolInvokeMessage(
+        type=ToolInvokeMessage.MessageType.TEXT,
+        message=ToolInvokeMessage.TextMessage(text=text),
     )
 
 
@@ -148,6 +222,144 @@ class TestSelfRefineListContent(unittest.TestCase):
             and m.message.status.value == "error"
         ]
         self.assertEqual(errors, [])
+
+
+class TestSelfRefineTools(unittest.TestCase):
+    """Tools are declared `required` in self_refine.yaml, so the tool path is the
+    default configuration rather than an edge case."""
+
+    def setUp(self):
+        self.strategy = SelfRefineStrategy(runtime=Mock(), session=Mock())
+
+    def _drain(self, gen):
+        try:
+            while True:
+                next(gen)
+        except StopIteration as stop:
+            return stop.value
+
+    def test_execute_agent_passes_prompt_message_tools_to_llm(self):
+        model = AgentModelConfig(provider="openai", model="gpt-4o", mode="chat")
+        self.strategy.session.model.llm.invoke = Mock(
+            return_value=LLMResult(
+                model="gpt-4o",
+                message=_list_content_message("done"),
+                usage=LLMUsage.empty_usage(),
+            )
+        )
+
+        result = self._drain(
+            self.strategy._execute_agent(_params(model, [_tool_entity()]), None, 1)
+        )
+
+        self.assertEqual(result["output"], "done")
+        tools = self.strategy.session.model.llm.invoke.call_args.kwargs["tools"]
+        self.assertEqual(len(tools), 1)
+        self.assertIsInstance(tools[0], PromptMessageTool)
+        self.assertEqual(tools[0].name, "search")
+        self.assertEqual(tools[0].description, "Search the web")
+        self.assertEqual(tools[0].parameters["required"], ["query"])
+
+    def test_execute_tools_invokes_with_provider_type_and_credential(self):
+        tool = _tool_entity()
+        self.strategy.session.tool.invoke = Mock(
+            return_value=iter([
+                ToolInvokeMessage(
+                    type=ToolInvokeMessage.MessageType.TEXT,
+                    message=ToolInvokeMessage.TextMessage(text="42"),
+                ),
+                ToolInvokeMessage(
+                    type=ToolInvokeMessage.MessageType.JSON,
+                    message=ToolInvokeMessage.JsonMessage(json_object={"answer": 42}),
+                ),
+            ])
+        )
+
+        results = self._drain(
+            self.strategy._execute_tools(
+                tool_calls=[("call-1", "search", {"query": "meaning of life"})],
+                tools=[tool],
+            )
+        )
+
+        self.strategy.session.tool.invoke.assert_called_once_with(
+            provider_type=ToolProviderType.BUILT_IN,
+            provider="tavily",
+            tool_name="search",
+            parameters={"query": "meaning of life"},
+            credential_id="credential-1",
+        )
+        self.assertEqual(results, ['42{"answer": 42}'])
+
+    def test_execute_agent_feeds_tool_results_back_to_the_model(self):
+        model = AgentModelConfig(provider="openai", model="gpt-4o", mode="chat")
+        self.strategy.session.model.llm.invoke = Mock(
+            side_effect=[
+                _tool_call_result(),
+                LLMResult(
+                    model="gpt-4o",
+                    message=_list_content_message("the answer is 42"),
+                    usage=LLMUsage.empty_usage(),
+                ),
+            ]
+        )
+        self.strategy.session.tool.invoke = Mock(
+            return_value=iter([_text_tool_message("42")])
+        )
+
+        result = self._drain(
+            self.strategy._execute_agent(_params(model, [_tool_entity()]), None, 1)
+        )
+
+        # The model must see the observation, otherwise the tool call is pointless.
+        self.assertEqual(self.strategy.session.model.llm.invoke.call_count, 2)
+        second_round = self.strategy.session.model.llm.invoke.call_args.kwargs[
+            "prompt_messages"
+        ]
+        tool_messages = [m for m in second_round if isinstance(m, ToolPromptMessage)]
+        self.assertEqual(len(tool_messages), 1)
+        self.assertEqual(tool_messages[0].tool_call_id, "call-1")
+        self.assertIn("42", tool_messages[0].content)
+        self.assertEqual(result["output"], "the answer is 42")
+
+    def test_maximum_iterations_caps_the_tool_loop(self):
+        model = AgentModelConfig(provider="openai", model="gpt-4o", mode="chat")
+        # A model that never stops asking for tools must not spin forever.
+        self.strategy.session.model.llm.invoke = Mock(
+            side_effect=lambda **_: _tool_call_result()
+        )
+        self.strategy.session.tool.invoke = Mock(
+            side_effect=lambda **_: iter([_text_tool_message("42")])
+        )
+
+        self._drain(
+            self.strategy._execute_agent(
+                _params(model, [_tool_entity()], maximum_iterations=2), None, 1
+            )
+        )
+
+        self.assertEqual(self.strategy.session.model.llm.invoke.call_count, 2)
+        # The final round has no follow-up round to read the observations,
+        # so its tool calls are not executed.
+        self.assertEqual(self.strategy.session.tool.invoke.call_count, 1)
+
+    def test_single_iteration_surfaces_the_tool_observation(self):
+        model = AgentModelConfig(provider="openai", model="gpt-4o", mode="chat")
+        self.strategy.session.model.llm.invoke = Mock(
+            side_effect=lambda **_: _tool_call_result()
+        )
+        self.strategy.session.tool.invoke = Mock(
+            return_value=iter([_text_tool_message("42")])
+        )
+
+        result = self._drain(
+            self.strategy._execute_agent(
+                _params(model, [_tool_entity()], maximum_iterations=1), None, 1
+            )
+        )
+
+        self.assertEqual(self.strategy.session.model.llm.invoke.call_count, 1)
+        self.assertEqual(result["output"], "42")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #3778

Attaching any tool to a Self-Refine agent node fails immediately with:

```
Error: Execution failed - 'AgentToolIdentity' object has no attribute 'provider_type'
```

`tools` is declared `required: true` in `strategies/self_refine.yaml`, so this is the documented default configuration rather than an edge case. The tool path is broken end to end — four separate defects, present since the plugin was added (`7b24b02b`) and still in `0.0.2`:

1. **`_init_prompt_tools` overrode the base `AgentStrategy` method with a broken implementation** (`strategies/self_refine.py:499`). It read `provider_type` off the tool *identity*, but `provider_type` is a field on `ToolEntity` — `AgentToolIdentity` only carries `author` / `name` / `label` / `provider`. Hence the `AttributeError`. The same method also built `ToolInvokeMeta` objects (actual fields: `time_cost` / `error` / `tool_config`) and passed them to `session.model.llm.invoke(tools=...)`, which expects `list[PromptMessageTool]`. `AgentStrategy._init_prompt_tools` has an identical signature and already does this correctly, so the override is deleted rather than patched.

2. **`session.tool.invoke()` was called without the required `provider_type` argument** (`:399`). Every tool call raised `TypeError`, which the surrounding `except` swallowed into the answer as `"<tool>: Error - ..."`. The tool's `credential_id` was not forwarded either, so multi-credential providers fell back to the session default.

3. **Tool output was concatenated as if it were a string** (`:408`): `result_text += message.message` adds a `TextMessage` model to a `str`, and `json.dumps(message.message)` cannot serialize a `JsonMessage`. Both raise `TypeError`. Now reads `.text` / `.json_object`.

4. **Tool results were never sent back to the model.** They were string-appended to the answer under a `[Tool Results]` header, so the model never saw the output it asked for and the "answer" was a raw dump. Observations are now returned as `ToolPromptMessage` and the execution phase loops until the model produces a final answer.

Two smaller things follow from (4):

- `maximum_iterations` was accepted, rendered in the UI and documented in the README, but never read anywhere in the code. It now bounds the tool loop, using the same last-round rule as the official `cot_agent` (on the final round of several, pending tool calls are not executed because no round is left to consume them). With `maximum_iterations=1` the observations are surfaced directly instead of returning an empty answer.
- Token usage is accumulated across rounds instead of reflecting only the last model call.

For reference, `cot_agent` reads `tool_instance.provider_type` and passes `provider_type=` to `session.tool.invoke()` — this PR brings `self_refine_agent` in line with it.

### Out of scope, noted for follow-up

- The system prompt still `json.dumps` the entire `ToolEntity` list (including `credential_id` and `runtime_parameters`) into `{{tools}}`, duplicating what `tools=` already carries.
- The README documents "stops when score ≥ 80" and "returns best output"; the code only consults `is_satisfactory` and returns the last output.
- A failed execution attempt consumes a refinement from `max_refinements`, conflating retries with refinement cycles.

Happy to fold any of these in if you'd prefer them here.

## Release Notes

Fixed agent nodes failing with `'AgentToolIdentity' object has no attribute 'provider_type'` as soon as a tool was attached. Tool calls now execute correctly and their results are returned to the model instead of being appended to the answer as raw text, so the agent can actually use the tools it calls. The `maximum_iterations` setting now takes effect, bounding the tool-calling loop.

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — `0.0.2` → `0.0.3`
- [x] `dify_plugin` declared in `pyproject.toml` and locked in `uv.lock` — unchanged by this PR (`>=0.9.0`, locked at `0.9.1`)

## Testing

- [ ] Local deployment — Dify version: 1.17.0
- [ ] SaaS (cloud.dify.ai)

**Unit tests** — clean `uv sync --frozen` environment, Python 3.12 (matching `manifest.yaml`) and 3.13:

```
$ uv run --with pytest python -m pytest tests/ -q
9 passed
```

The five new tests cover the tool path, which previously had none — `tests/test_self_refine.py` only ever built params without `tools`, which is why this shipped green. All five fail on `main`:

```
5 failed, 4 passed
FAILED tests/test_self_refine.py::TestSelfRefineTools::test_execute_agent_passes_prompt_message_tools_to_llm
FAILED tests/test_self_refine.py::TestSelfRefineTools::test_execute_tools_invokes_with_provider_type_and_credential
FAILED tests/test_self_refine.py::TestSelfRefineTools::test_execute_agent_feeds_tool_results_back_to_the_model
FAILED tests/test_self_refine.py::TestSelfRefineTools::test_maximum_iterations_caps_the_tool_loop
FAILED tests/test_self_refine.py::TestSelfRefineTools::test_single_iteration_surfaces_the_tool_observation
```

**Contract check against a real payload** — the tool dict was serialized by Dify 1.17.0 itself (`api/core/workflow/nodes/agent/runtime_support.py:168-175`, builtin Google Search tool) and replayed through the plugin with `dify_plugin` 0.9.1.

On `main`, it reproduces the reported failure exactly:

```
  File "strategies/self_refine.py", line 508, in _init_prompt_tools
    provider_type=tool.identity.provider_type or ToolProviderType.BUILT_IN,
AttributeError: 'AgentToolIdentity' object has no attribute 'provider_type'
```

On this branch, the same payload runs through:

```
parsed OK
  identity.provider : google
  provider_type     : <ToolProviderType.BUILT_IN: 'builtin'>
  credential_id     : 5f2e1a3c-...
  identity has provider_type? False

tool.invoke kwargs : {'provider_type': BUILT_IN, 'provider': 'google',
                      'tool_name': 'google_search', 'parameters': {'query': ...},
                      'credential_id': '5f2e1a3c-...'}
tools sent to LLM  : ['PromptMessageTool'] google_search {'type': 'object', 'required': ['query'], ...}
round-2 observation: [('google_search', 'The answer is 42.')]
final output       : '42, per Douglas Adams.'
```

This exercises the plugin-side contract (payload parsing and the arguments sent to the plugin daemon) with a mocked session; the daemon round trip itself is not covered by it.
