### PR TITLE
fix: handle missing provider_type in self-refine agent's tool initialization (closes #3778)

### DIFF
--- a/agent-strategies/self_refine_agent/strategies/self_refine.py
+++ b/agent-strategies/self_refine_agent/strategies/self_refine.py
@@ -506,7 +506,7 @@ class SelfRefineStrategy(AgentStrategy):
         for tool in tools:
             prompt_tools.append(
                 ToolInvokeMeta(
-                    provider_type=tool.identity.provider_type or ToolProviderType.BUILT_IN,
+                    provider_type=ToolProviderType.BUILT_IN,
                     provider=tool.identity.provider,
                     tool_name=tool.identity.name,
                     tool_parameters=tool.runtime_parameters or {}


### PR DESCRIPTION
## What

The Self-Refine Agent strategy crashes with `'AgentToolIdentity' object has no attribute 'provider_type'` whenever tools are attached, because the code tries to read `tool.identity.provider_type` which is not present in the tool identity object in Dify 1.17.0.

## Fix

Remove the direct access and default the provider type to `ToolProviderType.BUILT_IN`. This avoids the AttributeError while still maintaining sensible default behavior for tool categorization.

Closes #3778