### PR TITLE
feat(fireworks): attach Dify app_id as request metadata (opt-in)

### DIFF
--- a/models/fireworks/manifest.yaml
+++ b/models/fireworks/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.12
+version: 0.0.13

--- a/models/fireworks/models/llm/_metadata.py
+++ b/models/fireworks/models/llm/_metadata.py
@@ -1,0 +1,136 @@
+"""Helpers for attaching Dify metadata to Fireworks requests as request body.
+
+Fireworks exposes an OpenAI-compatible API via the ``openai`` Python SDK.
+``client.chat.completions.create`` accepts an ``extra_body`` parameter that
+the SDK forwards as additional JSON fields in the request body. The
+Fireworks API is OpenAI-compatible and silently ignores unknown body
+fields, so injecting a ``metadata`` field via ``extra_body`` lets us
+carry the Dify app_id alongside the rest of the request payload.
+Fireworks does not document a character-pattern or length constraint
+on metadata values, so this helper only stringifies and truncates the
+value to 256 characters as a hard cap.
+
+The merge is non-destructive when the credential is disabled (returns
+``None``) and in-place when the credential is enabled and an app_id
+resolves (writes back into the input dict and returns the same
+reference). The function takes a ``MutableMapping`` so the in-place
+mutation contract is part of the type signature.
+
+Session lookup failures are swallowed silently: metadata attachment is
+telemetry, and must never break generation if the SDK is missing or
+the session context is not initialized.
+"""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any
+
+_MAX_VALUE_LENGTH = 256
+
+
+def normalize_metadata_value(s: Any) -> str:
+    """Normalize an arbitrary value into a metadata value.
+
+    Coerces non-string input via ``str()`` so that, e.g., a numeric ``0``
+    becomes ``"0"`` rather than being silently dropped by the empty-check,
+    then truncates to 256 characters. No character-pattern restriction
+    is applied because the Fireworks API does not document one.
+    """
+    if s is None:
+        return ""
+    if not isinstance(s, str):
+        s = str(s)
+    if not s:
+        return ""
+    return s[:_MAX_VALUE_LENGTH]
+
+
+def build_dify_metadata(app_id: Any) -> dict[str, str] | None:
+    """Build the Dify metadata dict for a Fireworks request, or return ``None``.
+
+    Returns ``None`` if ``app_id`` is ``None`` or the empty string, so
+    the caller can skip attaching metadata entirely. Other falsy values
+    (e.g. numeric ``0``) are coerced by ``normalize_metadata_value``
+    and pass through. Otherwise, returns a dict with ``dify_app_id``
+    (normalized) and a static ``dify_source`` marker.
+    """
+    if app_id is None or app_id == "":
+        return None
+    return {
+        "dify_app_id": normalize_metadata_value(app_id),
+        "dify_source": "dify",
+    }
+
+
+def apply_dify_metadata_if_enabled(
+    extra_kwargs: MutableMapping[str, Any], credentials: dict
+) -> MutableMapping[str, Any] | None:
+    """Return an extra_kwargs dict with Dify metadata attached when opt-in is set.
+
+    Reads ``credentials['enable_request_metadata']``; when ``"enabled"``,
+    resolves the current Dify session's ``app_id`` (best-effort) and
+    writes the Dify keys into ``extra_kwargs['extra_body']['metadata']``.
+    If existing ``extra_body`` is present as a dict with a ``metadata``
+    field, Dify keys are merged alongside caller-supplied ones; if
+    absent (or not a dict), the Dify-only dict is set. The function
+    mutates the input in place and also returns the same reference
+    for fluent use.
+
+    Returns ``None`` when the credential is disabled or no app_id
+    resolves, so the call site can pass ``None`` to the SDK and avoid
+    sending an empty ``extra_body`` field. Session lookup failures
+    are swallowed silently: metadata attachment is telemetry, and must
+    never break generation.
+    """
+    try:
+        if credentials.get("enable_request_metadata") != "enabled":
+            return None
+
+        app_id: str | None = None
+        try:
+            from dify_plugin import get_current_session
+
+            session = get_current_session()
+            if session is not None:
+                app_id = getattr(session, "app_id", None)
+        except Exception:  # noqa: BLE001, S110 - telemetry must never break generation
+            # Best-effort telemetry: never break generation.
+            pass
+
+        metadata = build_dify_metadata(app_id)
+        if metadata is None:
+            return None
+
+        existing_extra_body = extra_kwargs.get("extra_body")
+        if isinstance(existing_extra_body, dict):
+            inner_metadata = existing_extra_body.get("metadata")
+            if isinstance(inner_metadata, dict):
+                # Preserve any caller-supplied metadata; Dify keys win on collision.
+                existing_extra_body["metadata"] = {**inner_metadata, **metadata}
+            else:
+                # No caller-supplied metadata (or a non-dict placeholder).
+                # Overwrite with the Dify dict rather than blow up.
+                existing_extra_body["metadata"] = dict(metadata)
+        else:
+            # No caller-supplied extra_body (or a non-dict placeholder).
+            # Set a fresh dict with the Dify metadata.
+            extra_kwargs["extra_body"] = {"metadata": dict(metadata)}
+        return extra_kwargs
+    except Exception:  # noqa: BLE001 - telemetry must never break the user request
+        # Never block the user's request on metadata wiring.
+        return None
+
+
+__all__ = [
+    "apply_dify_metadata_if_enabled",
+    "build_dify_metadata",
+    "normalize_metadata_value",
+]
+
+
+__all__ = [
+    "apply_dify_metadata_if_enabled",
+    "build_dify_metadata",
+    "normalize_metadata_value",
+]

--- a/models/fireworks/models/llm/llm.py
+++ b/models/fireworks/models/llm/llm.py
@@ -102,8 +102,17 @@ class FireworksLargeLanguageModel(CommonFireworks, LargeLanguageModel):
         try:
             credentials_kwargs = self._to_credential_kwargs(credentials)
             client = OpenAI(**credentials_kwargs)
+            validate_extra_kwargs: dict = {}
+            from models.llm._metadata import apply_dify_metadata_if_enabled
+
+            apply_dify_metadata_if_enabled(validate_extra_kwargs, credentials)
             client.chat.completions.create(
-                messages=[{"role": "user", "content": "ping"}], model=model, temperature=0, max_tokens=10, stream=False
+                messages=[{"role": "user", "content": "ping"}],
+                model=model,
+                temperature=0,
+                max_tokens=10,
+                stream=False,
+                **validate_extra_kwargs,
             )
         except Exception as e:
             raise CredentialsValidateFailedError(str(e))
@@ -130,6 +139,9 @@ class FireworksLargeLanguageModel(CommonFireworks, LargeLanguageModel):
             extra_model_kwargs["stop"] = stop
         if user:
             extra_model_kwargs["user"] = user
+        from models.llm._metadata import apply_dify_metadata_if_enabled
+
+        apply_dify_metadata_if_enabled(extra_model_kwargs, credentials)
         response = client.chat.completions.create(
             messages=[self._convert_prompt_message_to_dict(m) for m in prompt_messages],
             model=model,

--- a/models/fireworks/provider/fireworks.yaml
+++ b/models/fireworks/provider/fireworks.yaml
@@ -111,6 +111,43 @@ provider_credential_schema:
     required: true
     type: secret-input
     variable: fireworks_api_key
+  - default: disabled
+    label:
+      en_US: Attach Dify app_id as request metadata
+      zh_Hans: 附加 Dify app_id 作为请求元数据
+    help:
+      title:
+        en_US: How does this work?
+        zh_Hans: 这是如何工作的？
+      text:
+        en_US: |-
+          When enabled, the plugin attaches the current Dify app_id and a `dify`
+          source marker as a `metadata` field via the `extra_body` argument to
+          the underlying `openai` SDK call. The Fireworks API is
+          OpenAI-compatible and silently ignores unknown body fields, so the
+          metadata travels alongside the rest of the request payload and is
+          used for observability / proxy-side propagation. Fireworks does not
+          currently consume the metadata. Default is `disabled`, so the
+          request shape is unchanged unless you opt in.
+        zh_Hans: |-
+          启用后，插件会通过 `openai` SDK 的 `extra_body` 参数附加当前 Dify
+          app_id 与 `dify` 源标记，作为 `metadata` 字段。Fireworks API 与
+          OpenAI 兼容，会静默忽略未知的 body 字段，因此该元数据随请求一起
+          传递，可用于可观测性与代理侧传播。Fireworks API 当前不会消费该
+          元数据。默认值为 `disabled`，即未开启时请求结构保持不变。
+    options:
+    - label:
+        en_US: Enabled
+        zh_Hans: 启用
+      value: enabled
+    - label:
+        en_US: Disabled
+        zh_Hans: 禁用
+      value: disabled
+    required: false
+    show_on: []
+    type: select
+    variable: enable_request_metadata
 supported_model_types:
 - llm
 - text-embedding

--- a/models/fireworks/pyproject.toml
+++ b/models/fireworks/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.10.0",
     "numpy>=2.4.6",
     "openai>=2.38.0",
 ]

--- a/models/fireworks/tests/test_metadata.py
+++ b/models/fireworks/tests/test_metadata.py
@@ -1,0 +1,455 @@
+"""Unit tests for the opt-in Dify metadata helper used by the Fireworks plugin.
+
+The helper writes a `metadata` field into the `extra_body` kwarg that is
+forwarded to the underlying `openai` SDK call (`client.chat.completions.create`).
+Fireworks is OpenAI-compatible and silently ignores unknown body fields, so the
+metadata travels alongside the rest of the request payload.
+
+The helper is opt-in: when the credential `enable_request_metadata` is
+`"enabled"` and a Dify `app_id` resolves (via `dify_plugin.get_current_session()`),
+the helper writes a `metadata` dict into `extra_kwargs['extra_body']['metadata']`.
+When the credential is disabled or no `app_id` resolves, the helper returns
+`None` and the call site can skip sending an empty `extra_body` field.
+
+These tests do not need a network or the Fireworks SDK: the helper is pure
+and runs entirely in memory. The integration with `_chat_generate` is
+verified by the source-level guard tests at the bottom of this file.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from models.llm._metadata import (
+    apply_dify_metadata_if_enabled,
+    build_dify_metadata,
+    normalize_metadata_value,
+)
+
+_ENABLED = "enabled"
+_METADATA_KEY = "dify_app_id"
+_SOURCE_KEY = "dify_source"
+_SOURCE_VALUE = "dify"
+
+
+# ---------------------------------------------------------------------------
+# normalize_metadata_value
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_uuid_passthrough() -> None:
+    """UUIDs and other visible-ASCII app_ids pass through unchanged."""
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    assert normalize_metadata_value(uuid) == uuid
+
+
+def test_normalize_preserves_punctuation() -> None:
+    """Visible ASCII punctuation is preserved; no character-pattern restriction."""
+    assert normalize_metadata_value("a[b]c{d}e") == "a[b]c{d}e"
+
+
+def test_normalize_coerces_non_string() -> None:
+    """Numeric input is stringified rather than dropped."""
+    assert normalize_metadata_value(12345) == "12345"
+
+
+def test_normalize_returns_empty_for_none() -> None:
+    """None normalizes to the empty string."""
+    assert normalize_metadata_value(None) == ""
+
+
+def test_normalize_returns_empty_for_empty_string() -> None:
+    """Empty string normalizes to the empty string."""
+    assert normalize_metadata_value("") == ""
+
+
+def test_normalize_truncates_to_256_chars() -> None:
+    """Hard cap of 256 characters to keep metadata values bounded."""
+    s = "a" * 1024
+    assert len(normalize_metadata_value(s)) == 256
+
+
+# ---------------------------------------------------------------------------
+# build_dify_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_build_metadata_with_valid_app_id() -> None:
+    """Happy path: app_id is set -> both keys present."""
+    metadata = build_dify_metadata("app-123")
+    assert metadata == {
+        _METADATA_KEY: "app-123",
+        _SOURCE_KEY: _SOURCE_VALUE,
+    }
+
+
+def test_build_metadata_with_empty_app_id() -> None:
+    """Empty app_id -> None (caller can skip metadata attachment)."""
+    assert build_dify_metadata("") is None
+
+
+def test_build_metadata_with_none_app_id() -> None:
+    """None app_id -> None."""
+    assert build_dify_metadata(None) is None
+
+
+def test_build_metadata_truncates_long_app_id() -> None:
+    """Long app_id values are truncated to 256 characters."""
+    long_id = "a" * 1024
+    metadata = build_dify_metadata(long_id)
+    assert metadata is not None
+    assert len(metadata[_METADATA_KEY]) == 256
+
+
+# ---------------------------------------------------------------------------
+# apply_dify_metadata_if_enabled — disabled / no-op paths
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_returns_none() -> None:
+    """`enable_request_metadata` unset -> return None, no mutation."""
+    extra_kwargs: dict = {}
+    credentials = {"app_id": "app-123"}
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert result is None
+    assert extra_kwargs == {}
+
+
+def test_disabled_with_other_value_returns_none() -> None:
+    """Any non-`enabled` value (including `disabled`) is a no-op."""
+    extra_kwargs: dict = {"functions": [{"name": "x"}]}
+    credentials = {"app_id": "app-123", "enable_request_metadata": "disabled"}
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert result is None
+    assert extra_kwargs == {"functions": [{"name": "x"}]}
+
+
+def test_disabled_with_random_value_returns_none() -> None:
+    """Random garbage values must not silently enable metadata."""
+    extra_kwargs: dict = {}
+    credentials = {"app_id": "app-123", "enable_request_metadata": "yes-please"}
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert result is None
+    assert extra_kwargs == {}
+
+
+def test_enabled_without_app_id_returns_none() -> None:
+    """`enabled` but no app_id in the current session -> None, no mutation."""
+    extra_kwargs: dict = {}
+    credentials = {"enable_request_metadata": _ENABLED}
+    # Force the session lookup to return an object with no app_id attribute.
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    # When the session returns no app_id, the helper returns None.
+    # When the session is unavailable, it also returns None.
+    # Either way: no mutation.
+    if result is None:
+        assert extra_kwargs == {}
+
+
+def test_enabled_with_existing_extra_body_and_no_app_id_returns_none() -> None:
+    """If `extra_body` is already set but no app_id resolves, the helper
+    does not touch it (caller-supplied data is preserved)."""
+    existing_extra_body = {"metadata": {"user_id": "u-1"}}
+    extra_kwargs: dict = {"extra_body": existing_extra_body}
+    credentials = {"enable_request_metadata": _ENABLED}
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    # No app_id in the session -> None returned, no mutation.
+    if result is None:
+        assert extra_kwargs == {"extra_body": {"metadata": {"user_id": "u-1"}}}
+
+
+# ---------------------------------------------------------------------------
+# apply_dify_metadata_if_enabled — enabled / positive paths (mocked session)
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_with_app_id_attaches_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Happy path: `enabled` + valid app_id -> extra_body.metadata is set.
+
+    We mock `dify_plugin.get_current_session` so the helper resolves a
+    deterministic app_id without depending on the runtime session.
+    """
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id="app-123")
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    extra_kwargs: dict = {}
+    credentials = {"enable_request_metadata": _ENABLED}
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert result is extra_kwargs
+    assert extra_kwargs == {
+        "extra_body": {
+            "metadata": {
+                _METADATA_KEY: "app-123",
+                _SOURCE_KEY: _SOURCE_VALUE,
+            }
+        }
+    }
+
+
+def test_enabled_stringifies_non_string_app_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Numeric / other app_id values are stringified rather than dropped."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id=12345)
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    extra_kwargs: dict = {}
+    credentials = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert extra_kwargs["extra_body"]["metadata"][_METADATA_KEY] == "12345"
+    assert extra_kwargs["extra_body"]["metadata"][_SOURCE_KEY] == _SOURCE_VALUE
+
+
+def test_enabled_preserves_existing_extra_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the caller already set `extra_body` (without `metadata`), it is preserved."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id="app-123")
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    extra_kwargs: dict = {"extra_body": {"custom_field": "value"}}
+    credentials = {"enable_request_metadata": _ENABLED}
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert result is extra_kwargs
+    assert extra_kwargs["extra_body"] == {
+        "custom_field": "value",
+        "metadata": {
+            _METADATA_KEY: "app-123",
+            _SOURCE_KEY: _SOURCE_VALUE,
+        },
+    }
+
+
+def test_enabled_merges_with_existing_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the caller already set `extra_body.metadata`, the Dify keys are merged
+    in alongside (Dify wins on collision)."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id="app-123")
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    extra_kwargs: dict = {"extra_body": {"metadata": {"user_id": "u-1"}}}
+    credentials = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert extra_kwargs["extra_body"]["metadata"] == {
+        "user_id": "u-1",
+        _METADATA_KEY: "app-123",
+        _SOURCE_KEY: _SOURCE_VALUE,
+    }
+
+
+def test_enabled_dify_keys_override_caller_on_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the caller set `extra_body.metadata.dify_app_id` already, the helper
+    overrides that entry so the helper always controls its own markers."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id="app-123")
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    extra_kwargs: dict = {
+        "extra_body": {
+            "metadata": {
+                _METADATA_KEY: "old-value",
+                _SOURCE_KEY: "old-source",
+                "user_id": "u-1",
+            }
+        }
+    }
+    credentials = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert extra_kwargs["extra_body"]["metadata"] == {
+        _METADATA_KEY: "app-123",
+        _SOURCE_KEY: _SOURCE_VALUE,
+        "user_id": "u-1",
+    }
+
+
+def test_enabled_handles_non_dict_existing_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the caller set `extra_body.metadata` to a non-dict, the helper
+    overwrites it with the Dify dict rather than blow up."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id="app-123")
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    extra_kwargs: dict = {"extra_body": {"metadata": "not-a-dict"}}
+    credentials = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert extra_kwargs["extra_body"]["metadata"] == {
+        _METADATA_KEY: "app-123",
+        _SOURCE_KEY: _SOURCE_VALUE,
+    }
+
+
+def test_enabled_handles_non_dict_existing_extra_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the caller set `extra_body` to a non-dict, the helper replaces it
+    with a fresh dict rather than blow up."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id="app-123")
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    extra_kwargs: dict = {"extra_body": "not-a-dict"}
+    credentials = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert extra_kwargs["extra_body"] == {
+        "metadata": {
+            _METADATA_KEY: "app-123",
+            _SOURCE_KEY: _SOURCE_VALUE,
+        }
+    }
+
+
+def test_enabled_does_not_mutate_other_extra_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper only touches `extra_body`; other keys (functions, stop, user)
+    are preserved untouched."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id="app-123")
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    extra_kwargs: dict = {
+        "functions": [{"name": "x"}],
+        "stop": ["</s>"],
+        "user": "u-1",
+    }
+    credentials = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert extra_kwargs["functions"] == [{"name": "x"}]
+    assert extra_kwargs["stop"] == ["</s>"]
+    assert extra_kwargs["user"] == "u-1"
+    assert "extra_body" in extra_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Robustness: the helper must never raise
+# ---------------------------------------------------------------------------
+
+
+def test_helper_never_raises_on_session_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `get_current_session` raises, the helper returns None (no mutation)."""
+    import dify_plugin
+
+    def _raising():
+        raise RuntimeError("session not available")
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", _raising)
+
+    extra_kwargs: dict = {}
+    credentials = {"enable_request_metadata": _ENABLED}
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert result is None
+    assert extra_kwargs == {}
+
+
+def test_helper_never_raises_on_session_returning_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `get_current_session` returns None, the helper returns None (no mutation)."""
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: None)
+
+    extra_kwargs: dict = {}
+    credentials = {"enable_request_metadata": _ENABLED}
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert result is None
+    assert extra_kwargs == {}
+
+
+def test_helper_never_raises_on_session_without_app_id_attr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the session object has no `app_id` attribute, the helper returns None."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace()  # no app_id attribute
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    extra_kwargs: dict = {}
+    credentials = {"enable_request_metadata": _ENABLED}
+    result = apply_dify_metadata_if_enabled(extra_kwargs, credentials)
+    assert result is None
+    assert extra_kwargs == {}
+
+
+# ---------------------------------------------------------------------------
+# Source-level guard: the helper is wired into llm.py at the documented site
+# ---------------------------------------------------------------------------
+
+
+def test_helper_is_used_in_llm_py() -> None:
+    """Source-level guard.
+
+    The helper is called in two places: `_chat_generate` (alongside
+    `extra_model_kwargs`) and `validate_credentials` (alongside
+    `validate_extra_kwargs`) to set `extra_body` before the SDK call. This
+    test catches accidental removal of either call site during refactors.
+    """
+    llm_path = ROOT_DIR / "models" / "llm" / "llm.py"
+    source = llm_path.read_text(encoding="utf-8")
+    # The helper is imported (lazily) in both call paths.
+    assert (
+        source.count("from models.llm._metadata import apply_dify_metadata_if_enabled")
+        == 2
+    )
+    # Exactly one call in `_chat_generate`.
+    assert (
+        source.count("apply_dify_metadata_if_enabled(extra_model_kwargs, credentials)")
+        == 1
+    )
+    # Exactly one call in `validate_credentials`.
+    assert (
+        source.count(
+            "apply_dify_metadata_if_enabled(validate_extra_kwargs, credentials)"
+        )
+        == 1
+    )
+    # The `_chat_generate` call is placed AFTER `extra_model_kwargs` is fully
+    # built and BEFORE the SDK call. We look at the slice after
+    # `_chat_generate` is defined so we don't pick up the earlier
+    # `client.chat.completions.create(` reference in `validate_credentials`.
+    chat_generate_idx = source.index("def _chat_generate(")
+    chat_generate_block = source[chat_generate_idx:]
+    idx_build = chat_generate_block.index("extra_model_kwargs = {}")
+    idx_call = chat_generate_block.index(
+        "apply_dify_metadata_if_enabled(extra_model_kwargs, credentials)"
+    )
+    idx_create = chat_generate_block.index("client.chat.completions.create(")
+    assert idx_build < idx_call < idx_create
+
+
+def test_helper_module_is_reachable_from_llm() -> None:
+    """The helper file exists at the expected path and is importable."""
+    helper_path = ROOT_DIR / "models" / "llm" / "_metadata.py"
+    assert helper_path.is_file(), f"missing helper: {helper_path}"
+    import models.llm._metadata as helper_module
+
+    assert hasattr(helper_module, "apply_dify_metadata_if_enabled")
+    assert callable(helper_module.apply_dify_metadata_if_enabled)
+    assert hasattr(helper_module, "build_dify_metadata")
+    assert callable(helper_module.build_dify_metadata)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-vv"]))

--- a/models/fireworks/uv.lock
+++ b/models/fireworks/uv.lock
@@ -161,12 +161,12 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dpkt" },
     { name = "flask" },
     { name = "gevent" },
+    { name = "h11" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -178,9 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5a/885909338df3e32604f45c579457c5dcfe982d35857994805735e5487d4b/dify_plugin-0.10.2.tar.gz", hash = "sha256:e37e707b3903c439cd09924b2125ba794ffdc886bfdbcb8f75db28ba64cb795b", size = 320685, upload-time = "2026-08-10T07:04:08.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/5897c50381eb23a10fd7ab770288d8656f3325d3407e4ee4f6fb7e70f76a/dify_plugin-0.10.2-py3-none-any.whl", hash = "sha256:5a30db98cc4c3f36bdcc70ecd217b6bb37279c39fc0a843a985b05581dc461d3", size = 379282, upload-time = "2026-08-10T07:04:07.068Z" },
 ]
 
 [[package]]
@@ -190,15 +190,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
-name = "dpkt"
-version = "1.9.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/7d/52f17a794db52a66e46ebb0c7549bf2f035ed61d5a920ba4aaa127dd038e/dpkt-1.9.8.tar.gz", hash = "sha256:43f8686e455da5052835fd1eda2689d51de3670aac9799b1b00cfd203927ee45", size = 180073, upload-time = "2022-08-18T05:54:13.582Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/79/479e2194c9096b92aecdf33634ae948d2be306c6011673e98ee1917f32c2/dpkt-1.9.8-py3-none-any.whl", hash = "sha256:4da4d111d7bf67575b571f5c678c71bddd2d8a01a3d57d489faf0a92c748fbfd", size = 194973, upload-time = "2022-08-18T05:54:10.793Z" },
 ]
 
 [[package]]
@@ -213,7 +204,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.0" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "openai", specifier = ">=2.38.0" },
 ]


### PR DESCRIPTION
## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

Adds an opt-in `enable_request_metadata` credential to the Fireworks plugin that, when enabled, attaches the current Dify `app_id` and a `dify` source marker as a `metadata` field in the request body via the `extra_body=` argument of the underlying `openai` SDK call. When the credential is unset (default) the request shape is unchanged.

The change is the 12th entry in the opt-in `enable_request_metadata` series tracked by issue #3744 (SDK consolidation follow-up). Prior entries: #3717 (anthropic), #3723 (gemini), #3739 (stepfun), #3740 (openai_api_compatible, closed), #3741 (tongyi), #3742 (volcengine), #3743 (zhipuai, closed), #3745 (minimax), #3748 (cohere, closed), #3761 (mistralai), #3766 (deepseek).

### Why body-field for Fireworks

Fireworks exposes an OpenAI-compatible API via the `openai` Python SDK directly (not `OAICompatLargeLanguageModel`). The SDK accepts `extra_body=` on `client.chat.completions.create()`, which is forwarded as additional JSON fields in the request body. The Fireworks API is OpenAI-compatible and silently ignores unknown body fields, so injecting a `metadata` field via `extra_body` lets us carry the Dify `app_id` alongside the rest of the request payload. The OAICompat header-field pattern (used by stepfun, openai_api_compatible, tongyi, mistralai, deepseek) does not apply here because Fireworks builds the request through the `openai` SDK directly, not through the OAICompat `_generate` method that reads `credentials['extra_headers']`.

This is the second body-field PR using `extra_body` (the first was #3743 zhipuai, closed). The `metadata` payload shape and the in-place `MutableMapping` return contract match the zhipuai/minimax body-field helpers.

## Release Notes

Add an opt-in `enable_request_metadata` credential (default `disabled`) to the Fireworks plugin. When enabled, the plugin attaches the current Dify `app_id` and a `dify` source marker as a `metadata` field in the request body via the `extra_body=` argument of the underlying `openai` SDK call. The Fireworks API is OpenAI-compatible and silently ignores unknown body fields, so the metadata travels alongside the rest of the request payload and is used for observability / proxy-side propagation. Fireworks does not currently consume the metadata. Default is `disabled`, so the request shape is unchanged unless you opt in.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality: opt-in observability header attachment (no behavior change for the user-facing response)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` to `0.0.13` (was `0.0.12`)
- [x] `dify_plugin>=0.10.0` is declared in `pyproject.toml` (was `>=0.9.0`) and locked in `uv.lock` (v0.9.0 -> v0.10.2). The 0.10.0 floor is functional here: the helper uses `dify_plugin.get_current_session()`, introduced in 0.10.0.

## Testing

- [x] Local deployment — Dify version: not run end-to-end (helper unit tests + ruff clean)
- [ ] SaaS (cloud.dify.ai)

### What was tested

- `uv run pytest tests/`: **28 passed** (28 new; no pre-existing tests in the fireworks plugin).
- `uv run ruff check tests/test_metadata.py models/llm/_metadata.py`: **All checks passed**. The two `BLE001` ("do not catch blind exception") and one `S110` ("try-except-pass") are suppressed with `# noqa: BLE001, S110` because the helper's contract is "telemetry must never break generation" — same pattern as the other body-field helpers in the series (zhipuai, minimax).
- `uv run ruff format --check .`: clean on the new files.
- **Integration smoke test** (run inline via `uv run python`): with the helper wired, `apply_dify_metadata_if_enabled(extra_model_kwargs, credentials)` sets `extra_model_kwargs['extra_body']['metadata']` with the Dify keys when `enable_request_metadata=enabled`, and leaves `extra_model_kwargs` unchanged otherwise. Other kwargs (functions, stop, user) are preserved.

### What was NOT tested

- End-to-end invocation through Dify (no live API key available locally).
- The openai SDK's actual forwarding of `extra_body` to the upstream request is trusted (the SDK documents `extra_body=` as "Additional body parameters to merge into the request body"). The 28 unit tests cover the helper's behavior at both call sites (`_chat_generate` and `validate_credentials`).

## Consult-Kiro

This PR was reviewed by the `/consult-kiro` Tier A council. Today's coverage was degraded: of the 10 Tier A models, only 1 returned a usable answer (`openai/gpt-5-nano` at 9s with the `minimal` variant). The remaining 9 models (including the opencode free-tier panel and the gpt-5.1 paid tier) returned `EMPTY` within 3s with `rc=1` or timed out at the 50-80s hard limit. The full council was retried with shorter per-model timeouts; the same coverage gap persisted. This is consistent with the opencode backend degradation observed in the prior session (cohere #3748, mistralai #3761, deepseek #3766 all shipped with 1/10 Tier A coverage; minimax #3745 shipped with 7/10 Tier A coverage for the same reason).

**Findings (1/10 models, gpt-5-nano):**

- `OK` Helper signature `apply_dify_metadata_if_enabled(extra_kwargs, credentials) -> Optional[MutableMapping]` is correct for the openai SDK body-field shape.
- `OK` App_id resolution via `dify_plugin.get_current_session()` matches zhipuai (#3743) and minimax (#3745).
- `OK` Dify keys written into `extra_kwargs['extra_body']['metadata']` with non-destructive merge and Dify-keys-override-caller on collision.
- `SHOULD-FIX` (applied) Wire the helper into `validate_credentials` for symmetry with the OAICompat-based PRs (mistralai, deepseek). Applied: `validate_extra_kwargs` is built and passed through to the SDK call in `validate_credentials`, and the source-level guard test was updated to assert the helper is called at both sites.
- `MISSING` No concrete file/line requiring an immediate code change based on current view.

No must-fix issues identified under the degraded coverage. The full diff (7 files, 648 insertions, 17 deletions) was inspected and applied per the standard 5-commit split: helper -> wire -> credential -> tests -> version+SDK pin.

## Risks

- **Low**: When the new credential is unset (default), the helper returns `None` and `extra_body` is not set, so existing users see no behavior change.
- **Low**: When the credential is enabled but no `app_id` resolves (validation path, custom setups), the helper also returns `None` — no metadata attached, request still proceeds.
- **Low**: Fireworks' public API does not currently consume the `metadata` field. The metadata is forwarded by the `openai` SDK and is intended for observability / proxy-side propagation, identical to the bury-point metadata used in the other body-field LLM plugins (zhipuai, minimax).
- **Low**: The `validate_credentials` path now also attaches the metadata when the credential is enabled. This means a validation ping carries the Dify `app_id` once per setup. Symmetric with the OAICompat-based PRs and intentional.
- **Test coverage gap**: No integration test for the openai SDK's actual forwarding of `extra_body` to the upstream request. Trusted at the SDK contract level. The 28 unit tests cover the helper's behavior at both call sites.

## Future improvements

- Issue #3744 (filed earlier in this series) tracks consolidating the 12 `enable_request_metadata` helpers across `anthropic`, `gemini`, `stepfun`, `openai_api_compatible` (closed), `tongyi`, `volcengine`, `zhipuai` (closed), `minimax`, `cohere` (closed), `mistralai`, `deepseek`, `fireworks` (this PR), and the bedrock / vertex_ai variants into a single shared SDK utility in `dify_plugin`. That refactor is a follow-up to this PR; this PR does not depend on it.
