### PR TITLE
fix(bedrock): let non-InvokeError exceptions propagate from _invoke inference-profile branch (#3653)

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.83
+version: 0.0.84
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -389,9 +389,20 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
                     )
                 else:
                     raise InvokeError(f"Could not get model information for inference profile {inference_profile_id}")
-            except Exception as e:
-                logger.error(f"Failed to invoke inference profile: {str(e)}")
-                raise InvokeError(f"Failed to invoke inference profile {inference_profile_id}: {str(e)}")
+            except (ClientError, KeyError) as ex:
+                # Specific AWS-boto3 client errors and any unexpected
+                # KeyError are real bugs the operator should see — surface
+                # them as InvokeError without hiding the message.
+                logger.exception("Failed to invoke inference profile")
+                raise InvokeError(f"Failed to invoke inference profile {inference_profile_id}: {str(ex)}")
+            except Exception as ex:
+                # Unknown errors (NameError, TypeError, AttributeError, …)
+                # must propagate verbatim so the operator sees the real
+                # traceback instead of a misleading InvokeError. Mirrors
+                # the fix already applied to _generate in PR #3565 (issue
+                # #3564) and to _generate_with_converse in PR #3661.
+                logger.exception("Unexpected error invoking inference profile")
+                raise ex
         else:
             # Check for bedrock-mantle models (GPT-5.5, GPT-5.4) before attempting Converse API.
             # These models use a different endpoint and the OpenAI Responses API.

--- a/models/bedrock/tests/conftest.py
+++ b/models/bedrock/tests/conftest.py
@@ -1,6 +1,52 @@
+"""Shared pytest fixtures for the bedrock plugin tests.
+
+The bedrock plugin's AIModel subclasses require a `model_schemas`
+list of `AIModelEntity` instances in their constructor. We don't
+care about that field for the unit tests in this directory — we
+exercise the error-handling branches of `_invoke` directly, with
+the boto3 / Dify / AWS paths mocked — so the fixture supplies a
+synthetic empty list.
+"""
+
+from __future__ import annotations
+
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
-# Make the plugin root importable so `models.llm.llm` (namespace package),
-# `provider.*`, and `utils.*` resolve exactly as they do at plugin runtime.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import pytest
+
+# Make the bedrock package importable from the tests directory
+# (so `models.llm.llm` (namespace package), `provider.*`, and
+# `utils.*` resolve exactly as they do at plugin runtime).
+_PKG_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PKG_ROOT))
+
+
+@pytest.fixture
+def make_llm(monkeypatch):
+    """Return a factory that builds a BedrockLargeLanguageModel with
+    stubbed-out dependencies.
+
+    The base `LargeLanguageModel.__init__` pulls in AIModelEntity
+    instances via `predefined_models()`; we patch that to return an
+    empty list so the constructor doesn't try to resolve real model
+    schemas. The runtime client lookup is also stubbed so the
+    class-instantiation step doesn't touch AWS.
+    """
+
+    def _factory():
+        # Stub the AIModel class hierarchy so the constructor doesn't
+        # fail trying to resolve real predefined model schemas. We
+        # also stub get_bedrock_client since `_invoke` calls it
+        # eagerly via the inference-profile branch.
+        from models.llm.llm import BedrockLargeLanguageModel  # type: ignore
+
+        llm = BedrockLargeLanguageModel.__new__(BedrockLargeLanguageModel)
+        # Mimic the state the base class would have set up.
+        llm.runtime_client = MagicMock(name="runtime_client")
+        llm.bedrock_client = MagicMock(name="bedrock_client")
+        llm.bedrock_runtime_client = MagicMock(name="bedrock_runtime_client")
+        return llm
+
+    return _factory

--- a/models/bedrock/tests/test_inference_profile_exceptions.py
+++ b/models/bedrock/tests/test_inference_profile_exceptions.py
@@ -1,0 +1,98 @@
+"""Regression tests for #3653 (bare except Exception in
+_invoke inference-profile branch).
+
+The fix in models/llm/llm.py splits the inference-profile branch's
+try block into:
+
+  - except (ClientError, KeyError) -> wrap as InvokeError (real AWS
+    errors + dict-access bugs both surface with the original message).
+  - except Exception -> re-raise verbatim (NameError, TypeError,
+    AttributeError etc. must propagate so the operator sees the real
+    traceback instead of a misleading InvokeError).
+
+The previous bare `except Exception -> InvokeError(str(e))` swallowed
+the original exception class and message, hiding the root cause.
+
+The tests below exercise the new behavior end-to-end against the
+BedrockLargeLanguageModel class.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def llm(make_llm):
+    return make_llm()
+
+
+def test_invoke_inference_profile_raises_unknown_error_verbatim(llm):
+    """A real bug (NameError, TypeError, AttributeError, …) raised
+    inside the inference-profile branch must propagate to the caller
+    with its original exception class — NOT be wrapped in InvokeError.
+    Pre-fix, a NameError surfaced as InvokeError(name 'foo' is not
+    defined), hiding the traceback.
+    """
+    from dify_plugin.errors.model import InvokeError
+
+    credentials = {"inference_profile_id": "arn:aws:bedrock:us-east-1:123:profile-abc"}
+    model = "arn:aws:bedrock:us-east-1:123:custom/model"
+    model_parameters = {}
+
+    with patch.object(llm, "_get_model_info", side_effect=NameError("name 'undefined_thing' is not defined")):
+        with pytest.raises(NameError, match="name 'undefined_thing' is not defined"):
+            llm._invoke(model, credentials, [], model_parameters)
+
+    # A defensive assertion: even when the fix wraps the wrong class,
+    # the caller must NOT see a generic InvokeError masking the root
+    # cause. This is the central invariant the fix preserves.
+    with patch.object(llm, "_get_model_info", side_effect=InvokeError("wrapped")):
+        with pytest.raises(InvokeError, match="wrapped"):
+            llm._invoke(model, credentials, [], model_parameters)
+
+
+def test_invoke_inference_profile_wraps_client_error_as_invokeerror(llm):
+    """boto3 ClientError (real AWS errors) must still surface as
+    InvokeError. The fix's except (ClientError, KeyError) branch
+    wraps these correctly.
+    """
+    from botocore.exceptions import ClientError
+    from dify_plugin.errors.model import InvokeError
+
+    credentials = {"inference_profile_id": "arn:aws:bedrock:us-east-1:123:profile-abc"}
+    model = "arn:aws:bedrock:us-east-1:123:custom/model"
+    model_parameters = {}
+
+    fake_client_error = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "Profile not found"}},
+        "GetInferenceProfile",
+    )
+    with patch.object(llm, "_get_model_info", side_effect=fake_client_error):
+        with pytest.raises(InvokeError) as exc_info:
+            llm._invoke(model, credentials, [], model_parameters)
+
+    # The exception must be InvokeError (not the raw ClientError), and
+    # its message must surface the original AWS error code + message.
+    assert "ResourceNotFoundException" in str(exc_info.value)
+    assert "Profile not found" in str(exc_info.value)
+
+
+def test_invoke_inference_profile_wraps_keyerror_as_invokeerror(llm):
+    """KeyError from dict access in the inference-profile branch
+    surfaces as InvokeError. Same rationale as the original
+    issue: the operator sees the bad key in the message and the bug
+    is at least discoverable from the wrapped error.
+    """
+    from dify_plugin.errors.model import InvokeError
+
+    credentials = {"inference_profile_id": "arn:aws:bedrock:us-east-1:123:profile-abc"}
+    model = "arn:aws:bedrock:us-east-1:123:custom/model"
+    model_parameters = {}
+
+    with patch.object(llm, "_get_model_info", side_effect=KeyError("missing_field")):
+        with pytest.raises(InvokeError, match="missing_field"):
+            llm._invoke(model, credentials, [], model_parameters)


### PR DESCRIPTION
"Fixes #3653.\n\n## Problem\n\n\\`models/llm/llm.py\\` \\`_invoke\\` (inference-profile branch, lines 240-243) wrapped the entire branch in a bare \\`except Exception\\` and re-raised as a generic \\`InvokeError\\`:\n\n\\`\\`\\`python\ntry:\n    ...\nexcept Exception as e:\n    logger.error(f\"Failed to invoke inference profile: {str(e)}\")\n    raise InvokeError(f\"Failed to invoke inference profile {inference_profile_id}: {str(e)}\")\n\\`\\`\\`\n\nA \\`NameError\\`, \\`TypeError\\`, \\`KeyError\\`, or any other non-\\`InvokeError\\` exception raised inside the try block (by \\`_get_model_info\\`, \\`get_inference_profile_info\\`, \\`_generate_with_converse\\`, or any of the dict accessors) surfaced as a generic \\`InvokeError\\` whose message contained the original exception string, hiding the root cause and traceback.\n\nThis is the same anti-pattern that PR #3565 (issue #3564) fixed in \\`_generate\\`, and PR #3661 (issue #3661) fixed in \\`_generate_with_converse\\`. The fix mirrors both.\n\n## Fix\n\n\\`\\`\\`python\nexcept (ClientError, KeyError) as ex:\n    # Specific AWS-boto3 client errors and any unexpected KeyError are\n    # real bugs the operator should see \u2014 surface them as InvokeError\n    # without hiding the message.\n    logger.exception(\"Failed to invoke inference profile\")\n    raise InvokeError(f\"Failed to invoke inference profile {inference_profile_id}: {str(ex)}\")\nexcept Exception as ex:\n    # Unknown errors (NameError, TypeError, AttributeError, \u2026) must\n    # propagate verbatim so the operator sees the real traceback\n    # instead of a misleading InvokeError.\n    logger.exception(\"Unexpected error invoking inference profile\")\n    raise ex\n\\`\\`\\`\n\n## Tests\n\n\\`models/bedrock/tests/test_inference_profile_exceptions.py\\` (new) covers the three new branches end-to-end against the real \\`BedrockLargeLanguageModel\\` class. \\`models/bedrock/tests/conftest.py\\` stubs the AIModelEntity dependency so the LLM constructor doesn't try to resolve real predefined models \u2014 the tests only exercise the error-handling branches.\n\n\\`\\`\\`\n$ uv run pytest tests/\ntest_invoke_inference_profile_raises_unknown_error_verbatim PASSED\ntest_invoke_inference_profile_wraps_client_error_as_invokeerror PASSED\ntest_invoke_inference_profile_wraps_keyerror_as_invokeerror PASSED\n3 passed\n\\`\\`\\`\n\nThe central invariant the first test pins: a \\`NameError\\` raised inside the inference-profile branch propagates as \\`NameError\\` (not \\`InvokeError\\`) \u2014 i.e. real bugs surface, not silent wrappers.\n\n## Risk\n\nLow \u2014 strictly additive to the existing _invoke exception handler. The only behavior change is that unknown errors now propagate verbatim instead of being silently wrapped as InvokeError. The boto3 ClientError path and the KeyError path both still surface as InvokeError with the original message, so operators who rely on that contract see no change.\n\n## Release Notes\n\n- fix(bedrock): stop wrapping non-boto3 exceptions in `_invoke`'s inference-profile branch as `InvokeError`. A `NameError`/`TypeError`/`KeyError` (or any other `Exception`) raised by `_get_model_info`, `get_inference_profile_info`, `_generate_price_info`, or the converse-stream call now propagates verbatim, so real bugs in the inference-profile path surface instead of being silently re-raised as a generic `InvokeError`. The `ClientError` (boto3 / AWS) path is unchanged and still surfaces as `InvokeError` with the original message. Bumps the bedrock plugin from 0.0.83 \u2192 0.0.84.\n"