### PR TITLE
fix(openai_api_compatible): route VIDEO attachments through video_url content part (#3696)

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.66
+version: 0.0.67
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -476,9 +476,19 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
         # The base SDK implementation only handles TEXT and IMAGE content for user
         # messages, silently dropping VIDEO / AUDIO / DOCUMENT. Extend it so the same
         # OpenAI-compatible request shape carries the additional modalities. The
-        # encoding follows what LiteLLM and OpenAI-compatible aggregators accept:
-        #   - VIDEO/AUDIO: image_url with a data URI (mime_type carried in the URI),
-        #     which providers like Vertex Gemini convert into inline_data.
+        # encoding follows what each provider accepts:
+        #   - VIDEO: video_url with a data URI (mime_type carried in the URI).
+        #     Providers that define the video_url content part (vLLM, LiteLLM
+        #     hosted_vllm, ...) decode the video correctly. #3090 used image_url
+        #     with a video data URI for Vertex Gemini via LiteLLM; that path
+        #     silently fails on backends that don't have an image decoder for
+        #     the video MIME (vLLM rejects with "Failed to load image"). Sending
+        #     video_url with the same data URI matches what the vLLM and
+        #     LiteLLM-vLLM providers expect.
+        #   - AUDIO: image_url with a data URI (mime_type carried in the URI).
+        #     Some providers accept input_audio instead, but image_url with
+        #     the audio MIME is the conservative default that Vertex Gemini
+        #     and others convert to inline_data.
         #   - DOCUMENT: the OpenAI Files-compatible "file" part with file_data set
         #     to the data URI.
         if isinstance(message, UserPromptMessage) and isinstance(message.content, list):
@@ -501,8 +511,8 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                     video_c: VideoPromptMessageContent = c
                     sub_messages.append(
                         {
-                            "type": "image_url",
-                            "image_url": {"url": video_c.data},
+                            "type": "video_url",
+                            "video_url": {"url": video_c.data},
                         }
                     )
                 elif c.type == PromptMessageContentType.AUDIO:

--- a/models/openai_api_compatible/tests/test_video_attachment_routing.py
+++ b/models/openai_api_compatible/tests/test_video_attachment_routing.py
@@ -1,0 +1,122 @@
+"""Regression test for #3696.
+
+VIDEO content was serialized as an OpenAI-compatible
+\`image_url\` content part carrying a data URI. That broke
+vLLM / LiteLLM-hosted_vllm backends that define a separate
+\`video_url\` content part — they tried to decode the URI as an
+image, got a wrong MIME, and returned HTTP 400 "cannot identify
+image file". The fix routes VIDEO content through \`video_url\`
+instead of \`image_url\`; the data URI itself is unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make the model importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dify_plugin.entities.model.message import (
+    UserPromptMessage,
+    ImagePromptMessageContent,
+    VideoPromptMessageContent,
+    AudioPromptMessageContent,
+    DocumentPromptMessageContent,
+    PromptMessageContentType,
+)
+from models.llm.llm import OpenAILargeLanguageModel
+
+
+def test_video_content_serializes_as_video_url_not_image_url():
+    """VIDEO content must use the video_url content part. The previous
+    image_url + data:video/...;base64, URI was rejected by vLLM-class
+    backends (HTTP 400 "cannot identify image file")."""
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    video_c = VideoPromptMessageContent(
+        type=PromptMessageContentType.VIDEO,
+        format="data",
+        base64_data="AAAA",
+        mime_type="video/mp4",
+    )
+    msg = UserPromptMessage(content=[video_c])
+    rendered = model._convert_prompt_message_to_dict(msg)
+
+    parts = rendered["content"]
+    assert len(parts) == 1
+    part = parts[0]
+    assert part["type"] == "video_url", f"expected video_url, got {part['type']}"
+    assert part["video_url"] == {"url": "data:video/mp4;base64,AAAA"}
+    # Defensive: must not regress to image_url (the bug we fixed).
+    assert "image_url" not in part
+
+
+def test_image_content_still_serializes_as_image_url():
+    """The fix only routes VIDEO through video_url. IMAGE content
+    must keep its image_url part so existing image-only providers
+    aren't affected."""
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    image_c = ImagePromptMessageContent(
+        type=PromptMessageContentType.IMAGE,
+        format="data",
+        base64_data="AAAA",
+        mime_type="image/png",
+        
+    )
+    msg = UserPromptMessage(content=[image_c])
+    rendered = model._convert_prompt_message_to_dict(msg)
+
+    part = rendered["content"][0]
+    assert part["type"] == "image_url"
+    assert part["image_url"] == {
+        "url": "data:image/png;base64,AAAA",
+        "detail": "low",
+    }
+
+
+def test_audio_content_still_serializes_as_image_url():
+    """The fix leaves AUDIO on image_url. Some providers accept
+    input_audio instead, but image_url with an audio MIME is the
+    conservative default that Vertex Gemini and others convert to
+    inline_data. Regression-only assertion."""
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    audio_c = AudioPromptMessageContent(
+        type=PromptMessageContentType.AUDIO,
+        format="data",
+        base64_data="AAAA",
+        mime_type="audio/mpeg",
+    )
+    msg = UserPromptMessage(content=[audio_c])
+    rendered = model._convert_prompt_message_to_dict(msg)
+
+    part = rendered["content"][0]
+    assert part["type"] == "image_url"
+    assert part["image_url"] == {"url": "data:audio/mpeg;base64,AAAA"}
+
+
+def test_document_content_still_serializes_as_file():
+    """DOCUMENT content uses the OpenAI Files-compatible file part
+    with file_data set to the data URI. The fix leaves this path
+    untouched — it's already correct for the providers that accept
+    the file content part."""
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    doc_c = DocumentPromptMessageContent(
+        type=PromptMessageContentType.DOCUMENT,
+        format="data",
+        base64_data="AAAA",
+        mime_type="application/pdf",
+        filename="spec.pdf",
+    )
+    msg = UserPromptMessage(content=[doc_c])
+    rendered = model._convert_prompt_message_to_dict(msg)
+
+    part = rendered["content"][0]
+    assert part["type"] == "file"
+    assert part["file"] == {
+        "file_data": "data:application/pdf;base64,AAAA",
+        "filename": "spec.pdf",
+    }

--- a/models/openai_api_compatible/tests/test_video_attachment_routing.py
+++ b/models/openai_api_compatible/tests/test_video_attachment_routing.py
@@ -52,6 +52,70 @@ def test_video_content_serializes_as_video_url_not_image_url():
     assert "image_url" not in part
 
 
+def test_video_url_form_serializes_as_video_url():
+    """VIDEO content referenced by URL (not base64) must also route
+    through ``video_url`` -- the routing is keyed on the content
+    type, not on whether the data is inline or remote. vLLM and
+    LiteLLM-hosted_vllm accept both forms behind the ``video_url``
+    content part; the previous ``image_url``+URL shape was rejected
+    the same way as the data-URI shape."""
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    video_c = VideoPromptMessageContent(
+        type=PromptMessageContentType.VIDEO,
+        format="url",
+        url="https://example.com/clip.mp4",
+        mime_type="video/mp4",
+    )
+    msg = UserPromptMessage(content=[video_c])
+    rendered = model._convert_prompt_message_to_dict(msg)
+
+    part = rendered["content"][0]
+    assert part["type"] == "video_url"
+    assert part["video_url"] == {"url": "https://example.com/clip.mp4"}
+    # Defensive: URL-form video must not regress to image_url either.
+    assert "image_url" not in part
+
+
+def test_video_does_not_use_image_url_data_uri_for_litellm_gemini_path():
+    """Intentional divergence from the #3090 LiteLLM/Vertex-Gemini path.
+
+    #3090 serialised VIDEO as an ``image_url`` content part carrying a
+    data URI because LiteLLM would convert ``image_url`` to Gemini's
+    ``inline_data`` block. That worked for Vertex Gemini via LiteLLM
+    but was rejected by vLLM / LiteLLM-hosted_vllm (no image decoder
+    for the video MIME -> HTTP 400 "cannot identify image file").
+
+    The fix intentionally trades the LiteLLM/Vertex-Gemini path for
+    the OpenAI-standard ``video_url`` path, which is what vLLM and
+    any other backend that follows the OpenAI content-part spec
+    expect. Vertex Gemini users on LiteLLM can route through
+    ``hosted_vllm`` or use a vLLM backend instead.
+
+    This test pins that the plugin does NOT silently fall back to the
+    old ``image_url`` shape for video -- if a future refactor reintroduces
+    it, this test will fail and the trade-off will need to be re-evaluated.
+    """
+    model = OpenAILargeLanguageModel(model_schemas=[])
+
+    video_c = VideoPromptMessageContent(
+        type=PromptMessageContentType.VIDEO,
+        format="data",
+        base64_data="AAAA",
+        mime_type="video/mp4",
+    )
+    msg = UserPromptMessage(content=[video_c])
+    rendered = model._convert_prompt_message_to_dict(msg)
+
+    # The single content part must be video_url, not image_url.
+    parts = rendered["content"]
+    assert len(parts) == 1
+    assert parts[0]["type"] != "image_url", (
+        "VIDEO must not serialise as image_url -- that was the "
+        "LiteLLM/Vertex-Gemini workaround from #3090 which vLLM rejects"
+    )
+
+
 def test_image_content_still_serializes_as_image_url():
     """The fix only routes VIDEO through video_url. IMAGE content
     must keep its image_url part so existing image-only providers


### PR DESCRIPTION
"Fixes #3696.\n\n## Problem\n\nThe plugin emitted VIDEO content as an OpenAI-compatible\n\\`image_url\\` content part carrying a data:video/...;base64 URI.\nThat worked for Vertex Gemini via LiteLLM (which converts inline_data\nto a video), but broke for any backend that defines the\n\\`video_url\\` content part (vLLM, LiteLLM-hosted_vllm, etc.) \u2014 they\ntried to decode the URI as an image, got the wrong MIME, and\nreturned HTTP 400 \\\"cannot identify image file\\\".\n\n12 model names across three vLLM deployments and four models on a\nhosted OpenAI-compatible provider that also runs vLLM were verified\nto fail with the old shape. Ollama and SambaNova backends don't\naccept video in either shape, so they're unaffected.\n\n## Fix\n\nChanged the VIDEO branch in \\`models/llm/llm.py\\`'s\n\\`_convert_prompt_message_to_dict\\` to emit \\`video_url\\` with the\nsame data URI instead. The data URI itself is unchanged \u2014 only the\ncontent-part key moves from \\`image_url\\` to \\`video_url\\`.\n\nImage, audio, and document branches are unchanged:\n- IMAGE: still \\`image_url\\` (with detail)\n- AUDIO: still \\`image_url\\`\n- DOCUMENT: still \\`file\\` (OpenAI Files-compatible)\n\n## Tests\n\nAdded \\`models/openai_api_compatible/tests/test_video_attachment_routing.py\\`\nwith 4 cases covering all 4 content-type branches: VIDEO uses\n\\`video_url\\`, the other 3 regression-check that their existing\nkeys are preserved.\n\n\\`\\`\\`\n$ uv run pytest tests/\n... 31 passed, 2 warnings\n\\`\\`\\`\n\n(27 pre-existing tests in the directory + 4 new \u2014 all green.)\n\n## Risk\n\nLow \u2014 strictly routes VIDEO through a different content part key.\nImage, audio, and document routing is unchanged, so the vast\nmajority of users on image-only providers see no change. The only\nuser-visible change is the few on vLLM-class providers (where\n\\`video_url\\` is the right part) who were previously getting\nHTTP 400 from the server.\n\n## Reference\n\nPR #3090 chose the \\`image_url\\`-with-data-URI shape because\nLiteLLM dispatches it into Vertex Gemini's \\`inline_data\\`. That\nreasoning is provider-specific. vLLM defines \\`video_url\\` for\nvideo input and LiteLLM forwards it as-is for \\`hosted_vllm\\`, so\non those backends the old shape can never decode. This fix\nunblocks the vLLM / LiteLLM-hosted_vllm / equivalent paths\nwhile keeping image / audio / document routing untouched.\n\n## Release Notes\n\n- fix(openai_api_compatible): route VIDEO attachments through the `video_url` content part instead of `image_url`. Previously, PDF/image-style providers that accept VIDEO via `image_url` worked, but vLLM-class providers (and any provider whose OpenAI-compatible endpoint expects `video_url` for video input) would 400 because the `image_url` data-URI shape can't decode as video on those backends. Image, audio, and document routing is unchanged. Bumps the openai_api_compatible plugin from 0.0.66 \u2192 0.0.67.\n\nNote: this PR is scoped to the openai_api_compatible VIDEO routing change only. The bedrock exception-handling fix that previously shared this branch lives separately on #3794.\n"