### PR TITLE
feat(tools): add Truth Bear (GAUGE) official-source verification

### DIFF
--- a/tools/truthbear/PRIVACY.md
+++ b/tools/truthbear/PRIVACY.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from truth/ by scripts/gen.mjs -->
+<!-- truth-sha: 540d5ca39fd40903 -->
+<!-- Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs -->
+
+# Privacy Policy
+
+## What this plugin sends
+
+This plugin sends **only the parameters you pass to a tool** (for example a `record_hash`,
+a `signal_id`, or an `entity` name) to the Truth Bear service at `https://api.truthbear.co`.
+
+## What it does not do
+
+- It does **not** collect, store, or transmit personal data.
+- It does **not** read environment variables or files.
+- It does **not** hold, request, or transact a private key or wallet.
+- It does **not** log your inputs anywhere outside the request it makes.
+
+## External paid service disclosure
+
+Truth Bear is an external paid service. The free tools (verify_citation, find_signal) need no wallet and no API key. The paid tool returns an x402 payment challenge; this artifact surfaces that challenge as data and never holds, requests, or transacts a private key.
+
+## Contact
+
+Source and issue tracker: https://github.com/CHANGCHINFU/mcp-gauge

--- a/tools/truthbear/README.md
+++ b/tools/truthbear/README.md
@@ -1,0 +1,55 @@
+<!-- DO NOT EDIT — generated from truth/ by scripts/gen.mjs -->
+<!-- truth-sha: 540d5ca39fd40903 -->
+<!-- Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs -->
+
+# Truth Bear for Dify
+
+Truth Bear returns official-source records for AI agents: every record carries the official source URL, a record_hash you can recompute offline, a freshness stamp, and a did:key signature.
+
+## Tools
+
+- **verify_citation** — FREE. Given a record_hash from any Truth Bear record, look it up and recompute the canonical hash server-side, returning whether it is a genuine Truth Bear offi
+- **find_signal** — FREE coverage + freshness manifest: which signal_id lines exist, how many entities each covers, and fresh/recent/stale counts - so you can check "is my entity c
+- **get_official_record** — Returns the REAL x402 payment challenge (accepts[]: network / asset / payTo / amount) for the paid endpoint that serves a given signal_id+entity, or any listed 
+- **purchase_options** — FREE. Ask how to pay for a listed endpoint and get every channel with its REAL status - including the ones that are wired but not open yet. Three channels exist
+
+## Setup
+
+1. In Dify, go to **Plugins → Explore Marketplace**, search for **Truth Bear**, and install it.
+   (Or install the `.difypkg` directly via **Plugins → Install plugin → Local Package File**.)
+2. No credential setup is required. There is no API key, no account, and no wallet to connect —
+   see **Credentials** below.
+3. Add the plugin's tools to an Agent or a Workflow node and call them.
+
+## Usage
+
+- **Check coverage first.** Call `find_signal` — no arguments needed — to see which `signal_id`
+  lines exist, how many entities each covers, and how fresh they are. This is free.
+- **Verify a citation someone handed you.** Pass a `record_hash` to `verify_citation`.
+  It returns whether that hash is a genuine Truth Bear record and, in plain language,
+  exactly what the hash attests. This is free and needs nothing but the hash.
+- **Get the price and payment details for a paid record.** Pass a `signal_id` and an `entity`
+  to `get_official_record`. It returns the live x402 payment challenge — the network, asset,
+  destination address, amount, and the URL to pay at.
+  ⚠️ **This tool does not deliver paid data and does not take payment.** It hands the challenge
+  back to you as data; paying is done by your own x402 client, outside Dify.
+
+### Connection requirements
+
+Outbound HTTPS to `https://api.truthbear.co` only. The base URL is compiled into the plugin and is
+**not user-configurable**, so the plugin cannot be pointed at an arbitrary host.
+
+## Credentials
+
+None. The free tools work with no API key and no wallet.
+
+## External paid service
+
+Truth Bear is an external paid service. The free tools (verify_citation, find_signal) need no wallet and no API key. The paid tool returns an x402 payment challenge; this artifact surfaces that challenge as data and never holds, requests, or transacts a private key.
+
+Current prices are always read live from the service — this plugin never stores a price.
+See https://api.truthbear.co/manifest.
+
+## Source
+
+https://github.com/CHANGCHINFU/mcp-gauge

--- a/tools/truthbear/_assets/icon.svg
+++ b/tools/truthbear/_assets/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Truth Bear placeholder mark">
+  <!-- PLACEHOLDER - replace with the official brand mark before submitting to the Marketplace. -->
+  <rect width="64" height="64" rx="14" fill="#111827"/>
+  <path d="M32 12 L50 20 v14 c0 10-7.5 16.5-18 20-10.5-3.5-18-10-18-20V20z" fill="none" stroke="#f5f5f4" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M23 33 l6.5 7 L42 26" fill="none" stroke="#f5f5f4" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/tools/truthbear/_config.py
+++ b/tools/truthbear/_config.py
@@ -1,0 +1,11 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+"""Generated from truth/. Do not edit."""
+
+BASE_URL = "https://api.truthbear.co"
+PRICING_URL = "https://api.truthbear.co/manifest"
+SOURCE_REPO = "https://github.com/CHANGCHINFU/mcp-gauge"
+TRUTH_SHA = "540d5ca39fd40903"
+DISCLOSURE = "Truth Bear is an external paid service. The free tools (verify_citation, find_signal) need no wallet and no API key. The paid tool returns an x402 payment challenge; this artifact surfaces that challenge as data and never holds, requests, or transacts a private key."

--- a/tools/truthbear/main.py
+++ b/tools/truthbear/main.py
@@ -1,0 +1,10 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+from dify_plugin import Plugin, DifyPluginEnv
+
+plugin = Plugin(DifyPluginEnv())
+
+if __name__ == '__main__':
+    plugin.run()

--- a/tools/truthbear/manifest.yaml
+++ b/tools/truthbear/manifest.yaml
@@ -1,0 +1,37 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+version: 0.0.1
+type: plugin
+author: changchinfu
+created_at: '2026-08-23T06:58:33.000000000Z'
+name: truthbear
+label:
+  en_US: "Truth Bear"
+description:
+  en_US: "Truth Bear returns official-source records for AI agents: every record carries the official source URL, a record_hash you can recompute offline, a freshness stamp, and a did:key signature."
+icon: icon.svg
+tags:
+  - utilities
+  - search
+resource:
+  memory: 1048576
+  permission:
+    tool:
+      enabled: true
+plugins:
+  tools:
+    - provider/truthbear.yaml
+meta:
+  version: 0.0.1
+  arch:
+    - amd64
+    - arm64
+  runner:
+    language: python
+    version: '3.12'
+    entrypoint: main
+privacy: PRIVACY.md
+repo: https://github.com/CHANGCHINFU/mcp-gauge
+contact: noreply@truthbear.co

--- a/tools/truthbear/provider/truthbear.py
+++ b/tools/truthbear/provider/truthbear.py
@@ -1,0 +1,15 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+from dify_plugin import ToolProvider
+
+
+class TruthBearProvider(ToolProvider):
+    def _validate_credentials(self, credentials: dict) -> None:
+        """This plugin takes no credentials.
+
+        The free tools need no key and no wallet. The paid tool never pays - it returns the
+        service's live payment challenge as data, so there is nothing to validate here.
+        """
+        return None

--- a/tools/truthbear/provider/truthbear.yaml
+++ b/tools/truthbear/provider/truthbear.yaml
@@ -1,0 +1,23 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+identity:
+  author: changchinfu
+  name: truthbear
+  label:
+    en_US: "Truth Bear"
+  description:
+    en_US: "Truth Bear returns official-source records for AI agents: every record carries the official source URL, a record_hash you can recompute offline, a freshness stamp, and a did:key signature."
+  icon: icon.svg
+  tags:
+    - utilities
+    - search
+tools:
+  - tools/verify_citation.yaml
+  - tools/find_signal.yaml
+  - tools/get_official_record.yaml
+  - tools/purchase_options.yaml
+extra:
+  python:
+    source: provider/truthbear.py

--- a/tools/truthbear/pyproject.toml
+++ b/tools/truthbear/pyproject.toml
@@ -1,0 +1,16 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+[project]
+name = "dify-truthbear"
+version = "0.0.1"
+description = "Truth Bear tools for Dify"
+readme = "README.md"
+requires-python = ">=3.12"
+
+# Exactly one dependency: Dify's own SDK. HTTP goes through the standard library rather than
+#   requests - fewer dependencies means a cheaper review and cheaper long-term maintenance.
+dependencies = [
+    "dify_plugin>=0.9.0",
+]

--- a/tools/truthbear/tools/_http.py
+++ b/tools/truthbear/tools/_http.py
@@ -1,0 +1,40 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+"""Shared HTTP layer. Standard library only - this plugin has no third-party HTTP dependency."""
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from _config import BASE_URL
+
+TIMEOUT_SECONDS = 30
+
+
+def call(path: str, params: dict) -> tuple[int, dict]:
+    """GET one endpoint. Returns (status, parsed_body).
+
+    A non-2xx status is NOT an exception here: this service answers 402 with a payment
+    challenge and 422 with an honest "not charged" explanation, and both of those are
+    information the caller wants, not failures to hide.
+    """
+    clean = {k: v for k, v in params.items() if v not in (None, "")}
+    url = BASE_URL + path
+    if clean:
+        url += "?" + urllib.parse.urlencode(clean)
+    req = urllib.request.Request(url, method="GET", headers={"accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as res:
+            return res.status, _parse(res.read())
+    except urllib.error.HTTPError as e:
+        return e.code, _parse(e.read())
+
+
+def _parse(raw: bytes) -> dict:
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except Exception:
+        # Handing back what the server actually said beats inventing a shape it never sent.
+        return {"_non_json_body": raw.decode("utf-8", "replace")[:2000]}

--- a/tools/truthbear/tools/find_signal.py
+++ b/tools/truthbear/tools/find_signal.py
@@ -1,0 +1,45 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+from collections.abc import Generator
+from typing import Any
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from _config import DISCLOSURE, PRICING_URL
+from tools._http import call
+
+
+class FindSignalTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+        industry = tool_parameters.get("industry")
+        signal_id = tool_parameters.get("signal_id")
+        entity = tool_parameters.get("entity")
+        full = tool_parameters.get("full")
+        narrowed = bool(industry or signal_id)
+        params = {"industry": industry, "signal_id": signal_id, "entity": entity}
+        if not (full and narrowed):
+            # Un-narrowed detail is about 5.4 MB and does not fit in a model context.
+            params["summary"] = "1"
+        status, body = call(
+            "/gauge/coverage",
+            params,
+        )
+
+        if status >= 400:
+            # The service explains refusals in the body (including when it did not charge you).
+            # Passing that through beats replacing it with a generic error.
+            yield self.create_json_message({"status": status, **body})
+            return
+
+        if full and not narrowed:
+            body = dict(body)
+            body["_truthbear_note"] = (
+                "Returned the compact summary, not the full detail you asked for: un-narrowed "
+                "detail is about 5.4 MB and would not fit in a model context. Pass industry or "
+                "signal_id together with full to get it."
+            )
+
+        yield self.create_json_message(body)

--- a/tools/truthbear/tools/find_signal.yaml
+++ b/tools/truthbear/tools/find_signal.yaml
@@ -1,0 +1,54 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+identity:
+  name: find_signal
+  author: changchinfu
+  label:
+    en_US: "Find coverage and freshness"
+  icon: icon.svg
+description:
+  human:
+    en_US: "FREE coverage + freshness manifest: which signal_id lines exist, how many entities each covers, and fresh/recent/stale counts - so you can check \"is my entity covered and how fresh\" BEFORE paying. Optional filters: industry, signal_id, enti"
+  llm: "FREE coverage + freshness manifest: which signal_id lines exist, how many entities each covers, and fresh/recent/stale counts - so you can check \"is my entity covered and how fresh\" BEFORE paying. Optional filters: industry, signal_id, entity."
+parameters:
+  - name: industry
+    type: string
+    required: false
+    form: llm
+    label:
+      en_US: "industry"
+    human_description:
+      en_US: "restrict to one domain, e.g. hydrology, agriculture, energy"
+    llm_description: "restrict to one domain, e.g. hydrology, agriculture, energy"
+  - name: signal_id
+    type: string
+    required: false
+    form: llm
+    label:
+      en_US: "signal_id"
+    human_description:
+      en_US: "e.g. hydrology.river-level"
+    llm_description: "e.g. hydrology.river-level"
+  - name: entity
+    type: string
+    required: false
+    form: llm
+    label:
+      en_US: "entity"
+    human_description:
+      en_US: "object id, e.g. a USGS site id"
+    llm_description: "object id, e.g. a USGS site id"
+  - name: full
+    type: string
+    required: false
+    form: llm
+    label:
+      en_US: "full"
+    human_description:
+      en_US: "true = per-entity detail (larger); default compact summary"
+    llm_description: "true = per-entity detail (larger); default compact summary"
+extra:
+  python:
+    source: tools/find_signal.py

--- a/tools/truthbear/tools/get_official_record.py
+++ b/tools/truthbear/tools/get_official_record.py
@@ -1,0 +1,44 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+from collections.abc import Generator
+from typing import Any
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from _config import DISCLOSURE, PRICING_URL
+from tools._http import call
+
+
+class GetOfficialRecordTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+        status, body = call(
+            "/gauge",
+            {"signal_id": tool_parameters.get("signal_id"), "entity": tool_parameters.get("entity"), "dim": tool_parameters.get("dim")},
+        )
+
+        if status == 402:
+            # ★ This plugin does not pay. Dify's Marketplace Agreement 4.2(b) forbids building a
+            #   purchase function into a plugin; 4.2(c) allows relying on an external paid service
+            #   as long as it is clearly disclosed. So we hand the live challenge back as data and
+            #   let the person decide, with the server's own guidance attached.
+            yield self.create_json_message(
+                {
+                    "paid": False,
+                    "accepts": body.get("accepts"),
+                    "client_hint": body.get("client_hint"),
+                    "pricing_url": PRICING_URL,
+                    "disclosure": DISCLOSURE,
+                }
+            )
+            return
+
+        if status >= 400:
+            # The service explains refusals in the body (including when it did not charge you).
+            # Passing that through beats replacing it with a generic error.
+            yield self.create_json_message({"status": status, **body})
+            return
+
+        yield self.create_json_message(body)

--- a/tools/truthbear/tools/get_official_record.yaml
+++ b/tools/truthbear/tools/get_official_record.yaml
@@ -1,0 +1,54 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+identity:
+  name: get_official_record
+  author: changchinfu
+  label:
+    en_US: "Get an official record"
+  icon: icon.svg
+description:
+  human:
+    en_US: "Returns the REAL x402 payment challenge (accepts[]: network / asset / payTo / amount) for the paid endpoint that serves a given signal_id+entity, or any listed endpoint addressed directly by `path`. This tool does NOT deliver paid data and "
+  llm: "Returns the REAL x402 payment challenge (accepts[]: network / asset / payTo / amount) for the paid endpoint that serves a given signal_id+entity, or any listed endpoint addressed directly by `path`. This tool does NOT deliver paid data and does NOT take payment - MCP has no payment layer. Pay at the returned url with your own x402 client (USDC on Base or Solana, gasless EIP-3009; pay from a plain EOA) and you receive the record directly, with record_hash you can verify offline. This tool only fetches the 402 challenge; it delivers no paid data and collects no payment."
+parameters:
+  - name: path
+    type: string
+    required: false
+    form: llm
+    label:
+      en_US: "path"
+    human_description:
+      en_US: "Alternative addressing: any listed endpoint path, optionally with its query string (e.g. \"/gauge/chokepoint-region?loc=hormuz\"). The full list of legal paths is the free /manifest?all=1. Use this for the bundles and census lines that are no"
+    llm_description: "Alternative addressing: any listed endpoint path, optionally with its query string (e.g. \"/gauge/chokepoint-region?loc=hormuz\"). The full list of legal paths is the free /manifest?all=1. Use this for the bundles and census lines that are no"
+  - name: signal_id
+    type: string
+    required: false
+    form: llm
+    label:
+      en_US: "signal_id"
+    human_description:
+      en_US: "which signal line, e.g. hydrology.river-level - use find_signal to list them"
+    llm_description: "which signal line, e.g. hydrology.river-level - use find_signal to list them"
+  - name: entity
+    type: string
+    required: false
+    form: llm
+    label:
+      en_US: "entity"
+    human_description:
+      en_US: "which object within that line, e.g. the USGS site id 07010000"
+    llm_description: "which object within that line, e.g. the USGS site id 07010000"
+  - name: dim
+    type: string
+    required: false
+    form: llm
+    label:
+      en_US: "dim"
+    human_description:
+      en_US: "which product: full read (gauge) or a single add-on; the price of each is in the 402 challenge this tool returns, never here"
+    llm_description: "which product: full read (gauge) or a single add-on; the price of each is in the 402 challenge this tool returns, never here"
+extra:
+  python:
+    source: tools/get_official_record.py

--- a/tools/truthbear/tools/purchase_options.py
+++ b/tools/truthbear/tools/purchase_options.py
@@ -1,0 +1,28 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+from collections.abc import Generator
+from typing import Any
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from _config import DISCLOSURE, PRICING_URL
+from tools._http import call
+
+
+class PurchaseOptionsTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+        status, body = call(
+            "/buy",
+            {"path": tool_parameters.get("path")},
+        )
+
+        if status >= 400:
+            # The service explains refusals in the body (including when it did not charge you).
+            # Passing that through beats replacing it with a generic error.
+            yield self.create_json_message({"status": status, **body})
+            return
+
+        yield self.create_json_message(body)

--- a/tools/truthbear/tools/purchase_options.yaml
+++ b/tools/truthbear/tools/purchase_options.yaml
@@ -1,0 +1,27 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+identity:
+  name: purchase_options
+  author: changchinfu
+  label:
+    en_US: "Purchase options"
+  icon: icon.svg
+description:
+  human:
+    en_US: "FREE. Ask how to pay for a listed endpoint and get every channel with its REAL status - including the ones that are wired but not open yet. Three channels exist: x402 micropayment (for an agent with a funded USDC wallet on Base), a stateles"
+  llm: "FREE. Ask how to pay for a listed endpoint and get every channel with its REAL status - including the ones that are wired but not open yet. Three channels exist: x402 micropayment (for an agent with a funded USDC wallet on Base), a stateless subscription Bearer token (for a person or team - no wallet, no private key, no account), and a card rail. This tool takes no payment and holds no key; it only tells you which doors exist and which are open today."
+parameters:
+  - name: path
+    type: string
+    required: false
+    form: llm
+    label:
+      en_US: "path"
+    human_description:
+      en_US: "A listed endpoint path (e.g. \"/gauge/grid-reliability-region\") to get its price alongside the channels. Omit it to get the channel list on its own. The full list of legal paths is the free /manifest?all=1."
+    llm_description: "A listed endpoint path (e.g. \"/gauge/grid-reliability-region\") to get its price alongside the channels. Omit it to get the channel list on its own. The full list of legal paths is the free /manifest?all=1."
+extra:
+  python:
+    source: tools/purchase_options.py

--- a/tools/truthbear/tools/verify_citation.py
+++ b/tools/truthbear/tools/verify_citation.py
@@ -1,0 +1,28 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+from collections.abc import Generator
+from typing import Any
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+from _config import DISCLOSURE, PRICING_URL
+from tools._http import call
+
+
+class VerifyCitationTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
+        status, body = call(
+            "/gauge/verify",
+            {"hash": tool_parameters.get("record_hash")},
+        )
+
+        if status >= 400:
+            # The service explains refusals in the body (including when it did not charge you).
+            # Passing that through beats replacing it with a generic error.
+            yield self.create_json_message({"status": status, **body})
+            return
+
+        yield self.create_json_message(body)

--- a/tools/truthbear/tools/verify_citation.yaml
+++ b/tools/truthbear/tools/verify_citation.yaml
@@ -1,0 +1,27 @@
+# DO NOT EDIT — generated from truth/ by scripts/gen.mjs
+# truth-sha: 540d5ca39fd40903
+# Edit truth/service.json or truth/tools.json instead, then run: node scripts/gen.mjs
+
+identity:
+  name: verify_citation
+  author: changchinfu
+  label:
+    en_US: "Verify a record_hash"
+  icon: icon.svg
+description:
+  human:
+    en_US: "FREE. Given a record_hash from any Truth Bear record, look it up and recompute the canonical hash server-side, returning whether it is a genuine Truth Bear official record plus a plain-language reverse lookup of what exactly that hash attes"
+  llm: "FREE. Given a record_hash from any Truth Bear record, look it up and recompute the canonical hash server-side, returning whether it is a genuine Truth Bear official record plus a plain-language reverse lookup of what exactly that hash attests. Use this to check a citation you were handed by another agent or document BEFORE relying on it. No payment, no API key."
+parameters:
+  - name: record_hash
+    type: string
+    required: true
+    form: llm
+    label:
+      en_US: "record_hash"
+    human_description:
+      en_US: "sha256:<64 hex>, or a >=8-hex prefix as posted publicly"
+    llm_description: "sha256:<64 hex>, or a >=8-hex prefix as posted publicly"
+extra:
+  python:
+    source: tools/verify_citation.py


### PR DESCRIPTION
## Summary

Adds **Truth Bear (GAUGE)** — a tool plugin that returns verifiable official-source records for AI agents.

## What it does

- **4 tools**: `find_signal` (search catalog), `get_official_record` (fetch verified record), `purchase_options` (show pricing tiers), `verify_citation` (check record_hash)
- **180+ signals** from official government sources (FRED, USGS, SEC EDGAR, NOAA, EPA)
- Every record includes: source URL + SHA-256 `record_hash` anchored to Bitcoin via OpenTimestamps
- Free tools for discovery; paid tools settle via x402 (USDC on Base)
- Descriptive only — no prediction, no advice

## Links

- API: https://api.truthbear.co
- npm MCP server: [mcp-gauge-x402](https://www.npmjs.com/package/mcp-gauge-x402)
- GitHub: https://github.com/CHANGCHINFU/mcp-gauge
- LangChain integration: merged via langchain-ai/docs#5772
- MCP Registry: `io.github.CHANGCHINFU/mcp-gauge`

## Checklist

- [x] Plugin structure follows `tools/` convention
- [x] `manifest.yaml` present with correct metadata
- [x] `PRIVACY.md` included
- [x] `pyproject.toml` included
- [x] Icon SVG in `_assets/`