### PR TITLE
feat(vertex_ai): add Gemini 3.6 Flash and 3.7 Flash model support

### DIFF
--- a/models/vertex_ai/manifest.yaml
+++ b/models/vertex_ai/manifest.yaml
@@ -32,4 +32,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.62
+version: 0.0.63

--- a/models/vertex_ai/models/llm/gemini-3.6-flash.yaml
+++ b/models/vertex_ai/models/llm/gemini-3.6-flash.yaml
@@ -1,0 +1,135 @@
+# https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash
+model: gemini-3.6-flash
+label:
+  en_US: Gemini 3.6 Flash
+model_type: llm
+features:
+  - tool-call
+  - multi-tool-call
+  - agent-thought
+  - vision
+  - stream-tool-call
+  - document
+  - video
+  - audio
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    type: float
+    required: true
+    default: 1
+    min: 0
+    max: 2
+    label:
+      en_US: Temperature
+      zh_Hans: 温度
+    help:
+      en_US: For Gemini 3, best results at default 1.0. Lower values may impact reasoning.
+      zh_Hans: 对于 Gemini 3，使用默认值 1.0 可获得最佳效果。数值过低可能会影响推理能力。
+  - name: top_p
+    use_template: top_p
+    default: 0.95
+  - name: max_output_tokens
+    type: int
+    required: true
+    default: 65536
+    min: 1
+    max: 65536
+    label:
+      en_US: Output length
+      zh_Hans: 输出长度
+    help:
+      en_US: The maximum number of tokens to generate in the response.
+      zh_Hans: 模型单次输出的最大 tokens 数。
+  - name: thinking_level
+    label:
+      zh_Hans: 思考层级
+      en_US: Thinking Level
+    type: string
+    default: "Medium"
+    options:
+      - Minimal
+      - Low
+      - Medium
+      - High
+    required: false
+    help:
+      zh_Hans: 控制模型推理深度。High 提供最深入的推理，Minimal 适合最简单任务。默认为 Medium。注意此参数仅适用于 Gemini 3，与 thinking_budget 互斥。
+      en_US: Controls the maximum depth of the model's reasoning. High provides deepest reasoning, Minimal is suitable for simplest tasks. Defaults to Medium. Note this parameter is only for Gemini 3 and is mutually exclusive with thinking_budget.
+  - name: include_thoughts
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Include Thoughts
+      zh_Hans: 返回思考过程
+    help:
+      en_US: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available.
+      zh_Hans: 是否返回思考过程。若为 true 则只有模型支持思考且启动思考模式时才返回思考过程。
+  - name: media_resolution
+    type: string
+    required: false
+    default: "Default"
+    options:
+      - Default
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Media Resolution
+      zh_Hans: 媒体分辨率
+    help:
+      en_US: |
+        Fine-grained control over multimodal visual processing quality. Higher resolution improves small text reading and detail recognition but increases token usage and latency.
+
+        Token Impact: Images (High: 1120 tokens), PDF (Medium: 560 tokens), Video regular (Low/Medium: 70 tokens/frame), Video text-heavy (High: 280 tokens/frame).
+
+        If not specified, the model automatically selects the best resolution based on media type.
+      zh_Hans: |
+        对多模态视觉处理质量的精细控制。分辨率越高，模型读取细小文本和识别细节的能力越强，但会增加令牌用量和延迟。
+
+        令牌影响：图片(High: 1120 tokens)，PDF(Medium: 560 tokens)，视频常规(Low/Medium: 70 tokens/帧)，视频文字密集(High: 280 tokens/帧)。
+
+        如果不指定，模型会根据媒体类型自动选择最佳分辨率。
+  - name: grounding
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Grounding
+      zh_Hans: 事实核查
+    help:
+      en_US: Grounding with Google Search. The model will use Google search results as reference information.
+      zh_Hans: 使用 Google 搜索进行事实核查。模型会将搜索结果作为参考信息。
+  - name: url_context
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: URL Context
+      zh_Hans: 链接详情
+    help:
+      en_US: Browse the URL context. Get and analyze detailed information from URLs to provide reference for responses.
+      zh_Hans: 获取并分析链接的详细信息，为回答提供参考依据。
+  - name: code_execution
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Code Execution
+      zh_Hans: 代码执行
+    help:
+      en_US: Lets Gemini use code to solve complex tasks.
+      zh_Hans: 让 Gemini 使用代码来解决复杂任务。
+  - name: json_schema
+    use_template: json_schema
+# https://ai.google.dev/gemini-api/docs/pricing#gemini-3.6-flash
+# Introductory pricing applies through 2026-12-31.
+pricing:
+  input: '0.75'
+  output: '3.75'
+  unit: '0.000001'
+  currency: USD

--- a/models/vertex_ai/models/llm/gemini-3.7-flash.yaml
+++ b/models/vertex_ai/models/llm/gemini-3.7-flash.yaml
@@ -1,0 +1,134 @@
+# https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash
+model: gemini-3.7-flash
+label:
+  en_US: Gemini 3.7 Flash
+model_type: llm
+features:
+  - tool-call
+  - multi-tool-call
+  - agent-thought
+  - vision
+  - stream-tool-call
+  - document
+  - video
+  - audio
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: temperature
+    type: float
+    required: true
+    default: 1
+    min: 0
+    max: 2
+    label:
+      en_US: Temperature
+      zh_Hans: 温度
+    help:
+      en_US: For Gemini 3, best results at default 1.0. Lower values may impact reasoning.
+      zh_Hans: 对于 Gemini 3，使用默认值 1.0 可获得最佳效果。数值过低可能会影响推理能力。
+  - name: top_p
+    use_template: top_p
+    default: 0.95
+  - name: max_output_tokens
+    type: int
+    required: true
+    default: 65536
+    min: 1
+    max: 65536
+    label:
+      en_US: Output length
+      zh_Hans: 输出长度
+    help:
+      en_US: The maximum number of tokens to generate in the response.
+      zh_Hans: 模型单次输出的最大 tokens 数。
+  - name: thinking_level
+    label:
+      zh_Hans: 思考层级
+      en_US: Thinking Level
+    type: string
+    default: "Medium"
+    options:
+      - Low
+      - Medium
+      - High
+    required: false
+    help:
+      zh_Hans: 控制模型推理深度。High 提供最深入的推理，Low 适合对延迟敏感的任务。默认为 Medium。Gemini 3.7 Flash 不支持 Minimal。注意此参数仅适用于 Gemini 3，与 thinking_budget 互斥。
+      en_US: Controls the maximum depth of the model's reasoning. High provides deepest reasoning, Low is suitable for latency-critical tasks. Defaults to Medium. Gemini 3.7 Flash does not support Minimal. Note this parameter is only for Gemini 3 and is mutually exclusive with thinking_budget.
+  - name: include_thoughts
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Include Thoughts
+      zh_Hans: 返回思考过程
+    help:
+      en_US: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available.
+      zh_Hans: 是否返回思考过程。若为 true 则只有模型支持思考且启动思考模式时才返回思考过程。
+  - name: media_resolution
+    type: string
+    required: false
+    default: "Default"
+    options:
+      - Default
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Media Resolution
+      zh_Hans: 媒体分辨率
+    help:
+      en_US: |
+        Fine-grained control over multimodal visual processing quality. Higher resolution improves small text reading and detail recognition but increases token usage and latency.
+
+        Token Impact: Images (High: 1120 tokens), PDF (Medium: 560 tokens), Video regular (Low/Medium: 70 tokens/frame), Video text-heavy (High: 280 tokens/frame).
+
+        If not specified, the model automatically selects the best resolution based on media type.
+      zh_Hans: |
+        对多模态视觉处理质量的精细控制。分辨率越高，模型读取细小文本和识别细节的能力越强，但会增加令牌用量和延迟。
+
+        令牌影响：图片(High: 1120 tokens)，PDF(Medium: 560 tokens)，视频常规(Low/Medium: 70 tokens/帧)，视频文字密集(High: 280 tokens/帧)。
+
+        如果不指定，模型会根据媒体类型自动选择最佳分辨率。
+  - name: grounding
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Grounding
+      zh_Hans: 事实核查
+    help:
+      en_US: Grounding with Google Search. The model will use Google search results as reference information.
+      zh_Hans: 使用 Google 搜索进行事实核查。模型会将搜索结果作为参考信息。
+  - name: url_context
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: URL Context
+      zh_Hans: 链接详情
+    help:
+      en_US: Browse the URL context. Get and analyze detailed information from URLs to provide reference for responses.
+      zh_Hans: 获取并分析链接的详细信息，为回答提供参考依据。
+  - name: code_execution
+    type: boolean
+    required: false
+    default: false
+    label:
+      en_US: Code Execution
+      zh_Hans: 代码执行
+    help:
+      en_US: Lets Gemini use code to solve complex tasks.
+      zh_Hans: 让 Gemini 使用代码来解决复杂任务。
+  - name: json_schema
+    use_template: json_schema
+# https://ai.google.dev/gemini-api/docs/pricing#gemini-3.7-flash
+# Introductory pricing applies through 2026-12-31.
+pricing:
+  input: '0.75'
+  output: '3.75'
+  unit: '0.000001'
+  currency: USD

--- a/models/vertex_ai/models/llm/llm.py
+++ b/models/vertex_ai/models/llm/llm.py
@@ -60,6 +60,8 @@ GLOBAL_ONLY_MODELS_DEFAULT = [
     "gemini-3.1-flash-image-preview",
     "gemini-3.5-flash",
     "gemini-3.5-flash-lite",
+    "gemini-3.6-flash",
+    "gemini-3.7-flash",
 ]
 IMAGE_GENERATION_MODELS = {
     "gemini-3.1-flash-image-preview",


### PR DESCRIPTION
Adds the `gemini-3.6-flash` and `gemini-3.7-flash` model definitions under vertex_ai, mirroring the parameter style of the existing Gemini 3 family (temperature, top_p, max_output_tokens, thinking_level, include_thoughts, media_resolution, grounding, url_context, code_execution, json_schema).

- Both models: 1M context window, 65536 max output tokens, and introductory pricing of 0.75/M input and 3.75/M output USD (in effect through 2026-12-31), matching the gemini plugin's definitions for the same models.
- `gemini-3.7-flash` omits the `Minimal` thinking level, which Google documents as unsupported for that model; `gemini-3.6-flash` keeps the full Minimal/Low/Medium/High range.
- Added both to `GLOBAL_ONLY_MODELS_DEFAULT`: these models are served on the global endpoint only, so a regional vertex_location would 404. Still overridable via the `vertex_global_models` credential.
- Bumped manifest version to 0.0.63.

## Summary

Gemini 3.6 Flash and Gemini 3.7 Flash are generally available on Vertex AI, but the vertex_ai plugin's newest Gemini Flash entry is still `gemini-3.5-flash`, so neither model can be selected from the model list. The `gemini` (AI Studio) plugin already ships both models — this PR brings vertex_ai to parity.

No runtime code paths change. `llm.py` is touched only to append the two model ids to `GLOBAL_ONLY_MODELS_DEFAULT`; the existing `thinking_level` handling is already generic over the Gemini 3 family (`"gemini-3" in model`), so no new branching was needed.

## Release Notes

Added support for two new Gemini models on Vertex AI:

- **Gemini 3.6 Flash** (`gemini-3.6-flash`)
- **Gemini 3.7 Flash** (`gemini-3.7-flash`)

Both models support a 1M token context window, up to 65,536 output tokens, thinking levels, multimodal input (image / document / video / audio), tool calling, structured output, Google Search grounding, URL context, and code execution.

These models are served on Vertex AI's global endpoint only. The plugin routes them there automatically, so no change to your `vertex_location` setting is required.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos


https://github.com/user-attachments/assets/8e4a1e35-30b1-4347-b7fd-2c9fdd17a91a



| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — 0.0.62 → 0.0.63 (`meta.version` left at 0.0.1)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!-- This plugin already declares `dify_plugin>=0.10.0` (required for `get_current_session()`) and locks 0.10.2 in `uv.lock`. Dependencies are unchanged by this PR. -->

## Testing

- [x] Local deployment — Dify version: 1.17.0
- [ ] SaaS (cloud.dify.ai)