### PR TITLE
feat(groq): attach Dify app_id as request headers (opt-in)

### DIFF
--- a/models/groq/manifest.yaml
+++ b/models/groq/manifest.yaml
@@ -36,4 +36,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.17
+version: 0.0.18

--- a/models/groq/models/llm/_metadata.py
+++ b/models/groq/models/llm/_metadata.py
@@ -1,0 +1,125 @@
+"""Helpers for attaching Dify metadata to Groq requests as request headers.
+
+Groq's plugin extends ``dify_plugin.OAICompatLargeLanguageModel``,
+whose ``_generate`` method reads ``credentials['extra_headers']`` and
+merges the entries into the outbound HTTP request headers. The Dify
+app_id is therefore propagated by writing the dify headers into that
+credential.
+
+Header values are constrained to visible ASCII (0x20-0x7E inclusive) so
+``urllib3`` never rejects the request with ``InvalidHeader`` on CR/LF
+or other control characters. Values are truncated to 256 characters
+as a hard cap (UUID app_ids are 36 chars, so the cap is a safety net
+rather than a real bound).
+
+The helper is opt-in: when ``credentials['enable_request_metadata']`` is
+not the literal string ``"enabled"``, the helper does nothing and the
+request shape is unchanged. When enabled, the helper mutates
+``credentials['extra_headers']`` in place, preserving any
+caller-supplied entries (Dify keys are written alongside, with Dify
+keys winning on collision so the helper always controls its own
+observability markers).
+
+Caveats:
+- Groq's public API does not document these headers today, so the
+  value is purely for observability / proxy-side propagation, identical
+  to the bury-point headers used in the other LLM plugins (anthropic,
+  gemini, stepfun, openai_api_compatible, tongyi, volcengine, zhipuai,
+  minimax, cohere, mistralai, deepseek, fireworks, ollama,
+  togetherai, moonshot).
+- The helper never raises; if building the merged headers fails for
+  any reason, the call falls back to a no-op so user requests are not
+  blocked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_ENABLED = "enabled"
+_APP_ID_HEADER = "X-Dify-App-Id"
+_SOURCE_HEADER = "X-Dify-Source"
+_SOURCE_VALUE = "dify"
+_MAX_VALUE_LENGTH = 256
+
+
+def _normalize_header_value(s: Any) -> str:
+    """Normalize a value into a header-safe string.
+
+    Coerces non-string input via ``str()`` so that, e.g., a numeric ``0``
+    becomes ``"0"`` rather than being silently dropped by the empty-check,
+    strips CR/LF and other control characters (``urllib3`` rejects them
+    with ``InvalidHeader``), and truncates to 256 characters as a hard
+    cap.
+    """
+    if s is None:
+        return ""
+    if not isinstance(s, str):
+        s = str(s)
+    if not s:
+        return ""
+    # Strip CR/LF and other control characters; keep visible ASCII only.
+    s = "".join(ch for ch in s if 0x20 <= ord(ch) <= 0x7E)
+    if not s:
+        return ""
+    return s[:_MAX_VALUE_LENGTH]
+
+
+def build_dify_headers(app_id: Any) -> dict[str, str]:
+    """Build the Dify header dict, or return an empty dict.
+
+    Returns an empty dict if the resolved ``app_id`` is missing or
+    normalizes to the empty string, so the caller can skip attaching
+    metadata entirely.
+    """
+    app_id_normalized = _normalize_header_value(app_id)
+    if not app_id_normalized:
+        return {}
+    return {
+        _APP_ID_HEADER: app_id_normalized,
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+def apply_dify_headers_if_enabled(credentials: dict) -> None:
+    """Attach Dify observability headers to ``credentials['extra_headers']`` in place.
+
+    Reads ``credentials['enable_request_metadata']``; when ``"enabled"`` and
+    ``credentials['app_id']`` resolves to a non-empty string, writes the
+    Dify ``X-Dify-App-Id`` / ``X-Dify-Source`` headers into
+    ``credentials['extra_headers']``. Existing entries on
+    ``credentials['extra_headers']`` are preserved; on collision the Dify
+    keys win so the helper always controls its own observability markers.
+
+    When the credential is disabled, or no ``app_id`` resolves, the
+    helper does nothing. The function never raises; if anything goes
+    wrong while building the headers, it falls back to a no-op so the
+    user's request still proceeds.
+    """
+    try:
+        if credentials.get("enable_request_metadata") != _ENABLED:
+            return
+        app_id = credentials.get("app_id")
+        headers = build_dify_headers(app_id)
+        if not headers:
+            return
+        existing = credentials.get("extra_headers")
+        if existing is None:
+            credentials["extra_headers"] = headers
+            return
+        # Merge: copy to avoid mutating the caller's dict reference, and
+        # let Dify keys override any existing collision so the helper
+        # always controls its own observability markers.
+        merged = dict(existing)
+        merged.update(headers)
+        credentials["extra_headers"] = merged
+    except Exception:  # noqa: BLE001 - telemetry must never break the user request
+        # Never block the user's request on metadata wiring.
+        return
+
+
+__all__ = [
+    "_normalize_header_value",
+    "apply_dify_headers_if_enabled",
+    "build_dify_headers",
+]

--- a/models/groq/models/llm/llm.py
+++ b/models/groq/models/llm/llm.py
@@ -4,6 +4,8 @@ from dify_plugin import OAICompatLargeLanguageModel
 from dify_plugin.entities.model.llm import LLMResult
 from dify_plugin.entities.model.message import PromptMessage, PromptMessageTool
 
+from models.llm._metadata import apply_dify_headers_if_enabled
+
 
 class GroqLargeLanguageModel(OAICompatLargeLanguageModel):
     def _invoke(
@@ -18,10 +20,12 @@ class GroqLargeLanguageModel(OAICompatLargeLanguageModel):
         user: Optional[str] = None,
     ) -> Union[LLMResult, Generator]:
         self._add_custom_parameters(credentials)
+        apply_dify_headers_if_enabled(credentials)
         return super()._invoke(model, credentials, prompt_messages, model_parameters, tools, stop, stream)
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
         self._add_custom_parameters(credentials)
+        apply_dify_headers_if_enabled(credentials)
         super().validate_credentials(model, credentials)
 
     @staticmethod

--- a/models/groq/provider/groq.yaml
+++ b/models/groq/provider/groq.yaml
@@ -44,6 +44,44 @@ provider_credential_schema:
     required: true
     type: secret-input
     variable: api_key
+  - default: disabled
+    label:
+      en_US: Attach Dify app_id as request headers
+      zh_Hans: 附加 Dify app_id 作为请求头
+    help:
+      title:
+        en_US: How does this work?
+        zh_Hans: 这是如何工作的？
+      text:
+        en_US: |-
+          When enabled, the plugin attaches the current Dify app_id and a `dify`
+          source marker as `X-Dify-App-Id` / `X-Dify-Source` request headers on
+          every Groq SDK call. The headers are written into the
+          `extra_headers` credential, which the underlying OAICompat base
+          class merges into the outbound request alongside the rest of the
+          headers. The headers are forwarded by the underlying HTTP client
+          and are used for observability / proxy-side propagation. Groq
+          does not document them. Default is `disabled`, so the request
+          shape is unchanged unless you opt in.
+        zh_Hans: |-
+          启用后，插件会通过 `extra_headers` 凭据在每次 Groq 调用中附加当前 Dify
+          app_id 与 `dify` 源标记，作为 `X-Dify-App-Id` / `X-Dify-Source` 请求头。
+          底层 OAICompat 基类会将其与其它请求头合并后一并发送。这些请求头由底层
+          HTTP 客户端转发，用于可观测性与代理侧传播，Groq API 不会消费它们。
+          默认值为 `disabled`，即未开启时请求结构保持不变。
+    options:
+    - label:
+        en_US: Enabled
+        zh_Hans: 启用
+      value: enabled
+    - label:
+        en_US: Disabled
+        zh_Hans: 禁用
+      value: disabled
+    required: false
+    show_on: []
+    type: select
+    variable: enable_request_metadata
 supported_model_types:
 - llm
 - speech2text

--- a/models/groq/pyproject.toml
+++ b/models/groq/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.10.0",
 ]
 
 # uv run black . -C -l 100 && uv run ruff check --fix

--- a/models/groq/tests/test_metadata.py
+++ b/models/groq/tests/test_metadata.py
@@ -1,0 +1,281 @@
+"""Unit tests for the opt-in Dify metadata helper used by the Groq plugin.
+
+The helper writes Dify `X-Dify-App-Id` and `X-Dify-Source: dify` headers into
+`credentials['extra_headers']` when the credential `enable_request_metadata` is
+`"enabled"` and a Dify `app_id` resolves. The underlying OAICompat base class
+(`dify_plugin.OAICompatLargeLanguageModel`) reads `credentials['extra_headers']`
+and merges the entries into the outbound HTTP request headers, so writing to
+that credential is the carrier for observability metadata.
+
+When the credential is disabled, or `app_id` is missing / empty, the helper
+does nothing and the request shape is unchanged.
+
+These tests do not need a network or the Groq SDK: the helper is pure
+and runs entirely in memory. The integration with `_invoke` and
+`validate_credentials` is verified by the source-level guard tests at the
+bottom of this file.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from models.llm._metadata import (
+    _normalize_header_value,
+    apply_dify_headers_if_enabled,
+    build_dify_headers,
+)
+
+_ENABLED = "enabled"
+_APP_ID_HEADER = "X-Dify-App-Id"
+_SOURCE_HEADER = "X-Dify-Source"
+_SOURCE_VALUE = "dify"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_header_value
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_uuid_passthrough() -> None:
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    assert _normalize_header_value(uuid) == uuid
+
+
+def test_normalize_preserves_punctuation() -> None:
+    assert _normalize_header_value("a[b]c{d}e") == "a[b]c{d}e"
+
+
+def test_normalize_strips_cr_lf() -> None:
+    assert _normalize_header_value("a\r\nb") == "ab"
+
+
+def test_normalize_strips_other_control_chars() -> None:
+    assert _normalize_header_value("a\x00b\x07c") == "abc"
+
+
+def test_normalize_coerces_non_string() -> None:
+    assert _normalize_header_value(12345) == "12345"
+
+
+def test_normalize_returns_empty_for_none() -> None:
+    assert _normalize_header_value(None) == ""
+
+
+def test_normalize_truncates_to_256_chars() -> None:
+    s = "a" * 1024
+    assert len(_normalize_header_value(s)) == 256
+
+
+def test_normalize_returns_empty_for_all_control_chars() -> None:
+    assert _normalize_header_value("\r\n\t\x00") == ""
+
+
+# ---------------------------------------------------------------------------
+# build_dify_headers
+# ---------------------------------------------------------------------------
+
+
+def test_build_headers_with_valid_app_id() -> None:
+    headers = build_dify_headers("app-123")
+    assert headers == {
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+def test_build_headers_with_empty_app_id() -> None:
+    assert build_dify_headers("") == {}
+
+
+def test_build_headers_with_none_app_id() -> None:
+    assert build_dify_headers(None) == {}
+
+
+def test_build_headers_strips_cr_lf_in_app_id() -> None:
+    headers = build_dify_headers("app\r\n123")
+    assert headers == {
+        _APP_ID_HEADER: "app123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+# ---------------------------------------------------------------------------
+# apply_dify_headers_if_enabled — disabled / no-op paths
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_does_not_set_extra_headers() -> None:
+    credentials = {"app_id": "app-123"}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_disabled_with_other_value_does_not_set_extra_headers() -> None:
+    credentials = {"app_id": "app-123", "enable_request_metadata": "disabled"}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_disabled_with_random_value_does_not_set_extra_headers() -> None:
+    credentials = {"app_id": "app-123", "enable_request_metadata": "yes-please"}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_enabled_without_app_id_does_not_set_extra_headers() -> None:
+    credentials = {"enable_request_metadata": _ENABLED}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_enabled_with_empty_app_id_does_not_set_extra_headers() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": ""}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_enabled_with_none_app_id_does_not_set_extra_headers() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": None}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+# ---------------------------------------------------------------------------
+# apply_dify_headers_if_enabled — enabled / positive paths
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_with_app_id_attaches_both_headers() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": "app-123"}
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"] == {
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+def test_enabled_stringifies_non_string_app_id() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": 12345}
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"][_APP_ID_HEADER] == "12345"
+    assert credentials["extra_headers"][_SOURCE_HEADER] == _SOURCE_VALUE
+
+
+def test_enabled_preserves_existing_extra_headers() -> None:
+    credentials = {
+        "enable_request_metadata": _ENABLED,
+        "app_id": "app-123",
+        "extra_headers": {"X-Custom-Header": "value"},
+    }
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"] == {
+        "X-Custom-Header": "value",
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+def test_enabled_dify_keys_override_caller_on_collision() -> None:
+    credentials = {
+        "enable_request_metadata": _ENABLED,
+        "app_id": "app-123",
+        "extra_headers": {
+            _APP_ID_HEADER: "old-value",
+            _SOURCE_HEADER: "old-source",
+            "X-Custom-Header": "value",
+        },
+    }
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"] == {
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+        "X-Custom-Header": "value",
+    }
+
+
+def test_enabled_does_not_mutate_caller_dict_reference() -> None:
+    existing = {"X-Custom-Header": "value"}
+    credentials = {
+        "enable_request_metadata": _ENABLED,
+        "app_id": "app-123",
+        "extra_headers": existing,
+    }
+    apply_dify_headers_if_enabled(credentials)
+    assert existing == {"X-Custom-Header": "value"}
+    assert credentials["extra_headers"] is not existing
+    assert credentials["extra_headers"] == {
+        "X-Custom-Header": "value",
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+def test_helper_never_raises_on_garbage_credentials() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": "app-123"}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" in credentials
+
+
+def test_helper_handles_extra_headers_as_non_dict() -> None:
+    credentials = {
+        "enable_request_metadata": _ENABLED,
+        "app_id": "app-123",
+        "extra_headers": None,
+    }
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"] == {
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Source-level guard
+# ---------------------------------------------------------------------------
+
+
+def test_helper_is_imported_in_llm_py() -> None:
+    """The helper is wired into GroqLargeLanguageModel."""
+    llm_path = ROOT_DIR / "models" / "llm" / "llm.py"
+    source = llm_path.read_text(encoding="utf-8")
+    assert "from models.llm._metadata import apply_dify_headers_if_enabled" in source
+    # Used at both call sites: in `_invoke` (after `_add_custom_parameters`) and
+    # in `validate_credentials` (after `_add_custom_parameters`).
+    assert source.count("apply_dify_headers_if_enabled(credentials)") == 2
+    # Called only AFTER `_add_custom_parameters(credentials)` so the endpoint_url
+    # is set first; the helper does not depend on it, but ordering matters for
+    # maintainability.
+    invoke_block = source[
+        source.index("def _invoke(") : source.index("def _invoke(") + 2000
+    ]
+    assert invoke_block.find(
+        "self._add_custom_parameters(credentials)"
+    ) < invoke_block.find("apply_dify_headers_if_enabled(credentials)")
+
+
+def test_helper_module_is_reachable_from_llm() -> None:
+    helper_path = ROOT_DIR / "models" / "llm" / "_metadata.py"
+    assert helper_path.is_file(), f"missing helper: {helper_path}"
+    import models.llm._metadata as helper_module
+
+    assert hasattr(helper_module, "apply_dify_headers_if_enabled")
+    assert callable(helper_module.apply_dify_headers_if_enabled)
+    assert hasattr(helper_module, "build_dify_headers")
+    assert callable(helper_module.build_dify_headers)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-vv"]))

--- a/models/groq/uv.lock
+++ b/models/groq/uv.lock
@@ -161,12 +161,12 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dpkt" },
     { name = "flask" },
     { name = "gevent" },
+    { name = "h11" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -178,18 +178,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5a/885909338df3e32604f45c579457c5dcfe982d35857994805735e5487d4b/dify_plugin-0.10.2.tar.gz", hash = "sha256:e37e707b3903c439cd09924b2125ba794ffdc886bfdbcb8f75db28ba64cb795b", size = 320685, upload-time = "2026-08-10T07:04:08.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
-]
-
-[[package]]
-name = "dpkt"
-version = "1.9.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/7d/52f17a794db52a66e46ebb0c7549bf2f035ed61d5a920ba4aaa127dd038e/dpkt-1.9.8.tar.gz", hash = "sha256:43f8686e455da5052835fd1eda2689d51de3670aac9799b1b00cfd203927ee45", size = 180073, upload-time = "2022-08-18T05:54:13.582Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/79/479e2194c9096b92aecdf33634ae948d2be306c6011673e98ee1917f32c2/dpkt-1.9.8-py3-none-any.whl", hash = "sha256:4da4d111d7bf67575b571f5c678c71bddd2d8a01a3d57d489faf0a92c748fbfd", size = 194973, upload-time = "2022-08-18T05:54:10.793Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/5897c50381eb23a10fd7ab770288d8656f3325d3407e4ee4f6fb7e70f76a/dify_plugin-0.10.2-py3-none-any.whl", hash = "sha256:5a30db98cc4c3f36bdcc70ecd217b6bb37279c39fc0a843a985b05581dc461d3", size = 379282, upload-time = "2026-08-10T07:04:07.068Z" },
 ]
 
 [[package]]
@@ -335,7 +326,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "dify-plugin", specifier = ">=0.9.0" }]
+requires-dist = [{ name = "dify-plugin", specifier = ">=0.10.0" }]
 
 [package.metadata.requires-dev]
 dev = []


### PR DESCRIPTION
## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

Adds an opt-in `enable_request_metadata` credential to the Groq plugin that, when enabled, attaches the current Dify `app_id` and a `dify` source marker as `X-Dify-App-Id` / `X-Dify-Source` request headers on every Groq SDK call. When the credential is unset (default) the request shape is unchanged.

The change is the 16th entry in the opt-in `enable_request_metadata` series tracked by issue #3744 (SDK consolidation follow-up). Prior entries: #3717 (anthropic), #3723 (gemini), #3739 (stepfun), #3740 (openai_api_compatible, closed), #3741 (tongyi), #3742 (volcengine), #3743 (zhipuai, closed), #3745 (minimax), #3748 (cohere, closed), #3761 (mistralai), #3766 (deepseek), #3782 (fireworks), #3785 (ollama), #3792 (togetherai), #3798 (moonshot).

### Why header-field for Groq

Groq's plugin extends `dify_plugin.OAICompatLargeLanguageModel`, whose `_generate` method builds the outbound request from `credentials['extra_headers']` merged with the rest of the headers and `requests.post(endpoint_url, headers=..., data=...)`. The OAICompat base class does not forward a body-level `metadata` field, so the helper writes into `credentials['extra_headers']`, which is the same path the existing bury-point infrastructure and the other OAICompat-based PRs use.

## Release Notes

Add an opt-in `enable_request_metadata` credential (default `disabled`) to the Groq plugin. When enabled, the plugin attaches the current Dify `app_id` and a `dify` source marker as `X-Dify-App-Id` / `X-Dify-Source` request headers on every Groq SDK call. The headers are written into the `extra_headers` credential, which the underlying OAICompat base class merges into the outbound request alongside the rest of the headers. Default is `disabled`, so the request shape is unchanged unless you opt in. Groq does not currently consume these headers — they are used for observability / proxy-side propagation, identical to the bury-point headers used in the other LLM plugins.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality: opt-in observability header attachment (no behavior change for the user-facing response)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` to `0.0.18` (was `0.0.17`)
- [x] `dify_plugin>=0.10.0` is declared in `pyproject.toml` (was `>=0.9.0`) and locked in `uv.lock` (v0.9.0 -> v0.10.2)

## Testing

- [x] Local deployment — Dify version: not run end-to-end (helper unit tests + ruff clean)
- [ ] SaaS (cloud.dify.ai)

### What was tested

- `uv run pytest tests/`: **27 passed** (27 new; no pre-existing tests in the groq plugin).
- `uv run ruff check tests/test_metadata.py models/llm/_metadata.py`: **All checks passed**. The one `BLE001` ("do not catch blind exception") is suppressed with `# noqa: BLE001` because the helper's contract is "telemetry must never break the user request" — same pattern as the other 14 helpers in the series.

### What was NOT tested

- End-to-end invocation through Dify (no live API key available locally).
- The OAICompat base class's actual merging of `extra_headers` into the outbound request is trusted (verified by reading the OAICompat source: `_generate` reads `credentials.get("extra_headers")` and merges it into the `headers` dict before `requests.post`). The 27 unit tests cover the helper's behavior at both call sites.

## Consult-Kiro

This PR was reviewed by the `/consult-kiro` Tier A council. Today's coverage was degraded: of the 10 Tier A models, only 1 returned a usable answer (`openai/gpt-5-nano` at 15s with the `minimal` variant). The remaining 9 models (including the opencode free-tier panel and the gpt-5.1 paid tier) returned `EMPTY` within 3s with `rc=1` or timed out at the 50-80s hard limit. The full council was retried with shorter per-model timeouts; the same coverage gap persisted. This is consistent with the opencode backend degradation observed in the prior session (the deepseek #3766, fireworks #3782, ollama #3785, togetherai #3792, moonshot #3798, and the prior 10 PRs in the series all shipped with 1/10 or 7/10 Tier A coverage for the same reason).

**Findings (1/10 models, gpt-5-nano):**

- `OK` Helper signature `apply_dify_headers_if_enabled(credentials) -> None` (void, in-place mutation) is correct.
- `OK` Helper called in both `_invoke` and `validate_credentials` is correct.
- `OK` Helper called after `_add_custom_parameters` is correct.
- `OK` CR/LF + control-character stripping and 256-char truncation are consistent with the other 13 helpers in the series.
- `MISSING` No concrete file/line requiring an immediate code change based on current view.

No must-fix issues identified under the degraded coverage. The full diff (7 files, 455 insertions, 16 deletions) was inspected and applied per the standard 5-commit split: helper -> wire -> credential -> tests -> version+SDK pin.

## Risks

- **Low**: When the new credential is unset (default), the helper is a no-op and `credentials['extra_headers']` is not touched, so existing users see no behavior change.
- **Low**: When the credential is enabled but `app_id` is missing from the runtime credentials, the helper also no-ops.
- **Low**: Groq's public API does not currently consume `X-Dify-App-Id` / `X-Dify-Source`. The headers are forwarded by the SDK's HTTP transport and are intended for observability / proxy-side propagation, identical to the bury-point headers used in the other LLM plugins.
- **Low**: The `validate_credentials` path mutates `credentials['extra_headers']` even though the OAICompat base class does not currently consume it on that path. This is a no-op w.r.t. the wire request today, but if a future OAICompat refactor makes the validate path consume `extra_headers`, the helper will start applying there automatically.
- **Test coverage gap**: No integration test for OAICompat's actual merging of `extra_headers` into the outbound request.

## Future improvements

- Issue #3744 (filed earlier in this series) tracks consolidating the 16 `enable_request_metadata` helpers across `anthropic`, `gemini`, `stepfun`, `openai_api_compatible` (closed), `tongyi`, `volcengine`, `zhipuai` (closed), `minimax`, `cohere` (closed), `mistralai`, `deepseek`, `fireworks`, `ollama`, `togetherai`, `moonshot`, `groq` (this PR), and the bedrock / vertex_ai variants into a single shared SDK utility in `dify_plugin`. That refactor is a follow-up to this PR; this PR does not depend on it.
