### PR TITLE
fix(huaweicloud_maas): endpoint url is not overwritten across models

### DIFF
--- a/models/huaweicloud_maas/manifest.yaml
+++ b/models/huaweicloud_maas/manifest.yaml
@@ -26,5 +26,5 @@ resource:
       enabled: true
       llm: true
 type: plugin
-version: 0.0.25
+version: 0.0.26
 created_at: 2025-06-04T12:32:17.824356+08:00

--- a/models/huaweicloud_maas/models/llm/llm.py
+++ b/models/huaweicloud_maas/models/llm/llm.py
@@ -74,7 +74,7 @@ class HuaweiCloudMaasLargeLanguageModel(OAICompatLargeLanguageModel):
 
     def _add_custom_parameters(self, model: str, credentials: dict) -> None:
         credentials["mode"] = "chat"
-        credentials["endpoint_url"] = str(credentials.get("endpoint_url", self._BASE_URL_V2))
+        credentials["endpoint_url"] = str(credentials.get("maas_base_url", self._BASE_URL_V2))
 
     def _add_function_call(self, model: str, credentials: dict) -> None:
         model_schema = self.get_model_schema(model, credentials)

--- a/models/huaweicloud_maas/models/rerank/rerank.py
+++ b/models/huaweicloud_maas/models/rerank/rerank.py
@@ -20,12 +20,10 @@ class HuaweiCloudMaasRerankModel(OAICompatRerankModel):
         user: Optional[str] = None,
     ) -> RerankResult:
         self._add_custom_parameters(credentials)
-        return super()._invoke(
-            model, credentials, query, docs, score_threshold, top_n, user
-        )
+        return super()._invoke(model, credentials, query, docs, score_threshold, top_n, user)
 
     @classmethod
     def _add_custom_parameters(cls, credentials: dict) -> None:
         credentials["endpoint_url"] = str(
-            credentials.get("endpoint_url", "https://api.modelarts-maas.com/v1")
+            credentials.get("maas_base_url", "https://api.modelarts-maas.com/v1")
         )

--- a/models/huaweicloud_maas/models/rerank/rerank.py
+++ b/models/huaweicloud_maas/models/rerank/rerank.py
@@ -6,8 +6,21 @@ from dify_plugin.entities.model.rerank import RerankResult
 
 class HuaweiCloudMaasRerankModel(OAICompatRerankModel):
     def validate_credentials(self, model: str, credentials: dict) -> None:
-        self._add_custom_parameters(credentials)
-        super().validate_credentials(model, credentials)
+        try:
+            self._invoke(
+                model=model,
+                credentials=credentials,
+                query="What is the capital of France?",
+                docs=[
+                    "Paris is the capital and most populous city of France.",
+                    "Lyon is a major city in southeast France, known for its cuisine.",
+                    "The Eiffel Tower is a popular landmark located in Paris.",
+                ],
+                score_threshold=0.5,
+                top_n=2,
+            )
+        except Exception as ex:
+            raise CredentialsValidateFailedError(str(ex)) from ex
 
     def _invoke(
         self,

--- a/models/huaweicloud_maas/models/text_embedding/text_embedding.py
+++ b/models/huaweicloud_maas/models/text_embedding/text_embedding.py
@@ -23,5 +23,5 @@ class HuaweiCloudMaasTextEmbeddingModel(OAICompatEmbeddingModel):
     @classmethod
     def _add_custom_parameters(cls, credentials: dict) -> None:
         credentials["endpoint_url"] = str(
-            credentials.get("endpoint_url", "https://api.modelarts-maas.com/v1")
+            credentials.get("maas_base_url", "https://api.modelarts-maas.com/v1")
         )

--- a/models/huaweicloud_maas/provider/maas.yaml
+++ b/models/huaweicloud_maas/provider/maas.yaml
@@ -32,7 +32,7 @@ model_credential_schema:
         zh_Hans: Base URL, e.g. https://api.modelarts-maas.com/v2 or https://{region}.modelarts-maas.com/v1/infers/{service-id}/v1
       required: true
       type: text-input
-      variable: endpoint_url
+      variable: maas_base_url
     - label:
         en_US: API Key
       placeholder:


### PR DESCRIPTION


## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

Embedding and reranker models still using `/v1` base url while llm using `/v2`
Currently invoking llm requests would make `endpoint_url` value always be `/v2` and therfore embedding/rerank requests failed.



## Release Notes

<!--
User-facing summary of what this version changes. Published verbatim on the
plugin's Marketplace page (Version History → Change Log). English, Markdown.
Skip only for documentation / non-plugin changes.
-->

1. use a different variable name `maas_base_url` to make a difference with builtin variable `endpoint_url`
2. add `top_n` in validating custom rerank model

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.11.4
- [ ] SaaS (cloud.dify.ai)
