### PR TITLE
fix(duckduckgo): unable to search

### DIFF
--- a/tools/duckduckgo/README.md
+++ b/tools/duckduckgo/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-DuckDuckGo is a search engine focused on privacy. It offers search capabilities for web pages, images, and provides translation services. DuckDuckGo also features a private AI chat interface, providing users with an AI assistant that prioritizes data protection.
+DuckDuckGo is a search engine focused on privacy. This plugin offers web page search and image search.
+
+> **Note:** the AI Chat and Translate tools are deprecated and no longer functional. DuckDuckGo removed the endpoints they depended on, and the maintained search library this plugin uses (`ddgs`) provides no replacement. They remain registered so existing workflows still load, but calling them raises an explanatory error. Use an LLM node or a dedicated translation tool instead.
 
 ## Configuration
 
@@ -20,7 +22,7 @@ You can use the DuckDuckGo tool in the following application types.
 
 #### - Chatflow / Workflow applications
 
-Both Chatflow and Workflow applications support adding DuckDuckGo tool nodes, it provides four tools: ai chatbox, image search, simple search, and translation.
+Both Chatflow and Workflow applications support adding DuckDuckGo tool nodes. Two tools are functional: simple search and image search. The ai chatbox and translation tools are deprecated (see the note above).
 
 #### - Agent applications
 

--- a/tools/duckduckgo/manifest.yaml
+++ b/tools/duckduckgo/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.10
+version: 0.0.11
 type: plugin
 author: "langgenius"
 name: "duckduckgo"

--- a/tools/duckduckgo/pyproject.toml
+++ b/tools/duckduckgo/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 # Refresh the lockfile with: uv lock
 dependencies = [
     "dify_plugin>=0.9.0",
-    "duckduckgo-search>=7.5.5,<8.0.0",
+    "ddgs>=9.16.0,<10.0.0",
 ]
 
 # uv run black . -C -l 100 && uv run ruff check --fix

--- a/tools/duckduckgo/tools/ddgo_ai.py
+++ b/tools/duckduckgo/tools/ddgo_ai.py
@@ -1,23 +1,20 @@
 from typing import Any, Generator
 
-from duckduckgo_search import DDGS
-
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
 
 
 class DuckDuckGoAITool(Tool):
     """
-    Tool for performing a search using DuckDuckGo search engine.
+    Deprecated. DuckDuckGo AI Chat is no longer reachable from this plugin.
     """
 
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:
-        query_dict = {
-            "keywords": tool_parameters.get("query"),
-            "model": tool_parameters.get("model"),
-        }
-        proxy = tool_parameters.get("proxy_server", None)
-        response = DDGS(proxy=proxy).chat(**query_dict) if proxy else DDGS().chat(**query_dict)
-        yield self.create_text_message(text=response)
+        raise NotImplementedError(
+            "DuckDuckGo AI Chat is no longer supported by this plugin. DuckDuckGo changed the "
+            "duckai endpoint and the search library this plugin now uses (ddgs) provides no chat "
+            "API. Use a dedicated LLM node or model provider instead."
+        )
+        yield  # pragma: no cover - keeps this a generator function

--- a/tools/duckduckgo/tools/ddgo_ai.yaml
+++ b/tools/duckduckgo/tools/ddgo_ai.yaml
@@ -2,13 +2,13 @@ identity:
   name: ddgo_ai
   author: hjlarry
   label:
-    en_US: DuckDuckGo AI Chat
-    zh_Hans: DuckDuckGo AI聊天
+    en_US: DuckDuckGo AI Chat (deprecated)
+    zh_Hans: DuckDuckGo AI聊天（已弃用）
 description:
   human:
-    en_US: Use the anonymous private chat provided by DuckDuckGo.
-    zh_Hans: 使用DuckDuckGo提供的匿名私密聊天。
-  llm: Use the anonymous private chat provided by DuckDuckGo.
+    en_US: Deprecated and non-functional. DuckDuckGo no longer exposes its AI chat endpoint to this plugin; use an LLM node instead.
+    zh_Hans: 已弃用且无法使用。DuckDuckGo 不再向本插件开放 AI 聊天接口，请改用 LLM 节点。
+  llm: Deprecated and non-functional. Do not call this tool; use an LLM node instead.
 parameters:
   - name: query
     type: string

--- a/tools/duckduckgo/tools/ddgo_img.py
+++ b/tools/duckduckgo/tools/ddgo_img.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Generator
 
 from ddgs import DDGS
@@ -11,19 +10,6 @@ from dify_plugin import Tool
 # "d"/"w"/"m"/"y". Engines that reject the value are skipped silently, so we send the Bing
 # vocabulary -- the DuckDuckGo image engine is currently broken upstream and serves nothing.
 TIMELIMIT_MAP = {"Day": "day", "Week": "week", "Month": "month", "Year": "year"}
-
-
-class FileTransferMethod(str, Enum):
-    REMOTE_URL = "remote_url"
-    LOCAL_FILE = "local_file"
-    TOOL_FILE = "tool_file"
-
-    @staticmethod
-    def value_of(value):
-        for member in FileTransferMethod:
-            if member.value == value:
-                return member
-        raise ValueError(f"No matching enum found for value '{value}'")
 
 
 class DuckDuckGoImageSearchTool(Tool):
@@ -46,10 +32,13 @@ class DuckDuckGoImageSearchTool(Tool):
         proxy = tool_parameters.get("proxy_server", None)
         response = DDGS(proxy=proxy).images(query, **query_dict)
         for res in response:
-            res["transfer_method"] = FileTransferMethod.REMOTE_URL
-            msg = ToolInvokeMessage(
-                type=ToolInvokeMessage.MessageType.IMAGE_LINK,
+            # Yield IMAGE rather than IMAGE_LINK. Dify only derives a tool_file_id for an
+            # IMAGE_LINK by matching its URL against its own /files/tools/ route, so a remote
+            # search result would arrive without one and the agent node rejects it with
+            # "missing tool_file_id metadata". IMAGE makes Dify fetch the remote URL, register a
+            # tool file for it, and re-emit the IMAGE_LINK itself, keeping the meta below.
+            yield ToolInvokeMessage(
+                type=ToolInvokeMessage.MessageType.IMAGE,
                 message=ToolInvokeMessage.TextMessage(text=res.get("image")),
                 meta=res,
             )
-            yield msg

--- a/tools/duckduckgo/tools/ddgo_img.py
+++ b/tools/duckduckgo/tools/ddgo_img.py
@@ -1,10 +1,16 @@
 from enum import Enum
 from typing import Any, Generator
 
-from duckduckgo_search import DDGS
+from ddgs import DDGS
 
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
+
+# ddgs aggregates several image backends and they disagree on the time-range vocabulary:
+# the Bing engine expects "day"/"week"/"month"/"year" while the DuckDuckGo engine expects
+# "d"/"w"/"m"/"y". Engines that reject the value are skipped silently, so we send the Bing
+# vocabulary -- the DuckDuckGo image engine is currently broken upstream and serves nothing.
+TIMELIMIT_MAP = {"Day": "day", "Week": "week", "Month": "month", "Year": "year"}
 
 
 class FileTransferMethod(str, Enum):
@@ -28,20 +34,22 @@ class DuckDuckGoImageSearchTool(Tool):
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:
+        query = tool_parameters.get("query")
+        timelimit = tool_parameters.get("timelimit")
         query_dict = {
-            "keywords": tool_parameters.get("query"),
-            "timelimit": tool_parameters.get("timelimit"),
+            "timelimit": TIMELIMIT_MAP.get(timelimit, timelimit),
             "size": tool_parameters.get("size"),
             "max_results": tool_parameters.get("max_results"),
         }
+        # ddgs treats an explicit None size as a real filter value, so drop empty options.
+        query_dict = {k: v for k, v in query_dict.items() if v is not None}
         proxy = tool_parameters.get("proxy_server", None)
-        response = DDGS(proxy=proxy).images(**query_dict) if proxy else DDGS().images(**query_dict)
+        response = DDGS(proxy=proxy).images(query, **query_dict)
         for res in response:
             res["transfer_method"] = FileTransferMethod.REMOTE_URL
             msg = ToolInvokeMessage(
                 type=ToolInvokeMessage.MessageType.IMAGE_LINK,
-                message=res.get("image"),
-                save_as="",
+                message=ToolInvokeMessage.TextMessage(text=res.get("image")),
                 meta=res,
             )
             yield msg

--- a/tools/duckduckgo/tools/ddgo_search.py
+++ b/tools/duckduckgo/tools/ddgo_search.py
@@ -1,8 +1,7 @@
 from typing import Any, Generator
 
-from duckduckgo_search import DDGS
+from ddgs import DDGS
 
-from dify_plugin.entities.model.message import SystemPromptMessage
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
 
@@ -19,7 +18,7 @@ class DuckDuckGoSearchTool(Tool):
         max_results = tool_parameters.get("max_results", 5)
         require_summary = tool_parameters.get("require_summary", False)
         proxy = tool_parameters.get("proxy_server", None)
-        response = DDGS(proxy=proxy).text(query, max_results=max_results) if proxy else DDGS().text(query, max_results=max_results)
+        response = DDGS(proxy=proxy).text(query, max_results=max_results)
         if require_summary:
             results = "\n".join([res.get("body") for res in response])
             results = self.summary_results(content=results, query=query)

--- a/tools/duckduckgo/tools/ddgo_translate.py
+++ b/tools/duckduckgo/tools/ddgo_translate.py
@@ -1,26 +1,20 @@
 from typing import Any, Generator
 
-from duckduckgo_search import DDGS
-
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin import Tool
 
 
 class DuckDuckGoTranslateTool(Tool):
     """
-    Tool for performing a search using DuckDuckGo search engine.
+    Deprecated. DuckDuckGo's translate endpoint is no longer available.
     """
 
     def _invoke(
         self, tool_parameters: dict[str, Any]
     ) -> Generator[ToolInvokeMessage, None, None]:
-        query_dict = {
-            "keywords": tool_parameters.get("query"),
-            "to": tool_parameters.get("translate_to"),
-        }
-        proxy = tool_parameters.get("proxy_server", None)
-        if proxy:
-            response = (DDGS(proxy=proxy).translate(**query_dict)[0].get("translated", "Unable to translate!"))
-        else:
-            response = (DDGS().translate(**query_dict)[0].get("translated", "Unable to translate!"))
-        yield self.create_text_message(text=response)
+        raise NotImplementedError(
+            "DuckDuckGo Translate is no longer supported by this plugin. The upstream search "
+            "library dropped the translate endpoint and DuckDuckGo no longer exposes it. Use a "
+            "dedicated translation tool or an LLM node instead."
+        )
+        yield  # pragma: no cover - keeps this a generator function

--- a/tools/duckduckgo/tools/ddgo_translate.yaml
+++ b/tools/duckduckgo/tools/ddgo_translate.yaml
@@ -2,13 +2,13 @@ identity:
   name: ddgo_translate
   author: hjlarry
   label:
-    en_US: DuckDuckGo Translate
-    zh_Hans: DuckDuckGo 翻译
+    en_US: DuckDuckGo Translate (deprecated)
+    zh_Hans: DuckDuckGo 翻译（已弃用）
 description:
   human:
-    en_US: Use DuckDuckGo's translation feature.
-    zh_Hans: 使用DuckDuckGo的翻译功能。
-  llm: Use DuckDuckGo's translation feature.
+    en_US: Deprecated and non-functional. DuckDuckGo no longer exposes a translation endpoint; use a dedicated translation tool or an LLM node instead.
+    zh_Hans: 已弃用且无法使用。DuckDuckGo 不再提供翻译接口，请改用专门的翻译工具或 LLM 节点。
+  llm: Deprecated and non-functional. Do not call this tool; use an LLM node instead.
 parameters:
   - name: query
     type: string

--- a/tools/duckduckgo/uv.lock
+++ b/tools/duckduckgo/uv.lock
@@ -160,6 +160,20 @@ wheels = [
 ]
 
 [[package]]
+name = "ddgs"
+version = "9.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/30/dd2ff7d817573e30836fb99bdc04e167ce03ac5b878072b3e9e892aa810b/ddgs-9.16.0.tar.gz", hash = "sha256:161ca8e78ea08d40cd3f83fb12279b49322ffb342d981368bfa39bed9847d874", size = 38018, upload-time = "2026-08-26T21:52:33.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/0c/b43a87e81e45caf2c30fea9a5914dfd17b83a9f3c2c59ae22b6257bcf083/ddgs-9.16.0-py3-none-any.whl", hash = "sha256:175d9198c958a263f51a06a54368ba0b41294942c0cd29f4aa71be03dbcd5f4a", size = 47580, upload-time = "2026-08-26T21:52:32.001Z" },
+]
+
+[[package]]
 name = "dify-plugin"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -197,32 +211,18 @@ name = "duckduckgo"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "ddgs" },
     { name = "dify-plugin" },
-    { name = "duckduckgo-search" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "ddgs", specifier = ">=9.16.0,<10.0.0" },
     { name = "dify-plugin", specifier = ">=0.9.0" },
-    { name = "duckduckgo-search", specifier = ">=7.5.5,<8.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = []
-
-[[package]]
-name = "duckduckgo-search"
-version = "7.5.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "lxml" },
-    { name = "primp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/13/dc/919d3d51ed702890a3e6e736e1e152d5d90856393200306e82fb54fde39e/duckduckgo_search-7.5.5.tar.gz", hash = "sha256:44ef03bfa5484bada786590f2d4c213251131765721383a177a0da6fa5c5e41a", size = 24768, upload-time = "2025-03-27T08:11:26.951Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/da/8376678b4a9ae0f9418d93df9c9cf851dced49c95ceb38daac6651e38f7a/duckduckgo_search-7.5.5-py3-none-any.whl", hash = "sha256:c71a0661aa436f215d9a05d653af424affb58825ab3e79f3b788053cbdee9ebc", size = 20421, upload-time = "2025-03-27T08:11:25.515Z" },
-]
 
 [[package]]
 name = "flask"
@@ -678,40 +678,40 @@ wheels = [
 
 [[package]]
 name = "primp"
-version = "1.3.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/fc/a8de4d8d02a79ead2eb962ce8a09aaa5636975a1aa481d9993594a84e15b/primp-1.3.0.tar.gz", hash = "sha256:a8972627fff8abc44fec6ce3f8bade4a66a2b58a1fe7c8f6b5f08acb26d4e781", size = 1357346, upload-time = "2026-05-19T12:31:59.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2d/ca248003402f6863375acc77a886b0ab638efc6defb1be0ae9f99249cb66/primp-2.0.0.tar.gz", hash = "sha256:714ec75081b7a84f63d83f966eb36649b9a8ba93625113b142400c317f6e83c5", size = 1152502, upload-time = "2026-08-26T15:48:08.043Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/35/f46ee4b4edc791b5c3eb631bd4dbb0fbaa142b1637ba01b0bc0afd953415/primp-1.3.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2a4ce1d87055acee200a707b4c3698572e59e218556e0a4a3880c2507ad3a0e0", size = 5121084, upload-time = "2026-05-19T12:31:36.091Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/0c/74e81ef7edf4a4b0d34144f7b6e907d307aa2e0f012270657be580a8bcff/primp-1.3.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ff63d34be3ba9c2729c5345a758a8b423dc390d409e70461a12befff52505c0a", size = 4739943, upload-time = "2026-05-19T12:31:45.774Z" },
-    { url = "https://files.pythonhosted.org/packages/50/7a/52adf131849116079be467685b8e574b87c503770ef79f8aaa86a132402e/primp-1.3.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fee72d297b86b512d5c20b8bfbab691554cfac5840ad679b48f2059ea571f2b9", size = 5095887, upload-time = "2026-05-19T12:31:37.761Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/ed/a882ccdfd9200cdf743c3a0ffcd464282f5a5bcbc55093335260dfb9835a/primp-1.3.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:160d9425673fe3f11ae52a83879dfc25ac0be8a063acf4169e5f456a9752d7b2", size = 4736733, upload-time = "2026-05-19T12:31:43.922Z" },
-    { url = "https://files.pythonhosted.org/packages/18/02/87e9d04d127f18c9936f54cbc1c1eb4ff2b6c0ad3d3620e4f5f5c50f45c0/primp-1.3.0-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cad2f342e965957eaa55f8be42cf21743e71ea19d9c4a023021b87d1ea6c1862", size = 4996501, upload-time = "2026-05-19T12:31:52.44Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/8f/461fbacefbe4d8465eb460740de5d1d17770608af7b371fb076cbfca3144/primp-1.3.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e54c15473852010745c224e45b94a15a6748de38085660a6732821fb631a1e1a", size = 5333063, upload-time = "2026-05-19T12:31:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/23/4b/6f3f2ecab922742a735f1f1e67748a9deed2039d54791d97dcf70ddd1fd9/primp-1.3.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48ae9825d067932966707bf4f064f8d10b041f1450c2387fb9b5ad7b40c70adc", size = 5156534, upload-time = "2026-05-19T12:31:47.407Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/d5/0e2084b1b7fb8fd0e65010a946c85d0eba8e53024f9f688af73dd9857aa2/primp-1.3.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28eca0dc1322f9ee5db4fbd1804968dd7aa3a61c57c0a7b7c092f52f6d0f322c", size = 5344508, upload-time = "2026-05-19T12:31:16.944Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/91/7669cc15bdfa017ac268adb4ac115620fd3ba888e080f62c2dba5645fa51/primp-1.3.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4f07c0a15b660b1326ab6fdddc90312d5c68eff7e79f09b30fecfb3d2146530c", size = 5267217, upload-time = "2026-05-19T12:31:40.735Z" },
-    { url = "https://files.pythonhosted.org/packages/33/72/a04b98ff30cb019d5637797a6bdb94481a1bddb927fdfb542e7071771644/primp-1.3.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f9661c12e92c6ec3a2c9810844d0219ad64f1308a37fef19e57b1e756d1ce9dc", size = 4967946, upload-time = "2026-05-19T12:31:34.65Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/df/8352ac57de98d37e622b483e4ca8e17b57438dd50865f271647c6b6d325f/primp-1.3.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:33e485ae8cf9eb20fe451b24c604489765a39d6663c5d3b6c1e4503071e128ec", size = 5080616, upload-time = "2026-05-19T12:31:25.147Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ff/7c1c8dfb86ff82b74f6631827c963ac131ad93ece961988e575811250c72/primp-1.3.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:989d9ee514f1d9fab2a6943bd73e9896087c6e752ff617cdfda32358ae195234", size = 5605242, upload-time = "2026-05-19T12:31:49.057Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/cf/7a8fbe694c4d3cc074daedefdb2439cc02200f73ba022f7a7741df3ef395/primp-1.3.0-cp310-abi3-win32.whl", hash = "sha256:7c9d4be5b7fb36916d431eb11f4173af0fe5bf666cddcd03fccb3fcf86fcb97e", size = 4270640, upload-time = "2026-05-19T12:31:39.229Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/d0/6994b5618d7061c906c49fcb26f66bbb3cca8046d28f68aafd311ca5a712/primp-1.3.0-cp310-abi3-win_amd64.whl", hash = "sha256:1324d086f79c109a00cb64099b380471baf27f2bad42e5873f097030c9f54178", size = 4658010, upload-time = "2026-05-19T12:31:57.67Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/38/fea42f406d182fbb9d909952d0afeb7006e2194a19aeea8226968458c7a4/primp-1.3.0-cp310-abi3-win_arm64.whl", hash = "sha256:f71def26a490787b1fa7a42d110ab4b66ec79f977291f87da0694ddf6a91ff7e", size = 4627674, upload-time = "2026-05-19T12:31:13.36Z" },
-    { url = "https://files.pythonhosted.org/packages/48/fe/38016780e59c1ba5b15ab368b98bd5fee7b227485b58f84712d0e0fe058d/primp-1.3.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d2756c3c710ed2bf8551306f80d274d22c65124ec3b4faa07afd7b516062b7e9", size = 5115007, upload-time = "2026-05-19T12:31:18.759Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/86/673bb5f294b24085cb02b5b241fd348d45f4da25a8de96c1c37516a91f87/primp-1.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b075084842edac6dd3523e164967bada19447c101eecaeec7828e795990f0ef2", size = 4736014, upload-time = "2026-05-19T12:31:22.169Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/a2/cf055ebdfcf1332ead0fb02a98cd0c9dc2883a1b9889310e3fd82f35f8f7/primp-1.3.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4016a4cbcabcfd9420a0d4f9cb115729f24a0952ca720b2903610dc51c358ac8", size = 5093763, upload-time = "2026-05-19T12:31:42.369Z" },
-    { url = "https://files.pythonhosted.org/packages/27/eb/7cd04a5da74eeeab916104e2d0d340767de60defdcb8948e18a4647311b6/primp-1.3.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b37d00ddce9286d86ba121a6f47e21c2af6c386cbeec7dda6cce19389182b5db", size = 4735557, upload-time = "2026-05-19T12:31:23.555Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/23/df827f31786b70b1c8fe8f3866341e2ac0340daa95685e13c8377cc9c389/primp-1.3.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:21d8bdb9e9790c0ddbe13deeb7511ed08e7ec9205068951b039d8fb19dd41a0c", size = 5001037, upload-time = "2026-05-19T12:31:28.043Z" },
-    { url = "https://files.pythonhosted.org/packages/89/ee/9fb81d03e286ba3d6360ea263d3ebf9cce30e08bfd64b633ad9bda650e36/primp-1.3.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:310b79be5cb56f1e809b3dab5386514e9ec5ae94d55cc37f4926062df70ee36d", size = 5328304, upload-time = "2026-05-19T12:31:20.677Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/f7/30d8049cd6f0a2f8cbcbb51740243766c6ccc815fa0dff64694b3ab3fc5d/primp-1.3.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9117af11988f83fd033faf13677ac9fbd11cf366b00e621de6d1c369378947c7", size = 5139769, upload-time = "2026-05-19T12:31:29.804Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/1e/943b295a1eefed1befb5659d8dd4a89cd71b54300c4f7e623adc8ed71f5c/primp-1.3.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77740dab820c1169dd114b86047db3a87bd10b1dce04c09930aa5f4fe221a9ce", size = 5340248, upload-time = "2026-05-19T12:31:33.15Z" },
-    { url = "https://files.pythonhosted.org/packages/85/9f/fe3ed26a7b737da2cb95f438bc13b392a4093c8f8f77b5e8d7e04ead6bd3/primp-1.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e500e28cd48a972a3cb35c58d8285ff531883d77f56e6405b7b61e4a443adad7", size = 5258023, upload-time = "2026-05-19T12:31:50.907Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/9d/1eb8dc7a0c65733771c1fa7d845c1373704dc13d90fff2e575b8e5f10a27/primp-1.3.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1d11a9606992d37a4079f332a0696457d0f5b5c695fd9f9e9889efdc58167f72", size = 4963340, upload-time = "2026-05-19T12:31:31.494Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/4e/a96cee02291ab3c24e45b52a34a3c170b5561bc504098a960cc791ef0dda/primp-1.3.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:94566b551bc03b661cd4efc6a63945e1bfb3cc9845c6d7bbbae147b849078047", size = 5076858, upload-time = "2026-05-19T12:32:00.689Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/25/50e44c764925da32827638d5c8523163ecf1f2f13aab401a4308bf35ed93/primp-1.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ad9fee8f7bc3e86516979783f8022a490e9266ddf2e210ed6c6c60001f535ecd", size = 5598607, upload-time = "2026-05-19T12:31:14.972Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/54/82b2a828e7c5e839311a2dbb61ff3e132f1f41ec59e47bd9408c1c1f6d5a/primp-1.3.0-cp314-cp314t-win32.whl", hash = "sha256:a3803056bbc01afd9a35bd375081f6a68d79df6dc83119fc69beb9349c00fc8f", size = 4261703, upload-time = "2026-05-19T12:31:26.595Z" },
-    { url = "https://files.pythonhosted.org/packages/90/82/947e450a70785caa72631c895df9ddc335165d950edd40d2099ca60960f0/primp-1.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:053e710e7a755fa26294d8cdedccb30d2644a2d3dec206f3d83e1bc8fd459434", size = 4654068, upload-time = "2026-05-19T12:32:02.489Z" },
-    { url = "https://files.pythonhosted.org/packages/64/02/70b1b6e424fcdd42b4e05ec6a570b891b58a81958f5f3a78eea3d74be38e/primp-1.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:676d35d7244b605681d7c3107a813d4e083864a47126984cdf3a8e1d021b87b4", size = 4625600, upload-time = "2026-05-19T12:31:56.377Z" },
+    { url = "https://files.pythonhosted.org/packages/64/15/571bae369c3bb3ba2c5917fde3e6fa6db212bcde033f6c2b99fd94434c01/primp-2.0.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5de7c1a2c3437394d77dca87841796a0cb704bf00e764dcbd2f7c073a11cc969", size = 5652784, upload-time = "2026-08-26T15:47:19.729Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8d/c62601ab82b831e12b1dee9ad9e7de2082c33a8774c4e71a76c3f0f76af3/primp-2.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c55f8ab86b7cc076b34ee0316ded6c30e9932ea010aeae3f8fe5cf30d9ecccf7", size = 5253591, upload-time = "2026-08-26T15:47:21.681Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/f29096e299afee742e4bf3e3aa0bba8bb10b187fa5ace15b8299a21d1310/primp-2.0.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd191d6f381eb814e1a7cb34b7eb5f47df81e73abdaecd8a99a8635a866357a3", size = 5663102, upload-time = "2026-08-26T15:47:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/496162339faa9a3016557b332bc9b9c55b87b9e7efb87df64902d2e77236/primp-2.0.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d7c48b027246e09540ad645536d28966f618e09c6a4dff148db4c221ccf858d8", size = 5274167, upload-time = "2026-08-26T15:47:25.674Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ce/fe272baed222c65ec5fad80346bd2a6155b170302ec69cbe5169b2df8c32/primp-2.0.0-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9179d4d7839cf0f912700d201af239b1a87ca22225101e2a43d1a34c2a46c95", size = 5615512, upload-time = "2026-08-26T15:47:27.359Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0c/203318c90bd2edbf5f6c7cf20d0d4b0de237caf3b0bf19d6507d55ddeb3c/primp-2.0.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d46cea402c5c0e70d65c237d946d41b46ef1a550fe3053ad6b66a3776decb759", size = 5756508, upload-time = "2026-08-26T15:47:28.929Z" },
+    { url = "https://files.pythonhosted.org/packages/31/08/99c7e41d117ac3bed5b8814df9b295394420beb5a2249dad878927e64517/primp-2.0.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e8e16a3efc6a523da721fa56a7e4eab8ee62c36db910fb62782999398320d0a", size = 5914038, upload-time = "2026-08-26T15:47:30.597Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d9/2e7e75ccc0af97aa0a1b8506151c07453c2c5a1ec1a571f8ba8670ac8881/primp-2.0.0-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:e8d9354b078b8dc891d2546bd8e9109aa81f1351609262707f4c7cd2db5a7876", size = 5987036, upload-time = "2026-08-26T15:47:32.371Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/b5feb484e792359a674c9435a5a109f4ef7775321951316556adde0501d4/primp-2.0.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:75960909d205a88e234d4e50fbd4c7c36d8235ef51b0c085da67bb171900cadd", size = 5825231, upload-time = "2026-08-26T15:47:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/df/19/1b876edc4814cc7a56cc8c4daa4ffe5989743a16f7a0b1947c928bdeed52/primp-2.0.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:5ccc2f3b333254d80a63f291b6d3e122a3eebe445833995b136ed1b5ae5c66e7", size = 5511105, upload-time = "2026-08-26T15:47:35.324Z" },
+    { url = "https://files.pythonhosted.org/packages/89/82/474b834cb241cc2a655b7f78588b438a5bf1e7fa6c9ccf93fd618a69b4a2/primp-2.0.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:2bd730ca8d86912924a3e4b775ad7befbe2115e26d0cf5b3c214d09dee80cfba", size = 5695984, upload-time = "2026-08-26T15:47:36.853Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ba/75b8b2fcbea6ac2c8d073ef95337a9b363350c7d9d6a0de3aecc15e08895/primp-2.0.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:196896fa89c6b1eaa11331b14fe2cf539b9564b5e3398df8352c71ce30c46d84", size = 6173518, upload-time = "2026-08-26T15:47:38.725Z" },
+    { url = "https://files.pythonhosted.org/packages/27/34/8ce5c50363aa627b45f7fedcc38676ae9e71642839130bfff8620f5a193e/primp-2.0.0-cp310-abi3-win32.whl", hash = "sha256:0776fd400adcc940e47bb70896fb474f6607ffa545f5f7107ccda8d055fa02c9", size = 4820008, upload-time = "2026-08-26T15:47:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/97/92/2307030e0ade6503b7e959daf0b2e7819a896c32816a60a4252c97512e74/primp-2.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:7f205260fd41a0a409157deec95e6c4ec670476a79d9b4810d4c767ee7f9e49e", size = 5218051, upload-time = "2026-08-26T15:47:41.872Z" },
+    { url = "https://files.pythonhosted.org/packages/61/3b/d3f21f6fbfa5f255685dc475af5fa6ad976f4c3b787bc9bb75d912649c4d/primp-2.0.0-cp310-abi3-win_arm64.whl", hash = "sha256:caf90ecc042a12b18414e4110ce767f4f1b0cfbc70310c5df39af948cb3eb516", size = 5115469, upload-time = "2026-08-26T15:47:43.529Z" },
+    { url = "https://files.pythonhosted.org/packages/78/88/c7aa2c139282b417d447d05f441f7e70038fe6634b15673d1de230e7fba9/primp-2.0.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:2ef2652eb2fd0072e474452663ddc790531f337dafed280a62a43a36f95d2c76", size = 5654299, upload-time = "2026-08-26T15:47:45.186Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fc/e470167fbd7fc0c9894e637edd49576398b4c6e09248cd1785edd42969b6/primp-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fdc9abaf01b82e0e4b5ea925273bf690c31338c3bb7bc28f64420bf93f66647b", size = 5243997, upload-time = "2026-08-26T15:47:46.927Z" },
+    { url = "https://files.pythonhosted.org/packages/38/70/45699bf87b0ad15822dcd4e6790eecac944dbcb72f3df9b7413513c22151/primp-2.0.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b88af1baeaa70fb168a9cd8567cf40396b4d023d39895b4bab25b3e7dc6ddb20", size = 5667842, upload-time = "2026-08-26T15:47:48.424Z" },
+    { url = "https://files.pythonhosted.org/packages/44/43/99c1adf495a0bc677fc7039efbbd28fb768a3e6a89735b5f2c0d5491688b/primp-2.0.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:db6a9efabcef034918e0ee92a78c21c2ccd93bdb994550c49f3c0edf207a0bc4", size = 5265143, upload-time = "2026-08-26T15:47:50.138Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ed/515452269a2e47928b34300ea7043cf478be96133e87a7def2de7f52bdc7/primp-2.0.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e820ed0573d67b5d495252dcf29e6dba14c279453c5c2134955eb2b0fd3d258", size = 5603987, upload-time = "2026-08-26T15:47:51.712Z" },
+    { url = "https://files.pythonhosted.org/packages/09/96/15c9241d1848a9317be413201395e5e2b316be03ac8200fef7f300dd3f64/primp-2.0.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:819f1480be4efc1d0dca46fac7b9a3ec40fb0b89bc11932165b5abc7872dae00", size = 5760260, upload-time = "2026-08-26T15:47:53.296Z" },
+    { url = "https://files.pythonhosted.org/packages/09/30/758ab1b0e7a22ad5d738fdc04d0e01728ba266138453ce895fabc56fe1b5/primp-2.0.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c97a87afd27c490b5384433748bc664ecd358a8d0a688abf48716a6baf03050", size = 5921145, upload-time = "2026-08-26T15:47:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8f/e46528c0829204eb01a9145301fb19c6953eb5cb48b2870e7c656ccde730/primp-2.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:ca4efea30417cf1119aac732ead82fc649af40978d0c989a9c280e901f6d0b3a", size = 5985385, upload-time = "2026-08-26T15:47:56.277Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6e/6aa7c98636a6d9381784af830e5734908f3a78f0896591e50aa91eff5f2e/primp-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0ea78a7a2fc5d48a825fa73182911b956bcb58940297cbd60958963ec30375d4", size = 5831995, upload-time = "2026-08-26T15:47:58.011Z" },
+    { url = "https://files.pythonhosted.org/packages/79/68/161b26b1b6d1d6a9e21250a88f4791adb8bf3f05d5190a8bbb3e563bdbb5/primp-2.0.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0f309642cff4e9f966fb8f312bf19239df04c7698b1b4ae142285528d08c4ddd", size = 5503388, upload-time = "2026-08-26T15:47:59.52Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/52/35b48f1ecdcc9baa9b9f8bba0739c4b506995fd17e3776700752c11d4d6a/primp-2.0.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:422001e516110a3b2d44b106ac65d248c431fb98e1d6cad034e0a6ee8f1d6eb2", size = 5683792, upload-time = "2026-08-26T15:48:00.913Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7c/13f8d3e4465e5cd5968c79c6cf951475c286bf7605e328b23378dd744c34/primp-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1abcdcd5d0ef7b918bdd6e56ce07baeba5b2fd136e9df1fe9f9443c35a6af9ec", size = 6182628, upload-time = "2026-08-26T15:48:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f1/406105407cf42d7edbce6a9332a16303d05987efc76322e7b79ca5eab004/primp-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:8756ae0df3dda65591ef478e73c588588a4a07919ee5c8d871fdd4e78fefb357", size = 4811104, upload-time = "2026-08-26T15:48:03.688Z" },
+    { url = "https://files.pythonhosted.org/packages/05/34/3844343afe7154364be0767ff3fe03347aef5dc6a506522a4ac0c99fb720/primp-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a83bbfd798c1a9c2c7f1c8b02bbfb38f91fd63ac9072add967915e2463d68aa0", size = 5220594, upload-time = "2026-08-26T15:48:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b5/a194a527120442f76a417e4da89bbe25490a65be7756c8f785ebd9110fd8/primp-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5dfad2f926451a64bcc3a6d84e76593ec82840f77c5500d080e98387c7a018b8", size = 5112361, upload-time = "2026-08-26T15:48:06.592Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Duckduckgo plugin is unable to search, always giving 202 RateLimitError, no matter what proxy or searches made.

This issue is due to duckduckgo now rejects the TLS fingerprint that this plugin has been using, `primp==1.3.0`, duckduckgo requires `primp>=0.14.0`, so bumping is done.

Moreover, `duckduckgo-search` is dead on PyPI, and it is renamed to `ddgs`. This PR migrates to `ddgs>=9.16.0` (which brings primp 2.0.0) and relocks.

  | Tool | Before | After |
  | --- | --- | --- |
  | `ddgo_search` | ❌ `202 Ratelimit` | ✅ fixed |
  | `ddgo_img` | ❌ 403 — also fails on primp 2.0.0 | ✅ fixed |
  | `ddgo_ai` | ❌ DuckDuckGo changed the `duckai` endpoint | ⚠️  deprecated |
  | `ddgo_translate` | ❌ `AttributeError` | ⚠️  deprecated |

Phasing out AI and translate as both are dead since 7.x

## Release Notes

Duckduckgo plugin is unable to search, always giving 202 RateLimitError, no matter what proxy or searches made.

This issue is due to duckduckgo now rejects the TLS fingerprint that this plugin has been using, primp==1.3.0, duckduckgo requires primp>=0.14.0, so bumping is done.

Moreover, duckduckgo-search is dead on PyPI, and it is renamed to ddgs. This PR migrates to ddgs>=9.16.0 (which brings primp 2.0.0) and relocks.

<!--
User-facing summary of what this version changes. Published verbatim on the
plugin's Marketplace page (Version History → Change Log). English, Markdown.
Skip only for documentation / non-plugin changes.
-->

## Change Type

- [ ] Documentation / non-plugin change
- [x] Non-LLM plugin (tools, extensions, datasource, etc.)
- [ ] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|  <img width="1842" height="822" alt="image" src="https://github.com/user-attachments/assets/54dfa73b-8d63-451b-88f3-094334149dfb" />|  <img width="381" height="793" alt="image" src="https://github.com/user-attachments/assets/02071396-3cab-4e2e-8790-48084f28bcdf" />  <img width="407" height="836" alt="image" src="https://github.com/user-attachments/assets/3e1b24eb-d515-4fb7-b865-ba954137ce91" />|

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.9.0`

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.17.0
- [ ] SaaS (cloud.dify.ai)
