### PR TITLE
fix(openai_api_compatible): add provider_credential_schema for Knowledge Pipeline flow

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.64
+version: 0.0.65
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -14,6 +14,26 @@ supported_model_types:
   - tts
 configurate_methods:
   - customizable-model
+provider_credential_schema:
+  credential_form_schemas:
+    - variable: api_key
+      label:
+        en_US: API Key
+        zh_Hans: API Key
+      type: secret-input
+      required: true
+      placeholder:
+        en_US: Enter your API Key
+        zh_Hans: 在此输入您的 API Key
+    - variable: endpoint_url
+      label:
+        en_US: API Base URL
+        zh_Hans: API 基础地址
+      type: text-input
+      required: false
+      placeholder:
+        en_US: 'Optional — leave blank to use the default OpenAI endpoint, or set to your OpenAI-compatible server URL.'
+        zh_Hans: 选填 — 留空使用默认 OpenAI 端点，或填写您的 OpenAI 兼容服务器地址。
 model_credential_schema:
   model:
     label:

--- a/models/openai_api_compatible/tests/test_provider_credential_schema.py
+++ b/models/openai_api_compatible/tests/test_provider_credential_schema.py
@@ -1,0 +1,95 @@
+"""Regression coverage for issue #3682.
+
+Dify's Knowledge Pipeline flow requires every provider used there to
+declare a top-level ``provider_credential_schema`` so the credential
+authorization form can render. The OpenAI-API-compatible plugin only
+declared ``model_credential_schema``; the provider-level schema was
+missing and the form failed with "does not have
+provider_credential_schema" when the user wired a custom model into a
+Knowledge Pipeline.
+
+These tests pin the provider credential schema in place so the bug
+cannot regress.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+PROVIDER_YAML = (
+    Path(__file__).resolve().parent.parent / "provider" / "openai_api_compatible.yaml"
+)
+
+
+def _load_provider_yaml() -> dict:
+    with PROVIDER_YAML.open(encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def test_provider_credential_schema_is_declared():
+    data = _load_provider_yaml()
+    assert "provider_credential_schema" in data, (
+        "Knowledge Pipeline credential setup needs a top-level "
+        "provider_credential_schema (see issue #3682)."
+    )
+
+
+def test_provider_credential_schema_uses_documented_form_shape():
+    data = _load_provider_yaml()
+    schema = data["provider_credential_schema"]
+    assert "credential_form_schemas" in schema
+    assert isinstance(schema["credential_form_schemas"], list)
+    assert schema["credential_form_schemas"]
+
+
+def test_api_key_field_is_required_secret_input():
+    data = _load_provider_yaml()
+    fields = {
+        field["variable"]: field
+        for field in data["provider_credential_schema"]["credential_form_schemas"]
+    }
+    assert "api_key" in fields
+    api_key = fields["api_key"]
+    assert api_key["type"] == "secret-input"
+    assert api_key["required"] is True
+    assert "en_US" in api_key["label"]
+    assert "zh_Hans" in api_key["label"]
+
+
+def test_endpoint_url_field_is_optional_text_input():
+    data = _load_provider_yaml()
+    fields = {
+        field["variable"]: field
+        for field in data["provider_credential_schema"]["credential_form_schemas"]
+    }
+    assert "endpoint_url" in fields
+    endpoint = fields["endpoint_url"]
+    assert endpoint["type"] == "text-input"
+    assert endpoint["required"] is False
+    assert "en_US" in endpoint["label"]
+    assert "zh_Hans" in endpoint["label"]
+
+
+def test_model_credential_schema_remains_unchanged():
+    """The fix is strictly additive: per-model credential fields stay."""
+    data = _load_provider_yaml()
+    assert "model_credential_schema" in data
+    model_fields = data["model_credential_schema"].get("credential_form_schemas", [])
+    assert len(model_fields) >= 30, (
+        "Per-model credential form schema should keep its 30+ fields; "
+        "regression would break existing custom-model configuration flows."
+    )
+    variables = {field["variable"] for field in model_fields}
+    assert "api_key" in variables
+    assert "endpoint_url" in variables
+
+
+def test_provider_credential_schema_yaml_round_trips():
+    """The new field survives a yaml round-trip without loss."""
+    data = _load_provider_yaml()
+    reserialized = yaml.safe_load(yaml.safe_dump(data, allow_unicode=True))
+    assert (
+        reserialized["provider_credential_schema"] == data["provider_credential_schema"]
+    )


### PR DESCRIPTION
Fixes #3682

## What problem does this PR solve?

Configuring a credential for an OpenAI-API-compatible custom model in a Knowledge Pipeline failed with **"does not have provider_credential_schema"** — the form could not render and the user saw a red error toast. Dify requires every provider used in a Knowledge Pipeline to declare a top-level `provider_credential_schema` so the authorization form can render; the OpenAI-API-compatible plugin only declared `model_credential_schema`, so the provider-level schema was missing.

## What is changed and how it works?

- `provider/openai_api_compatible.yaml`: adds `provider_credential_schema` with the two universal fields every OpenAI-compatible server needs:
  - `api_key` (required, `secret-input`): the bearer token for the provider.
  - `endpoint_url` (optional, `text-input`): the OpenAI-compatible server URL. Empty falls back to the default OpenAI endpoint; set to point at LM Studio / vLLM / LiteLLM / etc.
- `manifest.yaml`: bumps version 0.0.64 → 0.0.65.
- The model-level `credential_form_schemas` (30+ fields) is preserved unchanged, so existing per-model configuration flows are not affected.

## How it was tested?

```
$ uv run pytest tests/
63 passed
```

- 6 new tests in `tests/test_provider_credential_schema.py`: pin the presence of `provider_credential_schema`, the form shape, the `api_key` / `endpoint_url` field types and required flags, that the per-model schema is unchanged, and a yaml round-trip.
- All 57 pre-existing tests still pass.
- `ruff check` and `ruff format --check` clean on the new test file.