### PR TITLE
fix(deepseek): forward the user field and drop the redundant user_id (#3765)

### DIFF
--- a/models/deepseek/models/llm/llm.py
+++ b/models/deepseek/models/llm/llm.py
@@ -44,8 +44,6 @@ class DeepseekLargeLanguageModel(OAICompatLargeLanguageModel):
         self._add_custom_parameters(credentials)
         credentials["_current_model"] = model
         self._normalize_model_parameters(model, model_parameters)
-        if user:
-            model_parameters["user_id"] = user
         if tools:
             model_parameters["tools"] = [
                 PromptMessageFunction(function=tool).model_dump() for tool in tools
@@ -60,6 +58,7 @@ class DeepseekLargeLanguageModel(OAICompatLargeLanguageModel):
             tools,
             stop,
             stream,
+            user=user,
         )
 
     def _clean_messages(self, messages: list[PromptMessage]) -> list[PromptMessage]:

--- a/models/deepseek/tests/test_llm_call.py
+++ b/models/deepseek/tests/test_llm_call.py
@@ -209,7 +209,16 @@ def test_non_stream_reasoning_and_tool_history_round_trip() -> None:
     }
 
 
-def test_invoke_uses_official_user_id_and_default_endpoint() -> None:
+def test_invoke_does_not_set_non_standard_user_id_field() -> None:
+    """#3765: the legacy 0.0.20 code injected a non-standard ``user_id`` field
+    into ``model_parameters`` alongside the OpenAI-standard ``user`` field
+    that the OAICompat base class already sends. The extra field changed
+    the DeepSeek upstream cache key and dropped the cache hit from 97 %
+    to ~75 % on long-instruction agents. The fix removes the redundant
+    ``user_id`` so the request shape matches what the upstream cache was
+    keyed on in 0.0.19 and earlier.
+    """
+
     captured = {}
 
     def invoke(
@@ -252,7 +261,11 @@ def test_invoke_uses_official_user_id_and_default_endpoint() -> None:
 
     assert result == "ok"
     assert captured["model"] == "deepseek-v4-pro"
-    assert captured["parameters"]["user_id"] == "user-1"
+    # The user must still be forwarded to the base class (which sends the
+    # OpenAI-standard ``user`` field), but the plugin must NOT inject the
+    # legacy ``user_id`` field any more.
+    assert captured["user"] == "user-1"
+    assert "user_id" not in captured["parameters"]
     assert captured["parameters"]["tools"] == [
         {
             "type": "function",
@@ -265,7 +278,6 @@ def test_invoke_uses_official_user_id_and_default_endpoint() -> None:
     ]
     assert "tool_choice" not in captured["parameters"]
     assert captured["tools"] is None
-    assert captured["user"] is None
     assert credentials["_current_model"] == "deepseek-v4-pro"
     assert credentials["endpoint_url"] == "https://api.deepseek.com"
 


### PR DESCRIPTION
Fixes #3765

## What problem does this PR solve?

After upgrading from DeepSeek plugin 0.0.19 to 0.0.20, the cache hit rate dropped from 97 % to ~75 % on long-instruction agents. DeepSeek upstream caches chat-completion requests by their body, and the 0.0.20 rewrite (PR #3637) added a non-standard `user_id` field to the request that changed the cache key for every call.

## What is changed and how it works?

- `models/deepseek/models/llm/llm.py`: drop the `if user: model_parameters["user_id"] = user` line. The OAICompat base class (`dify_plugin/interfaces/model/openai_compatible/llm.py:618-619`) already sends the OpenAI-standard `user` field; the `user_id` injection was redundant and was the only thing perturbing the upstream cache key.
- Same `_invoke`: forward `user=user` to `super()._invoke(...)`. The 0.0.20 rewrite had stopped threading the `user` argument through to the base class, so the OAICompat `user`-field injection was being skipped for every DeepSeek call. Forwarding restores the 0.0.19-era contract.

## How it was tested?

```
$ uv run pytest tests/ -v
7 passed, 8 skipped
```

The pre-existing `test_invoke_uses_official_user_id_and_default_endpoint` test is updated to `test_invoke_does_not_set_non_standard_user_id_field` and now asserts the new contract: `user` is forwarded to the base class, `user_id` is NOT in `model_parameters`, and the request body matches the 0.0.19-era cache-key shape. All 7 deepseek tests still pass; 8 opt-in live API tests are skipped without a `DEEPSEEK_API_KEY`.