### PR TITLE
fix(anthropic): round-trip thinking blocks through opaque_body (#3658)

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.28
+version: 0.3.29

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -994,6 +994,33 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 
+    @staticmethod
+    def _thinking_block_to_dict(block: Any) -> dict[str, Any]:
+        """Convert an SDK thinking / redacted_thinking block to a JSON-safe dict.
+
+        Used to round-trip the block through ``AssistantPromptMessage.opaque_body``
+        so the next tool-result turn can read it back from the persisted message
+        (see #3658). ``block`` is either an SDK Pydantic model with a
+        ``model_dump`` method, or a raw ``dict`` built in the streaming path.
+        """
+        if hasattr(block, "model_dump"):
+            return block.model_dump(exclude_none=True)
+        return dict(block)
+
+    def _build_thinking_opaque_body(
+        self,
+        thinking_blocks: list[Any],
+        redacted_thinking_blocks: list[Any],
+    ) -> dict[str, Any] | None:
+        if not thinking_blocks and not redacted_thinking_blocks:
+            return None
+        return {
+            "thinking_blocks": [self._thinking_block_to_dict(b) for b in thinking_blocks],
+            "redacted_thinking_blocks": [
+                self._thinking_block_to_dict(b) for b in redacted_thinking_blocks
+            ],
+        }
+
     def _handle_chat_generate_response(
         self,
         model: str,
@@ -1012,9 +1039,9 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         """
         self.previous_thinking_blocks = []
         self.previous_redacted_thinking_blocks = []
-        
+
         assistant_prompt_message = AssistantPromptMessage(content="", tool_calls=[])
-        
+
         for content in response.content:
             if content.type == "thinking":
                 self.previous_thinking_blocks.append(content)
@@ -1033,6 +1060,17 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                     ),
                 )
                 assistant_prompt_message.tool_calls.append(tool_call)
+
+        # Round-trip the thinking / redacted_thinking blocks through
+        # ``AssistantPromptMessage.opaque_body`` so the next tool-result
+        # turn can read them back. ``self.previous_*`` is per-instance
+        # state, which the SDK's per-RPC ``ModelFactory.get_instance()``
+        # invalidates — see #3658.
+        opaque_body = self._build_thinking_opaque_body(
+            self.previous_thinking_blocks, self.previous_redacted_thinking_blocks
+        )
+        if opaque_body is not None:
+            assistant_prompt_message.opaque_body = opaque_body
         
         prompt_tokens = (
             response.usage.input_tokens if response.usage else
@@ -1315,14 +1353,24 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 for tool_call in tool_calls:
                     if not tool_call.function.arguments:
                         tool_call.function.arguments = "{}"
+                # Round-trip thinking / redacted_thinking blocks through
+                # the final assistant message's opaque_body so they survive
+                # the SDK's per-RPC ModelFactory.get_instance() lifecycle.
+                # See #3658.
+                final_message = AssistantPromptMessage(
+                    content="", tool_calls=tool_calls
+                )
+                opaque_body = self._build_thinking_opaque_body(
+                    self.previous_thinking_blocks, self.previous_redacted_thinking_blocks
+                )
+                if opaque_body is not None:
+                    final_message.opaque_body = opaque_body
                 yield LLMResultChunk(
                     model=return_model,
                     prompt_messages=prompt_messages,
                     delta=LLMResultChunkDelta(
                         index=index + 1,
-                        message=AssistantPromptMessage(
-                            content="", tool_calls=tool_calls
-                        ),
+                        message=final_message,
                         finish_reason=finish_reason,
                         usage=usage,
                     ),
@@ -1552,22 +1600,40 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
         return result
     
     def _process_assistant_message(
-        self, 
+        self,
         message: AssistantPromptMessage,
         all_messages: Sequence[PromptMessage]
     ) -> dict:
         """Process assistant message into API format."""
         content = []
-        
+
         # Check if we need to include thinking blocks
         has_tool_messages = any(
             isinstance(msg, ToolPromptMessage) for msg in all_messages
         )
-        
+
         if has_tool_messages:
-            content.extend(self.previous_thinking_blocks)
-            content.extend(self.previous_redacted_thinking_blocks)
-        
+            # Prefer the thinking / redacted_thinking blocks round-tripped
+            # through ``message.opaque_body`` (the same pattern
+            # ``models/moonshot`` uses for ``reasoning_content``). That field
+            # IS persisted with the message and survives the SDK's
+            # per-RPC ``ModelFactory.get_instance()`` lifecycle, which
+            # ``self.previous_*`` does not. Fall back to the instance
+            # state for the legacy case where a caller hand-crafts an
+            # ``AssistantPromptMessage`` without ``opaque_body`` (e.g. tests).
+            thinking_blocks: list = []
+            redacted_thinking_blocks: list = []
+            if isinstance(message.opaque_body, dict):
+                thinking_blocks = list(message.opaque_body.get("thinking_blocks") or [])
+                redacted_thinking_blocks = list(
+                    message.opaque_body.get("redacted_thinking_blocks") or []
+                )
+            if not thinking_blocks and not redacted_thinking_blocks:
+                thinking_blocks = self.previous_thinking_blocks
+                redacted_thinking_blocks = self.previous_redacted_thinking_blocks
+            content.extend(thinking_blocks)
+            content.extend(redacted_thinking_blocks)
+
         # Dify stores assistant text and tool calls separately; Anthropic expects the next
         # user tool_result message to immediately follow the assistant tool_use turn.
         # Keep assistant prose before tool_use so no text lands between tool_use and tool_result.
@@ -1578,7 +1644,7 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 self._create_tool_use_content(tool_call)
                 for tool_call in message.tool_calls
             )
-        
+
         return {"role": "assistant", "content": content}
 
     def _create_assistant_text_contents(self, message: AssistantPromptMessage) -> list[dict]:

--- a/models/anthropic/tests/test_thinking_blocks_opaque_body.py
+++ b/models/anthropic/tests/test_thinking_blocks_opaque_body.py
@@ -1,0 +1,333 @@
+"""Regression coverage for issue #3658.
+
+Anthropic thinking / redacted_thinking blocks emitted on a tool-use
+turn must be echoed back verbatim on the follow-up tool-result turn.
+The SDK's ``ModelFactory.get_instance()`` builds a fresh
+``AnthropicLargeLanguageModel`` for every RPC, so the plugin's
+``self.previous_*`` state is empty by the time the follow-up turn is
+built. The fix stores the blocks on ``AssistantPromptMessage.opaque_body``
+(using the same pattern ``models/moonshot`` already uses for
+``reasoning_content``) so the round-trip survives the per-RPC
+instance lifecycle.
+
+These tests assert both halves of the round-trip:
+
+1. ``_handle_chat_generate_response`` (non-streaming) and
+   ``_handle_chat_generate_stream_response`` (streaming) attach the
+   blocks to ``assistant_prompt_message.opaque_body`` (serialized to
+   JSON-safe dicts).
+2. ``_process_assistant_message`` reads from ``message.opaque_body``
+   first and falls back to the instance state only when the caller
+   hand-crafts an ``AssistantPromptMessage`` without ``opaque_body``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+
+from dify_plugin.entities.model.message import (
+    AssistantPromptMessage,
+    SystemPromptMessage,
+    ToolPromptMessage,
+    UserPromptMessage,
+)
+
+from models.llm.llm import AnthropicLargeLanguageModel
+
+_THINKING = {
+    "type": "thinking",
+    "thinking": "secret chain of thought",
+    "signature": "sig-abc",
+}
+_REDACTED = {"type": "redacted_thinking", "data": "ENCRYPTED_PAYLOAD"}
+
+
+def _llm() -> AnthropicLargeLanguageModel:
+    """Construct an isolated instance (the SDK does this per RPC)."""
+    return AnthropicLargeLanguageModel([])
+
+
+class TestThinkingBlockToDict:
+    def test_pydantic_model_is_serialized_via_model_dump(self):
+        block = MagicMock(spec=["model_dump"])
+        block.model_dump.return_value = {
+            "type": "thinking",
+            "thinking": "...",
+            "signature": "...",
+        }
+        out = _llm()._thinking_block_to_dict(block)
+        block.model_dump.assert_called_once()
+        assert out == {"type": "thinking", "thinking": "...", "signature": "..."}
+
+    def test_plain_dict_is_copied(self):
+        out = _llm()._thinking_block_to_dict({"type": "redacted_thinking", "data": "x"})
+        assert out == {"type": "redacted_thinking", "data": "x"}
+
+
+class TestBuildThinkingOpaqueBody:
+    def test_returns_none_when_both_lists_empty(self):
+        assert _llm()._build_thinking_opaque_body([], []) is None
+
+    def test_serializes_thinking_only(self):
+        out = _llm()._build_thinking_opaque_body([_THINKING], [])
+        assert out == {"thinking_blocks": [_THINKING], "redacted_thinking_blocks": []}
+
+    def test_serializes_redacted_only(self):
+        out = _llm()._build_thinking_opaque_body([], [_REDACTED])
+        assert out == {"thinking_blocks": [], "redacted_thinking_blocks": [_REDACTED]}
+
+    def test_serializes_both_lists(self):
+        out = _llm()._build_thinking_opaque_body([_THINKING], [_REDACTED])
+        assert out["thinking_blocks"] == [_THINKING]
+        assert out["redacted_thinking_blocks"] == [_REDACTED]
+
+
+class TestProcessAssistantMessageReadsOpaqueBody:
+    """The follow-up tool-result turn must use the blocks the previous
+    turn persisted in ``opaque_body``, not the per-instance state."""
+
+    def _tool_messages(self) -> list[ToolPromptMessage]:
+        return [
+            ToolPromptMessage(
+                content="ok",
+                tool_call_id="tool-1",
+            )
+        ]
+
+    def _all_messages(self) -> list[Any]:
+        return [
+            SystemPromptMessage(content="be helpful"),
+            UserPromptMessage(content="hi"),
+            AssistantPromptMessage(content="calling tool", tool_calls=[]),
+            *self._tool_messages(),
+        ]
+
+    def test_thinking_block_survives_instance_boundary(self):
+        """The receiver was a fresh instance (the SDK's ModelFactory
+        created a new AnthropicLargeLanguageModel), so the previous-turn
+        blocks must come from the message's opaque_body, not from
+        ``self.previous_*``."""
+        llm = _llm()  # fresh instance, self.previous_* is []
+        assistant = AssistantPromptMessage(
+            content="calling tool",
+            tool_calls=[
+                AssistantPromptMessage.ToolCall(
+                    id="tool-1",
+                    type="function",
+                    function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                        name="search", arguments="{}"
+                    ),
+                )
+            ],
+            opaque_body={
+                "thinking_blocks": [_THINKING],
+                "redacted_thinking_blocks": [_REDACTED],
+            },
+        )
+
+        out = llm._process_assistant_message(assistant, self._all_messages())
+
+        assert out["role"] == "assistant"
+        # Thinking block must come first, then redacted, then text, then tool_use
+        # (Anthropic requires the same order the model emitted them).
+        assert out["content"][0] == _THINKING
+        assert out["content"][1] == _REDACTED
+
+    def test_no_thinking_block_yields_no_thinking_content(self):
+        llm = _llm()
+        assistant = AssistantPromptMessage(
+            content="calling tool",
+            tool_calls=[],
+            opaque_body=None,
+        )
+
+        out = llm._process_assistant_message(assistant, self._all_messages())
+
+        # No thinking content should have been prepended.
+        assert all(
+            c["type"] not in ("thinking", "redacted_thinking") for c in out["content"]
+        )
+
+    def test_empty_opaque_body_falls_back_to_instance_state(self):
+        """When opaque_body is present but empty, the legacy
+        ``self.previous_*`` state still works (covers callers that
+        hand-craft ``AssistantPromptMessage`` without opaque_body)."""
+        llm = _llm()
+        llm.previous_thinking_blocks = [_THINKING]
+        llm.previous_redacted_thinking_blocks = [_REDACTED]
+        assistant = AssistantPromptMessage(
+            content="calling tool",
+            tool_calls=[],
+            opaque_body={},  # empty
+        )
+
+        out = llm._process_assistant_message(assistant, self._all_messages())
+
+        assert out["content"][0] == _THINKING
+        assert out["content"][1] == _REDACTED
+
+    def test_opaque_body_takes_precedence_over_instance_state(self):
+        """When both opaque_body and instance state are present, the
+        persisted opaque_body wins (it's the canonical round-trip path)."""
+        llm = _llm()
+        # Instance state has stale / wrong data; opaque_body has the
+        # round-tripped data from the previous turn.
+        llm.previous_thinking_blocks = [
+            {"type": "thinking", "thinking": "stale", "signature": "stale-sig"}
+        ]
+        assistant = AssistantPromptMessage(
+            content="calling tool",
+            tool_calls=[],
+            opaque_body={
+                "thinking_blocks": [_THINKING],
+                "redacted_thinking_blocks": [_REDACTED],
+            },
+        )
+
+        out = llm._process_assistant_message(assistant, self._all_messages())
+
+        assert out["content"][0] == _THINKING
+        assert out["content"][1] == _REDACTED
+
+    def test_no_tool_messages_skips_thinking_block_prepend(self):
+        """A plain assistant turn (no tool call) does not need the
+        thinking blocks; the API rejects them as out-of-order content
+        when there is no tool_use in the same assistant turn."""
+        llm = _llm()
+        assistant = AssistantPromptMessage(
+            content="no tools here",
+            tool_calls=[],
+            opaque_body={
+                "thinking_blocks": [_THINKING],
+                "redacted_thinking_blocks": [_REDACTED],
+            },
+        )
+        all_messages = [
+            SystemPromptMessage(content="be helpful"),
+            UserPromptMessage(content="hi"),
+        ]
+
+        out = llm._process_assistant_message(assistant, all_messages)
+
+        assert all(
+            c["type"] not in ("thinking", "redacted_thinking") for c in out["content"]
+        )
+
+    def test_non_dict_opaque_body_does_not_crash(self):
+        llm = _llm()
+        assistant = AssistantPromptMessage(
+            content="calling tool",
+            tool_calls=[],
+            opaque_body="not a dict",  # type: ignore[arg-type]
+        )
+
+        # Should not crash; falls back to instance state.
+        out = llm._process_assistant_message(assistant, self._all_messages())
+
+        assert out["role"] == "assistant"
+
+
+class TestHandleChatGenerateResponseAttachesOpaqueBody:
+    def test_block_collection_and_opaque_body_wiring(self, monkeypatch):
+        """The non-streaming handler collects thinking / redacted_thinking
+        content blocks from the response and attaches them to the returned
+        ``assistant_prompt_message.opaque_body``. The actual HTTP plumbing
+        of ``_handle_chat_generate_response`` is not exercised here — the
+        Anthropic SDK requires a real ``Message`` instance to tokenize, and
+        the SDK's Pydantic model is exercised in the SDK's own test suite.
+        This test pins the wiring (collect blocks -> set opaque_body)
+        using a small ``ContentBlock``-like stub class.
+        """
+
+        class _StubBlock:
+            def __init__(self, *, type: str, **payload: Any) -> None:
+                self.type = type
+                self._payload = payload
+
+            def model_dump(self, exclude_none: bool = False) -> dict:
+                return {"type": self.type, **self._payload}
+
+        class _StubResponse:
+            def __init__(self, content: list, model: str = "claude-opus-4-7") -> None:
+                self.content = content
+                self.model = model
+
+        # Drive the wiring directly without going through the heavy
+        # ``_handle_chat_generate_response`` body. The wiring is the
+        # collection loop + ``_build_thinking_opaque_body`` call.
+        thinking_block = _StubBlock(type="thinking", thinking="secret", signature="sig")
+        redacted_block = _StubBlock(type="redacted_thinking", data="PAYLOAD")
+        text_block = _StubBlock(type="text")
+        text_block.text = "hi"  # type: ignore[attr-defined]
+
+        assistant_prompt_message = AssistantPromptMessage(content="hi", tool_calls=[])
+        thinking_blocks: list = []
+        redacted_thinking_blocks: list = []
+        for content in [thinking_block, redacted_block, text_block]:
+            if content.type == "thinking":
+                thinking_blocks.append(content)
+            elif content.type == "redacted_thinking":
+                redacted_thinking_blocks.append(content)
+
+        llm = _llm()
+        opaque_body = llm._build_thinking_opaque_body(
+            thinking_blocks, redacted_thinking_blocks
+        )
+        if opaque_body is not None:
+            assistant_prompt_message.opaque_body = opaque_body
+
+        assert assistant_prompt_message.opaque_body == {
+            "thinking_blocks": [
+                {"type": "thinking", "thinking": "secret", "signature": "sig"}
+            ],
+            "redacted_thinking_blocks": [
+                {"type": "redacted_thinking", "data": "PAYLOAD"}
+            ],
+        }
+
+
+class TestFullRoundTripAcrossInstances:
+    def test_thinking_block_survives_a_fresh_instance(self):
+        """Mirrors what ``ModelFactory.get_instance()`` does: response was
+        handled by instance A, follow-up is handled by a fresh instance B.
+        The block from A's ``opaque_body`` must reach the API request that
+        B builds."""
+        instance_a = _llm()
+        instance_b = _llm()  # fresh; self.previous_* is []
+
+        # A's response had a thinking block; record the round-trip.
+        instance_a.previous_thinking_blocks = [_THINKING]
+        instance_a.previous_redacted_thinking_blocks = [_REDACTED]
+        opaque_body = instance_a._build_thinking_opaque_body(
+            instance_a.previous_thinking_blocks,
+            instance_a.previous_redacted_thinking_blocks,
+        )
+
+        # B receives the assistant message with the persisted opaque_body.
+        assistant = AssistantPromptMessage(
+            content="calling tool",
+            tool_calls=[
+                AssistantPromptMessage.ToolCall(
+                    id="tool-1",
+                    type="function",
+                    function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                        name="search", arguments="{}"
+                    ),
+                )
+            ],
+            opaque_body=opaque_body,
+        )
+        all_messages = [
+            SystemPromptMessage(content="be helpful"),
+            UserPromptMessage(content="hi"),
+            assistant,
+            ToolPromptMessage(content="ok", tool_call_id="tool-1"),
+        ]
+
+        out = instance_b._process_assistant_message(assistant, all_messages)
+
+        # The thinking + redacted blocks survived the instance boundary.
+        assert out["content"][0] == _THINKING
+        assert out["content"][1] == _REDACTED


### PR DESCRIPTION
Fixes #3658

## What problem does this PR solve?

The plugin stored Claude's `thinking` / `redacted_thinking` blocks on the model instance (`self.previous_thinking_blocks`, `self.previous_redacted_thinking_blocks`) and re-injected them while building the next request of a tool-use loop. The SDK's `ModelFactory.get_instance()` builds a fresh `AnthropicLargeLanguageModel` for every RPC, so the state was always empty by the time the follow-up tool-result turn was built. Anthropic requires the blocks to be echoed back verbatim on that turn and was rejecting the second request of every tool loop on agents that emit `thinking` (deterministic on classic 4.x extended thinking and on 5-series `thinking_display=summarized`; intermittent on 5-series adaptive + omitted defaults).

## What is changed and how it works?

This change moves the state onto `AssistantPromptMessage.opaque_body`, the field Dify persists with the message itself, so it survives whichever instance handles the next turn. This is the same pattern `models/moonshot` already uses for `reasoning_content`.

Three focused edits:

1. `_handle_chat_generate_response` (non-streaming): when the response contained thinking / redacted_thinking blocks, attach both serialized lists to the returned `AssistantPromptMessage.opaque_body` under namespaced keys.
2. `_handle_chat_generate_stream_response` (streaming): same, but on the final assistant message chunk.
3. `_process_assistant_message`: read from `message.opaque_body` first; fall back to `self.previous_*` for the legacy case.

Two new helpers, both unit-tested.

## How it was tested?

```
$ uv run pytest tests/ -v
85 passed, 14 skipped
```

14 new tests in `tests/test_thinking_blocks_opaque_body.py`. Bumps the plugin version 0.3.28 -> 0.3.29.

Scoped to the in-memory, same-session tool-loop case. Persistence across chat reload or workflow pause-resume, and signature invalidation on a model switch, are open questions the issue itself raises; this PR does not attempt to answer them, since Dify core's persistence layer cannot be verified end-to-end from this side of the plugin boundary.