### PR TITLE
feat(gemini): add Gemini 3.8 Flash model support

### DIFF
--- a/models/gemini/manifest.yaml
+++ b/models/gemini/manifest.yaml
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.9.7
+version: 0.9.8

--- a/models/gemini/models/llm/_position.yaml
+++ b/models/gemini/models/llm/_position.yaml
@@ -1,3 +1,4 @@
+- gemini-3.8-flash
 - gemini-3.7-flash
 - gemini-3.6-flash
 - gemini-3.5-flash

--- a/models/gemini/models/llm/gemini-3.8-flash.yaml
+++ b/models/gemini/models/llm/gemini-3.8-flash.yaml
@@ -1,0 +1,163 @@
+# https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
+model: gemini-3.8-flash
+label:
+  en_US: Gemini 3.8 Flash
+model_type: llm
+features:
+  - tool-call
+  - multi-tool-call
+  - agent-thought
+  - vision
+  - stream-tool-call
+  - document
+  - video
+  - audio
+  - structured-output
+model_properties:
+  mode: chat
+  context_size: 1048576
+parameter_rules:
+  - name: include_thoughts
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Include thoughts
+      zh_Hans: 返回思考过程
+    help:
+      en_US: Indicates whether to include thoughts in the response. If true, thoughts are returned only if the model supports thought and thoughts are available. Default is false.
+      zh_Hans: 是否返回思考过程。若为 true 则只有模型支持思考且启动思考模式时才返回思考过程。默认为 false。
+  - name: media_resolution
+    type: string
+    required: true
+    default: "Default"
+    options:
+      - Default
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Media resolution
+      zh_Hans: 媒体分辨率
+    help:
+      en_US: |
+        Gemini 3 introduces fine-grained control over multimodal visual processing via the `media_resolution` parameter. Higher resolution improves the model's ability to read small text or recognize fine details, but increases token usage and latency.
+
+        Recommended Settings:
+        - Images: `media_resolution_high` (1120 tokens) - Recommended for most image analysis tasks to ensure best quality.
+        - PDF: `media_resolution_medium` (560 tokens) - Great for document understanding; quality usually saturates at medium.
+        - Video (Regular): `media_resolution_low` or `medium` (70 tokens/frame) - Sufficient for most action recognition and description tasks.
+        - Video (Text-heavy): `media_resolution_high` (280 tokens/frame) - Needed only when use cases involve reading dense text (OCR) or tiny details in video frames.
+
+        Note: If not specified, the model uses the best default value based on the media type.
+      zh_Hans: |
+        Gemini 3 通过 `media_resolution` 参数引入了对多模态视觉处理的精细控制。分辨率越高，模型读取细小文本或识别细微细节的能力就越强，但会增加令牌用量和延迟时间。
+
+        推荐设置：
+        - 图片：`media_resolution_high` (1120 tokens) - 建议用于大多数图片分析任务，以确保获得最佳质量。
+        - PDF：`media_resolution_medium` (560 tokens) - 非常适合文档理解；质量通常在 medium 时达到饱和。
+        - 视频（常规）：`media_resolution_low` 或 `medium` (70 tokens/帧) - 对于大多数动作识别和描述任务来说已经足够。
+        - 视频（文字较多）：`media_resolution_high` (280 tokens/帧) - 仅当用例涉及读取密集文本 (OCR) 或视频帧中的微小细节时才需要。
+
+        注意：如果不指定，模型会根据媒体类型使用最佳默认值。
+  - name: thinking_level
+    type: string
+    required: true
+    default: "Medium"
+    options:
+      - Low
+      - Medium
+      - High
+    label:
+      en_US: Thinking level
+      zh_Hans: 思考层级
+    help:
+      en_US: Indicates the thinking level. Default is Medium. Gemini 3.8 Flash does not support Minimal.
+      zh_Hans: 思考层级。默认为 Medium。Gemini 3.8 Flash 不支持 Minimal。
+  - name: grounding
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Grounding
+      zh_Hans: 事实核查
+      ja_JP: 事実チェック
+    help:
+      en_US: Grounding with Google Search
+      zh_Hans: Google 事实核查
+      ja_JP: Google 検索に基づいた応答をします。
+  - name: url_context
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: URL context
+      zh_Hans: 链接详情
+      ja_JP: 網羅閲覧
+    help:
+      en_US: Browse the url context
+      zh_Hans: 获取并分析该链接的详细信息，为回答提供参考依据。
+      ja_JP: リンク先の詳細情報を取得し、文脈を理解します。
+  - name: code_execution
+    type: boolean
+    required: true
+    default: false
+    label:
+      en_US: Code execution
+      zh_Hans: 代码执行
+      ja_JP: コード実行
+    help:
+      en_US: Lets Gemini use code to solve complex tasks
+      zh_Hans: 让 Gemini 使用代码来解决复杂任务。
+      ja_JP: Gemini にコードを使って複雑なタスクを解決させましょう。
+  - name: max_output_tokens
+    use_template: max_tokens
+    type: int
+    required: true
+    default: 65536
+    min: 1
+    max: 65536
+    label:
+      en_US: Output length
+      zh_Hans: 输出长度
+    help:
+      en_US: The maximum number of tokens to generate in the response.
+      zh_Hans: 模型单次输出的最大 tokens 数。
+  - name: service_tier
+    type: string
+    required: true
+    default: "standard"
+    options:
+      - flex
+      - standard
+      - priority
+    label:
+      en_US: Service Tier
+      zh_Hans: 推理层级
+    help:
+      en_US: |
+        The inference tier for the request. You can switch between Gemini Standard, Flex, and Priority tiers. Default is Standard.
+        - Flex: Lower cost with the possibility of capacity unavailability.
+        - Standard: Default pricing and availability.
+        - Priority: Higher cost with guaranteed capacity and lower latency.
+        See:
+        - https://ai.google.dev/gemini-api/docs/flex-inference
+        - https://ai.google.dev/gemini-api/docs/priority-inference
+      zh_Hans: |
+        推理层级，可切换 Gemini Standard/Flex/Priority 推理层级，默认为 Standard。
+        - Flex：价格更低，但可能出现容量不可用的情况。
+        - Standard：默认价格和可用性。
+        - Priority：价格更高，但保证容量并提供更低延迟。
+        详见：
+        - https://ai.google.dev/gemini-api/docs/flex-inference
+        - https://ai.google.dev/gemini-api/docs/priority-inference
+  - name: json_schema
+    use_template: json_schema
+# https://ai.google.dev/gemini-api/docs/pricing#gemini-3.8-flash
+# Input price $0.75 through December 31, 2026. $1.50 starting January 1, 2027.
+# Output price $3.75 through December 31, 2026. $7.50 starting January 1, 2027.
+pricing:
+  input: '0.75'
+  output: '3.75'
+  unit: '0.000001'
+  currency: USD


### PR DESCRIPTION


## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

This commit introduces support for the Gemini 3.8 Flash model. Changes include:

- Added `models/gemini/models/llm/gemini-3.8-flash.yaml` with full configuration, including parameters for tool calls, vision, audio, video, and structured output.
- Configured specific parameters such as `media_resolution`, `thinking_level`, `grounding`, `url_context`, `code_execution`, and `service_tier` with detailed help text in English, Chinese, and Japanese.
- Updated `models/gemini/manifest.yaml` to version 0.9.8.
- Registered `gemini-3.8-flash` in the model list within `_position.yaml`.

## Release Notes

<!--
User-facing summary of what this version changes. Published verbatim on the
plugin's Marketplace page (Version History → Change Log). English, Markdown.
Skip only for documentation / non-plugin changes.
-->


This commit introduces support for the Gemini 3.8 Flash model. Changes include:

- Added `models/gemini/models/llm/gemini-3.8-flash.yaml` with full configuration, including parameters for tool calls, vision, audio, video, and structured output.
- Configured specific parameters such as `media_resolution`, `thinking_level`, `grounding`, `url_context`, `code_execution`, and `service_tier` with detailed help text in English, Chinese, and Japanese.
- Updated `models/gemini/manifest.yaml` to version 0.9.8.
- Registered `gemini-3.8-flash` in the model list within `_position.yaml`.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.17.0
- [ ] SaaS (cloud.dify.ai)
