### PR TITLE
fix(tongyi): isolate DashScope sessions per embedding invocation

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -25,5 +25,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.2.15
+version: 0.2.16
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/models/text_embedding/text_embedding.py
+++ b/models/tongyi/models/text_embedding/text_embedding.py
@@ -90,17 +90,24 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
             indices += [i]
         batched_embeddings = []
         _iter = range(0, len(inputs), max_chunks)
-        for i in _iter:
-            (embeddings_batch, embedding_used_tokens) = self.embed_documents(
-                credentials_kwargs=credentials_kwargs,
-                model=model,
-                texts=inputs[i : i + max_chunks],
-                base_address=http_base_address,
+        session = requests.Session()
+        try:
+            for i in _iter:
+                (embeddings_batch, embedding_used_tokens) = self.embed_documents(
+                    credentials_kwargs=credentials_kwargs,
+                    model=model,
+                    texts=inputs[i : i + max_chunks],
+                    base_address=http_base_address,
+                    session=session,
+                )
+                used_tokens += embedding_used_tokens
+                batched_embeddings += embeddings_batch
+            usage = self._calc_response_usage(
+                model=model, credentials=credentials, tokens=used_tokens
             )
-            used_tokens += embedding_used_tokens
-            batched_embeddings += embeddings_batch
-        usage = self._calc_response_usage(model=model, credentials=credentials, tokens=used_tokens)
-        return TextEmbeddingResult(embeddings=batched_embeddings, usage=usage, model=model)
+            return TextEmbeddingResult(embeddings=batched_embeddings, usage=usage, model=model)
+        finally:
+            session.close()
 
     def get_num_tokens(self, model: str, credentials: dict, texts: list[str]) -> list[int]:
         """
@@ -126,6 +133,7 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         :param credentials: model credentials
         :return:
         """
+        session = requests.Session()
         try:
             credentials_kwargs = self._to_credential_kwargs(credentials)
             http_base_address = get_http_base_address(credentials)
@@ -134,9 +142,12 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                 model=model,
                 texts=["ping"],
                 base_address=http_base_address,
+                session=session,
             )
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
+        finally:
+            session.close()
 
     @staticmethod
     def embed_documents(
@@ -144,6 +155,7 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         model: str,
         texts: list[str],
         base_address: str,
+        session: requests.Session,
     ) -> tuple[list[list[float]], int]:
         """Call out to Tongyi's embedding endpoint.
 
@@ -151,6 +163,7 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
             credentials_kwargs: The credentials to use for the call.
             model: The model to use for embedding.
             texts: The list of texts to embed.
+            session: The requests session for this invocation.
 
         Returns:
             List of embeddings, one for each text, and tokens usage.
@@ -165,6 +178,7 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                 model,
                 documents,
                 base_address,
+                session,
             )
 
         embeddings = []
@@ -177,6 +191,7 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                     model=model,
                     input=[{"text": text}],
                     base_address=base_address,
+                    session=session,
                 )
             else:
                 return dashscope.TextEmbedding.call(
@@ -186,6 +201,7 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                     headers=BURY_POINT_HEADER,
                     text_type="document",
                     base_address=base_address,
+                    session=session,
                 )
 
         for text in texts:
@@ -288,18 +304,27 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         """
         http_base_address = get_http_base_address(credentials)
         credentials_kwargs = self._to_credential_kwargs(credentials)
-        (embeddings_batch, embedding_used_tokens) = self.embed_multimodal_documents(
-            credentials_kwargs=credentials_kwargs,
-            model=model,
-            documents=documents,
-            base_address=http_base_address,
-        )
-        usage = self._calc_response_usage(model=model, credentials=credentials, tokens=embedding_used_tokens)
-        return MultiModalEmbeddingResult(
-            model=model,
-            embeddings=embeddings_batch,
-            usage=usage,
-        )     
+        session = requests.Session()
+        try:
+            (embeddings_batch, embedding_used_tokens) = self.embed_multimodal_documents(
+                credentials_kwargs=credentials_kwargs,
+                model=model,
+                documents=documents,
+                base_address=http_base_address,
+                session=session,
+            )
+            usage = self._calc_response_usage(
+                model=model,
+                credentials=credentials,
+                tokens=embedding_used_tokens,
+            )
+            return MultiModalEmbeddingResult(
+                model=model,
+                embeddings=embeddings_batch,
+                usage=usage,
+            )
+        finally:
+            session.close()
 
     @staticmethod
     def embed_multimodal_documents(
@@ -307,6 +332,7 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         model: str,
         documents: list[MultiModalContent],
         base_address: str,
+        session: requests.Session,
     ) -> tuple[list[list[float]], int]:
         """Call out to Tongyi's embedding endpoint.
 
@@ -314,6 +340,7 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
             credentials_kwargs: The credentials to use for the call.
             model: The model to use for embedding.
             documents: The list of documents to embed.
+            session: The requests session for this invocation.
 
         Returns:
             List of embeddings, one for each text, and tokens usage.
@@ -350,6 +377,7 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                 model=model,
                 input=[input],
                 base_address=base_address,
+                session=session,
             )
 
         for document in documents:

--- a/models/tongyi/tests/test_text_embedding_retry.py
+++ b/models/tongyi/tests/test_text_embedding_retry.py
@@ -142,21 +142,25 @@ def sleeps(monkeypatch) -> list:
 
 
 def _embed_documents():
+    session = MagicMock(spec=requests.Session)
     return TongyiTextEmbeddingModel.embed_documents(
         credentials_kwargs=CREDENTIALS,
         model=TEXT_MODEL,
         texts=["hello"],
         base_address=BASE_ADDRESS,
+        session=session,
     )
 
 
 def _embed_multimodal_documents():
     documents = [MultiModalContent(content_type=MultiModalContentType.TEXT, content="hello")]
+    session = MagicMock(spec=requests.Session)
     return TongyiTextEmbeddingModel.embed_multimodal_documents(
         credentials_kwargs=CREDENTIALS,
         model=MULTIMODAL_MODEL,
         documents=documents,
         base_address=BASE_ADDRESS,
+        session=session,
     )
 
 

--- a/models/tongyi/tests/test_text_embedding_session_cleanup.py
+++ b/models/tongyi/tests/test_text_embedding_session_cleanup.py
@@ -1,0 +1,272 @@
+import sys
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from dify_plugin.entities.model.text_embedding import (
+    EmbeddingUsage,
+    MultiModalContent,
+    MultiModalContentType,
+)
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+_PLUGIN_DIR = Path(__file__).resolve().parent.parent
+if str(_PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_DIR))
+
+from models.text_embedding import text_embedding as te  # noqa: E402
+
+TongyiTextEmbeddingModel = te.TongyiTextEmbeddingModel
+
+CREDENTIALS = {"dashscope_api_key": "test-key"}
+BASE_ADDRESS = "https://dashscope.aliyuncs.com/api/v1"
+TEXT_MODEL = "text-embedding-v3"
+MULTIMODAL_MODEL = "multimodal-embedding-v1"
+
+
+class _TextResponse:
+    def __init__(self) -> None:
+        self.status_code = 200
+        self.output = {"embeddings": [{"embedding": [0.1, 0.2, 0.3], "type": "text"}]}
+        self.usage = {"total_tokens": 7}
+
+
+class _MultiModalResponse:
+    def __init__(self) -> None:
+        self.status_code = 200
+        self.output = {"embeddings": [{"embedding": [0.4, 0.5], "type": "text"}]}
+        self.usage = {"input_tokens": 5, "image_tokens": 0}
+
+
+class _RateLimitedResponse:
+    def __init__(self) -> None:
+        self.status_code = 429
+        self.output = None
+        self.usage = None
+
+
+def _usage() -> EmbeddingUsage:
+    return EmbeddingUsage(
+        tokens=0,
+        total_tokens=0,
+        unit_price=Decimal("0"),
+        price_unit=Decimal("0"),
+        total_price=Decimal("0"),
+        currency="RMB",
+        latency=0,
+    )
+
+
+def _model(max_chunks: int = 10) -> TongyiTextEmbeddingModel:
+    model = TongyiTextEmbeddingModel(model_schemas=MagicMock())
+    model._get_context_size = MagicMock(return_value=8192)
+    model._get_max_chunks = MagicMock(return_value=max_chunks)
+    model._get_num_tokens_by_gpt2 = MagicMock(return_value=1)
+    model._calc_response_usage = MagicMock(return_value=_usage())
+    return model
+
+
+def _invoke(model: TongyiTextEmbeddingModel, texts: list[str] | None = None):
+    return model._invoke(
+        model=TEXT_MODEL,
+        credentials=CREDENTIALS,
+        texts=texts or ["hello"],
+    )
+
+
+def test_text_embedding_call_receives_session() -> None:
+    session = MagicMock(spec=requests.Session)
+    with patch.object(te.dashscope.TextEmbedding, "call", return_value=_TextResponse()) as call:
+        result = TongyiTextEmbeddingModel.embed_documents(
+            credentials_kwargs=CREDENTIALS,
+            model=TEXT_MODEL,
+            texts=["hello"],
+            base_address=BASE_ADDRESS,
+            session=session,
+        )
+
+    assert result == ([[0.1, 0.2, 0.3]], 7)
+    assert call.call_args.kwargs["session"] is session
+
+
+def test_multimodal_embedding_call_receives_session_through_text_path() -> None:
+    session = MagicMock(spec=requests.Session)
+    with patch.object(
+        te.dashscope.MultiModalEmbedding,
+        "call",
+        return_value=_MultiModalResponse(),
+    ) as call:
+        result = TongyiTextEmbeddingModel.embed_documents(
+            credentials_kwargs=CREDENTIALS,
+            model=MULTIMODAL_MODEL,
+            texts=["hello"],
+            base_address=BASE_ADDRESS,
+            session=session,
+        )
+
+    assert result == ([[0.4, 0.5]], 5)
+    assert call.call_args.kwargs["session"] is session
+
+
+def test_text_batches_reuse_one_session_and_close_it() -> None:
+    model = _model(max_chunks=2)
+    session = MagicMock(spec=requests.Session)
+    batches = []
+
+    def embed_documents(**kwargs):
+        batches.append((kwargs["texts"], kwargs["session"]))
+        return ([[0.1]] * len(kwargs["texts"]), len(kwargs["texts"]))
+
+    with patch.object(
+        te.requests, "Session", return_value=session
+    ) as session_factory, patch.object(
+        model,
+        "embed_documents",
+        side_effect=embed_documents,
+    ):
+        result = _invoke(model, ["one", "two", "three"])
+
+    assert result.embeddings == [[0.1], [0.1], [0.1]]
+    assert [batch for batch, _ in batches] == [["one", "two"], ["three"]]
+    assert [batch_session for _, batch_session in batches] == [session, session]
+    model._calc_response_usage.assert_called_once_with(
+        model=TEXT_MODEL,
+        credentials=CREDENTIALS,
+        tokens=3,
+    )
+    session_factory.assert_called_once_with()
+    session.close.assert_called_once_with()
+
+
+def test_each_text_invocation_gets_an_isolated_session() -> None:
+    model = _model()
+    first, second = MagicMock(spec=requests.Session), MagicMock(spec=requests.Session)
+
+    with patch.object(te.requests, "Session", side_effect=[first, second]), patch.object(
+        model,
+        "embed_documents",
+        return_value=([[0.1]], 1),
+    ) as embed_documents:
+        _invoke(model)
+        _invoke(model)
+
+    assert [item.kwargs["session"] for item in embed_documents.call_args_list] == [first, second]
+    first.close.assert_called_once_with()
+    second.close.assert_called_once_with()
+
+
+def test_multimodal_documents_reuse_one_session_and_close_it() -> None:
+    model = _model()
+    session = MagicMock(spec=requests.Session)
+    documents = [
+        MultiModalContent(content_type=MultiModalContentType.TEXT, content="one"),
+        MultiModalContent(content_type=MultiModalContentType.TEXT, content="two"),
+    ]
+
+    with patch.object(te.requests, "Session", return_value=session), patch.object(
+        te.dashscope.MultiModalEmbedding,
+        "call",
+        return_value=_MultiModalResponse(),
+    ) as call:
+        result = model._invoke_multimodal(
+            model=MULTIMODAL_MODEL,
+            credentials=CREDENTIALS,
+            documents=documents,
+        )
+
+    assert result.embeddings == [[0.4, 0.5], [0.4, 0.5]]
+    assert [item.kwargs["session"] for item in call.call_args_list] == [session, session]
+    model._calc_response_usage.assert_called_once_with(
+        model=MULTIMODAL_MODEL,
+        credentials=CREDENTIALS,
+        tokens=10,
+    )
+    session.close.assert_called_once_with()
+
+
+def test_retry_reuses_session_and_closes_it(monkeypatch) -> None:
+    model = _model()
+    session = MagicMock(spec=requests.Session)
+    error = requests.exceptions.ConnectionError("connection dropped")
+    sleeps = []
+    monkeypatch.setattr(te.time, "sleep", sleeps.append)
+
+    with patch.object(te.requests, "Session", return_value=session), patch.object(
+        te.dashscope.TextEmbedding,
+        "call",
+        side_effect=[error, _TextResponse()],
+    ) as call:
+        assert _invoke(model).embeddings == [[0.1, 0.2, 0.3]]
+
+    assert [item.kwargs["session"] for item in call.call_args_list] == [session, session]
+    assert sleeps == [1]
+    session.close.assert_called_once_with()
+
+
+def test_rate_limit_retry_reuses_session_and_closes_it(monkeypatch) -> None:
+    model = _model()
+    session = MagicMock(spec=requests.Session)
+    sleeps = []
+    monkeypatch.setattr(te.time, "sleep", sleeps.append)
+
+    with patch.object(te.requests, "Session", return_value=session), patch.object(
+        te.dashscope.TextEmbedding,
+        "call",
+        side_effect=[_RateLimitedResponse(), _TextResponse()],
+    ) as call:
+        assert _invoke(model).embeddings == [[0.1, 0.2, 0.3]]
+
+    assert [item.kwargs["session"] for item in call.call_args_list] == [session, session]
+    assert sleeps == [10]
+    session.close.assert_called_once_with()
+
+
+def test_persistent_connection_error_closes_session(monkeypatch) -> None:
+    model = _model()
+    session = MagicMock(spec=requests.Session)
+    error = requests.exceptions.ConnectionError("connection dropped")
+    sleeps = []
+    monkeypatch.setattr(te.time, "sleep", sleeps.append)
+
+    with patch.object(te.requests, "Session", return_value=session), patch.object(
+        te.dashscope.TextEmbedding,
+        "call",
+        side_effect=error,
+    ) as call, pytest.raises(requests.exceptions.ConnectionError) as exc_info:
+        _invoke(model)
+
+    assert exc_info.value is error
+    assert [item.kwargs["session"] for item in call.call_args_list] == [session] * 3
+    assert sleeps == [1, 3]
+    session.close.assert_called_once_with()
+
+
+def test_validate_credentials_closes_session_on_success() -> None:
+    model = _model()
+    session = MagicMock(spec=requests.Session)
+
+    with patch.object(te.requests, "Session", return_value=session), patch.object(
+        te.dashscope.TextEmbedding,
+        "call",
+        return_value=_TextResponse(),
+    ) as call:
+        model.validate_credentials(TEXT_MODEL, CREDENTIALS)
+
+    assert call.call_args.kwargs["session"] is session
+    session.close.assert_called_once_with()
+
+
+def test_validate_credentials_closes_session_on_error() -> None:
+    model = _model()
+    session = MagicMock(spec=requests.Session)
+
+    with patch.object(te.requests, "Session", return_value=session), patch.object(
+        te.dashscope.TextEmbedding,
+        "call",
+        side_effect=ValueError("invalid response"),
+    ), pytest.raises(CredentialsValidateFailedError, match="invalid response"):
+        model.validate_credentials(TEXT_MODEL, CREDENTIALS)
+
+    session.close.assert_called_once_with()


### PR DESCRIPTION
## Summary

Fixes #3815.

DashScope uses a process-wide synchronous `requests.Session` for connection pooling. Tongyi embedding calls currently do not provide an explicit Session, so independent invocations can reuse connections from the same process-wide pool.

When a pooled connection becomes stale, an embedding request can remain blocked until DashScope's 300-second read timeout expires before the plugin's existing retry succeeds. This produces a successful response after approximately 301 seconds instead of surfacing the initial timeout.

This change gives each text or multimodal embedding invocation an isolated Session:

- create one `requests.Session` per embedding invocation;
- reuse it across all batches and retries within that invocation;
- pass it to both `TextEmbedding.call` and `MultiModalEmbedding.call`;
- close it after success, validation failure, retry exhaustion, or any other exception;
- preserve the existing connection retry, HTTP 429 handling, and token accounting behavior;
- add offline regression coverage for Session injection, isolation, reuse, and cleanup;
- bump the Tongyi plugin version from 0.2.15 to 0.2.16.

This is a focused plugin-level mitigation: it prevents connection pools from crossing embedding invocation boundaries while retaining connection reuse within each invocation.

The shared-session lifecycle is owned by the DashScope SDK. This PR provides a scoped plugin-level mitigation without changing the SDK's process-wide connection-pooling behavior.

## Release Notes

Fixed intermittent long stalls in Tongyi text and multimodal embedding requests by isolating their HTTP sessions between invocations.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

N/A — this is a transport/session lifecycle fix covered by offline regression tests and live API smoke tests.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (embedding requests)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (embedding transport/session lifecycle)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` from 0.2.15 to 0.2.16
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`)

The second box remains unchecked because Tongyi already declares `dify_plugin>=0.10.2,<0.11.0`; the dependency declaration and `uv.lock` are unchanged by this PR.

## Testing

- [ ] Local deployment — Dify version: 1.13.3
- [ ] SaaS (cloud.dify.ai)

Verification completed in a clean Python 3.12 environment matching `manifest.yaml` and `uv.lock`:

- focused embedding regression tests: `20 passed`;
- full Tongyi test suite: `166 passed, 82 skipped`;
- `uv lock --check`;
- Black and Ruff checks for the changed Python files;
- `python -m py_compile` and `git diff --check`;
- Dify CLI packaging and archive integrity check;
- live smoke tests against the DashScope China endpoint covering credential validation, isolated single invocations, and a multi-batch invocation.
