### PR TITLE
feat(sagemaker): attach Dify app_id as request body (opt-in)

### DIFF
--- a/models/sagemaker/manifest.yaml
+++ b/models/sagemaker/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.18
+version: 0.0.19
 type: plugin
 author: langgenius
 name: sagemaker

--- a/models/sagemaker/models/llm/_metadata.py
+++ b/models/sagemaker/models/llm/_metadata.py
@@ -1,0 +1,118 @@
+"""Helpers for attaching Dify metadata to SageMaker requests as a request-body field.
+
+SageMaker's plugin uses ``boto3`` and the ``sagemaker.Predictor`` directly
+(no OAICompat base class). The ``inference`` function builds a payload
+dict and passes it to ``predictor.predict(payload)``. The Dify app_id is
+propagated by writing the dify keys into a namespaced payload field
+(``_dify_metadata``) when the new ``enable_request_metadata`` credential
+is ``"enabled"``.
+
+The namespaced field (``_dify_metadata`` with an underscore-prefixed key)
+is used so it doesn't collide with model-specific payload fields. The
+SageMaker endpoint is expected to ignore unknown body fields (consistent
+with OpenAI-compatible body behavior); the dify metadata is purely for
+observability / proxy-side propagation.
+
+Caveats:
+- SageMaker endpoints may have strict payload validation and reject
+  unknown fields. If your endpoint rejects the `_dify_metadata` field,
+  disable the credential (`enable_request_metadata=disabled`). The
+  helper never sends the field unless the credential is enabled.
+- SageMaker's public endpoint API does not document a custom metadata
+  field, so the value is purely for observability / proxy-side
+  propagation, identical to the bury-point metadata used in the other
+  LLM plugins (anthropic, gemini, stepfun, openai_api_compatible,
+  tongyi, volcengine, zhipuai, minimax, cohere, mistralai, deepseek,
+  fireworks, ollama, togetherai, moonshot, groq, xai, openrouter).
+- The helper never raises; if building the merged metadata fails for
+  any reason, the call falls back to a no-op so user requests are not
+  blocked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_ENABLED = "enabled"
+_METADATA_KEY = "_dify_metadata"
+_APP_ID_KEY = "dify_app_id"
+_SOURCE_KEY = "dify_source"
+_SOURCE_VALUE = "dify"
+_MAX_VALUE_LENGTH = 256
+
+
+def _normalize_metadata_value(s: Any) -> str:
+    """Normalize a value into a metadata-safe string.
+
+    Coerces non-string input via ``str()`` so that, e.g., a numeric ``0``
+    becomes ``"0"`` rather than being silently dropped by the empty-check,
+    and truncates to 256 characters as a hard cap. No character-pattern
+    restriction is applied because the SageMaker payload field does not
+    document one.
+    """
+    if s is None:
+        return ""
+    if not isinstance(s, str):
+        s = str(s)
+    if not s:
+        return ""
+    return s[:_MAX_VALUE_LENGTH]
+
+
+def build_dify_metadata(app_id: Any) -> dict[str, str] | None:
+    """Build the Dify metadata dict, or return ``None``.
+
+    Returns ``None`` if ``app_id`` is ``None`` or the empty string, so
+    the caller can skip attaching metadata entirely. Other falsy values
+    (e.g. numeric ``0``) are coerced by ``_normalize_metadata_value``
+    and pass through. Otherwise, returns a dict with ``dify_app_id``
+    (normalized) and a static ``dify_source`` marker.
+    """
+    if app_id is None or app_id == "":
+        return None
+    return {
+        _APP_ID_KEY: _normalize_metadata_value(app_id),
+        _SOURCE_KEY: _SOURCE_VALUE,
+    }
+
+
+def apply_dify_metadata_if_enabled(credentials: dict) -> None:
+    """Attach Dify observability metadata to ``credentials[_dify_metadata]`` in place.
+
+    Reads ``credentials['enable_request_metadata']``; when ``"enabled"`` and
+    a Dify ``app_id`` resolves from the current session (best-effort),
+    writes the Dify ``dify_app_id`` / ``dify_source`` keys into
+    ``credentials[_dify_metadata]``. The ``inference`` function then
+    merges this dict into the request payload.
+
+    When the credential is disabled, or no ``app_id`` resolves, the
+    helper does nothing. The function never raises; if anything goes
+    wrong while building the metadata, it falls back to a no-op so the
+    user's request still proceeds.
+    """
+    try:
+        if credentials.get("enable_request_metadata") != _ENABLED:
+            return
+        app_id: str | None = None
+        try:
+            from dify_plugin import get_current_session
+
+            session = get_current_session()
+            if session is not None:
+                app_id = getattr(session, "app_id", None)
+        except Exception:  # noqa: BLE001, S110 - best-effort telemetry
+            pass
+        metadata = build_dify_metadata(app_id)
+        if metadata is None:
+            return
+        credentials[_METADATA_KEY] = metadata
+    except Exception:  # noqa: BLE001 - telemetry must never break the user request
+        # Never block the user's request on metadata wiring.
+        return
+
+
+__all__ = [
+    "_normalize_metadata_value",
+    "apply_dify_metadata_if_enabled",
+    "build_dify_metadata",
+]

--- a/models/sagemaker/models/llm/llm.py
+++ b/models/sagemaker/models/llm/llm.py
@@ -8,7 +8,9 @@ from typing import Any, Optional, Union, cast
 import boto3  # type: ignore
 from sagemaker import Predictor, serializers  # type: ignore
 from sagemaker.session import Session  # type: ignore
-        
+
+from models.llm._metadata import apply_dify_metadata_if_enabled
+
 from dify_plugin.entities.model import (
     AIModelEntity,
     DefaultParameterName,
@@ -51,7 +53,15 @@ from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
 logger = logging.getLogger(__name__)
 
 
-def inference(predictor, messages: list[dict[str, Any]], params: dict[str, Any], stop: list, model_id: str, stream=False):
+def inference(
+    predictor,
+    messages: list[dict[str, Any]],
+    params: dict[str, Any],
+    stop: list,
+    model_id: str,
+    stream=False,
+    extra_metadata: dict[str, Any] | None = None,
+):
     """
     params:
     predictor : Sagemaker Predictor
@@ -77,6 +87,12 @@ def inference(predictor, messages: list[dict[str, Any]], params: dict[str, Any],
         "top_p": params.get("top_p", 0.9),
         "stop": stop,
     }
+    if extra_metadata:
+        # Namespaced under a single key so the endpoint sees at most one
+        # extra top-level field, reducing the risk of payload-validation
+        # rejections. The endpoint is expected to ignore unknown body
+        # fields (consistent with OpenAI-compatible body behavior).
+        payload["_dify_metadata"] = dict(extra_metadata)
 
     if not stream:
         response = predictor.predict(payload)
@@ -325,8 +341,15 @@ class SageMakerLargeLanguageModel(LargeLanguageModel):
             )
 
         messages: list[dict[str, Any]] = [self._convert_prompt_message_to_dict(p) for p in prompt_messages]
+        apply_dify_metadata_if_enabled(credentials)
         response = inference(
-            predictor=self.predictor, messages=messages, params=model_parameters, stop=stop, model_id=credentials.get("model_id", ""), stream=stream
+            predictor=self.predictor,
+            messages=messages,
+            params=model_parameters,
+            stop=stop,
+            model_id=credentials.get("model_id", ""),
+            stream=stream,
+            extra_metadata=credentials.get("_dify_metadata"),
         )
 
         if stream:
@@ -472,7 +495,7 @@ class SageMakerLargeLanguageModel(LargeLanguageModel):
         """
         try:
             # get model mode
-            pass
+            apply_dify_metadata_if_enabled(credentials)
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
 

--- a/models/sagemaker/provider/sagemaker.yaml
+++ b/models/sagemaker/provider/sagemaker.yaml
@@ -112,6 +112,47 @@ model_credential_schema:
           label:
             en_US: Not Support
             zh_Hans: 不支持
+    - variable: enable_request_metadata
+      show_on:
+        - variable: __model_type
+          value: llm
+      label:
+        en_US: Attach Dify app_id as request body
+        zh_Hans: 附加 Dify app_id 作为请求体
+      help:
+        title:
+          en_US: How does this work?
+          zh_Hans: 这是如何工作的？
+        text:
+          en_US: |-
+            When enabled, the plugin attaches the current Dify app_id and a
+            `dify` source marker as a `_dify_metadata` field in the request
+            body sent to the SageMaker endpoint. The endpoint is expected
+            to ignore unknown body fields (consistent with OpenAI-compatible
+            body behavior); the metadata is purely for observability /
+            proxy-side propagation. If your endpoint has strict payload
+            validation and rejects unknown fields, disable the credential
+            (`enable_request_metadata=disabled`). Default is `disabled`, so
+            the request shape is unchanged unless you opt in.
+          zh_Hans: |-
+            启用后，插件会通过在发给 SageMaker 端点的请求体中附加 `_dify_metadata`
+            字段来携带当前 Dify app_id 与 `dify` 源标记。SageMaker 端点预期会静默
+            忽略未知的 body 字段（与 OpenAI 兼容 body 行为一致），该元数据仅用于
+            可观测性与代理侧传播。如果端点对 payload 有严格校验且拒绝未知字段，
+            请将凭据设置为 `enable_request_metadata=disabled`。默认值为 `disabled`，
+            即未开启时请求结构保持不变。
+      type: select
+      required: false
+      default: disabled
+      options:
+        - value: enabled
+          label:
+            en_US: Enabled
+            zh_Hans: 启用
+        - value: disabled
+          label:
+            en_US: Disabled
+            zh_Hans: 禁用
     - variable: vision_support
       show_on:
         - variable: __model_type

--- a/models/sagemaker/pyproject.toml
+++ b/models/sagemaker/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.12"
 dependencies = [
     "boto3>=1.43.13",
     "botocore>=1.43.13",
-    "dify_plugin>=0.9.0",
+    "dify_plugin>=0.10.0",
     "requests>=2.33.1",
     "sagemaker>=3.8.0,<3.8.1",
 ]

--- a/models/sagemaker/tests/test_metadata.py
+++ b/models/sagemaker/tests/test_metadata.py
@@ -1,0 +1,285 @@
+"""Unit tests for the opt-in Dify metadata helper used by the SageMaker plugin.
+
+The helper writes a `dify_app_id` and `dify_source` keys into
+`credentials['_dify_metadata']` when the credential `enable_request_metadata`
+is `"enabled"` and a Dify `app_id` resolves (via
+`dify_plugin.get_current_session()`). The `inference` function then
+merges this dict into the SageMaker request payload as
+`payload['_dify_metadata']`.
+
+When the credential is disabled, or `app_id` is missing / empty, the
+helper does nothing and the request shape is unchanged.
+
+These tests do not need a network or the SageMaker SDK: the helper is
+pure and runs entirely in memory. The integration with `inference` and
+`_invoke` is verified by the source-level guard tests at the bottom of
+this file.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from models.llm._metadata import (
+    _normalize_metadata_value,
+    apply_dify_metadata_if_enabled,
+    build_dify_metadata,
+)
+
+_ENABLED = "enabled"
+_METADATA_KEY = "_dify_metadata"
+_APP_ID_KEY = "dify_app_id"
+_SOURCE_KEY = "dify_source"
+_SOURCE_VALUE = "dify"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_metadata_value
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_uuid_passthrough() -> None:
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    assert _normalize_metadata_value(uuid) == uuid
+
+
+def test_normalize_preserves_punctuation() -> None:
+    assert _normalize_metadata_value("a[b]c{d}e") == "a[b]c{d}e"
+
+
+def test_normalize_coerces_non_string() -> None:
+    assert _normalize_metadata_value(12345) == "12345"
+
+
+def test_normalize_returns_empty_for_none() -> None:
+    assert _normalize_metadata_value(None) == ""
+
+
+def test_normalize_returns_empty_for_empty_string() -> None:
+    assert _normalize_metadata_value("") == ""
+
+
+def test_normalize_truncates_to_256_chars() -> None:
+    s = "a" * 1024
+    assert len(_normalize_metadata_value(s)) == 256
+
+
+# ---------------------------------------------------------------------------
+# build_dify_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_build_metadata_with_valid_app_id() -> None:
+    metadata = build_dify_metadata("app-123")
+    assert metadata == {
+        _APP_ID_KEY: "app-123",
+        _SOURCE_KEY: _SOURCE_VALUE,
+    }
+
+
+def test_build_metadata_with_empty_app_id() -> None:
+    assert build_dify_metadata("") is None
+
+
+def test_build_metadata_with_none_app_id() -> None:
+    assert build_dify_metadata(None) is None
+
+
+def test_build_metadata_truncates_long_app_id() -> None:
+    long_id = "a" * 1024
+    metadata = build_dify_metadata(long_id)
+    assert metadata is not None
+    assert len(metadata[_APP_ID_KEY]) == 256
+
+
+# ---------------------------------------------------------------------------
+# apply_dify_metadata_if_enabled — disabled / no-op paths
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_returns_without_setting_metadata() -> None:
+    credentials: dict = {}
+    apply_dify_metadata_if_enabled(credentials)
+    assert _METADATA_KEY not in credentials
+
+
+def test_disabled_with_other_value_returns_without_setting_metadata() -> None:
+    credentials: dict = {"enable_request_metadata": "disabled"}
+    apply_dify_metadata_if_enabled(credentials)
+    assert _METADATA_KEY not in credentials
+
+
+def test_disabled_with_random_value_returns_without_setting_metadata() -> None:
+    credentials: dict = {"enable_request_metadata": "yes-please"}
+    apply_dify_metadata_if_enabled(credentials)
+    assert _METADATA_KEY not in credentials
+
+
+def test_enabled_without_app_id_returns_without_setting_metadata() -> None:
+    credentials: dict = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(credentials)
+    assert _METADATA_KEY not in credentials
+
+
+def test_enabled_with_empty_app_id_returns_without_setting_metadata() -> None:
+    credentials: dict = {"enable_request_metadata": _ENABLED, "app_id": ""}
+    apply_dify_metadata_if_enabled(credentials)
+    assert _METADATA_KEY not in credentials
+
+
+# ---------------------------------------------------------------------------
+# apply_dify_metadata_if_enabled — enabled / positive paths (with monkeypatched
+# dify_plugin.get_current_session)
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_with_app_id_sets_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: `enabled` + valid app_id -> credentials[_dify_metadata] is set."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id="app-123")
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    credentials: dict = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(credentials)
+    assert credentials[_METADATA_KEY] == {
+        _APP_ID_KEY: "app-123",
+        _SOURCE_KEY: _SOURCE_VALUE,
+    }
+
+
+def test_enabled_overwrites_existing_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `credentials[_dify_metadata]` is already set, the helper overwrites it
+    so the helper always controls its own observability markers."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id="app-123")
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    credentials: dict = {
+        "enable_request_metadata": _ENABLED,
+        _METADATA_KEY: {_APP_ID_KEY: "old-value", _SOURCE_KEY: "old-source"},
+    }
+    apply_dify_metadata_if_enabled(credentials)
+    assert credentials[_METADATA_KEY] == {
+        _APP_ID_KEY: "app-123",
+        _SOURCE_KEY: _SOURCE_VALUE,
+    }
+
+
+def test_enabled_stringifies_non_string_app_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Numeric / other app_id values are stringified rather than dropped."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace(app_id=12345)
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    credentials: dict = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(credentials)
+    assert credentials[_METADATA_KEY][_APP_ID_KEY] == "12345"
+    assert credentials[_METADATA_KEY][_SOURCE_KEY] == _SOURCE_VALUE
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+def test_helper_never_raises_on_session_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `get_current_session` raises, the helper is a no-op (no mutation)."""
+    import dify_plugin
+
+    def _raising():
+        raise RuntimeError("session not available")
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", _raising)
+
+    credentials: dict = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(credentials)
+    assert _METADATA_KEY not in credentials
+
+
+def test_helper_never_raises_on_session_returning_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `get_current_session` returns None, the helper is a no-op (no mutation)."""
+    import dify_plugin
+
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: None)
+
+    credentials: dict = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(credentials)
+    assert _METADATA_KEY not in credentials
+
+
+def test_helper_never_raises_on_session_without_app_id_attr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the session object has no `app_id` attribute, the helper is a no-op."""
+    import dify_plugin
+
+    fake_session = SimpleNamespace()  # no app_id attribute
+    monkeypatch.setattr(dify_plugin, "get_current_session", lambda: fake_session)
+
+    credentials: dict = {"enable_request_metadata": _ENABLED}
+    apply_dify_metadata_if_enabled(credentials)
+    assert _METADATA_KEY not in credentials
+
+
+# ---------------------------------------------------------------------------
+# Source-level guard
+# ---------------------------------------------------------------------------
+
+
+def test_helper_is_imported_in_llm_py() -> None:
+    """The helper is wired into SageMakerLargeLanguageModel."""
+    llm_path = ROOT_DIR / "models" / "llm" / "llm.py"
+    source = llm_path.read_text(encoding="utf-8")
+    assert "from models.llm._metadata import apply_dify_metadata_if_enabled" in source
+    # Helper is called in both `_invoke` and `validate_credentials`.
+    assert source.count("apply_dify_metadata_if_enabled(credentials)") == 2
+    # The `_invoke` call is placed AFTER messages are built and BEFORE the
+    # `inference(...)` call so the helper has a chance to set
+    # `credentials[_dify_metadata]` before `inference` reads it.
+    invoke_idx = source.index("def _invoke(")
+    # Read a wide enough window to span both the helper call and the
+    # inference call.
+    invoke_block = source[invoke_idx : invoke_idx + 6000]
+    idx_helper = invoke_block.index("apply_dify_metadata_if_enabled(credentials)")
+    # The `extra_metadata=` kwarg appears only at the inference call site
+    # (not in the function definition), so this directly targets the call.
+    idx_call = invoke_block.index("response = inference(")
+    idx_extra_metadata = invoke_block.index("extra_metadata=")
+    assert idx_helper < idx_call
+    assert idx_call < idx_extra_metadata
+
+
+def test_helper_module_is_reachable_from_llm() -> None:
+    helper_path = ROOT_DIR / "models" / "llm" / "_metadata.py"
+    assert helper_path.is_file(), f"missing helper: {helper_path}"
+    import models.llm._metadata as helper_module
+
+    assert hasattr(helper_module, "apply_dify_metadata_if_enabled")
+    assert callable(helper_module.apply_dify_metadata_if_enabled)
+    assert hasattr(helper_module, "build_dify_metadata")
+    assert callable(helper_module.build_dify_metadata)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-vv"]))

--- a/models/sagemaker/uv.lock
+++ b/models/sagemaker/uv.lock
@@ -856,12 +856,12 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dpkt" },
     { name = "flask" },
     { name = "gevent" },
+    { name = "h11" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -873,9 +873,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5a/885909338df3e32604f45c579457c5dcfe982d35857994805735e5487d4b/dify_plugin-0.10.2.tar.gz", hash = "sha256:e37e707b3903c439cd09924b2125ba794ffdc886bfdbcb8f75db28ba64cb795b", size = 320685, upload-time = "2026-08-10T07:04:08.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/5897c50381eb23a10fd7ab770288d8656f3325d3407e4ee4f6fb7e70f76a/dify_plugin-0.10.2-py3-none-any.whl", hash = "sha256:5a30db98cc4c3f36bdcc70ecd217b6bb37279c39fc0a843a985b05581dc461d3", size = 379282, upload-time = "2026-08-10T07:04:07.068Z" },
 ]
 
 [[package]]
@@ -899,7 +899,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.43.13" },
     { name = "botocore", specifier = ">=1.43.13" },
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.0" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "sagemaker", specifier = ">=3.8.0,<3.8.1" },
 ]
@@ -919,15 +919,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
-]
-
-[[package]]
-name = "dpkt"
-version = "1.9.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/7d/52f17a794db52a66e46ebb0c7549bf2f035ed61d5a920ba4aaa127dd038e/dpkt-1.9.8.tar.gz", hash = "sha256:43f8686e455da5052835fd1eda2689d51de3670aac9799b1b00cfd203927ee45", size = 180073, upload-time = "2022-08-18T05:54:13.582Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/79/479e2194c9096b92aecdf33634ae948d2be306c6011673e98ee1917f32c2/dpkt-1.9.8-py3-none-any.whl", hash = "sha256:4da4d111d7bf67575b571f5c678c71bddd2d8a01a3d57d489faf0a92c748fbfd", size = 194973, upload-time = "2022-08-18T05:54:10.793Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

Adds an opt-in `enable_request_metadata` credential to the SageMaker plugin that, when enabled, attaches the current Dify `app_id` and a `dify` source marker as a `_dify_metadata` field in the request body sent to the SageMaker endpoint. When the credential is unset (default) the request shape is unchanged.

The change is the 19th entry in the opt-in `enable_request_metadata` series tracked by issue #3744 (SDK consolidation follow-up). Prior entries: #3717 (anthropic), #3723 (gemini), #3739 (stepfun), #3740 (openai_api_compatible, closed), #3741 (tongyi), #3742 (volcengine), #3743 (zhipuai, closed), #3745 (minimax), #3748 (cohere, closed), #3761 (mistralai), #3766 (deepseek), #3782 (fireworks), #3785 (ollama), #3792 (togetherai), #3798 (moonshot), #3801 (groq), #3807 (xai), #3812 (openrouter).

### Why body-field for SageMaker (not header-field)

SageMaker's plugin uses `boto3` and `sagemaker.Predictor` directly (no OAICompat base class). The OAICompat header-field pattern (used by stepfun, openai_api_compatible, tongyi, mistralai, deepseek, togetherai, ollama, moonshot, groq, xai, openrouter) does not apply because the SageMaker transport is boto3-based, not `requests.post` with explicit headers. The cleanest way to attach metadata is via a custom payload field. The helper mutates `credentials['_dify_metadata']` (a single dict with both keys), and the `inference` function merges that dict into the request payload as `payload['_dify_metadata']`.

The namespaced field (`_dify_metadata` with an underscore-prefixed key) is used so it doesn't collide with model-specific payload fields. The SageMaker endpoint is expected to ignore unknown body fields (consistent with OpenAI-compatible body behavior).

## Release Notes

Add an opt-in `enable_request_metadata` credential (default `disabled`) to the SageMaker plugin. When enabled, the plugin attaches the current Dify `app_id` and a `dify` source marker as a `_dify_metadata` field in the request body sent to the SageMaker endpoint. The endpoint is expected to ignore unknown body fields (consistent with OpenAI-compatible body behavior); the metadata is purely for observability / proxy-side propagation. **If your endpoint has strict payload validation and rejects unknown fields, disable the credential (`enable_request_metadata=disabled`).** Default is `disabled`, so the request shape is unchanged unless you opt in. SageMaker does not currently consume this metadata.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

| Before | After |
| ------ | ----- |
|        |       |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality: opt-in observability metadata attachment (no behavior change for the user-facing response)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` to `0.0.19` (was `0.0.18`)
- [x] `dify_plugin>=0.10.0` is declared in `pyproject.toml` (was `>=0.9.0`) and locked in `uv.lock` (v0.9.0 -> v0.10.2). The 0.10.0 floor is required at runtime: the helper uses `dify_plugin.get_current_session()` introduced in 0.10.0.

## Testing

- [x] Local deployment — Dify version: not run end-to-end (helper unit tests + ruff clean)
- [ ] SaaS (cloud.dify.ai)

### What was tested

- `uv run pytest tests/test_metadata.py`: **23 passed** (23 new; no pre-existing tests in the sagemaker plugin).
- `uv run ruff check tests/test_metadata.py models/llm/_metadata.py`: **All checks passed**. The two `BLE001` ("do not catch blind exception") and one `S110` ("try-except-pass") are suppressed with `# noqa: BLE001, S110` because the helper's contract is "telemetry must never break generation" — same pattern as the other body-field helpers (zhipuai, fireworks).

### What was NOT tested

- End-to-end invocation through Dify (no live SageMaker endpoint available locally).
- Whether the user's SageMaker endpoint accepts the `_dify_metadata` field is endpoint-specific; endpoints with strict payload validation may reject it. The help text in the credential schema warns users about this and instructs them to disable the credential if their endpoint rejects the field.

## Consult-Kiro

This PR was reviewed by the `/consult-kiro` Tier A council. Today's coverage was degraded: of the 10 Tier A models, only 1 returned a usable answer (`openai/gpt-5-nano` at 12s with the `minimal` variant). The remaining 9 models (including the opencode free-tier panel and the gpt-5.1 paid tier) returned `EMPTY` within 3s with `rc=1` or timed out at the 50-80s hard limit. The full council was retried with shorter per-model timeouts; the same coverage gap persisted. This is consistent with the opencode backend degradation observed in the prior session (the deepseek #3766, fireworks #3782, ollama #3785, togetherai #3792, moonshot #3798, groq #3801, xai #3807, openrouter #3812, and the prior 12 PRs in the series all shipped with 1/10 or 7/10 Tier A coverage for the same reason).

**Findings (1/10 models, gpt-5-nano):**

- `OK` Body-field approach with a namespaced field (`_dify_metadata`) is the right shape for SageMaker.
- `OK` Helper signature `apply_dify_metadata_if_enabled(credentials) -> None` (void, in-place mutation) is correct.
- `OK` `inference` function signature extended with `extra_metadata` parameter (backwards-compatible default `None`) is correct.
- `OK` Dify keys written into `credentials['_dify_metadata']` (a single dict) is correct.
- `MISSING` No concrete file/line requiring an immediate code change based on current view.

No must-fix issues identified under the degraded coverage. The full diff (7 files, 478 insertions, 20 deletions) was inspected and applied per the standard 5-commit split: helper -> wire -> credential -> tests -> version+SDK pin.

## Risks

- **Low**: When the new credential is unset (default), the helper is a no-op and `credentials['_dify_metadata']` is not set; the `inference` function does not add a `_dify_metadata` field to the payload, so existing users see no behavior change.
- **Low**: When the credential is enabled but `app_id` is missing from the current session, the helper also no-ops.
- **Medium**: SageMaker endpoints with strict payload validation may reject unknown fields. If your endpoint rejects the `_dify_metadata` field, the SDK will return a 400 Bad Request. The help text in the credential schema warns users about this and instructs them to disable the credential if their endpoint rejects the field. The helper is opt-in (default `disabled`), so users who don't enable the credential are not affected.
- **Low**: SageMaker's public endpoint API does not currently consume the `_dify_metadata` field. The metadata is forwarded by the boto3/SageMaker transport and is intended for observability / proxy-side propagation, identical to the bury-point metadata used in the other LLM plugins.
- **Low**: The `validate_credentials` path is currently a no-op (`pass` statement) in the SageMaker plugin, so the helper call there is a no-op w.r.t. any wire request. The helper is still wired in for symmetry with the other OAICompat-based PRs and in case the validate path is updated in the future to make a real API call.
- **Test coverage gap**: No integration test for boto3/SageMaker actual forwarding of the payload field.

## Future improvements

- Issue #3744 (filed earlier in this series) tracks consolidating the 19 `enable_request_metadata` helpers across `anthropic`, `gemini`, `stepfun`, `openai_api_compatible` (closed), `tongyi`, `volcengine`, `zhipuai` (closed), `minimax`, `cohere` (closed), `mistralai`, `deepseek`, `fireworks`, `ollama`, `togetherai`, `moonshot`, `groq`, `xai`, `openrouter`, `sagemaker` (this PR), and the bedrock / vertex_ai variants into a single shared SDK utility in `dify_plugin`. That refactor is a follow-up to this PR; this PR does not depend on it.
