### PR TITLE
fix(openai_api_compatible): correct parameter handling for o1/o3/gpt-5 reasoning models

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.64
+version: 0.0.65
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -330,11 +330,15 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
                     name="reasoning_effort",
                     label=I18nObject(en_us="Reasoning effort", zh_hans="推理工作"),
                     help=I18nObject(
-                        en_us="Constrains effort on reasoning for reasoning models.",
-                        zh_hans="限制推理模型的推理工作。",
+                        en_us="Constrains effort on reasoning for reasoning models. "
+                        "Not every level is accepted by every model — 'none' and 'xhigh' in "
+                        "particular are only supported by newer OpenAI reasoning models. The "
+                        "upstream endpoint validates the value.",
+                        zh_hans="限制推理模型的推理工作。并非所有模型都接受全部级别，"
+                        "其中 none 与 xhigh 仅较新的 OpenAI 推理模型支持，具体由上游端点校验。",
                     ),
                     type=ParameterType.STRING,
-                    options=["low", "medium", "high"],
+                    options=["none", "minimal", "low", "medium", "high", "xhigh"],
                     required=False,
                 )
             )

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -167,29 +167,43 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
 
         SAFE_MIN_TOKENS = 16
 
+        # `stream_mode_auth` is read by the base implementation, which validate_credentials()
+        # skips for o1/o3/gpt-5 models via its early return. Honour it here so the setting is
+        # not silently ignored for exactly the models that take this path.
+        use_stream = credentials.get("stream_mode_auth", "not_use") == "use"
+
         try:
             if mode == "chat":
                 if use_max_completion:
-                    client.chat.completions.create(
+                    response = client.chat.completions.create(
                         model=endpoint_model,
                         messages=[{"role": "user", "content": "ping"}],
                         max_completion_tokens=SAFE_MIN_TOKENS,
-                        stream=False,
+                        stream=use_stream,
                     )
                 else:
-                    client.chat.completions.create(
+                    response = client.chat.completions.create(
                         model=endpoint_model,
                         messages=[{"role": "user", "content": "ping"}],
                         max_tokens=SAFE_MIN_TOKENS,
-                        stream=False,
+                        stream=use_stream,
                     )
             else:
-                client.completions.create(
+                response = client.completions.create(
                     model=endpoint_model,
                     prompt="ping",
                     max_tokens=SAFE_MIN_TOKENS,
-                    stream=False,
+                    stream=use_stream,
                 )
+
+            if use_stream:
+                # Pull the first chunk so transport and auth failures surface as a
+                # validation error instead of leaving an unread stream behind.
+                try:
+                    for _ in response:
+                        break
+                finally:
+                    response.close()
         except Exception as sub_e:
             raise CredentialsValidateFailedError(str(sub_e)) from sub_e
 

--- a/models/openai_api_compatible/models/llm/llm.py
+++ b/models/openai_api_compatible/models/llm/llm.py
@@ -646,13 +646,15 @@ class OpenAILargeLanguageModel(OAICompatLargeLanguageModel):
             self._drop_analyze_channel(prompt_messages)
 
         # Map token parameter name when needed (Responses API style)
+        # Auto-detection must look at the model the endpoint actually receives, which is
+        # `endpoint_model_name` when set. validate_credentials() and the Responses API path
+        # already resolve it this way; using the Dify-side display name here made the same
+        # credentials validate as max_completion_tokens but invoke with max_tokens.
         param_pref = credentials.get("token_param_name", "auto")
-
-        def _needs_max_completion_tokens(m: str) -> bool:
-            return bool(re.match(r"^(o1|o3|gpt-5)", m, re.IGNORECASE))
+        endpoint_model = credentials.get("endpoint_model_name") or model
 
         use_max_completion = (param_pref == "max_completion_tokens") or (
-            param_pref == "auto" and _needs_max_completion_tokens(model)
+            param_pref == "auto" and self._needs_max_completion_tokens(endpoint_model)
         )
 
         if use_max_completion:

--- a/models/openai_api_compatible/tests/test_reasoning_effort_levels.py
+++ b/models/openai_api_compatible/tests/test_reasoning_effort_levels.py
@@ -1,0 +1,34 @@
+"""Unit tests for the reasoning_effort parameter rule exposed by get_customizable_model_schema.
+
+OpenAI's reasoning models accept more effort levels than low/medium/high: `minimal`
+(gpt-5), `none` (gpt-5.1+) and `xhigh` (gpt-5.4+). The plugin is a generic
+OpenAI-compatible provider and cannot know which levels a given endpoint supports, so it
+offers all of them and lets the upstream endpoint reject what it does not accept.
+"""
+
+import pytest
+
+from models.llm.llm import OpenAILargeLanguageModel
+
+EXPECTED_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh"]
+
+
+def _reasoning_effort_rule(agent_thought_support):
+    llm = OpenAILargeLanguageModel(model_schemas=[])
+    entity = llm.get_customizable_model_schema(
+        "gpt-5.6-luna",
+        {"mode": "chat", "context_size": "922000", "agent_thought_support": agent_thought_support},
+    )
+    return next((rule for rule in entity.parameter_rules if rule.name == "reasoning_effort"), None)
+
+
+@pytest.mark.parametrize("agent_thought_support", ["only_thinking_supported", "supported"])
+def test_reasoning_effort_exposes_every_openai_level(agent_thought_support):
+    rule = _reasoning_effort_rule(agent_thought_support)
+
+    assert rule is not None
+    assert rule.options == EXPECTED_LEVELS
+
+
+def test_reasoning_effort_absent_without_thinking_support():
+    assert _reasoning_effort_rule("not_supported") is None

--- a/models/openai_api_compatible/tests/test_stream_mode_auth_safe_min_tokens.py
+++ b/models/openai_api_compatible/tests/test_stream_mode_auth_safe_min_tokens.py
@@ -1,0 +1,85 @@
+"""Unit tests for stream_mode_auth handling in _retry_with_safe_min_tokens.
+
+validate_credentials() short-circuits to _retry_with_safe_min_tokens() for o1/o3/gpt-5
+models, which skips the base implementation that reads `stream_mode_auth`. The helper has
+to honour the credential itself, otherwise the setting is silently ignored for exactly the
+models that take this path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dify_plugin.errors.model import CredentialsValidateFailedError
+
+from models.llm.llm import OpenAILargeLanguageModel
+
+OPENAI_CLIENT = "models.llm.llm.OpenAI"
+
+BASE_CREDENTIALS = {
+    "endpoint_url": "https://api.example.com/v1/",
+    "api_key": "test-key",
+    "mode": "chat",
+}
+
+
+def _run(credentials, model="gpt-5.6-luna", stream_chunks=(MagicMock(),)):
+    """Call _retry_with_safe_min_tokens with a stubbed OpenAI client and return the kwargs."""
+    llm = OpenAILargeLanguageModel(model_schemas=[])
+    stream = MagicMock()
+    stream.__iter__ = lambda self: iter(stream_chunks)
+
+    with patch(OPENAI_CLIENT) as client_cls:
+        client_cls.return_value.chat.completions.create.return_value = stream
+        client_cls.return_value.completions.create.return_value = stream
+        llm._retry_with_safe_min_tokens(model, credentials)
+        create = client_cls.return_value.chat.completions.create
+        if not create.called:
+            create = client_cls.return_value.completions.create
+        return create.call_args.kwargs, stream
+
+
+def test_stream_mode_auth_use_validates_with_streaming():
+    kwargs, stream = _run({**BASE_CREDENTIALS, "stream_mode_auth": "use"})
+
+    assert kwargs["stream"] is True
+    # The stream must be consumed and released, not handed back unread.
+    stream.close.assert_called_once()
+
+
+def test_stream_mode_auth_not_use_validates_without_streaming():
+    kwargs, stream = _run({**BASE_CREDENTIALS, "stream_mode_auth": "not_use"})
+
+    assert kwargs["stream"] is False
+    stream.close.assert_not_called()
+
+
+def test_stream_mode_auth_defaults_to_non_streaming():
+    kwargs, _ = _run(BASE_CREDENTIALS)
+
+    assert kwargs["stream"] is False
+
+
+def test_completion_mode_also_honours_stream_mode_auth():
+    kwargs, _ = _run({**BASE_CREDENTIALS, "mode": "completion", "stream_mode_auth": "use"})
+
+    assert kwargs["stream"] is True
+
+
+def test_streaming_failure_surfaces_as_validation_error():
+    """An error raised while reading the stream must not escape as a raw exception."""
+    llm = OpenAILargeLanguageModel(model_schemas=[])
+    stream = MagicMock()
+
+    def _boom(_self):
+        raise RuntimeError("connection reset")
+
+    stream.__iter__ = _boom
+
+    with patch(OPENAI_CLIENT) as client_cls:
+        client_cls.return_value.chat.completions.create.return_value = stream
+        with pytest.raises(CredentialsValidateFailedError):
+            llm._retry_with_safe_min_tokens(
+                "gpt-5.6-luna", {**BASE_CREDENTIALS, "stream_mode_auth": "use"}
+            )
+
+    stream.close.assert_called_once()

--- a/models/openai_api_compatible/tests/test_token_param_name.py
+++ b/models/openai_api_compatible/tests/test_token_param_name.py
@@ -1,0 +1,115 @@
+"""Unit tests for the token parameter name mapping in OpenAILargeLanguageModel._invoke.
+
+`token_param_name: auto` must decide between `max_tokens` and `max_completion_tokens`
+from the model the endpoint actually receives — `endpoint_model_name` when it is set,
+otherwise the Dify-side model name. This is the same resolution validate_credentials()
+and the Responses API path already use.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from dify_plugin.entities.model.message import UserPromptMessage
+
+from models.llm.llm import OpenAILargeLanguageModel
+
+SUPER_INVOKE = (
+    "dify_plugin.interfaces.model.openai_compatible.llm.OAICompatLargeLanguageModel._invoke"
+)
+
+
+def _prompt_messages():
+    return [UserPromptMessage(content="ping")]
+
+
+def _capture_invoke(credentials, model="gpt-4o-mini", model_parameters=None):
+    """Run _invoke with the base implementation stubbed out and return model_parameters."""
+    llm = OpenAILargeLanguageModel(model_schemas=[])
+    captured = {}
+
+    def fake_super(
+        self, model, credentials, prompt_messages, model_parameters, tools, stop, stream, user
+    ):
+        captured["model_parameters"] = dict(model_parameters)
+        # Non-streaming: the caller post-processes an LLMResult, so return a stand-in.
+        return MagicMock()
+
+    with patch(SUPER_INVOKE, new=fake_super):
+        llm._invoke(
+            model=model,
+            credentials=credentials,
+            prompt_messages=_prompt_messages(),
+            model_parameters=dict(
+                model_parameters if model_parameters is not None else {"max_tokens": 128}
+            ),
+            stream=False,
+        )
+
+    return captured["model_parameters"]
+
+
+def test_auto_resolves_from_endpoint_model_name():
+    """A non-gpt-5 Dify name must not hide a gpt-5 endpoint model."""
+    params = _capture_invoke(
+        {"mode": "chat", "endpoint_model_name": "gpt-5.6-luna", "token_param_name": "auto"},
+        model="Luna",
+    )
+
+    assert params.get("max_completion_tokens") == 128
+    assert "max_tokens" not in params
+
+
+def test_auto_falls_back_to_model_when_no_endpoint_override():
+    """Without endpoint_model_name the Dify-side model name is the endpoint model."""
+    params = _capture_invoke({"mode": "chat", "token_param_name": "auto"}, model="gpt-5.6-luna")
+
+    assert params.get("max_completion_tokens") == 128
+    assert "max_tokens" not in params
+
+
+def test_auto_does_not_map_when_endpoint_model_is_not_reasoning():
+    """A gpt-5 Dify name must not force max_completion_tokens onto a non-gpt-5 deployment."""
+    params = _capture_invoke(
+        {"mode": "chat", "endpoint_model_name": "my-custom-deployment", "token_param_name": "auto"},
+        model="gpt-5.6-luna",
+    )
+
+    assert params.get("max_tokens") == 128
+    assert "max_completion_tokens" not in params
+
+
+def test_auto_leaves_max_tokens_for_non_reasoning_models():
+    params = _capture_invoke({"mode": "chat", "token_param_name": "auto"}, model="gpt-4o-mini")
+
+    assert params.get("max_tokens") == 128
+    assert "max_completion_tokens" not in params
+
+
+def test_explicit_max_completion_tokens_overrides_detection():
+    params = _capture_invoke(
+        {"mode": "chat", "token_param_name": "max_completion_tokens"}, model="gpt-4o-mini"
+    )
+
+    assert params.get("max_completion_tokens") == 128
+    assert "max_tokens" not in params
+
+
+def test_explicit_max_tokens_disables_detection():
+    params = _capture_invoke(
+        {"mode": "chat", "endpoint_model_name": "gpt-5.6-luna", "token_param_name": "max_tokens"},
+        model="gpt-5.6-luna",
+    )
+
+    assert params.get("max_tokens") == 128
+    assert "max_completion_tokens" not in params
+
+
+def test_existing_max_completion_tokens_is_preserved():
+    """An explicit max_completion_tokens from the caller wins over the mapping."""
+    params = _capture_invoke(
+        {"mode": "chat", "endpoint_model_name": "gpt-5.6-luna", "token_param_name": "auto"},
+        model="Luna",
+        model_parameters={"max_tokens": 128, "max_completion_tokens": 256},
+    )
+
+    assert params.get("max_completion_tokens") == 256
+    assert params.get("max_tokens") == 128


### PR DESCRIPTION
## Summary

Three related defects in the OpenAI-API-compatible provider, all around how it handles OpenAI reasoning models (`o1` / `o3` / `gpt-5`) — especially when they are reached through a gateway such as LiteLLM, where the Dify-side model name and the model name the endpoint receives are often different.

**1. `token_param_name: auto` resolved the wrong model name (`models/llm/llm.py`)**

Auto-detection matches the model name against `^(o1|o3|gpt-5)` to choose between `max_tokens` and `max_completion_tokens`. `validate_credentials()`, `_retry_with_safe_min_tokens()` and the Responses API path all resolve that name as `endpoint_model_name or model`, but `_invoke()` matched against the Dify-side model name only — the one call site out of four that disagreed.

A model registered under a display-style name with its real id in **model name for API endpoint** (e.g. `Luna` → `gpt-5.6-luna`) therefore passed credential validation as `max_completion_tokens`, then sent `max_tokens` at invoke time, which the gpt-5 family rejects. The mirror case was equally wrong: a Dify-side name of `gpt-5.x` forced `max_completion_tokens` onto a deployment whose endpoint model is not a reasoning model.

**2. The `Reasoning effort` parameter was missing three levels**

The dropdown offered only `low` / `medium` / `high`. OpenAI's reasoning models also accept `minimal` (gpt-5), `none` (gpt-5.1 and newer) and `xhigh` (gpt-5.4 and newer).

`none` matters beyond convenience: on gpt-5.5 / gpt-5.6 it is the level at which the upstream API accepts a non-default `temperature`, so a user who cannot select it also cannot use `temperature` on those models at all.

This provider is deliberately generic and cannot know which levels a given endpoint supports, so it now offers all of them and lets the endpoint validate — the same contract the other passthrough parameters already follow. Existing configurations are unaffected: stored values stay valid and the parameter remains optional with no default.

**3. `Stream mode auth` was silently ignored for o1/o3/gpt-5**

`validate_credentials()` returns early into `_retry_with_safe_min_tokens()` whenever the endpoint model needs `max_completion_tokens`, so it never reaches the base implementation that reads `stream_mode_auth`. The helper hardcoded `stream=False`, so the credential was ignored for exactly the models that take this path — the UI offered the setting and saved it, and nothing used it. Gateways that only authorise streaming requests had no way to opt in.

The helper now reads the credential, validates with `stream=True` when it is set, and pulls the first chunk so transport and auth failures surface as a validation error instead of leaving an unread stream behind.

The three changes are submitted together because they touch the same file and would otherwise conflict on the `manifest.yaml` version bump.

## Release Notes

- Fixed `Token parameter name` auto-detection using the Dify-side model name instead of the model the endpoint actually receives. Models registered with a display-style name plus a separate **model name for API endpoint** (e.g. `Luna` → `gpt-5.6-luna`) passed credential validation but then sent `max_tokens`, which the gpt-5 family rejects.
- Added the remaining OpenAI reasoning effort levels to the **Reasoning effort** parameter: `none`, `minimal` and `xhigh`. Only `low` / `medium` / `high` were selectable before. Note that `none` is what allows a non-default `temperature` on gpt-5.5 / gpt-5.6.
- Fixed **Stream mode auth** being ignored when validating credentials for `o1` / `o3` / `gpt-5` models. The setting was saved but never applied on that code path.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Only change 2 has a visible UI surface — the **Reasoning effort** dropdown in the model parameter panel.

| Before | After |
| ------ | ----- |
| `low`, `medium`, `high` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` |

Changes 1 and 3 are request-construction and credential-validation fixes with no UI surface; they are covered by the unit tests listed under Testing.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`) — `0.0.64` → `0.0.65`
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

> Left unchecked because the stated range no longer matches this plugin: `pyproject.toml` on `main` already declares `dify_plugin>=0.9.0`, and `uv.lock` pins `0.9.0`. This PR does not change either file. The intent of the item — the dependency is declared and locked — is satisfied.

## Testing

- [x] Local deployment — Dify version: 1.10.1
- [ ] SaaS (cloud.dify.ai)

Unit tests, run against the plugin's own `uv` environment (Python 3.12, `uv.lock`):

```
$ uv run pytest tests/ -q
72 passed, 2 warnings
```

15 new tests were added across three files. Each was confirmed to fail on `main` and pass with this change:

| File | Tests | Fail on `main` |
| ---- | ----- | -------------- |
| `tests/test_token_param_name.py` | 7 | 2 |
| `tests/test_reasoning_effort_levels.py` | 3 | 2 |
| `tests/test_stream_mode_auth_safe_min_tokens.py` | 5 | 3 |

The remaining tests in those files cover behaviour that is unchanged, so they pass both before and after.
