### PR TITLE
docs: add Hubris OpenAI-compatible example

### DIFF
--- a/models/openai_api_compatible/README.md
+++ b/models/openai_api_compatible/README.md
@@ -25,3 +25,17 @@ Use `https://api.tokenlab.sh/v1` for LLM/chat models. For non-LLM model types wh
 Other TokenLab chat models can be added the same way, for example `gpt-5.5`, `claude-opus-4-8`, `claude-sonnet-5`, `gemini-3.5-flash`, `grok-4.3`, `qwen3.7-max`, `deepseek-v4-pro`, `deepseek-v4-flash`, `glm-5.2`, `minimax-m3`, and `kimi-k2.7-code`.
 
 TokenLab also provides native endpoint families such as Responses, Anthropic Messages, and Gemini-compatible APIs. This OpenAI-API-compatible plugin uses TokenLab's `/v1` OpenAI-compatible endpoint.
+
+### Hubris example
+
+[Hubris](https://hubris.pw) is a ruble-billed OpenAI-compatible LLM gateway (400+ models) that can be configured through this plugin:
+
+| Field | Value |
+| --- | --- |
+| Type | `LLM` |
+| Model Name | `claude-sonnet-5` |
+| API Key | Your Hubris API key (create at [hubris.pw/keys](https://hubris.pw/keys)) |
+| API Base URL | `https://api.hubris.pw/v1` |
+| Completion mode | `Chat` |
+
+Other Hubris models can be added the same way — see the full catalog at [hubris.pw/models](https://hubris.pw/models).


### PR DESCRIPTION
Adds a documented example for [Hubris](https://hubris.pw) — a ruble-billed OpenAI-compatible LLM gateway (400+ models) — to the openai_api_compatible plugin README, following the same format as the existing TokenLab example.

No code changes, no manifest version bump — docs only, same pattern as #3406.