### PR TITLE
fix(bedrock): pass a CredentialProvider when minting mantle bearer 

### DIFF
--- a/models/bedrock/manifest.yaml
+++ b/models/bedrock/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.82
+version: 0.0.83
 type: plugin
 author: langgenius
 name: bedrock

--- a/models/bedrock/models/llm/llm.py
+++ b/models/bedrock/models/llm/llm.py
@@ -8,6 +8,7 @@ from typing import Optional, Union, cast
 # 3rd import
 import boto3  # type: ignore
 from botocore.config import Config  # type: ignore
+from botocore.credentials import Credentials as BotocoreCredentials  # type: ignore
 from botocore.exceptions import (  # type: ignore
     ClientError,
     EndpointConnectionError,
@@ -63,6 +64,27 @@ from utils.inference_profile import (
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 logger = logging.getLogger(__name__)
+
+
+class _StaticCredentialsProvider:
+    """Minimal credentials provider for aws-bedrock-token-generator.
+
+    ``provide_token()`` requires an object with ``load()`` (a CredentialProvider).
+    Passing a raw ``botocore.credentials.Credentials`` raises AttributeError.
+    """
+
+    def __init__(self, access_key: str, secret_key: str, token: Optional[str] = None):
+        session_token = (token or "").strip() or None
+        self._credentials = BotocoreCredentials(
+            access_key=access_key,
+            secret_key=secret_key,
+            token=session_token,
+        )
+
+    def load(self) -> BotocoreCredentials:
+        return self._credentials
+
+
 ANTHROPIC_BLOCK_MODE_PROMPT = """You should always follow the instructions and output a valid {{block}} object.
 The structure of the {{block}} object you can found in the instructions, use {"answer": "$your_answer"} as the default structure
 if you are not sure about the structure.
@@ -2077,7 +2099,9 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         - Access_Secret_Key / IAM_Role: generate a short-lived token via
           aws-bedrock-token-generator (official AWS library).
         """
-        auth_method = credentials.get("auth_method", "IAM_Role")
+        # Match get_bedrock_client(): omit auth_method → Access_Secret_Key, so
+        # configured access/secret keys are used on mantle the same way as Converse.
+        auth_method = credentials.get("auth_method", "Access_Secret_Key")
         region = credentials.get("aws_region", "us-east-2")
 
         if auth_method == "API_Key":
@@ -2099,13 +2123,12 @@ class BedrockLargeLanguageModel(LargeLanguageModel):
         aws_secret_access_key = credentials.get("aws_secret_access_key")
 
         if auth_method == "Access_Secret_Key" and aws_access_key_id and aws_secret_access_key:
-            from botocore.credentials import Credentials as BotocoreCredentials
-            creds = BotocoreCredentials(
+            provider = _StaticCredentialsProvider(
                 access_key=aws_access_key_id,
                 secret_key=aws_secret_access_key,
                 token=credentials.get("aws_session_token"),
             )
-            return provide_token(region=region, aws_credentials_provider=creds)
+            return provide_token(region=region, aws_credentials_provider=provider)
 
         # IAM_Role: rely on the environment (instance profile, env vars, etc.)
         return provide_token(region=region)

--- a/models/bedrock/tests/test_mantle_responses_api.py
+++ b/models/bedrock/tests/test_mantle_responses_api.py
@@ -228,10 +228,90 @@ class TestGetMantleAuthToken:
         fake.provide_token.assert_called_once()
         kwargs = fake.provide_token.call_args.kwargs
         assert kwargs["region"] == "us-west-2"
-        creds = kwargs["aws_credentials_provider"]
+        provider = kwargs["aws_credentials_provider"]
+        # aws-bedrock-token-generator calls provider.load() — must not be a
+        # raw botocore Credentials object.
+        assert hasattr(provider, "load")
+        creds = provider.load()
         assert creds.access_key == "AKIAEXAMPLE"
         assert creds.secret_key == "secret"
         assert creds.token == "session"
+
+    @pytest.mark.parametrize("session_token", ["", "   "])
+    def test_access_secret_key_blank_session_token_is_omitted(
+        self, session_token: str
+    ) -> None:
+        instance = _make_instance()
+        fake = self._fake_token_module()
+        credentials = {
+            "auth_method": "Access_Secret_Key",
+            "aws_region": "us-west-2",
+            "aws_access_key_id": "AKIAEXAMPLE",
+            "aws_secret_access_key": "secret",
+            "aws_session_token": session_token,
+        }
+        with patch.dict(sys.modules, {"aws_bedrock_token_generator": fake}):
+            instance._get_mantle_auth_token(credentials)
+        creds = fake.provide_token.call_args.kwargs["aws_credentials_provider"].load()
+        assert creds.token is None
+
+    def test_missing_auth_method_uses_configured_access_keys(self) -> None:
+        # Same default as get_bedrock_client: keys in credentials must be used.
+        instance = _make_instance()
+        fake = self._fake_token_module()
+        credentials = {
+            "aws_region": "us-east-1",
+            "aws_access_key_id": "AKIAEXAMPLE",
+            "aws_secret_access_key": "secret",
+        }
+        with patch.dict(sys.modules, {"aws_bedrock_token_generator": fake}):
+            instance._get_mantle_auth_token(credentials)
+        kwargs = fake.provide_token.call_args.kwargs
+        creds = kwargs["aws_credentials_provider"].load()
+        assert kwargs["region"] == "us-east-1"
+        assert creds.access_key == "AKIAEXAMPLE"
+
+    def test_iam_role_ignores_leftover_access_keys(self) -> None:
+        # Switching auth_method in the UI can leave AK/SK in the payload.
+        instance = _make_instance()
+        fake = self._fake_token_module()
+        with patch.dict(sys.modules, {"aws_bedrock_token_generator": fake}):
+            instance._get_mantle_auth_token(
+                {
+                    "auth_method": "IAM_Role",
+                    "aws_region": "us-west-2",
+                    "aws_access_key_id": "AKIA-SHOULD-IGNORE",
+                    "aws_secret_access_key": "secret-should-ignore",
+                }
+            )
+        fake.provide_token.assert_called_once_with(region="us-west-2")
+
+    def test_api_key_ignores_leftover_access_keys(self) -> None:
+        instance = _make_instance()
+        fake = self._fake_token_module()
+        with patch.dict(sys.modules, {"aws_bedrock_token_generator": fake}):
+            token = instance._get_mantle_auth_token(
+                {
+                    "auth_method": "API_Key",
+                    "bedrock_api_key": "long-term-key",
+                    "aws_access_key_id": "AKIA-SHOULD-IGNORE",
+                    "aws_secret_access_key": "secret-should-ignore",
+                }
+            )
+        assert token == "long-term-key"
+        fake.provide_token.assert_not_called()
+
+    def test_static_provider_satisfies_real_provide_token_load_contract(self) -> None:
+        # Regression for Credentials-has-no-load: sign locally, no network.
+        from aws_bedrock_token_generator import provide_token
+
+        provider = llm_mod._StaticCredentialsProvider(
+            access_key="AKIAEXAMPLE",
+            secret_key="secret",
+            token="session",
+        )
+        token = provide_token(region="us-west-2", aws_credentials_provider=provider)
+        assert token.startswith("bedrock-api-key-")
 
     def test_iam_role_auth_uses_environment_credentials_and_default_region(
         self,


### PR DESCRIPTION
## Summary

Fixes #3836

Bedrock GPT-5.x (bedrock-mantle) invocations with **Access_Secret_Key** fail in plugin **0.0.82**:

`AttributeError: 'Credentials' object has no attribute 'load'`

`_get_mantle_auth_token` passed a raw botocore `Credentials` object into `aws-bedrock-token-generator.provide_token()`. That API expects a **credential provider** and calls `.load()`.

This wraps static access keys in `_StaticCredentialsProvider` so the same AK/SK (and optional session token) are used, without changing API Key or IAM Role behavior. If `auth_method` is omitted, mantle now defaults to `Access_Secret_Key` like `get_bedrock_client()`.

Plugin version: `0.0.82` → `0.0.83`.

## Release Notes

- Fix GPT-5.x (bedrock-mantle) invocations that used Access Key / Secret Key authentication: generate the short-lived bearer token via a credential provider (`load()`), so requests no longer fail with `'Credentials' object has no attribute 'load'`.
- API Key and IAM Role auth are unchanged.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

N/A — invoke-time `PluginInvokeError`; no UI change. Before/after is the traceback vs a successful mantle request.

| Before | After |
| ------ | ----- |
| `InvokeError: 'Credentials' object has no attribute 'load'` on GPT-5.x with Access_Secret_Key | Short-lived `bedrock-api-key-…` token minted; invoke proceeds |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [ ] New models / model parameter fixes

</details>

Auth only for the bedrock-mantle (GPT-5.x Responses API) path.

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [ ] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

Bedrock already declares `dify_plugin>=0.10.0` in `pyproject.toml` (needed for `get_current_session()`). This PR does not change the SDK pin.

## Testing

- [ ] Local deployment — Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

Unit tests (plugin venv, Python 3.12+ as in `manifest.yaml`):

```bash
cd models/bedrock
uv run pytest tests/test_mantle_responses_api.py::TestGetMantleAuthToken tests/test_get_bedrock_client.py -q