### PR TITLE
fix: fix call anthropic model type error

### DIFF
--- a/models/anthropic/manifest.yaml
+++ b/models/anthropic/manifest.yaml
@@ -25,4 +25,4 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.3.29
+version: 0.3.30

--- a/models/anthropic/models/llm/llm.py
+++ b/models/anthropic/models/llm/llm.py
@@ -535,6 +535,20 @@ class AnthropicLargeLanguageModel(LargeLanguageModel):
                 for key in ("temperature", "top_p", "top_k"):
                     model_parameters.pop(key, None)
 
+        # Anthropic SDK 1.x removed sampling parameters from the generated
+        # messages.create() signature. Older models (for example Sonnet 4.6)
+        # still support them through the HTTP API, so forward the parameters
+        # in extra_body after model/thinking capability filtering above.
+        sampling_parameters = {
+            key: model_parameters.pop(key)
+            for key in ("temperature", "top_p", "top_k")
+            if key in model_parameters
+        }
+        if sampling_parameters:
+            extra_body = dict(model_parameters.pop("extra_body", {}) or {})
+            extra_body.update(sampling_parameters)
+            model_parameters["extra_body"] = extra_body
+
         # Native structured output: when Dify provides a JSON schema, send it via
         # output_config.format (API constrained decoding) instead of the code-fence
         # prompt hack. Merges with effort/task_budget set above for adaptive models.

--- a/models/anthropic/tests/test_sampling_parameters.py
+++ b/models/anthropic/tests/test_sampling_parameters.py
@@ -1,0 +1,141 @@
+"""Regression tests for Anthropic SDK 1.x sampling-parameter compatibility."""
+
+import inspect
+
+import pytest
+from anthropic.resources.messages.messages import Messages as _SdkMessages
+from dify_plugin.entities.model.message import PromptMessageTool, UserPromptMessage
+
+from models.llm import llm as llm_module
+from models.llm.llm import AnthropicLargeLanguageModel
+
+
+class _SignatureCheckedMessages:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self._valid_params = set(inspect.signature(_SdkMessages.create).parameters)
+
+    def create(self, **kwargs):
+        unknown = set(kwargs) - self._valid_params
+        if unknown:
+            raise TypeError(
+                f"create() got an unexpected keyword argument {min(unknown)!r}"
+            )
+        self.calls.append(kwargs)
+        return _Response()
+
+
+class _Response:
+    def model_dump_json(self, **kwargs) -> str:
+        return "{}"
+
+
+class _Anthropic:
+    instances: list["_Anthropic"] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.messages = _SignatureCheckedMessages()
+        self.instances.append(self)
+
+
+def _capture_payload(
+    monkeypatch,
+    model_parameters: dict,
+    *,
+    stream: bool = True,
+    tools: list[PromptMessageTool] | None = None,
+) -> dict:
+    _Anthropic.instances = []
+    monkeypatch.setattr(llm_module, "Anthropic", _Anthropic)
+
+    llm = AnthropicLargeLanguageModel()
+    if not stream:
+        monkeypatch.setattr(llm, "_handle_chat_generate_response", lambda *args: object())
+
+    llm._chat_generate(
+        model="claude-sonnet-4-6",
+        credentials={"anthropic_api_key": "test-key"},
+        prompt_messages=[UserPromptMessage(content="Hello")],
+        model_parameters=dict(model_parameters),
+        tools=tools,
+        stream=stream,
+    )
+
+    return _Anthropic.instances[0].messages.calls[0]
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_sampling_parameters_use_extra_body_with_sdk_1_x(monkeypatch, stream) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {
+            "max_tokens": 1024,
+            "temperature": 0.7,
+            "top_p": 0,
+            "top_k": 40,
+        },
+        stream=stream,
+    )
+
+    assert not {"temperature", "top_p", "top_k"} & payload.keys()
+    assert payload["extra_body"] == {
+        "temperature": 0.7,
+        "top_p": 0,
+        "top_k": 40,
+    }
+
+
+def test_sampling_parameters_merge_with_existing_extra_body(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {
+            "max_tokens": 1024,
+            "temperature": 0.7,
+            "extra_body": {"custom_parameter": True, "temperature": 0.1},
+        },
+    )
+
+    assert payload["extra_body"] == {
+        "custom_parameter": True,
+        "temperature": 0.7,
+    }
+
+
+def test_sampling_parameters_use_extra_body_with_tools(monkeypatch) -> None:
+    tool = PromptMessageTool(
+        name="lookup",
+        description="Look something up",
+        parameters={"type": "object", "properties": {}},
+    )
+
+    payload = _capture_payload(
+        monkeypatch,
+        {"max_tokens": 1024, "temperature": 0.7},
+        tools=[tool],
+    )
+
+    assert payload["extra_body"] == {"temperature": 0.7}
+    assert payload["tools"] == [
+        {
+            "name": "lookup",
+            "description": "Look something up",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+    ]
+
+
+def test_thinking_removes_sampling_parameters(monkeypatch) -> None:
+    payload = _capture_payload(
+        monkeypatch,
+        {
+            "max_tokens": 4096,
+            "thinking": True,
+            "thinking_budget": 1024,
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "top_k": 40,
+        },
+    )
+
+    assert payload["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+    assert "extra_body" not in payload


### PR DESCRIPTION
## Summary

<!--
Link related issues (e.g. Fixes #123) and/or briefly describe why this change is needed.

⚠️ This repository is for Dify **Official** Plugins only.
For community contributions, submit to https://github.com/langgenius/dify-plugins instead.
-->

fix #3842 base https://github.com/anthropics/anthropic-sdk-python/blob/main/MIGRATION.md#removed-deprecated-request-parameters



## Release Notes

- Fixed Anthropic model calls failing with a `TypeError` when Temperature, Top P, or Top
  K is enabled on supported Claude models with Anthropic SDK 1.x.

<!--
User-facing summary of what this version changes. Published verbatim on the
plugin's Marketplace page (Version History → Change Log). English, Markdown.
Skip only for documentation / non-plugin changes.
-->

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

<!--
Drag and drop images or videos directly into this box — GitHub uploads them automatically.
Show the fix, the new feature, or before/after behavior for breaking changes.

| Before | After |
| ------ | ----- |
|        |       |
-->

| Before | After |
| ------ | ----- |
|        |       |


## LLM Plugin Checklist

<!-- Only required if "LLM plugin" is checked above. Skip otherwise.
Reference: https://github.com/langgenius/dify-official-plugins/blob/main/.assets/test-examples/llm-plugin-tests/llm_test_example.md
-->

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [ ] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock` (or kept in `requirements.txt` for legacy plugins without `uv.lock`) — [SDK docs](https://github.com/langgenius/dify-plugin-sdks/blob/main/python/README.md)

<!--
Version format: MAJOR.MINOR.PATCH — each segment may be 2 digits (e.g. 10.11.22)
- MAJOR: architectural or incompatible API changes
- MINOR: new features, backward-compatible
- PATCH: bug fixes and minor improvements
-->

## Testing

<!-- At least one environment must be tested with a clean setup matching production:
Python venv aligned with `manifest.yaml`, `pyproject.toml`, and `uv.lock` (or `requirements.txt` for legacy plugins).
-->

- [x] Local deployment — Dify version: 1.17.1
- [ ] SaaS (cloud.dify.ai)
