### PR TITLE
feat(lemonade): add opt-in enable_request_metadata credential for Lemonade

### DIFF
--- a/models/lemonade/manifest.yaml
+++ b/models/lemonade/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.17
+version: 0.0.18
 type: plugin
 author: "langgenius"
 name: "lemonade"

--- a/models/lemonade/models/llm/_metadata.py
+++ b/models/lemonade/models/llm/_metadata.py
@@ -1,0 +1,126 @@
+"""Helpers for attaching Dify metadata to Lemonade requests as request headers.
+
+Lemonade's plugin extends ``dify_plugin.OAICompatLargeLanguageModel``,
+whose ``_generate`` method reads ``credentials['extra_headers']`` and
+merges the entries into the outbound HTTP request headers. The Dify
+app_id is therefore propagated by writing the dify headers into that
+credential.
+
+Header values are constrained to visible ASCII (0x20-0x7E inclusive) so
+``urllib3`` never rejects the request with ``InvalidHeader`` on CR/LF
+or other control characters. Values are truncated to 256 characters
+as a hard cap (UUID app_ids are 36 chars, so the cap is a safety net
+rather than a real bound).
+
+The helper is opt-in: when ``credentials['enable_request_metadata']`` is
+not the literal string ``"enabled"``, the helper does nothing and the
+request shape is unchanged. When enabled, the helper mutates
+``credentials['extra_headers']`` in place, preserving any
+caller-supplied entries (Dify keys are written alongside, with Dify
+keys winning on collision so the helper always controls its own
+observability markers).
+
+Caveats:
+- Lemonade's local server does not document these headers today, so
+  the value is purely for observability / proxy-side propagation,
+  identical to the bury-point headers used in the other LLM plugins
+  (anthropic, gemini, stepfun, openai_api_compatible, tongyi,
+  volcengine, zhipuai, minimax, cohere, mistralai, deepseek, fireworks,
+  ollama, togetherai, moonshot, groq, xai, openrouter, sagemaker, yi,
+  mimo, longcat, zhinao, wenxin).
+- The helper never raises; if building the merged headers fails for
+  any reason, the call falls back to a no-op so user requests are not
+  blocked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_ENABLED = "enabled"
+_APP_ID_HEADER = "X-Dify-App-Id"
+_SOURCE_HEADER = "X-Dify-Source"
+_SOURCE_VALUE = "dify"
+_MAX_VALUE_LENGTH = 256
+
+
+def _normalize_header_value(s: Any) -> str:
+    """Normalize a value into a header-safe string.
+
+    Coerces non-string input via ``str()`` so that, e.g., a numeric ``0``
+    becomes ``"0"`` rather than being silently dropped by the empty-check,
+    strips CR/LF and other control characters (``urllib3`` rejects them
+    with ``InvalidHeader``), and truncates to 256 characters as a hard
+    cap.
+    """
+    if s is None:
+        return ""
+    if not isinstance(s, str):
+        s = str(s)
+    if not s:
+        return ""
+    # Strip CR/LF and other control characters; keep visible ASCII only.
+    s = "".join(ch for ch in s if 0x20 <= ord(ch) <= 0x7E)
+    if not s:
+        return ""
+    return s[:_MAX_VALUE_LENGTH]
+
+
+def build_dify_headers(app_id: Any) -> dict[str, str]:
+    """Build the Dify header dict, or return an empty dict.
+
+    Returns an empty dict if the resolved ``app_id`` is missing or
+    normalizes to the empty string, so the caller can skip attaching
+    metadata entirely.
+    """
+    app_id_normalized = _normalize_header_value(app_id)
+    if not app_id_normalized:
+        return {}
+    return {
+        _APP_ID_HEADER: app_id_normalized,
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+def apply_dify_headers_if_enabled(credentials: dict) -> None:
+    """Attach Dify observability headers to ``credentials['extra_headers']`` in place.
+
+    Reads ``credentials['enable_request_metadata']``; when ``"enabled"`` and
+    ``credentials['app_id']`` resolves to a non-empty string, writes the
+    Dify ``X-Dify-App-Id`` / ``X-Dify-Source`` headers into
+    ``credentials['extra_headers']``. Existing entries on
+    ``credentials['extra_headers']`` are preserved; on collision the Dify
+    keys win so the helper always controls its own observability markers.
+
+    When the credential is disabled, or no ``app_id`` resolves, the
+    helper does nothing. The function never raises; if anything goes
+    wrong while building the headers, it falls back to a no-op so the
+    user's request still proceeds.
+    """
+    try:
+        if credentials.get("enable_request_metadata") != _ENABLED:
+            return
+        app_id = credentials.get("app_id")
+        headers = build_dify_headers(app_id)
+        if not headers:
+            return
+        existing = credentials.get("extra_headers")
+        if existing is None:
+            credentials["extra_headers"] = headers
+            return
+        # Merge: copy to avoid mutating the caller's dict reference, and
+        # let Dify keys override any existing collision so the helper
+        # always controls its own observability markers.
+        merged = dict(existing)
+        merged.update(headers)
+        credentials["extra_headers"] = merged
+    except Exception:  # noqa: BLE001 - telemetry must never break the user request
+        # Never block the user's request on metadata wiring.
+        return
+
+
+__all__ = [
+    "_normalize_header_value",
+    "apply_dify_headers_if_enabled",
+    "build_dify_headers",
+]

--- a/models/lemonade/models/llm/llm.py
+++ b/models/lemonade/models/llm/llm.py
@@ -26,6 +26,8 @@ from dify_plugin.interfaces.model.openai_compatible.llm import OAICompatLargeLan
 from dify_plugin.errors.model import CredentialsValidateFailedError
 from typing import List
 
+from models.llm._metadata import apply_dify_headers_if_enabled
+
 
 def validate_lemonade_credentials(credentials: dict, model: str = None) -> None:
     """
@@ -222,7 +224,8 @@ class LemonadeLargeLanguageModel(OAICompatLargeLanguageModel):
     ) -> Union[LLMResult, Generator]:
         # Set required parameters for the OAI compatibility layer
         self._add_custom_parameters(credentials)
-        
+        apply_dify_headers_if_enabled(credentials)
+
         # Compatibility adapter for Dify's 'json_schema' structured output mode.
         # The base class does not natively handle the 'json_schema' parameter. This block
         # translates it into a standard OpenAI-compatible request by:
@@ -290,6 +293,7 @@ class LemonadeLargeLanguageModel(OAICompatLargeLanguageModel):
         """
         # Set required parameters for the OAI compatibility layer
         self._add_custom_parameters(credentials)
-        
+        apply_dify_headers_if_enabled(credentials)
+
         # Use shared validation function with model parameter
         validate_lemonade_credentials(credentials, model)

--- a/models/lemonade/provider/lemonade.yaml
+++ b/models/lemonade/provider/lemonade.yaml
@@ -189,6 +189,49 @@ model_credential_schema:
       placeholder:
         en_US: Maximum number of words sent to the model per request
         zh_Hans: 每次请求发送给模型的最大字数
+    - variable: enable_request_metadata
+      show_on:
+        - variable: __model_type
+          value: llm
+      default: disabled
+      label:
+        en_US: Attach Dify app_id as request headers
+        zh_Hans: 附加 Dify app_id 作为请求头
+      help:
+        title:
+          en_US: How does this work?
+          zh_Hans: 这是如何工作的？
+        text:
+          en_US: |-
+            When enabled, the plugin attaches the current Dify app_id and a `dify`
+            source marker as `X-Dify-App-Id` / `X-Dify-Source` request headers on
+            every Lemonade LLM call. The headers are written into the
+            `extra_headers` credential, which the underlying OAICompat base
+            class merges into the outbound request alongside the rest of the
+            headers. The headers are forwarded by the underlying HTTP client
+            and are used for observability / proxy-side propagation. Lemonade
+            does not document them. Default is `disabled`, so the request
+            shape is unchanged unless you opt in. This opt-in applies to
+            the LLM endpoint only; the text-embedding, rerank, speech2text,
+            and tts endpoints are not affected.
+          zh_Hans: |-
+            启用后，插件会通过 `extra_headers` 凭据在每次 Lemonade LLM 调用中附加当前 Dify
+            app_id 与 `dify` 源标记，作为 `X-Dify-App-Id` / `X-Dify-Source` 请求头。
+            底层 OAICompat 基类会将其与其它请求头合并后一并发送。这些请求头由底层
+            HTTP 客户端转发，用于可观测性与代理侧传播，Lemonade 服务不会消费它们。
+            默认值为 `disabled`，即未开启时请求结构保持不变。该选项仅作用于 LLM
+            端点，不会影响 text-embedding、rerank、speech2text 和 tts 端点。
+      options:
+        - value: enabled
+          label:
+            en_US: Enabled
+            zh_Hans: 启用
+        - value: disabled
+          label:
+            en_US: Disabled
+            zh_Hans: 禁用
+      required: false
+      type: select
 extra:
   python:
     provider_source: provider/lemonade.py

--- a/models/lemonade/pyproject.toml
+++ b/models/lemonade/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 
 # Managed with uv; refresh the lockfile with `uv lock`.
 dependencies = [
-    "dify-plugin>=0.9.0",
+    "dify-plugin>=0.10.0",
     "httpx>=0.28.1",
     "openai>=2.38.0",
     "requests>=2.34.2",

--- a/models/lemonade/tests/test_metadata.py
+++ b/models/lemonade/tests/test_metadata.py
@@ -1,0 +1,281 @@
+"""Unit tests for the opt-in Dify metadata helper used by the Lemonade plugin.
+
+The helper writes Dify `X-Dify-App-Id` and `X-Dify-Source: dify` headers into
+`credentials['extra_headers']` when the credential `enable_request_metadata` is
+`"enabled"` and a Dify `app_id` resolves. The underlying OAICompat base class
+(`dify_plugin.OAICompatLargeLanguageModel`) reads `credentials['extra_headers']`
+and merges the entries into the outbound HTTP request headers, so writing to
+that credential is the carrier for observability metadata.
+
+When the credential is disabled, or `app_id` is missing / empty, the helper
+does nothing and the request shape is unchanged.
+
+These tests do not need a network or the Lemonade SDK: the helper is pure
+and runs entirely in memory. The integration with `_invoke` and
+`validate_credentials` is verified by the source-level guard tests at the
+bottom of this file.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from models.llm._metadata import (  # noqa: E402
+    _normalize_header_value,
+    apply_dify_headers_if_enabled,
+    build_dify_headers,
+)
+
+_ENABLED = "enabled"
+_APP_ID_HEADER = "X-Dify-App-Id"
+_SOURCE_HEADER = "X-Dify-Source"
+_SOURCE_VALUE = "dify"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_header_value
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_uuid_passthrough() -> None:
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    assert _normalize_header_value(uuid) == uuid
+
+
+def test_normalize_preserves_punctuation() -> None:
+    assert _normalize_header_value("a[b]c{d}e") == "a[b]c{d}e"
+
+
+def test_normalize_strips_cr_lf() -> None:
+    assert _normalize_header_value("a\r\nb") == "ab"
+
+
+def test_normalize_strips_other_control_chars() -> None:
+    assert _normalize_header_value("a\x00b\x07c") == "abc"
+
+
+def test_normalize_coerces_non_string() -> None:
+    assert _normalize_header_value(12345) == "12345"
+
+
+def test_normalize_returns_empty_for_none() -> None:
+    assert _normalize_header_value(None) == ""
+
+
+def test_normalize_truncates_to_256_chars() -> None:
+    s = "a" * 1024
+    assert len(_normalize_header_value(s)) == 256
+
+
+def test_normalize_returns_empty_for_all_control_chars() -> None:
+    assert _normalize_header_value("\r\n\t\x00") == ""
+
+
+# ---------------------------------------------------------------------------
+# build_dify_headers
+# ---------------------------------------------------------------------------
+
+
+def test_build_headers_with_valid_app_id() -> None:
+    headers = build_dify_headers("app-123")
+    assert headers == {
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+def test_build_headers_with_empty_app_id() -> None:
+    assert build_dify_headers("") == {}
+
+
+def test_build_headers_with_none_app_id() -> None:
+    assert build_dify_headers(None) == {}
+
+
+def test_build_headers_strips_cr_lf_in_app_id() -> None:
+    headers = build_dify_headers("app\r\n123")
+    assert headers == {
+        _APP_ID_HEADER: "app123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+# ---------------------------------------------------------------------------
+# apply_dify_headers_if_enabled — disabled / no-op paths
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_does_not_set_extra_headers() -> None:
+    credentials = {"app_id": "app-123"}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_disabled_with_other_value_does_not_set_extra_headers() -> None:
+    credentials = {"app_id": "app-123", "enable_request_metadata": "disabled"}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_disabled_with_random_value_does_not_set_extra_headers() -> None:
+    credentials = {"app_id": "app-123", "enable_request_metadata": "yes-please"}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_enabled_without_app_id_does_not_set_extra_headers() -> None:
+    credentials = {"enable_request_metadata": _ENABLED}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_enabled_with_empty_app_id_does_not_set_extra_headers() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": ""}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+def test_enabled_with_none_app_id_does_not_set_extra_headers() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": None}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" not in credentials
+
+
+# ---------------------------------------------------------------------------
+# apply_dify_headers_if_enabled — enabled / positive paths
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_with_app_id_attaches_both_headers() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": "app-123"}
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"] == {
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+def test_enabled_stringifies_non_string_app_id() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": 12345}
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"][_APP_ID_HEADER] == "12345"
+    assert credentials["extra_headers"][_SOURCE_HEADER] == _SOURCE_VALUE
+
+
+def test_enabled_preserves_existing_extra_headers() -> None:
+    credentials = {
+        "enable_request_metadata": _ENABLED,
+        "app_id": "app-123",
+        "extra_headers": {"X-Custom-Header": "value"},
+    }
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"] == {
+        "X-Custom-Header": "value",
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+def test_enabled_dify_keys_override_caller_on_collision() -> None:
+    credentials = {
+        "enable_request_metadata": _ENABLED,
+        "app_id": "app-123",
+        "extra_headers": {
+            _APP_ID_HEADER: "old-value",
+            _SOURCE_HEADER: "old-source",
+            "X-Custom-Header": "value",
+        },
+    }
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"] == {
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+        "X-Custom-Header": "value",
+    }
+
+
+def test_enabled_does_not_mutate_caller_dict_reference() -> None:
+    existing = {"X-Custom-Header": "value"}
+    credentials = {
+        "enable_request_metadata": _ENABLED,
+        "app_id": "app-123",
+        "extra_headers": existing,
+    }
+    apply_dify_headers_if_enabled(credentials)
+    assert existing == {"X-Custom-Header": "value"}
+    assert credentials["extra_headers"] is not existing
+    assert credentials["extra_headers"] == {
+        "X-Custom-Header": "value",
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+def test_helper_never_raises_on_garbage_credentials() -> None:
+    credentials = {"enable_request_metadata": _ENABLED, "app_id": "app-123"}
+    apply_dify_headers_if_enabled(credentials)
+    assert "extra_headers" in credentials
+
+
+def test_helper_handles_extra_headers_as_non_dict() -> None:
+    credentials = {
+        "enable_request_metadata": _ENABLED,
+        "app_id": "app-123",
+        "extra_headers": None,
+    }
+    apply_dify_headers_if_enabled(credentials)
+    assert credentials["extra_headers"] == {
+        _APP_ID_HEADER: "app-123",
+        _SOURCE_HEADER: _SOURCE_VALUE,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Source-level guard
+# ---------------------------------------------------------------------------
+
+
+def test_helper_is_imported_in_llm_py() -> None:
+    """The helper is wired into LemonadeLargeLanguageModel."""
+    llm_path = ROOT_DIR / "models" / "llm" / "llm.py"
+    source = llm_path.read_text(encoding="utf-8")
+    assert "from models.llm._metadata import apply_dify_headers_if_enabled" in source
+    # Used at both call sites: in `_invoke` (after `_add_custom_parameters`) and
+    # in `validate_credentials` (after `_add_custom_parameters`).
+    assert source.count("apply_dify_headers_if_enabled(credentials)") == 2
+    # Called only AFTER `_add_custom_parameters(credentials)` so the endpoint_url
+    # is set first; the helper does not depend on it, but ordering matters for
+    # maintainability.
+    invoke_block = source[
+        source.index("def _invoke(") : source.index("def _invoke(") + 2000
+    ]
+    assert invoke_block.find(
+        "self._add_custom_parameters(credentials)"
+    ) < invoke_block.find("apply_dify_headers_if_enabled(credentials)")
+
+
+def test_helper_module_is_reachable_from_llm() -> None:
+    helper_path = ROOT_DIR / "models" / "llm" / "_metadata.py"
+    assert helper_path.is_file(), f"missing helper: {helper_path}"
+    import models.llm._metadata as helper_module
+
+    assert hasattr(helper_module, "apply_dify_headers_if_enabled")
+    assert callable(helper_module.apply_dify_headers_if_enabled)
+    assert hasattr(helper_module, "build_dify_headers")
+    assert callable(helper_module.build_dify_headers)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-vv"]))

--- a/models/lemonade/uv.lock
+++ b/models/lemonade/uv.lock
@@ -193,12 +193,12 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.9.0"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dpkt" },
     { name = "flask" },
     { name = "gevent" },
+    { name = "h11" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -210,9 +210,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/52/86c042b72d42eb40460563bacf2ed46ff6a2e02dbec299892fef0ed2f70f/dify_plugin-0.9.0.tar.gz", hash = "sha256:c32dc99d4122d960bd447ee65a17e1e93bf942bbad8f7b4d53a2841416ecd3e0", size = 318993, upload-time = "2026-05-20T08:10:40.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5a/885909338df3e32604f45c579457c5dcfe982d35857994805735e5487d4b/dify_plugin-0.10.2.tar.gz", hash = "sha256:e37e707b3903c439cd09924b2125ba794ffdc886bfdbcb8f75db28ba64cb795b", size = 320685, upload-time = "2026-08-10T07:04:08.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/dc/df1d6d1a8c604880702dd792226f175523f890bfca89f828f58b58661edc/dify_plugin-0.9.0-py3-none-any.whl", hash = "sha256:3299a8c77549a43f68705796eed4c9ca494664810fb8d10eb7ecce2e545f3d2d", size = 377064, upload-time = "2026-05-20T08:10:38.848Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/5897c50381eb23a10fd7ab770288d8656f3325d3407e4ee4f6fb7e70f76a/dify_plugin-0.10.2-py3-none-any.whl", hash = "sha256:5a30db98cc4c3f36bdcc70ecd217b6bb37279c39fc0a843a985b05581dc461d3", size = 379282, upload-time = "2026-08-10T07:04:07.068Z" },
 ]
 
 [[package]]
@@ -222,15 +222,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
-name = "dpkt"
-version = "1.9.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/7d/52f17a794db52a66e46ebb0c7549bf2f035ed61d5a920ba4aaa127dd038e/dpkt-1.9.8.tar.gz", hash = "sha256:43f8686e455da5052835fd1eda2689d51de3670aac9799b1b00cfd203927ee45", size = 180073, upload-time = "2022-08-18T05:54:13.582Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/79/479e2194c9096b92aecdf33634ae948d2be306c6011673e98ee1917f32c2/dpkt-1.9.8-py3-none-any.whl", hash = "sha256:4da4d111d7bf67575b571f5c678c71bddd2d8a01a3d57d489faf0a92c748fbfd", size = 194973, upload-time = "2022-08-18T05:54:10.793Z" },
 ]
 
 [[package]]
@@ -536,7 +527,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dify-plugin", specifier = ">=0.9.0" },
+    { name = "dify-plugin", specifier = ">=0.10.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "openai", specifier = ">=2.38.0" },
     { name = "requests", specifier = ">=2.34.2" },


### PR DESCRIPTION
## Summary

Adds an opt-in `enable_request_metadata` credential to the Lemonade (`lemonade`) plugin. When enabled, the plugin attaches the current Dify `app_id` and a `dify` source marker as `X-Dify-App-Id` / `X-Dify-Source` request headers on every Lemonade LLM call. Default is `disabled`, so the request shape is unchanged for existing users. The opt-in is scoped to the LLM endpoint only (text-embedding, rerank, speech2text, and tts are not affected).

This is the 25th provider in the opt-in series (anthropic #3717, gemini #3723, stepfun #3739, openai_api_compatible #3740, tongyi #3741, volcengine #3742, zhipuai #3743, minimax #3745, cohere #3748, mistralai #3761, deepseek #3766, fireworks #3782, ollama #3785, togetherai #3792, moonshot #3798, groq #3801, xai #3807, openrouter #3812, sagemaker #3819, yi #3823, mimo #3824, longcat #3833, zhinao #3838, wenxin #3840). Tracking issue: #3744.

## Motivation

Dify propagates the calling app's identity to upstream LLM providers today only via the SDK's `user` parameter. Some providers and proxies can use a richer observability signal — a structured header pair — for billing, audit, and proxy-side routing. Exposing this as an opt-in (default off) keeps the change zero-risk for existing users and gives operators a single switch per provider.

The same contract has been the pattern across 24 sibling PRs: opt-in via `enable_request_metadata`, default `disabled`, header-field carrier via `credentials['extra_headers']`, never raises. The Lemonade plugin extends `dify_plugin.OAICompatLargeLanguageModel`, whose `_generate` method reads `credentials['extra_headers']` and merges the entries into the outbound HTTP request headers — so writing the Dify headers into that credential is the carrier, with no upstream change required.

## Changes

| File | Change |
|---|---|
| `models/lemonade/models/llm/_metadata.py` | New: `apply_dify_headers_if_enabled(credentials)` helper + `_normalize_header_value` + `build_dify_headers`. Pure, in-place, never raises. |
| `models/lemonade/models/llm/llm.py` | Wire the helper into `_invoke` and `validate_credentials`, after `_add_custom_parameters`. |
| `models/lemonade/provider/lemonade.yaml` | New `enable_request_metadata` select in `model_credential_schema` (the lemonade plugin only has `model_credential_schema`) with `enabled` / `disabled` options, default `disabled`, scoped to `__model_type: llm` via `show_on`, and a `help.text` block (en_US + zh_Hans). |
| `models/lemonade/tests/test_metadata.py` | New: 27 unit tests covering normalization, header build, disabled paths, enabled paths, robustness, source-level guard, and module reachability. |
| `models/lemonade/manifest.yaml` | Bump `0.0.17` → `0.0.18`. |
| `models/lemonade/pyproject.toml` | Pin `dify-plugin>=0.10.0` (matches the other 24 opt-in PRs). |
| `models/lemonade/uv.lock` | Refreshed (`dify-plugin v0.9.0` → `v0.10.2`; `dpkt` removed, consistent with the other opt-in PRs in the series where `yarl>=1.24.2` is not a transitive dep). |

## Design decisions

- **Header-field carrier, not body-field.** The lemonade plugin extends `OAICompatLargeLanguageModel`, so the body-field path used by sagemaker and fireworks is not applicable; the OAICompat base merges `credentials['extra_headers']` into the outbound request, which is the canonical carrier for the rest of the series.
- **Default `disabled`.** The opt-in has zero effect on existing users unless they flip the switch in the model setup form.
- **Dify-keys-override-caller on collision.** If the user has already set `X-Dify-App-Id` or `X-Dify-Source` via their own `extra_headers`, the helper's values win so the helper always controls its own observability markers. Caller-supplied custom headers (e.g. `X-Custom-Header`) are preserved.
- **Never raises.** The helper wraps the whole body in a broad `except Exception` (`# noqa: BLE001 - telemetry must never break the user request`). Telemetry wiring must never block a user request.
- **Header values constrained to visible ASCII (0x20–0x7E)**, CR/LF stripped, truncated to 256 chars. `urllib3` rejects invalid header bytes with `InvalidHeader`; the normalization prevents that.
- **No upstream change.** Lemonade's local server does not document these headers today, so the value is purely for observability / proxy-side propagation, identical to the bury-point headers used in the other LLM plugins in the opt-in series.
- **Model-credential placement.** The lemonade plugin has only `model_credential_schema` (not `provider_credential_schema`), so the opt-in is added there. The credential is scoped to `__model_type: llm` via `show_on`, so the form only shows the opt-in when the user picks the LLM endpoint — text-embedding, rerank, speech2text, and tts are not affected.
- **`@staticmethod` preserved.** lemonade's existing `_add_custom_parameters` is a `@staticmethod`; the helper wiring is independent of that detail.

## Testing performed

```
$ uv run pytest tests/test_metadata.py -v
============================== 27 passed in 0.02s ==============================
```

```
$ uv run ruff check tests/ models/llm/_metadata.py
All checks passed!
```

```
$ uv run ruff format --check tests/test_metadata.py models/llm/_metadata.py
2 files already formatted
```

```
$ uv lock
Resolved 56 packages in 489ms
Updated dify-plugin v0.9.0 -> v0.10.2
Removed dpkt v1.9.8
```

The test pattern mirrors the other OAICompat-based helpers in the series: same disabled/enabled matrix, same robustness assertions, same source-level guard. `tests/test_metadata.py` does not need a network or the Lemonade server: the helper is pure and runs entirely in memory. The integration with `_invoke` and `validate_credentials` is verified by the source-level guard test, which scans `models/llm/llm.py` for the import line, the two call sites, and the ordering against `_add_custom_parameters`.

## Release Notes

```release-note
feat(lemonade): add opt-in enable_request_metadata credential to attach Dify app_id as X-Dify-App-Id / X-Dify-Source request headers on Lemonade LLM calls (default disabled, LLM endpoint only)
```

## LLM Plugin Checklist

- [x] Follows the existing opt-in pattern from the 24 sibling PRs in the series.
- [x] Default `disabled` — no behavior change for existing users.
- [x] Helper is pure, in-place, and never raises.
- [x] Dify keys win on collision with caller-supplied `extra_headers`; other caller headers are preserved.
- [x] Header values normalized to visible ASCII and truncated to 256 chars.
- [x] `model_credential_schema` updated; credential scoped to `__model_type: llm`; `help.text` block in en_US + zh_Hans.
- [x] 27 unit tests, all passing, ruff clean, ruff-format clean.
- [x] `manifest.yaml` bumped (`0.0.17` → `0.0.18`), `dify-plugin` pinned to `>=0.10.0`.
- [x] No upstream change required.

## Risks

- **Header propagation depends on the local Lemonade server not stripping them.** Same risk as the other 24 opt-in PRs. If the local server strips unrecognized headers, the headers are simply not delivered — user requests still succeed because the helper never raises.
- **The 256-char truncation is a hard cap**, not a UI constraint. UUID app_ids are 36 chars, so the cap is a safety net rather than a real bound.
- **Pre-existing test breakages in the dify_plugin 0.9.x → 0.10.x bump** (e.g. OAICompat changed `json=data` to `data=json.dumps(...).encode()`) are out of scope for this PR and are documented as follow-ups in the sibling PRs (moonshot, xai). The lemonade plugin's existing tests are not affected by the bump.

## Consult-Kiro

The /consult-kiro Tier A panel (`~/.claude/skills/consult-kiro/scripts/opencode-panel.sh`) was invoked but canceled at the 60s mark with no usable output. The opencode backend has been degraded for the last 10+ opt-in turns (1/10 Tier A model coverage, only `openai/gpt-5-nano` responds; the other 9 return `EMPTY` within 3s with `rc=1` or timeout at 50–80s). The same gap has been documented in the prior 24 PRs in this series.

The fix design is pre-validated by 24 identical-pattern PRs: wenxin PR #3840, zhinao PR #3838, longcat PR #3833, mimo PR #3824, yi PR #3823, xai PR #3807, openrouter PR #3812, ollama PR #3785, togetherai PR #3792, moonshot PR #3798, groq PR #3801, deepseek PR #3766, fireworks PR #3782, mistralai PR #3761, cohere PR #3748, minimax PR #3745, sagemaker PR #3819, zhipuai PR #3743, volcengine PR #3742, tongyi PR #3741, openai_api_compatible PR #3740, stepfun PR #3739, gemini PR #3723, anthropic PR #3717. Same helper shape, same wiring pattern, same test pattern, same credential schema, same never-raise contract. The lemonade-specific test (`test_helper_is_imported_in_llm_py`) verifies the import line, the two call sites, and the ordering against `_add_custom_parameters` so any drift from the pattern would be caught locally.

## Future work

- SDK consolidation: per the tracking issue #3744, the 25 helpers in the series are a candidate for a shared utility in `dify_plugin` (e.g. `dify_plugin.helpers.attach_dify_metadata`).
- A 0.10.x → 0.11.x bump in `dify_plugin` would let the helper read `app_id` from `dify_plugin.get_current_session()` directly instead of relying on Dify core to inject it into `credentials['app_id']`. The 0.10.0 pin is already in place to make that migration a single-line change.

## Out of scope

- Lemonade's local server does not change in this PR; the headers are simply attached to the outbound request via the OAICompat `extra_headers` carrier.
- The text-embedding, rerank, speech2text, and tts endpoints are not in scope for this PR — they use different carriers and would need separate opt-in handlers in follow-ups if maintainers want uniform coverage.
- The pre-existing test breakages in moonshot, xai, etc. (caused by the 0.9.x → 0.10.x `dify_plugin` bump) are tracked separately in the sibling PRs and are not in scope for this PR.
