### PR TITLE
feat(volcengine_maas): add Seed 2.1 and DeepSeek V4 GA models

### DIFF
--- a/models/volcengine_maas/README.md
+++ b/models/volcengine_maas/README.md
@@ -17,6 +17,27 @@ If you want to call Ark **base models directly** without creating endpoints, use
 3. In Dify, go to **Settings -> Model Provider -> Volcengine Ark (Endpoint)**.
 4. Click **Add Model**, fill in the fields, and save.
 
+### Seed 2.1 and DeepSeek V4 GA
+
+Select the base model matching your deployed endpoint:
+
+| Base Model | Model version | Context / max output tokens |
+| --- | --- | --- |
+| Doubao-Seed-2.1-pro | doubao-seed-2-1-pro-260628 | 256K / 256K |
+| Doubao-Seed-2.1-turbo | doubao-seed-2-1-turbo-260628 | 256K / 256K |
+| DeepSeek-V4-Pro-GA | deepseek-v4-pro-ga-260813 | 1M / 384K |
+| DeepSeek-V4-Flash-GA | deepseek-v4-flash-ga-260731 | 1M / 384K |
+
+Continue to enter your `ep-...` Endpoint ID. Seed 2.1 supports image/video input,
+structured output, and reasoning effort from `minimal` to `high` (default `high`).
+DeepSeek V4 GA supports text input and reasoning effort up to `max`.
+
+Specifications and standard online token prices checked on 2026-09-07:
+[Seed 2.1 Pro](https://console.volcengine.com/ark/region:cn-beijing/model/detail?name=doubao-seed-2-1-pro),
+[Seed 2.1 Turbo](https://console.volcengine.com/ark/region:cn-beijing/model/detail?name=doubao-seed-2-1-turbo),
+[DeepSeek V4 Pro GA](https://console.volcengine.com/ark/region:cn-beijing/model/detail?name=deepseek-v4-pro-ga),
+[DeepSeek V4 Flash GA](https://console.volcengine.com/ark/region:cn-beijing/model/detail?name=deepseek-v4-flash-ga).
+
 ![img.png](_assets/img.png)
 
 ## Troubleshooting | 常见问题

--- a/models/volcengine_maas/manifest.yaml
+++ b/models/volcengine_maas/manifest.yaml
@@ -35,4 +35,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.53
+version: 0.0.54

--- a/models/volcengine_maas/models/llm/llm.py
+++ b/models/volcengine_maas/models/llm/llm.py
@@ -629,6 +629,10 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
             "doubao-seed-2.0-lite",
             "doubao-seed-2.0-mini",
             "doubao-seed-2.0-code",
+            "doubao-seed-2.1-pro",
+            "doubao-seed-2.1-turbo",
+            "deepseek-v4-pro-ga",
+            "deepseek-v4-flash-ga",
         ):
             rules.append(
                 ParameterRule(
@@ -657,6 +661,24 @@ class VolcengineMaaSLargeLanguageModel(LargeLanguageModel):
                     options=["minimal", "low", "medium", "high"],
                 )
             )
+        if base_model.lower() in (
+            "doubao-seed-2.1-pro",
+            "doubao-seed-2.1-turbo",
+            "deepseek-v4-pro-ga",
+            "deepseek-v4-flash-ga",
+        ):
+            is_deepseek = base_model.lower().startswith("deepseek-")
+            rules.append(
+                ParameterRule(
+                    name="reasoning_effort",
+                    type=ParameterType.STRING,
+                    default="medium" if is_deepseek else "high",
+                    label=I18nObject(zh_hans="思考强度", en_us="Reasoning Effort"),
+                    options=["minimal", "low", "medium", "high", "max"]
+                    if is_deepseek else ["minimal", "low", "medium", "high"],
+                )
+            )
+
         # Add structured output parameters for supported models
         if ModelFeature.STRUCTURED_OUTPUT in model_config.features:
             rules.extend([

--- a/models/volcengine_maas/models/llm/models.py
+++ b/models/volcengine_maas/models/llm/models.py
@@ -23,6 +23,32 @@ class ModelConfig(BaseModel):
 
 
 configs: dict[str, ModelConfig] = {
+    "Doubao-Seed-2.1-pro": ModelConfig(
+        properties=ModelProperties(context_size=262144, max_tokens=262144, mode=LLMMode.CHAT),
+        features=[ModelFeature.AGENT_THOUGHT, ModelFeature.VISION, ModelFeature.VIDEO,
+                  ModelFeature.TOOL_CALL, ModelFeature.MULTI_TOOL_CALL,
+                  ModelFeature.STREAM_TOOL_CALL, ModelFeature.STRUCTURED_OUTPUT],
+        pricing=PriceConfig(input=Decimal("0.0060"), output=Decimal("0.0300"), unit=Decimal("0.001"), currency="RMB"),
+    ),
+    "Doubao-Seed-2.1-turbo": ModelConfig(
+        properties=ModelProperties(context_size=262144, max_tokens=262144, mode=LLMMode.CHAT),
+        features=[ModelFeature.AGENT_THOUGHT, ModelFeature.VISION, ModelFeature.VIDEO,
+                  ModelFeature.TOOL_CALL, ModelFeature.MULTI_TOOL_CALL,
+                  ModelFeature.STREAM_TOOL_CALL, ModelFeature.STRUCTURED_OUTPUT],
+        pricing=PriceConfig(input=Decimal("0.0030"), output=Decimal("0.0150"), unit=Decimal("0.001"), currency="RMB"),
+    ),
+    "DeepSeek-V4-Pro-GA": ModelConfig(
+        properties=ModelProperties(context_size=1048576, max_tokens=393216, mode=LLMMode.CHAT),
+        features=[ModelFeature.AGENT_THOUGHT, ModelFeature.TOOL_CALL,
+                  ModelFeature.MULTI_TOOL_CALL, ModelFeature.STREAM_TOOL_CALL],
+        pricing=PriceConfig(input=Decimal("0.0090"), output=Decimal("0.0270"), unit=Decimal("0.001"), currency="RMB"),
+    ),
+    "DeepSeek-V4-Flash-GA": ModelConfig(
+        properties=ModelProperties(context_size=1048576, max_tokens=393216, mode=LLMMode.CHAT),
+        features=[ModelFeature.AGENT_THOUGHT, ModelFeature.TOOL_CALL,
+                  ModelFeature.MULTI_TOOL_CALL, ModelFeature.STREAM_TOOL_CALL],
+        pricing=PriceConfig(input=Decimal("0.0030"), output=Decimal("0.0090"), unit=Decimal("0.001"), currency="RMB"),
+    ),
     "Doubao-Seed-2.0-pro": ModelConfig(
         properties=ModelProperties(context_size=262144, max_tokens=131072, mode=LLMMode.CHAT),
         features=[ModelFeature.AGENT_THOUGHT, ModelFeature.VISION, ModelFeature.VIDEO,

--- a/models/volcengine_maas/provider/volcengine_maas.yaml
+++ b/models/volcengine_maas/provider/volcengine_maas.yaml
@@ -114,6 +114,32 @@ model_credential_schema:
       zh_Hans: 基础模型
     options:
     - label:
+        en_US: Doubao-Seed-2.1-pro
+      value: Doubao-Seed-2.1-pro
+      show_on:
+        - variable: __model_type
+          value: llm
+    - label:
+        en_US: Doubao-Seed-2.1-turbo
+      value: Doubao-Seed-2.1-turbo
+      show_on:
+        - variable: __model_type
+          value: llm
+    - label:
+        en_US: DeepSeek-V4-Pro-GA
+        zh_Hans: DeepSeek-V4-Pro 正式版
+      value: DeepSeek-V4-Pro-GA
+      show_on:
+        - variable: __model_type
+          value: llm
+    - label:
+        en_US: DeepSeek-V4-Flash-GA
+        zh_Hans: DeepSeek-V4-Flash 正式版
+      value: DeepSeek-V4-Flash-GA
+      show_on:
+        - variable: __model_type
+          value: llm
+    - label:
         en_US: Doubao-Seed-2.0-pro
       value: Doubao-Seed-2.0-pro
       show_on:


### PR DESCRIPTION
## Summary

Add Doubao-Seed-2.1-pro, Doubao-Seed-2.1-turbo, DeepSeek-V4-Pro-GA, and DeepSeek-V4-Flash-GA to the Volcengine Ark (Endpoint) provider's Base Model selector. Users can select the matching preset while continuing to invoke their configured Endpoint ID.

Register model capabilities, context/output limits, standard online token pricing, thinking controls, and reasoning effort options. Seed 2.1 also exposes image/video input and structured output. Document the corresponding deployed model versions and official specification links, checked on September 7, 2026.

## Release Notes

- Added Doubao Seed 2.1 Pro and Turbo endpoint presets with 256K context/output limits, multimodal input, structured output, and reasoning effort controls.
- Added DeepSeek V4 Pro GA and Flash GA endpoint presets with 1M context, 384K output limits, tool calling, and reasoning effort controls up to `max`.
- Updated model pricing metadata and setup documentation.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin
- [x] LLM plugin

## LLM Plugin Checklist

Areas affected:

- [x] Multimodal input
- [x] Structured output
- [x] Other LLM functionality (reasoning)
- [x] New models / model parameter fixes

## Version

- [x] Bumped top-level `manifest.yaml` version from `0.0.53` to `0.0.54`.
- Existing dependency requirements and lockfile remain unchanged (`dify_plugin>=0.9.0`).

## Testing

- Passed Python syntax parsing and YAML parsing.
- Verified all four selector entries map to registered model configurations, expected context/output limits, and thinking/reasoning schema branches.
- Verified unique selector values and the manifest version.
- Passed `git diff --check`.
- Full runtime tests were not run: the existing Windows virtual environment points to a missing Python installation, the available Python lacks required plugin dependencies, and WSL lacks `ensurepip`.
- No live Ark API requests or Dify UI integration tests were performed.

- [x] Local deployment
- [ ] SaaS (cloud.dify.ai)