### PR TITLE
feat(deepseek): support deepseek-v4-flash-vision-exp

### DIFF
--- a/models/deepseek/README.md
+++ b/models/deepseek/README.md
@@ -1,8 +1,14 @@
 # Overview
 
-This plugin integrates the current official DeepSeek models, `deepseek-v4-flash` and `deepseek-v4-pro`.
+This plugin integrates the official DeepSeek models `deepseek-v4-flash`, `deepseek-v4-pro`, and the experimental `deepseek-v4-flash-vision-exp`.
 
-These stable API IDs automatically use the latest model versions.
+The stable `deepseek-v4-flash` and `deepseek-v4-pro` API IDs automatically use the latest model versions.
+
+Select `deepseek-v4-flash-vision-exp` for text and image input with reasoning, tool calling, and JSON Output.
+It uses the same API key and base URL as the text models, with a 1M-token context and up to 384K output tokens.
+Images can be supplied as URLs or inline Base64 in user messages through Chat Completions.
+Supported image formats are JPEG, PNG, GIF, and WebP; see the [official vision guide](https://api-docs.deepseek.com/guides/vision/) for size and request limits.
+Local token estimates exclude images; the API's returned token usage includes them.
 
 DeepSeek pricing varies by cache status and time window, so refer to the [official pricing page](https://api-docs.deepseek.com/quick_start/pricing/) for current rates.
 

--- a/models/deepseek/manifest.yaml
+++ b/models/deepseek/manifest.yaml
@@ -1,8 +1,8 @@
 author: langgenius
 created_at: '2024-09-20T00:13:50.29298939-04:00'
 description:
-  en_US: Official DeepSeek models, including deepseek-v4-flash and deepseek-v4-pro.
-  zh_Hans: DeepSeek 官方模型，包括 deepseek-v4-flash 和 deepseek-v4-pro。
+  en_US: Official DeepSeek V4 models with reasoning, tool calling, and experimental vision.
+  zh_Hans: DeepSeek 官方 V4 模型，支持推理、工具调用和实验性视觉理解。
 icon: icon_s_en.svg
 label:
   en_US: DeepSeek
@@ -34,4 +34,4 @@ resource:
     tool:
       enabled: true
 type: plugin
-version: 0.0.21
+version: 0.0.22

--- a/models/deepseek/models/llm/_position.yaml
+++ b/models/deepseek/models/llm/_position.yaml
@@ -1,2 +1,3 @@
 - deepseek-v4-flash
+- deepseek-v4-flash-vision-exp
 - deepseek-v4-pro

--- a/models/deepseek/models/llm/deepseek-v4-flash-vision-exp.yaml
+++ b/models/deepseek/models/llm/deepseek-v4-flash-vision-exp.yaml
@@ -1,0 +1,78 @@
+model: deepseek-v4-flash-vision-exp
+label:
+  zh_Hans: deepseek-v4-flash-vision-exp
+  en_US: deepseek-v4-flash-vision-exp
+model_type: llm
+features:
+  - vision
+  - agent-thought
+  - tool-call
+  - multi-tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 1000000
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    type: float
+    default: 1
+    min: 0.0
+    max: 2.0
+    help:
+      zh_Hans: 控制生成结果的多样性和随机性。数值越小，越严谨；数值越大，越发散。
+      en_US: Control the diversity and randomness of generated results. The smaller the value, the more rigorous it is; the larger the value, the more divergent it is.
+  - name: max_tokens
+    use_template: max_tokens
+    type: int
+    default: 4096
+    min: 1
+    max: 384000
+    help:
+      zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
+      en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
+  - name: top_p
+    use_template: top_p
+    type: float
+    default: 1
+    min: 0.01
+    max: 1.00
+    help:
+      zh_Hans: 控制生成结果的随机性。数值越小，随机性越弱；数值越大，随机性越强。一般而言，top_p 和 temperature 两个参数选择一个进行调整即可。
+      en_US: Control the randomness of generated results. The smaller the value, the weaker the randomness; the larger the value, the stronger the randomness. Generally speaking, you can adjust one of the two parameters top_p and temperature.
+  - name: thinking
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking Mode
+    type: boolean
+    default: true
+    required: false
+    help:
+      zh_Hans: 控制是否启用 DeepSeek v4 的思考模式。
+      en_US: Controls whether DeepSeek v4 thinking mode is enabled.
+  - name: reasoning_effort
+    label:
+      zh_Hans: 思考强度
+      en_US: Reasoning Effort
+    type: string
+    default: high
+    required: false
+    options:
+      - low
+      - high
+      - max
+    help:
+      zh_Hans: 控制思考模式下的推理强度。官方文档支持 low、high 和 max。
+      en_US: Controls reasoning effort in thinking mode. The official docs support low, high, and max.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object

--- a/models/deepseek/models/llm/llm.py
+++ b/models/deepseek/models/llm/llm.py
@@ -24,7 +24,11 @@ class DeepseekLargeLanguageModel(OAICompatLargeLanguageModel):
         rf"<think>\n{re.escape(_THINK_MARKER)}(.*?)\n</think>",
         re.DOTALL | re.IGNORECASE,
     )
-    _V4_MODELS = ("deepseek-v4-flash", "deepseek-v4-pro")
+    _V4_MODELS = (
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-vision-exp",
+        "deepseek-v4-pro",
+    )
     _THINKING_UNSUPPORTED_PARAMETERS = (
         "temperature",
         "top_p",

--- a/models/deepseek/provider/deepseek.yaml
+++ b/models/deepseek/provider/deepseek.yaml
@@ -2,8 +2,8 @@ background: '#c0cdff'
 configurate_methods:
 - predefined-model
 description:
-  en_US: Official DeepSeek models, including deepseek-v4-flash and deepseek-v4-pro.
-  zh_Hans: DeepSeek 官方模型，包括 deepseek-v4-flash 和 deepseek-v4-pro。
+  en_US: Official DeepSeek V4 models with reasoning, tool calling, and experimental vision.
+  zh_Hans: DeepSeek 官方 V4 模型，支持推理、工具调用和实验性视觉理解。
 extra:
   python:
     model_sources:

--- a/models/deepseek/tests/test_live.py
+++ b/models/deepseek/tests/test_live.py
@@ -140,7 +140,9 @@ def test_vision_recognizes_an_inline_image(stream: bool) -> None:
         pytest.param(True, False, "max", 32, id="nonthinking-stream"),
     ],
 )
+@pytest.mark.parametrize("model", MODELS)
 def test_thinking_modes_and_effort_boundaries(
+    model: str,
     stream: bool,
     thinking: bool | None,
     effort: str | None,
@@ -154,6 +156,7 @@ def test_thinking_modes_and_effort_boundaries(
 
     chunks = _invoke(
         [UserPromptMessage(content="Calculate 17 * 19, then reply only with 323.")],
+        model=model,
         parameters=parameters,
         stream=stream,
     )
@@ -173,7 +176,8 @@ def test_thinking_modes_and_effort_boundaries(
     _terminal(chunks)
 
 
-def test_thinking_tool_call_replays_reasoning_content() -> None:
+@pytest.mark.parametrize("model", MODELS)
+def test_thinking_tool_call_replays_reasoning_content(model: str) -> None:
     tool = PromptMessageTool(
         name="get_live_test_marker",
         description="Return the marker required to finish the live test.",
@@ -195,6 +199,7 @@ def test_thinking_tool_call_replays_reasoning_content() -> None:
     for sub_turn in range(3):
         chunks = _invoke(
             messages,
+            model=model,
             parameters=parameters,
             tools=[tool],
             stream=False,
@@ -227,7 +232,8 @@ def test_thinking_tool_call_replays_reasoning_content() -> None:
     assert "LIVE_TOOL_OK" in answer
 
 
-def test_json_object_output() -> None:
+@pytest.mark.parametrize("model", MODELS)
+def test_json_object_output(model: str) -> None:
     chunks = _invoke(
         [
             UserPromptMessage(
@@ -237,6 +243,7 @@ def test_json_object_output() -> None:
                 )
             )
         ],
+        model=model,
         parameters={
             "thinking": False,
             "max_tokens": 64,

--- a/models/deepseek/tests/test_live.py
+++ b/models/deepseek/tests/test_live.py
@@ -8,8 +8,10 @@ import yaml
 from dify_plugin.entities.model import AIModelEntity
 from dify_plugin.entities.model.llm import LLMResultChunk
 from dify_plugin.entities.model.message import (
+    ImagePromptMessageContent,
     PromptMessage,
     PromptMessageTool,
+    TextPromptMessageContent,
     ToolPromptMessage,
     UserPromptMessage,
 )
@@ -95,6 +97,37 @@ def test_every_current_model_accepts_a_minimal_request(model: str) -> None:
     )
 
     assert _text(chunks).strip()
+    _terminal(chunks)
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_vision_recognizes_an_inline_image(stream: bool) -> None:
+    # A 32x32 red PNG keeps the live request small and independent of external URLs.
+    image = ImagePromptMessageContent(
+        format="png",
+        mime_type="image/png",
+        base64_data=(
+            "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR4nO3NsQ0A"
+            "AAzCMP5/un0CNkuZ41wybXsHAAAAAAAAAAAAxR4yw/wuPL6QkAAAAABJRU5ErkJggg=="
+        ),
+    )
+    chunks = _invoke(
+        [
+            UserPromptMessage(
+                content=[
+                    TextPromptMessageContent(
+                        data="Name the color of this image in one English word."
+                    ),
+                    image,
+                ]
+            )
+        ],
+        model="deepseek-v4-flash-vision-exp",
+        parameters={"thinking": False, "max_tokens": 16},
+        stream=stream,
+    )
+
+    assert "red" in _text(chunks).lower()
     _terminal(chunks)
 
 

--- a/models/deepseek/tests/test_llm_call.py
+++ b/models/deepseek/tests/test_llm_call.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
@@ -8,6 +9,7 @@ from dify_plugin import OAICompatLargeLanguageModel
 from dify_plugin.entities.model import AIModelEntity
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
+    ImagePromptMessageContent,
     PromptMessageTool,
     ToolPromptMessage,
     UserPromptMessage,
@@ -20,6 +22,8 @@ sys.path.insert(0, str(ROOT))
 from models.llm.llm import DeepseekLargeLanguageModel
 from provider.deepseek import DeepSeekProvider
 
+MODELS = ("deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro")
+
 
 def _llm() -> DeepseekLargeLanguageModel:
     return DeepseekLargeLanguageModel(model_schemas=[])
@@ -29,7 +33,7 @@ def test_v4_catalog_and_parameter_boundaries() -> None:
     directory = ROOT / "models" / "llm"
     position = yaml.safe_load((directory / "_position.yaml").read_text())
 
-    assert position == ["deepseek-v4-flash", "deepseek-v4-pro"]
+    assert position == list(MODELS)
     assert {
         path.stem for path in directory.glob("*.yaml") if path.name != "_position.yaml"
     } == set(position)
@@ -38,6 +42,9 @@ def test_v4_catalog_and_parameter_boundaries() -> None:
         schema = yaml.safe_load((directory / f"{model}.yaml").read_text())
         AIModelEntity.model_validate(schema)
         rules = {rule["name"]: rule for rule in schema["parameter_rules"]}
+        assert ("vision" in schema["features"]) == (
+            model == "deepseek-v4-flash-vision-exp"
+        )
         assert schema["model_properties"]["context_size"] == 1_000_000
         assert rules["max_tokens"]["max"] == 384_000
         assert rules["thinking"]["default"] is True
@@ -48,7 +55,8 @@ def test_v4_catalog_and_parameter_boundaries() -> None:
 
 
 @pytest.mark.parametrize("thinking", [True, False])
-def test_thinking_parameters_are_normalized(thinking: bool) -> None:
+@pytest.mark.parametrize("model", MODELS)
+def test_thinking_parameters_are_normalized(model: str, thinking: bool) -> None:
     unsupported = {
         "temperature": 0.7,
         "top_p": 0.8,
@@ -62,7 +70,7 @@ def test_thinking_parameters_are_normalized(thinking: bool) -> None:
         **unsupported,
     }
 
-    _llm()._normalize_model_parameters("deepseek-v4-pro", parameters)
+    _llm()._normalize_model_parameters(model, parameters)
 
     expected = {
         "thinking": {"type": "enabled" if thinking else "disabled"},
@@ -76,7 +84,7 @@ def test_thinking_parameters_are_normalized(thinking: bool) -> None:
 
     if thinking:
         implicit_parameters = {"temperature": 0.7, "top_p": 0.8}
-        _llm()._normalize_model_parameters("deepseek-v4-pro", implicit_parameters)
+        _llm()._normalize_model_parameters(model, implicit_parameters)
         assert implicit_parameters == {"thinking": {"type": "enabled"}}
 
 
@@ -116,12 +124,13 @@ def test_sdk_stream_wrapper_keeps_reasoning_content_and_tools() -> None:
     assert is_reasoning is False
 
 
-def test_non_stream_reasoning_and_tool_history_round_trip() -> None:
+@pytest.mark.parametrize("model", MODELS)
+def test_non_stream_reasoning_and_tool_history_round_trip(model: str) -> None:
     reasoning_content = "  must preserve </think> & &lt; exactly\n"
     response = Mock()
     response.json.return_value = {
         "id": "chatcmpl-1",
-        "model": "deepseek-v4-pro",
+        "model": model,
         "choices": [
             {
                 "finish_reason": "tool_calls",
@@ -152,7 +161,7 @@ def test_non_stream_reasoning_and_tool_history_round_trip() -> None:
     llm = _llm()
 
     result = llm._handle_generate_response(
-        "deepseek-v4-pro",
+        model,
         credentials,
         response,
         [UserPromptMessage(content="hi")],
@@ -166,7 +175,7 @@ def test_non_stream_reasoning_and_tool_history_round_trip() -> None:
         payload = llm._convert_prompt_message_to_dict(
             message,
             {
-                "_current_model": "deepseek-v4-pro",
+                "_current_model": model,
                 "function_calling_type": "tool_call",
             },
         )
@@ -201,7 +210,7 @@ def test_non_stream_reasoning_and_tool_history_round_trip() -> None:
     )
     assert llm._convert_prompt_message_to_dict(
         merged,
-        {"_current_model": "deepseek-v4-pro"},
+        {"_current_model": model},
     ) == {
         "role": "assistant",
         "content": "a <think>literal answer tag</think>\n\nb",
@@ -209,7 +218,8 @@ def test_non_stream_reasoning_and_tool_history_round_trip() -> None:
     }
 
 
-def test_invoke_uses_official_user_id_and_default_endpoint() -> None:
+@pytest.mark.parametrize("model", MODELS)
+def test_invoke_uses_official_user_id_and_default_endpoint(model: str) -> None:
     captured = {}
 
     def invoke(
@@ -235,7 +245,7 @@ def test_invoke_uses_official_user_id_and_default_endpoint() -> None:
     credentials = {"api_key": "test", "endpoint_url": ""}
     with patch.object(OAICompatLargeLanguageModel, "_invoke", invoke):
         result = _llm()._invoke(
-            "deepseek-v4-pro",
+            model,
             credentials,
             [UserPromptMessage(content="hi")],
             {},
@@ -251,7 +261,7 @@ def test_invoke_uses_official_user_id_and_default_endpoint() -> None:
         )
 
     assert result == "ok"
-    assert captured["model"] == "deepseek-v4-pro"
+    assert captured["model"] == model
     assert captured["parameters"]["user_id"] == "user-1"
     assert captured["parameters"]["tools"] == [
         {
@@ -266,8 +276,100 @@ def test_invoke_uses_official_user_id_and_default_endpoint() -> None:
     assert "tool_choice" not in captured["parameters"]
     assert captured["tools"] is None
     assert captured["user"] is None
-    assert credentials["_current_model"] == "deepseek-v4-pro"
+    assert credentials["_current_model"] == model
     assert credentials["endpoint_url"] == "https://api.deepseek.com"
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_vision_images_reach_chat_completions(stream: bool) -> None:
+    model = "deepseek-v4-flash-vision-exp"
+    images = [
+        ImagePromptMessageContent(
+            format="png", mime_type="image/png", url="https://example.com/image.png"
+        ),
+        ImagePromptMessageContent(
+            format="png",
+            mime_type="image/png",
+            base64_data="aW1hZ2U=",
+            detail=ImagePromptMessageContent.DETAIL.HIGH,
+        ),
+    ]
+    messages = [
+        UserPromptMessage(content="Compare these images."),
+        UserPromptMessage(content=images),
+        UserPromptMessage(content="Describe the difference."),
+        AssistantPromptMessage(content="I can compare them."),
+        UserPromptMessage(content="Please continue."),
+    ]
+    originals = [message.model_copy(deep=True) for message in messages]
+    usage = {"prompt_tokens": 400, "completion_tokens": 2, "total_tokens": 402}
+    response = Mock(status_code=200, encoding="utf-8")
+    response.json.return_value = {
+        "model": model,
+        "choices": [
+            {"message": {"content": "Different colors."}, "finish_reason": "stop"}
+        ],
+        "usage": usage,
+    }
+    response.iter_lines.return_value = [
+        'data: {"choices":[{"delta":{"content":"Different colors."},"finish_reason":null}]}',
+        "data: "
+        + json.dumps(
+            {
+                "choices": [{"delta": {}, "finish_reason": "stop"}],
+                "usage": usage,
+            }
+        ),
+        "data: [DONE]",
+    ]
+
+    with patch("requests.post", return_value=response) as post:
+        result = _llm()._invoke(
+            model,
+            {"api_key": "test"},
+            messages,
+            {"thinking": False},
+            stream=stream,
+        )
+        if stream:
+            result = list(result)[-1].delta
+
+    assert result.usage.prompt_tokens == 400
+    assert messages == originals
+    assert post.call_args.args == ("https://api.deepseek.com/chat/completions",)
+    payload = json.loads(post.call_args.kwargs["data"])
+    assert payload["model"] == model
+    assert payload["stream"] is stream
+    assert payload["thinking"] == {"type": "disabled"}
+    assert payload["messages"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Compare these images."},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://example.com/image.png",
+                        "detail": "low",
+                    },
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,aW1hZ2U=",
+                        "detail": "high",
+                    },
+                },
+                {"type": "text", "text": "Describe the difference."},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": "I can compare them.",
+            "reasoning_content": "",
+        },
+        {"role": "user", "content": "Please continue."},
+    ]
 
 
 def test_provider_validation_does_not_fallback_to_retired_models() -> None:


### PR DESCRIPTION
## Summary

Closes #3856.

The official DeepSeek provider currently exposes only text models, so users cannot select DeepSeek's experimental vision model for image analysis.
Add `deepseek-v4-flash-vision-exp` with vision, tool calling, JSON Output, and the same 1M-context / 384K-output configuration as the existing V4 models.
Include the new ID in the shared V4 model list so thinking parameters and assistant reasoning history are handled correctly.
Image URLs and inline Base64 reuse the existing Chat Completions implementation in the SDK.

Verified against the [official release announcement](https://api-docs.deepseek.com/news/news260821/), [model specifications](https://api-docs.deepseek.com/quick_start/pricing/), and [vision guide](https://api-docs.deepseek.com/guides/vision/).
Pricing remains linked to the official page because it varies by cache status and time window.

## Release Notes

Add the experimental `deepseek-v4-flash-vision-exp` model for text and image input, with thinking controls, tool calling, and JSON Output.
Use the existing DeepSeek API key and base URL to analyze images supplied as URLs or inline Base64.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not captured; validation used automated SDK requests and a packaged plugin startup check.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change</summary>

- [x] Message flow (system messages, user ↔ assistant turn-taking)
- [x] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `manifest.yaml` version from `0.0.21` to `0.0.22`.
- [x] Preserved the existing `dify_plugin>=0.10.2` dependency and frozen `uv.lock` resolving SDK `0.10.2`.

## Testing

Python 3.12.13 in a fresh external virtual environment installed with `uv sync --all-groups --frozen --python 3.12`.

- `RUN_DEEPSEEK_LIVE=1 python -m pytest tests -v --tb=short`: 67 passed (44 offline and 23 live), with no skipped or xfailed tests.
- Ruff checks passed for all changed Python files, run from `models/deepseek`.
- Model YAML schemas validated with the installed Dify SDK.
- Mock HTTP tests verified URL/Base64 image payloads, consecutive user-message merging without mutation, assistant reasoning fields, and API-reported usage for both streaming and non-streaming calls.
- Existing thinking-parameter, reasoning/tool-history, and request-construction tests cover all three V4 model IDs.
- Dify CLI packaging passed from a clean staging copy; the package contains the new model and excludes local environments and caches.
- The official Marketplace Toolkit's plugin installation check passed against the extracted package in serverless mode.
- `git diff --check` passed.
- Independent ponytail review completed after validation: no simplification findings.
- Independent correctness review found no actionable issues; omitting the new V4 registration makes the focused regression tests fail.

Live API validation passed on September 8, 2026 for all three model IDs.
This covers minimal text requests, default/high and low/max thinking effort, non-thinking mode, streaming and non-streaming responses, multi-round tool calls with reasoning history, and JSON Object output.
The vision model correctly identified an inline 32×32 red PNG in both streaming and non-streaming modes.
The live tests retain explicit opt-in through `RUN_DEEPSEEK_LIVE=1` and `DEEPSEEK_API_KEY`.
To rerun the vision cases, use `RUN_DEEPSEEK_LIVE=1 uv run --frozen pytest tests/test_live.py -k vision -q` from `models/deepseek`.
Local token estimates exclude images; token usage returned by the API includes them.

- [ ] Local deployment — Dify application UI not tested.
- [ ] SaaS (cloud.dify.ai)
