### PR TITLE
fix(openai_api_compatible): add provider_credential_schema for Knowledge Pipeline flow (#3682)

### DIFF
--- a/models/openai_api_compatible/manifest.yaml
+++ b/models/openai_api_compatible/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.66
+version: 0.0.68
 type: plugin
 author: "langgenius"
 name: "openai_api_compatible"

--- a/models/openai_api_compatible/provider/openai_api_compatible.yaml
+++ b/models/openai_api_compatible/provider/openai_api_compatible.yaml
@@ -14,6 +14,26 @@ supported_model_types:
   - tts
 configurate_methods:
   - customizable-model
+provider_credential_schema:
+  credential_form_schemas:
+    - variable: api_key
+      label:
+        en_US: API Key
+        zh_Hans: API Key
+      type: secret-input
+      required: true
+      placeholder:
+        en_US: Enter your API Key
+        zh_Hans: 在此输入您的 API Key
+    - variable: endpoint_url
+      label:
+        en_US: API Base URL
+        zh_Hans: API 基础地址
+      type: text-input
+      required: false
+      placeholder:
+        en_US: 'Optional — leave blank to use the default OpenAI endpoint, or set to your OpenAI-compatible server URL.'
+        zh_Hans: 选填 — 留空使用默认 OpenAI 端点，或填写您的 OpenAI 兼容服务器地址。
 model_credential_schema:
   model:
     label:

--- a/models/openai_api_compatible/tests/test_provider_credential_schema.py
+++ b/models/openai_api_compatible/tests/test_provider_credential_schema.py
@@ -1,0 +1,107 @@
+"""Regression test for #3682.
+
+Configuring a credential for an OpenAI-API-compatible custom model in a
+Knowledge Pipeline failed with "does not have
+provider_credential_schema" -- the form could not render and the user
+saw a red error toast. Dify requires every provider used in a Knowledge
+Pipeline to declare a top-level ``provider_credential_schema`` so the
+authorization form can render; the OpenAI-API-compatible plugin only
+declared ``model_credential_schema``, so the provider-level schema
+was missing.
+
+These tests pin the shape of the new ``provider_credential_schema``
+and the unchanged ``model_credential_schema`` so a future refactor
+cannot accidentally drop the provider-level schema.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Make the plugin importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+PROVIDER_YAML = (
+    Path(__file__).resolve().parent.parent / "provider" / "openai_api_compatible.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def provider_doc() -> dict:
+    assert PROVIDER_YAML.exists(), f"missing provider yaml: {PROVIDER_YAML}"
+    with PROVIDER_YAML.open(encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def test_provider_yaml_declares_provider_credential_schema(provider_doc):
+    """The whole point of #3682: provider_credential_schema must exist."""
+    assert "provider_credential_schema" in provider_doc, (
+        "OpenAI-API-compatible provider must declare provider_credential_schema "
+        "so the Knowledge Pipeline authorization form can render. See #3682."
+    )
+    assert provider_doc["provider_credential_schema"] is not None
+
+
+def test_provider_credential_form_has_api_key(provider_doc):
+    """The two universal fields every OpenAI-compatible server needs:
+    a bearer token and an optional endpoint URL.
+    """
+    form_schemas = provider_doc["provider_credential_schema"]["credential_form_schemas"]
+    api_key_fields = [f for f in form_schemas if f.get("variable") == "api_key"]
+    assert len(api_key_fields) == 1
+    api_key = api_key_fields[0]
+    assert api_key["type"] == "secret-input"
+    assert api_key["required"] is True
+    # The label is bilingual so the form renders in both en_US and zh_Hans.
+    assert "en_US" in api_key["label"]
+    assert "zh_Hans" in api_key["label"]
+
+
+def test_provider_credential_form_has_optional_endpoint_url(provider_doc):
+    """endpoint_url is optional so users on the default OpenAI endpoint
+    don't have to set it. The credential form must accept an empty value."""
+    form_schemas = provider_doc["provider_credential_schema"]["credential_form_schemas"]
+    url_fields = [f for f in form_schemas if f.get("variable") == "endpoint_url"]
+    assert len(url_fields) == 1
+    url_field = url_fields[0]
+    assert url_field["type"] == "text-input"
+    assert url_field["required"] is False
+
+
+def test_model_credential_schema_preserved(provider_doc):
+    """Adding provider_credential_schema must not displace the
+    per-model schema -- existing image/audio/llm/rerank/tts flows
+    depend on it.
+    """
+    assert "model_credential_schema" in provider_doc
+    model_schema = provider_doc["model_credential_schema"]
+    # The model schema carries the same per-model credentials it did
+    # before the fix; presence of the per-model "model" block is the
+    # regression guard.
+    assert "model" in model_schema
+    assert "credential_form_schemas" in model_schema
+    form_variables = {f["variable"] for f in model_schema["credential_form_schemas"]}
+    # Spot-check a few of the per-model fields that have always been there.
+    for required_field in ("api_key", "mode", "context_size"):
+        assert required_field in form_variables, (
+            f"model_credential_schema lost the {required_field!r} form field "
+            f"in the provider_credential_schema refactor"
+        )
+
+
+def test_provider_yaml_round_trip():
+    """YAML parses cleanly with PyYAML safe_load -- the credential
+    schema must not introduce tags or other unsafe constructs.
+    """
+    with PROVIDER_YAML.open(encoding="utf-8") as f:
+        raw = f.read()
+    # A no-op round trip: parse then re-emit and re-parse. Catches
+    # accidentally using !!python/str or other tags.
+    first = yaml.safe_load(raw)
+    second = yaml.safe_load(yaml.safe_dump(first, sort_keys=False))
+    assert first == second


### PR DESCRIPTION
"Fixes #3682.\n\n## Problem\n\nConfiguring a credential for an OpenAI-API-compatible custom model in a Knowledge Pipeline failed with `\"does not have provider_credential_schema\"` \u2014 the form could not render and the user saw a red error toast.\n\nDify requires every provider used in a Knowledge Pipeline to declare a top-level `provider_credential_schema` so the authorization form can render. The OpenAI-API-compatible plugin only declared `model_credential_schema`, so the provider-level schema was missing. (Other configurable-model plugins like `openai`, `anthropic`, `gemini`, `mistral`, etc. all have it.)\n\n## Fix\n\nAdded the missing `provider_credential_schema` with the two universal fields every OpenAI-compatible server needs:\n\n| Field | Type | Required | Notes |\n| --- | --- | --- | --- |\n| `api_key` | `secret-input` | yes | The bearer token for the provider. |\n| `endpoint_url` | `text-input` | no | The OpenAI-compatible server URL. Empty falls back to the default OpenAI endpoint; set to point at LM Studio / vLLM / LiteLLM / etc. |\n\nThe model-level `credential_form_schemas` is preserved unchanged, so existing per-model configuration flows (LLM / Embedding / Rerank / Speech2Text / TTS) are not affected. The `configurate_methods` list still contains only `customizable-model`, so the global provider credential form is the only new entry point.\n\n## Tests\n\n`models/openai_api_compatible/tests/test_provider_credential_schema.py` (5 tests):\n\n- `test_provider_yaml_declares_provider_credential_schema` \u2014 the whole point of the fix.\n- `test_provider_credential_form_has_api_key` \u2014 pins type (`secret-input`), required flag, and bilingual label.\n- `test_provider_credential_form_has_optional_endpoint_url` \u2014 pins type (`text-input`), required flag = False.\n- `test_model_credential_schema_preserved` \u2014 guards against accidentally dropping the per-model schema during the refactor.\n- `test_provider_yaml_round_trip` \u2014 PyYAML safe_load round-trip, catches accidentally using `!!python/str` or other unsafe tags.\n\n```\n$ uv run pytest tests/test_provider_credential_schema.py -v\n========================= 5 passed, 2 warnings in 0.11s ==========================\n```\n\n`$ uv run pytest tests/` \u2014 **93 passed** (88 pre-existing + 5 new). `ruff check` and `ruff format --check` clean on the new file.\n\n## Release Notes\n\n- fix(openai_api_compatible): add the top-level `provider_credential_schema` so the Knowledge Pipeline credential form can render. Previously, configuring a credential for an OpenAI-API-compatible custom model in a Knowledge Pipeline failed with \"does not have provider_credential_schema\" \u2014 the form could not render and the user saw a red error toast. The new schema adds `api_key` (required) and `endpoint_url` (optional) form fields. The per-model `credential_form_schemas` is preserved unchanged. Bumps the plugin from 0.0.66 \u2192 0.0.68.\n"