### PR TITLE
Fix/aihubmix claude usage pricing

### DIFF
--- a/models/aihubmix/models/llm/llm.py
+++ b/models/aihubmix/models/llm/llm.py
@@ -88,6 +88,8 @@ class AihubmixLargeLanguageModel(OAICompatLargeLanguageModel):
         
         # 检查模型名称是否以 "claude" 开头
         if model.startswith("claude"):
+            # 按请求构造并传入 provider 的模型 schema，get_price 才能按 YAML 定价计费
+            anthropic_llm = AnthropicLargeLanguageModel(self.model_schemas)
             return anthropic_llm._invoke(model, credentials, prompt_messages, model_parameters, tools, stop, stream, user)
         
         # 检查模型名称是否以 "gemini" 开头且不以 "-nothink" 或 "-search" 结尾

--- a/models/aihubmix/tests/test_claude_error_mapping.py
+++ b/models/aihubmix/tests/test_claude_error_mapping.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import anthropic
+import httpx
+import pytest
+import yaml
+from dify_plugin.entities.model import AIModelEntity
+from dify_plugin.entities.model.message import UserPromptMessage
+from dify_plugin.errors.model import (
+    InvokeAuthorizationError,
+    InvokeBadRequestError,
+    InvokeConnectionError,
+    InvokeRateLimitError,
+    InvokeServerUnavailableError,
+)
+
+from models.llm import anthropic as anthropic_module
+from models.llm.llm import AihubmixLargeLanguageModel
+
+MODEL = "claude-opus-5"
+SCHEMA_PATH = Path(__file__).parents[1] / "models" / "llm" / f"{MODEL}.yaml"
+REQUEST = httpx.Request("POST", "https://example.invalid/v1/messages")
+
+
+def _status_error(cls: type[anthropic.APIStatusError], status_code: int) -> anthropic.APIStatusError:
+    response = httpx.Response(status_code, request=REQUEST)
+    return cls(f"Error code: {status_code}", response=response, body=None)
+
+
+def _invoke_raising(monkeypatch, error: Exception) -> None:
+    class _Messages:
+        def create(self, **kwargs):
+            raise error
+
+    class _Anthropic:
+        def __init__(self, **kwargs) -> None:
+            self.messages = _Messages()
+
+    monkeypatch.setattr(anthropic_module, "Anthropic", _Anthropic)
+
+    schemas = [AIModelEntity.model_validate(yaml.safe_load(SCHEMA_PATH.read_text(encoding="utf-8")))]
+    llm = AihubmixLargeLanguageModel(schemas)
+    with llm.timing_context():
+        llm._invoke(
+            model=MODEL,
+            credentials={"api_key": "fake-key-for-test", "api_url": "https://example.invalid"},
+            prompt_messages=[UserPromptMessage(content="Hello")],
+            model_parameters={"max_tokens": 64, "thinking": False, "effort": "high"},
+            stream=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("upstream_error", "expected"),
+    [
+        (_status_error(anthropic.AuthenticationError, 401), InvokeAuthorizationError),
+        (_status_error(anthropic.RateLimitError, 429), InvokeRateLimitError),
+        (_status_error(anthropic.BadRequestError, 400), InvokeBadRequestError),
+        (_status_error(anthropic.InternalServerError, 500), InvokeServerUnavailableError),
+    ],
+    ids=["401", "429", "400", "500"],
+)
+def test_claude_upstream_errors_map_to_specific_invoke_errors(monkeypatch, upstream_error, expected) -> None:
+    with pytest.raises(expected):
+        _invoke_raising(monkeypatch, upstream_error)
+
+
+def test_claude_connection_error_maps_to_invoke_connection_error(monkeypatch) -> None:
+    with pytest.raises(InvokeConnectionError):
+        _invoke_raising(monkeypatch, anthropic.APIConnectionError(request=REQUEST))

--- a/models/aihubmix/tests/test_claude_usage_pricing.py
+++ b/models/aihubmix/tests/test_claude_usage_pricing.py
@@ -1,0 +1,59 @@
+from decimal import Decimal
+from pathlib import Path
+
+import yaml
+from anthropic.types import Message, TextBlock, Usage
+from dify_plugin.entities.model import AIModelEntity
+from dify_plugin.entities.model.message import UserPromptMessage
+
+from models.llm import anthropic as anthropic_module
+from models.llm.llm import AihubmixLargeLanguageModel
+
+MODEL = "claude-opus-5"
+SCHEMA_PATH = Path(__file__).parents[1] / "models" / "llm" / f"{MODEL}.yaml"
+
+
+class _Messages:
+    def create(self, **kwargs):
+        return Message(
+            id="msg_fake",
+            type="message",
+            role="assistant",
+            model=MODEL,
+            content=[TextBlock(type="text", text="hi")],
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage=Usage(input_tokens=1000, output_tokens=100),
+        )
+
+
+class _Anthropic:
+    def __init__(self, **kwargs) -> None:
+        self.messages = _Messages()
+
+
+def _load_schemas() -> list[AIModelEntity]:
+    return [AIModelEntity.model_validate(yaml.safe_load(SCHEMA_PATH.read_text(encoding="utf-8")))]
+
+
+def test_claude_usage_price_follows_yaml_pricing(monkeypatch) -> None:
+    monkeypatch.setattr(anthropic_module, "Anthropic", _Anthropic)
+
+    schemas = _load_schemas()
+    pricing = schemas[0].pricing
+    assert pricing is not None
+    expected_total = (Decimal(1000) * pricing.input + Decimal(100) * pricing.output) * pricing.unit
+
+    llm = AihubmixLargeLanguageModel(schemas)
+    with llm.timing_context():
+        result = llm._invoke(
+            model=MODEL,
+            credentials={"api_key": "fake-key-for-test", "api_url": "https://example.invalid"},
+            prompt_messages=[UserPromptMessage(content="Hello")],
+            model_parameters={"max_tokens": 64, "thinking": False, "effort": "high"},
+            stream=False,
+        )
+
+    assert result.usage.prompt_tokens == 1000
+    assert result.usage.completion_tokens == 100
+    assert result.usage.total_price == expected_total


### PR DESCRIPTION
1.范围与发现
选择的是claude调用链路

发现一：claude响应计费为0。——已复现缺陷，并mock修复，未经真实环境验证。
位置及触发条件：
 llm.py:25-27 在模块导入时用空列表构造了 anthropic_llm = AnthropicLargeLanguageModel(model_schemas)（model_schemas = []）。
anthropic.py:912（非流式）和 anthropic.py:1146（流式）调用 super()._calc_response_usage(...)，self 是那个空 schema 实例。
结果是 claude-opus-5.yaml 中 pricing: input 5.00 / output 25.00 从未被读取，Dify 侧每次 Claude 调用的 prompt_price、completion_price、total_price 均为 0。token 数本身是对的（来自响应的 usage），所以功能正常、回答正常，

发现二：所有上游错误都被报成 InvokeConnectionError —— 已复现缺陷，本 PR 只加回归测试、未修复
llm.py:218-224 的 _invoke_error_mapping 五个键的值全部是 [Exception]；
anthropic.py:1564-1590 虽然定义了一张正确的映射表，但是却从未使用。
llm.py:93 直接调用 anthropic_llm._invoke，所有异常都是直接向上冒到 llm.py:158 时使用的是外层，并未走自己的映射。

发现三：模块级单例携带请求级可变状态 —— 待验证风险，未修复
model_schemas = []  # 
anthropic_llm = AnthropicLargeLanguageModel(model_schemas)
anthropic_llm为模块级别单例。但是单例上带有
previous_thinking_blocks（anthropic.py:177）、previous_redacted_thinking_blocks等带有状态的字段。
多线程环境下，可能会有跨请求串上下文的情况，未验证。

2.本次修改。
新增两个测试文件和 llm.py line:92 一行代码。
3.本地验证。
验证计费问题。 
uv run pytest test_claude_usage_pricing.py
注释llm.py line:92，然后执行一遍测试，可以发现计费预期不同。取消注释，再执行一遍,计费正常。
uv run pytest test_claude_error_mapping.py
发现错误只有一种符合预期，其他都被吞了。
4.插件优化建议。
修复错误映射问题。方便dify根据对应的错误执行对应的补偿机制。
调研是否应该使用模块级单例，模型的并发调用顺序是什么样的，共享状态的问题是否真实存在。

5.过程说明
耗时：2小时
阻塞：计费为0的问题等代码逻辑涉及到sdk里面的源码，只能通过ai去解析，然后自己看测试来验证。
ai使用范围：理解代码、发现可能存在的问题。生成测试类。
亲自核实关键结论：
根据ai翻出来的源码，验证空 `model_schemas` 导致 `get_price` 返回 0。
claude里面的错误映射并没有发挥总用。
