### PR TITLE
fix(aihubmix): align GPT-5.6 pricing and parameters

### DIFF
--- a/models/aihubmix/manifest.yaml
+++ b/models/aihubmix/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.45
+version: 0.0.46
 type: plugin
 author: langgenius
 name: aihubmix

--- a/models/aihubmix/models/llm/gpt-5.6-luna.yaml
+++ b/models/aihubmix/models/llm/gpt-5.6-luna.yaml
@@ -47,19 +47,6 @@ parameter_rules:
       - high
       - xhigh
       - max
-  - name: reasoning_mode
-    label:
-      zh_Hans: 推理模式
-      en_US: Reasoning Mode
-    type: string
-    help:
-      zh_Hans: 标准模式平衡质量与延迟；Pro 模式会投入更多模型计算。
-      en_US: Standard mode balances quality and latency; Pro mode applies more model work.
-    required: false
-    default: standard
-    options:
-      - standard
-      - pro
   - name: verbosity
     label:
       zh_Hans: 详细程度
@@ -85,7 +72,7 @@ parameter_rules:
     required: true
     default: true
 pricing:
-  input: '1'
-  output: '6'
+  input: '0.2'
+  output: '1.2'
   unit: '0.000001'
   currency: USD

--- a/models/aihubmix/models/llm/gpt-5.6-sol.yaml
+++ b/models/aihubmix/models/llm/gpt-5.6-sol.yaml
@@ -47,19 +47,6 @@ parameter_rules:
       - high
       - xhigh
       - max
-  - name: reasoning_mode
-    label:
-      zh_Hans: 推理模式
-      en_US: Reasoning Mode
-    type: string
-    help:
-      zh_Hans: 标准模式平衡质量与延迟；Pro 模式会投入更多模型计算。
-      en_US: Standard mode balances quality and latency; Pro mode applies more model work.
-    required: false
-    default: standard
-    options:
-      - standard
-      - pro
   - name: verbosity
     label:
       zh_Hans: 详细程度
@@ -85,7 +72,7 @@ parameter_rules:
     required: true
     default: true
 pricing:
-  input: '5'
-  output: '30'
+  input: '4'
+  output: '20'
   unit: '0.000001'
   currency: USD

--- a/models/aihubmix/models/llm/gpt-5.6-terra.yaml
+++ b/models/aihubmix/models/llm/gpt-5.6-terra.yaml
@@ -47,19 +47,6 @@ parameter_rules:
       - high
       - xhigh
       - max
-  - name: reasoning_mode
-    label:
-      zh_Hans: 推理模式
-      en_US: Reasoning Mode
-    type: string
-    help:
-      zh_Hans: 标准模式平衡质量与延迟；Pro 模式会投入更多模型计算。
-      en_US: Standard mode balances quality and latency; Pro mode applies more model work.
-    required: false
-    default: standard
-    options:
-      - standard
-      - pro
   - name: verbosity
     label:
       zh_Hans: 详细程度
@@ -85,7 +72,7 @@ parameter_rules:
     required: true
     default: true
 pricing:
-  input: '2.5'
-  output: '15'
+  input: '2'
+  output: '12'
   unit: '0.000001'
   currency: USD


### PR DESCRIPTION
## Summary

Align the AIHubMix GPT-5.6 Luna, Sol, and Terra prices with the current AIHubMix Models API and remove the unsupported `reasoning_mode` parameter from their Dify controls.

## Release Notes

Corrected GPT-5.6 Luna, Sol, and Terra pricing and removed a parameter that caused AIHubMix requests to fail.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

Not applicable. This updates model metadata and removes a rejected parameter.

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [ ] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [x] Structured output (JSON, XML, etc.)
- [x] Token consumption metrics
- [x] Other LLM functionality (reasoning, grounding, prompt caching, etc.)
- [x] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` (not the one under `meta`)
- [x] The existing plugin dependency declaration and lockfile are unchanged

Version: `0.0.45` -> `0.0.46`.

## Testing

- [ ] Local deployment - Dify version: 1.7.0
- [ ] SaaS (cloud.dify.ai)

Configuration and protocol validation completed:

- Full AIHubMix Dify configuration validation passed: 213 model YAML files, no errors
- High-risk provider simulation passed for all three models
- `reasoning_mode=standard` was rejected by each model with HTTP 400 `unknown_parameter`
- After removing `reasoning_mode`, each model returned HTTP 200 with `reasoning_effort=medium`, `verbosity=medium`, non-empty JSON schema, and `max_completion_tokens=8192`
- `dify-plugin` packaged version `0.0.46` successfully
- `git diff --check` passed

Current AIHubMix prices in USD per 1M tokens:

| Model | Input | Output |
| --- | ---: | ---: |
| `gpt-5.6-luna` | 0.2 | 1.2 |
| `gpt-5.6-sol` | 4 | 20 |
| `gpt-5.6-terra` | 2 | 12 |
