### PR TITLE
fix(agent): do not promote JSON inside Thought: to tool actions

### DIFF
--- a/agent-strategies/cot_agent/output_parser/cot_output_parser.py
+++ b/agent-strategies/cot_agent/output_parser/cot_output_parser.py
@@ -163,24 +163,26 @@ class CotAgentOutputParser:
         json_in_string = False
         json_escape = False
         pending_action_json = False
+        json_promote_as_action = False
+        saw_thought_prefix = False
         json_stack: list[str] = []
 
         cur_state = ReactState.THINKING
         last_character = ""
 
-        def emit_json_blob(blob: str):
+        def emit_json_blob(blob: str, *, promote_as_action: bool):
             """Yield a completed JSON blob as an Action or as (flagged) text."""
             action = parse_action(blob)
-            if action is not None and cur_state is ReactState.THINKING:
+            if promote_as_action and action is not None and cur_state is ReactState.THINKING:
                 yield action
-            elif action is None and cur_state is ReactState.THINKING:
+            elif promote_as_action and action is None and cur_state is ReactState.THINKING:
                 # JSON that is not a valid action: keep it as thought text
                 # but flag the parse failure so the strategy can surface it
                 # instead of ending the round silently.
                 yield ReactChunk(cur_state, blob, parse_failed=True)
             else:
-                # In the answer state a JSON blob is part of the final answer
-                # and can never become a tool call.
+                # JSON inside Thought: (issue #3861), in the answer state, or
+                # otherwise not following an explicit Action: marker stays as text.
                 yield ReactChunk(cur_state, blob)
 
         class PrefixMatcher:
@@ -306,7 +308,7 @@ class CotAgentOutputParser:
                 # overwrite an unprocessed blob in json_cache.
                 if got_json:
                     got_json = False
-                    yield from emit_json_blob(json_cache)
+                    yield from emit_json_blob(json_cache, promote_as_action=json_promote_as_action)
                     json_cache = ""
                     in_json = False
                     json_in_string = False
@@ -333,10 +335,14 @@ class CotAgentOutputParser:
                         continue
 
                     if cur_state is not ReactState.ANSWER:
-                        yield_raw_delta, emitted_chunk, delta_consumed, _ = thought_matcher.step(delta)
+                        yield_raw_delta, emitted_chunk, delta_consumed, matched_thought_prefix = (
+                            thought_matcher.step(delta)
+                        )
                         if emitted_chunk is not None:
                             yield emitted_chunk
                         yield_delta = yield_delta or yield_raw_delta
+                        if matched_thought_prefix:
+                            saw_thought_prefix = True
                         if delta_consumed:
                             index += steps
                             continue
@@ -354,6 +360,9 @@ class CotAgentOutputParser:
                 if not in_json and delta in {"{", "["}:
                     in_json = True
                     got_json = False
+                    # Only JSON after an explicit Action: (or bare JSON at the
+                    # very start before Thought:) may become a tool call.
+                    json_promote_as_action = pending_action_json or not saw_thought_prefix
                     json_cache = delta
                     json_in_string = False
                     json_escape = False
@@ -398,7 +407,7 @@ class CotAgentOutputParser:
                 index += steps
 
         if json_cache:
-            yield from emit_json_blob(json_cache)
+            yield from emit_json_blob(json_cache, promote_as_action=json_promote_as_action)
 
         # Flush the chunk tail held back as a possible partial think tag.
         # (If the stream ended inside an unclosed think block, the buffered

--- a/agent-strategies/cot_agent/tests/test_cot_output_parser.py
+++ b/agent-strategies/cot_agent/tests/test_cot_output_parser.py
@@ -210,15 +210,55 @@ class TestReActStreamParsing(unittest.TestCase):
         actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
         self.assertEqual(len(actions), 1)
 
-    def test_action_input_free_text_flags_parse_failure(self):
-        # Issue #3699 (2nd scenario): "Action_input: {...}" written as free
-        # text inside the thought instead of a properly formatted action line.
+    def test_action_input_free_text_keeps_json_in_thought(self):
+        # "Action_input: {...}" written as free text inside the thought is
+        # kept as thought text; only JSON after an explicit Action: prefix
+        # may become a tool call (issue #3861).
         results = _parse('Thought: I need to search\nAction_input: {"input": "x"}')
         actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
         self.assertEqual(actions, [])
         failed = [r for r in results if isinstance(r, ReactChunk) and r.parse_failed]
-        self.assertEqual(len(failed), 1)
-        self.assertEqual(failed[0].content, '{"input": "x"}')
+        self.assertEqual(failed, [])
+        thought = "".join(
+            r.content for r in results if isinstance(r, ReactChunk) and r.state == ReactState.THINKING
+        )
+        self.assertIn('{"input": "x"}', thought)
+
+    def test_action_like_json_inside_thought_is_not_an_action(self):
+        # Issue #3861: JSON quoted inside Thought: must not overwrite a real Action.
+        results = _parse(
+            'Thought: For example {"action": "fake_tool", "action_input": {"q": "x"}} '
+            'before deciding.\nAction: {"action": "real_search", "action_input": {"q": "actual"}}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0].action_name, "real_search")
+        thought = "".join(
+            r.content for r in results if isinstance(r, ReactChunk) and r.state == ReactState.THINKING
+        )
+        self.assertIn("fake_tool", thought)
+        self.assertIn("before deciding.", thought)
+
+    def test_action_like_json_inside_thought_without_action_line(self):
+        results = _parse(
+            'Thought: Example call {"action": "fake_tool", "action_input": {"q": "x"}} end.'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(actions, [])
+        thought = "".join(
+            r.content for r in results if isinstance(r, ReactChunk) and r.state == ReactState.THINKING
+        )
+        self.assertIn("fake_tool", thought)
+        self.assertIn("end.", thought)
+
+    def test_real_action_not_overwritten_by_later_thought_json(self):
+        results = _parse(
+            'Thought: planning\nAction: {"action": "real_search", "action_input": {"q": "actual"}}\n'
+            'Thought: follow-up {"action": "fake_tool", "action_input": {}}'
+        )
+        actions = [r for r in results if isinstance(r, AgentScratchpadUnit.Action)]
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0].action_name, "real_search")
 
     def test_json_after_final_answer_is_not_an_action(self):
         results = _parse('FinalAnswer: {"action": "webSearch", "action_input": {"q": 1}}')

--- a/agent-strategies/cot_agent/tests/test_react.py
+++ b/agent-strategies/cot_agent/tests/test_react.py
@@ -187,21 +187,16 @@ class TestReActSilentRoundTermination(unittest.TestCase):
         # the final answer is streamed chunk by chunk
         self.assertEqual("".join(self._texts(messages)).strip(), "done")
 
-    def test_unparseable_output_surfaces_error_log(self):
-        # Issue #3699 (2nd scenario): "Action_input: {...}" written as free
-        # text must surface a visible error instead of ending the round
-        # silently; the thought is still used as the final answer.
+    def test_action_input_free_text_keeps_json_in_thought(self):
+        # Issue #3861: JSON inside Thought: without an Action: prefix is kept
+        # as thought text rather than misparsed as a tool call or flagged as
+        # a parse failure.
         raw = 'Thought: I need to search\nAction_input: {"input": "x"}'
         strategy = self._strategy([self._llm_chunks(raw)])
         messages = self._run(strategy)
 
         strategy.session.tool.invoke.assert_not_called()
-        error_logs = self._error_logs(messages)
-        self.assertEqual(len(error_logs), 1)
-        self.assertEqual(error_logs[0].message.label, "Action parse failed")
-        self.assertIn(
-            "did not contain a valid Action", error_logs[0].message.data["error"]
-        )
+        self.assertEqual(self._error_logs(messages), [])
         self.assertEqual(
             self._texts(messages)[-1], 'I need to search\nAction_input: {"input": "x"}'
         )


### PR DESCRIPTION
## Summary

Fixes #3861.

The ReAct output parser (agent strategy v0.0.47) promoted **any** action-like JSON blob found while in `THINKING` state to a real tool call — including JSON the model wrote inside free-form `Thought:` text (e.g. when Qwen quotes an example call). That could:

- overwrite the real `Action:` JSON (last blob wins),
- truncate `scratchpad.thought` after the bogus action is set, and
- end the agent loop early with truncated reasoning as the final answer.

This change gates JSON → Action promotion so it only happens when:

1. the JSON follows an explicit `Action:` prefix, **or**
2. the model emits bare JSON before any `Thought:` marker (preserves existing support for wrapper envelopes and adjacent JSON roots).

JSON embedded in `Thought:` is kept as thought text instead.

## Test plan

- [x] `uv run pytest tests/test_cot_output_parser.py -v` (44 passed)
- [x] Added regression tests for:
  - action-like JSON inside `Thought:` with a real `Action:` line afterward
  - action-like JSON inside `Thought:` with no `Action:` line
  - real `Action:` not overwritten by later thought JSON