### PR TITLE
fix(tongyi): use DashScope keepalive session pool

### DIFF
--- a/models/tongyi/manifest.yaml
+++ b/models/tongyi/manifest.yaml
@@ -26,5 +26,5 @@ resource:
     model:
       enabled: false
 type: plugin
-version: 0.2.19
+version: 0.2.20
 created_at: "2026-06-04T10:13:50.29298939+08:00"

--- a/models/tongyi/models/text_embedding/text_embedding.py
+++ b/models/tongyi/models/text_embedding/text_embedding.py
@@ -90,24 +90,17 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
             indices += [i]
         batched_embeddings = []
         _iter = range(0, len(inputs), max_chunks)
-        session = requests.Session()
-        try:
-            for i in _iter:
-                (embeddings_batch, embedding_used_tokens) = self.embed_documents(
-                    credentials_kwargs=credentials_kwargs,
-                    model=model,
-                    texts=inputs[i : i + max_chunks],
-                    base_address=http_base_address,
-                    session=session,
-                )
-                used_tokens += embedding_used_tokens
-                batched_embeddings += embeddings_batch
-            usage = self._calc_response_usage(
-                model=model, credentials=credentials, tokens=used_tokens
+        for i in _iter:
+            (embeddings_batch, embedding_used_tokens) = self.embed_documents(
+                credentials_kwargs=credentials_kwargs,
+                model=model,
+                texts=inputs[i : i + max_chunks],
+                base_address=http_base_address,
             )
-            return TextEmbeddingResult(embeddings=batched_embeddings, usage=usage, model=model)
-        finally:
-            session.close()
+            used_tokens += embedding_used_tokens
+            batched_embeddings += embeddings_batch
+        usage = self._calc_response_usage(model=model, credentials=credentials, tokens=used_tokens)
+        return TextEmbeddingResult(embeddings=batched_embeddings, usage=usage, model=model)
 
     def get_num_tokens(self, model: str, credentials: dict, texts: list[str]) -> list[int]:
         """
@@ -133,7 +126,6 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         :param credentials: model credentials
         :return:
         """
-        session = requests.Session()
         try:
             credentials_kwargs = self._to_credential_kwargs(credentials)
             http_base_address = get_http_base_address(credentials)
@@ -142,12 +134,9 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                 model=model,
                 texts=["ping"],
                 base_address=http_base_address,
-                session=session,
             )
         except Exception as ex:
             raise CredentialsValidateFailedError(str(ex))
-        finally:
-            session.close()
 
     @staticmethod
     def embed_documents(
@@ -155,7 +144,6 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         model: str,
         texts: list[str],
         base_address: str,
-        session: requests.Session,
     ) -> tuple[list[list[float]], int]:
         """Call out to Tongyi's embedding endpoint.
 
@@ -163,7 +151,6 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
             credentials_kwargs: The credentials to use for the call.
             model: The model to use for embedding.
             texts: The list of texts to embed.
-            session: The requests session for this invocation.
 
         Returns:
             List of embeddings, one for each text, and tokens usage.
@@ -178,7 +165,6 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                 model,
                 documents,
                 base_address,
-                session,
             )
 
         embeddings = []
@@ -191,7 +177,6 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                     model=model,
                     input=[{"text": text}],
                     base_address=base_address,
-                    session=session,
                 )
             else:
                 return dashscope.TextEmbedding.call(
@@ -201,7 +186,6 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                     headers=BURY_POINT_HEADER,
                     text_type="document",
                     base_address=base_address,
-                    session=session,
                 )
 
         for text in texts:
@@ -304,27 +288,18 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         """
         http_base_address = get_http_base_address(credentials)
         credentials_kwargs = self._to_credential_kwargs(credentials)
-        session = requests.Session()
-        try:
-            (embeddings_batch, embedding_used_tokens) = self.embed_multimodal_documents(
-                credentials_kwargs=credentials_kwargs,
-                model=model,
-                documents=documents,
-                base_address=http_base_address,
-                session=session,
-            )
-            usage = self._calc_response_usage(
-                model=model,
-                credentials=credentials,
-                tokens=embedding_used_tokens,
-            )
-            return MultiModalEmbeddingResult(
-                model=model,
-                embeddings=embeddings_batch,
-                usage=usage,
-            )
-        finally:
-            session.close()
+        (embeddings_batch, embedding_used_tokens) = self.embed_multimodal_documents(
+            credentials_kwargs=credentials_kwargs,
+            model=model,
+            documents=documents,
+            base_address=http_base_address,
+        )
+        usage = self._calc_response_usage(model=model, credentials=credentials, tokens=embedding_used_tokens)
+        return MultiModalEmbeddingResult(
+            model=model,
+            embeddings=embeddings_batch,
+            usage=usage,
+        )
 
     @staticmethod
     def embed_multimodal_documents(
@@ -332,7 +307,6 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
         model: str,
         documents: list[MultiModalContent],
         base_address: str,
-        session: requests.Session,
     ) -> tuple[list[list[float]], int]:
         """Call out to Tongyi's embedding endpoint.
 
@@ -340,7 +314,6 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
             credentials_kwargs: The credentials to use for the call.
             model: The model to use for embedding.
             documents: The list of documents to embed.
-            session: The requests session for this invocation.
 
         Returns:
             List of embeddings, one for each text, and tokens usage.
@@ -377,7 +350,6 @@ class TongyiTextEmbeddingModel(_CommonTongyi, TextEmbeddingModel):
                 model=model,
                 input=[input],
                 base_address=base_address,
-                session=session,
             )
 
         for document in documents:

--- a/models/tongyi/tests/test_text_embedding_retry.py
+++ b/models/tongyi/tests/test_text_embedding_retry.py
@@ -142,25 +142,21 @@ def sleeps(monkeypatch) -> list:
 
 
 def _embed_documents():
-    session = MagicMock(spec=requests.Session)
     return TongyiTextEmbeddingModel.embed_documents(
         credentials_kwargs=CREDENTIALS,
         model=TEXT_MODEL,
         texts=["hello"],
         base_address=BASE_ADDRESS,
-        session=session,
     )
 
 
 def _embed_multimodal_documents():
     documents = [MultiModalContent(content_type=MultiModalContentType.TEXT, content="hello")]
-    session = MagicMock(spec=requests.Session)
     return TongyiTextEmbeddingModel.embed_multimodal_documents(
         credentials_kwargs=CREDENTIALS,
         model=MULTIMODAL_MODEL,
         documents=documents,
         base_address=BASE_ADDRESS,
-        session=session,
     )
 
 

--- a/models/tongyi/tests/test_text_embedding_session_cleanup.py
+++ b/models/tongyi/tests/test_text_embedding_session_cleanup.py
@@ -3,14 +3,11 @@ from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-import requests
 from dify_plugin.entities.model.text_embedding import (
     EmbeddingUsage,
     MultiModalContent,
     MultiModalContentType,
 )
-from dify_plugin.errors.model import CredentialsValidateFailedError
 
 _PLUGIN_DIR = Path(__file__).resolve().parent.parent
 if str(_PLUGIN_DIR) not in sys.path:
@@ -40,13 +37,6 @@ class _MultiModalResponse:
         self.usage = {"input_tokens": 5, "image_tokens": 0}
 
 
-class _RateLimitedResponse:
-    def __init__(self) -> None:
-        self.status_code = 429
-        self.output = None
-        self.usage = None
-
-
 def _usage() -> EmbeddingUsage:
     return EmbeddingUsage(
         tokens=0,
@@ -68,205 +58,83 @@ def _model(max_chunks: int = 10) -> TongyiTextEmbeddingModel:
     return model
 
 
-def _invoke(model: TongyiTextEmbeddingModel, texts: list[str] | None = None):
-    return model._invoke(
-        model=TEXT_MODEL,
-        credentials=CREDENTIALS,
-        texts=texts or ["hello"],
-    )
-
-
-def test_text_embedding_call_receives_session() -> None:
-    session = MagicMock(spec=requests.Session)
+def test_text_embedding_call_uses_sdk_managed_session() -> None:
     with patch.object(te.dashscope.TextEmbedding, "call", return_value=_TextResponse()) as call:
         result = TongyiTextEmbeddingModel.embed_documents(
             credentials_kwargs=CREDENTIALS,
             model=TEXT_MODEL,
             texts=["hello"],
             base_address=BASE_ADDRESS,
-            session=session,
         )
 
     assert result == ([[0.1, 0.2, 0.3]], 7)
-    assert call.call_args.kwargs["session"] is session
+    assert "session" not in call.call_args.kwargs
 
 
-def test_multimodal_embedding_call_receives_session_through_text_path() -> None:
-    session = MagicMock(spec=requests.Session)
+def test_multimodal_embedding_call_uses_sdk_managed_session_through_text_path() -> None:
     with patch.object(
-        te.dashscope.MultiModalEmbedding,
-        "call",
-        return_value=_MultiModalResponse(),
+        te.dashscope.MultiModalEmbedding, "call", return_value=_MultiModalResponse()
     ) as call:
         result = TongyiTextEmbeddingModel.embed_documents(
             credentials_kwargs=CREDENTIALS,
             model=MULTIMODAL_MODEL,
             texts=["hello"],
             base_address=BASE_ADDRESS,
-            session=session,
         )
 
     assert result == ([[0.4, 0.5]], 5)
-    assert call.call_args.kwargs["session"] is session
+    assert "session" not in call.call_args.kwargs
 
 
-def test_text_batches_reuse_one_session_and_close_it() -> None:
+def test_text_batches_delegate_session_management_to_sdk() -> None:
     model = _model(max_chunks=2)
-    session = MagicMock(spec=requests.Session)
-    batches = []
+    batches: list[list[str]] = []
 
     def embed_documents(**kwargs):
-        batches.append((kwargs["texts"], kwargs["session"]))
+        assert "session" not in kwargs
+        batches.append(kwargs["texts"])
         return ([[0.1]] * len(kwargs["texts"]), len(kwargs["texts"]))
 
     with patch.object(
-        te.requests, "Session", return_value=session
-    ) as session_factory, patch.object(
-        model,
-        "embed_documents",
-        side_effect=embed_documents,
-    ):
-        result = _invoke(model, ["one", "two", "three"])
-
-    assert result.embeddings == [[0.1], [0.1], [0.1]]
-    assert [batch for batch, _ in batches] == [["one", "two"], ["three"]]
-    assert [batch_session for _, batch_session in batches] == [session, session]
-    model._calc_response_usage.assert_called_once_with(
-        model=TEXT_MODEL,
-        credentials=CREDENTIALS,
-        tokens=3,
-    )
-    session_factory.assert_called_once_with()
-    session.close.assert_called_once_with()
-
-
-def test_each_text_invocation_gets_an_isolated_session() -> None:
-    model = _model()
-    first, second = MagicMock(spec=requests.Session), MagicMock(spec=requests.Session)
-
-    with patch.object(te.requests, "Session", side_effect=[first, second]), patch.object(
-        model,
-        "embed_documents",
-        return_value=([[0.1]], 1),
-    ) as embed_documents:
-        _invoke(model)
-        _invoke(model)
-
-    assert [item.kwargs["session"] for item in embed_documents.call_args_list] == [first, second]
-    first.close.assert_called_once_with()
-    second.close.assert_called_once_with()
-
-
-def test_multimodal_documents_reuse_one_session_and_close_it() -> None:
-    model = _model()
-    session = MagicMock(spec=requests.Session)
-    documents = [
-        MultiModalContent(content_type=MultiModalContentType.TEXT, content="one"),
-        MultiModalContent(content_type=MultiModalContentType.TEXT, content="two"),
-    ]
-
-    with patch.object(te.requests, "Session", return_value=session), patch.object(
-        te.dashscope.MultiModalEmbedding,
-        "call",
-        return_value=_MultiModalResponse(),
-    ) as call:
-        result = model._invoke_multimodal(
-            model=MULTIMODAL_MODEL,
-            credentials=CREDENTIALS,
-            documents=documents,
+        te.requests,
+        "Session",
+        side_effect=AssertionError("the plugin must not create a requests.Session"),
+    ), patch.object(model, "embed_documents", side_effect=embed_documents):
+        result = model._invoke(
+            model=TEXT_MODEL, credentials=CREDENTIALS, texts=["one", "two", "three"]
         )
 
-    assert result.embeddings == [[0.4, 0.5], [0.4, 0.5]]
-    assert [item.kwargs["session"] for item in call.call_args_list] == [session, session]
-    model._calc_response_usage.assert_called_once_with(
-        model=MULTIMODAL_MODEL,
-        credentials=CREDENTIALS,
-        tokens=10,
-    )
-    session.close.assert_called_once_with()
+    assert result.embeddings == [[0.1], [0.1], [0.1]]
+    assert batches == [["one", "two"], ["three"]]
 
 
-def test_retry_reuses_session_and_closes_it(monkeypatch) -> None:
+def test_multimodal_invoke_delegates_session_management_to_sdk() -> None:
     model = _model()
-    session = MagicMock(spec=requests.Session)
-    error = requests.exceptions.ConnectionError("connection dropped")
-    sleeps = []
-    monkeypatch.setattr(te.time, "sleep", sleeps.append)
+    documents = [MultiModalContent(content_type=MultiModalContentType.TEXT, content="hello")]
 
-    with patch.object(te.requests, "Session", return_value=session), patch.object(
-        te.dashscope.TextEmbedding,
-        "call",
-        side_effect=[error, _TextResponse()],
-    ) as call:
-        assert _invoke(model).embeddings == [[0.1, 0.2, 0.3]]
+    with patch.object(
+        te.requests,
+        "Session",
+        side_effect=AssertionError("the plugin must not create a requests.Session"),
+    ), patch.object(
+        model, "embed_multimodal_documents", return_value=([[0.4, 0.5]], 5)
+    ) as embed_multimodal_documents:
+        result = model._invoke_multimodal(
+            model=MULTIMODAL_MODEL, credentials=CREDENTIALS, documents=documents
+        )
 
-    assert [item.kwargs["session"] for item in call.call_args_list] == [session, session]
-    assert sleeps == [1]
-    session.close.assert_called_once_with()
+    assert result.embeddings == [[0.4, 0.5]]
+    assert "session" not in embed_multimodal_documents.call_args.kwargs
 
 
-def test_rate_limit_retry_reuses_session_and_closes_it(monkeypatch) -> None:
+def test_validate_credentials_delegates_session_management_to_sdk() -> None:
     model = _model()
-    session = MagicMock(spec=requests.Session)
-    sleeps = []
-    monkeypatch.setattr(te.time, "sleep", sleeps.append)
 
-    with patch.object(te.requests, "Session", return_value=session), patch.object(
-        te.dashscope.TextEmbedding,
-        "call",
-        side_effect=[_RateLimitedResponse(), _TextResponse()],
-    ) as call:
-        assert _invoke(model).embeddings == [[0.1, 0.2, 0.3]]
-
-    assert [item.kwargs["session"] for item in call.call_args_list] == [session, session]
-    assert sleeps == [10]
-    session.close.assert_called_once_with()
-
-
-def test_persistent_connection_error_closes_session(monkeypatch) -> None:
-    model = _model()
-    session = MagicMock(spec=requests.Session)
-    error = requests.exceptions.ConnectionError("connection dropped")
-    sleeps = []
-    monkeypatch.setattr(te.time, "sleep", sleeps.append)
-
-    with patch.object(te.requests, "Session", return_value=session), patch.object(
-        te.dashscope.TextEmbedding,
-        "call",
-        side_effect=error,
-    ) as call, pytest.raises(requests.exceptions.ConnectionError) as exc_info:
-        _invoke(model)
-
-    assert exc_info.value is error
-    assert [item.kwargs["session"] for item in call.call_args_list] == [session] * 3
-    assert sleeps == [1, 3]
-    session.close.assert_called_once_with()
-
-
-def test_validate_credentials_closes_session_on_success() -> None:
-    model = _model()
-    session = MagicMock(spec=requests.Session)
-
-    with patch.object(te.requests, "Session", return_value=session), patch.object(
-        te.dashscope.TextEmbedding,
-        "call",
-        return_value=_TextResponse(),
-    ) as call:
+    with patch.object(
+        te.requests,
+        "Session",
+        side_effect=AssertionError("the plugin must not create a requests.Session"),
+    ), patch.object(model, "embed_documents", return_value=([[0.1]], 1)) as embed_documents:
         model.validate_credentials(TEXT_MODEL, CREDENTIALS)
 
-    assert call.call_args.kwargs["session"] is session
-    session.close.assert_called_once_with()
-
-
-def test_validate_credentials_closes_session_on_error() -> None:
-    model = _model()
-    session = MagicMock(spec=requests.Session)
-
-    with patch.object(te.requests, "Session", return_value=session), patch.object(
-        te.dashscope.TextEmbedding,
-        "call",
-        side_effect=ValueError("invalid response"),
-    ), pytest.raises(CredentialsValidateFailedError, match="invalid response"):
-        model.validate_credentials(TEXT_MODEL, CREDENTIALS)
-
-    session.close.assert_called_once_with()
+    assert "session" not in embed_documents.call_args.kwargs


### PR DESCRIPTION
## Summary

Follow-up to #3815 and #3817.

DashScope confirmed that its process-wide shared synchronous session could
reuse silently stale pooled connections, causing requests to block until the
default 300-second read timeout. The underlying issue was fixed in
https://github.com/dashscope/dashscope-sdk-python/pull/187 and released in
DashScope SDK 1.27.4.

Tongyi 0.2.19 already locks DashScope 1.27.4, but the embedding implementation
still creates a separate `requests.Session` for each invocation and passes it
explicitly to the SDK. This bypasses the SDK-managed shared session and its new
keepalive-enabled HTTP adapter.

This change removes explicit session creation and injection from:

- Text embedding
- Multimodal embedding
- Embedding credential validation

Embedding requests now use the shared session managed by DashScope 1.27.4.
Existing batching, token accounting, connection-error retries, timeout
handling, and HTTP 429 handling remain unchanged.

The LLM and rerank implementations are not changed.

## Release Notes

Use DashScope's keepalive-enabled shared connection pool for Tongyi text and
multimodal embedding requests, reducing the risk of long stalls caused by stale
idle connections.

## Change Type

- [ ] Documentation / non-plugin change
- [ ] Non-LLM plugin (tools, extensions, datasource, etc.)
- [x] LLM plugin

## Screenshots / Videos

This is a backend connection-management change and has no user-interface
changes.

| Before | After |
| ------ | ----- |
| Embedding requests could intermittently take approximately 301 seconds after an idle connection became stale. | The approximately 301-second stall was not reproduced with the validation build using DashScope's keepalive-enabled shared session. |

## LLM Plugin Checklist

<details>
<summary>Areas affected by this change (check all that apply)</summary>

- [ ] Message flow (system messages, user ↔ assistant turn-taking)
- [ ] Tool interaction flow (multi-round usage, Agent App and Agent Node)
- [x] Multimodal input (images, PDFs, audio, video, etc.)
- [ ] Multimodal output (images, audio, video, etc.)
- [ ] Structured output (JSON, XML, etc.)
- [ ] Token consumption metrics
- [x] Other LLM functionality (text and multimodal embedding connection management)
- [ ] New models / model parameter fixes

</details>

## Version

- [x] Bumped top-level `version` in `manifest.yaml` from `0.2.19` to `0.2.20`
- [x] `dify_plugin>=0.3.0,<0.6.0` is declared in `pyproject.toml` and locked in `uv.lock`

## Testing

- [x] Local deployment — Dify version: 1.13.3 (self-hosted local build)
- [ ] SaaS (cloud.dify.ai)

Validation performed:

- Packaged the plugin from a clean Git archive using the Dify Plugin CLI.
- Installed frozen dependencies under Python 3.12.
- Confirmed that `uv.lock` resolves `dashscope==1.27.4`.
- Passed the official serverless plugin installation validator.
- Ran the complete test suite from the unpacked `.difypkg`.
- Test result: `167 passed, 83 skipped`.
- Deployed the `0.2.20-dev1` validation package to two self-hosted
  `plugin_daemon` nodes.
- Text embedding and knowledge retrieval remained responsive after more than
  two hours of idle time, without reproducing the approximately 301-second stall.