### PR TITLE
fix(self_refine_agent): honor score threshold and return best output

### DIFF
--- a/agent-strategies/self_refine_agent/manifest.yaml
+++ b/agent-strategies/self_refine_agent/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.3
+version: 0.0.4
 type: plugin
 author: "langgenius"
 name: "self_refine_agent"

--- a/agent-strategies/self_refine_agent/strategies/self_refine.py
+++ b/agent-strategies/self_refine_agent/strategies/self_refine.py
@@ -26,6 +26,11 @@ from prompt.templates import SELF_REFINE_TEMPLATES
 
 logger = logging.getLogger(__name__)
 
+# Documented quality contract (see README): stop refining once an evaluated
+# output reaches this score; when the budget is exhausted below it, return
+# the highest-scoring evaluated output instead of the most recent one.
+SCORE_STOP_THRESHOLD = 80
+
 
 class LogMetadata:
     """Metadata keys for logging"""
@@ -114,6 +119,8 @@ class SelfRefineStrategy(AgentStrategy):
         refinement_count = 0
         previous_critique: Optional[str] = None
         final_output = ""
+        best_output: Optional[str] = None
+        best_score = -1
         total_metadata = ExecutionMetadata()
 
         while refinement_count <= params.max_refinements:
@@ -165,8 +172,10 @@ class SelfRefineStrategy(AgentStrategy):
                 continue
 
             # === EVALUATION PHASE ===
-            if refinement_count >= params.max_refinements:
-                logger.info("Max refinements reached, skipping evaluation")
+            # With refinements disabled this stays a single standard-agent
+            # execution: no evaluator call is added.
+            if params.max_refinements <= 0:
+                logger.info("Refinements disabled (max_refinements=0), skipping evaluation")
                 break
 
             yield self.create_log_message(
@@ -181,7 +190,11 @@ class SelfRefineStrategy(AgentStrategy):
                     output=final_output
                 )
 
-                if evaluation.is_satisfactory:
+                if evaluation.score > best_score:
+                    best_score = evaluation.score
+                    best_output = final_output
+
+                if evaluation.score >= SCORE_STOP_THRESHOLD:
                     yield self.create_log_message(
                         label="Quality Check: PASS",
                         data={"score": evaluation.score},
@@ -212,6 +225,13 @@ class SelfRefineStrategy(AgentStrategy):
                 break
 
         # === FINAL OUTPUT ===
+        # When the budget was exhausted below the threshold, return the
+        # highest-scoring evaluated output instead of the most recent one.
+        # (On a threshold PASS, best_output already is this output; when no
+        # evaluation ran at all, best_output stays None.)
+        if best_output is not None:
+            final_output = best_output
+
         yield self.create_text_message(final_output)
 
         yield self.create_json_message({

--- a/agent-strategies/self_refine_agent/tests/test_self_refine.py
+++ b/agent-strategies/self_refine_agent/tests/test_self_refine.py
@@ -190,7 +190,9 @@ class TestSelfRefineListContent(unittest.TestCase):
     def test_invoke_end_to_end_satisfactory_on_first_attempt(self):
         model = AgentModelConfig(provider="google", model="gemini-1.5-pro", mode="chat")
 
-        eval_json = '{"is_satisfactory": true, "issues": "", "score": 10}'
+        # The documented stop rule is score>=80 (issue #3874), so a passing
+        # first attempt must clear the threshold, not just set the boolean.
+        eval_json = '{"is_satisfactory": true, "issues": "", "score": 95}'
         responses = [
             LLMResult(
                 model="gemini-1.5-pro",
@@ -360,6 +362,101 @@ class TestSelfRefineTools(unittest.TestCase):
 
         self.assertEqual(self.strategy.session.model.llm.invoke.call_count, 1)
         self.assertEqual(result["output"], "42")
+
+
+def _exec_result(text: str) -> LLMResult:
+    return LLMResult(
+        model="gpt-4o",
+        message=_list_content_message(text),
+        usage=LLMUsage.empty_usage(),
+    )
+
+
+def _eval_result(is_satisfactory: bool, score: int) -> LLMResult:
+    return LLMResult(
+        model="gpt-4o",
+        message=_list_content_message(
+            '{"is_satisfactory": %s, "issues": "", "score": %d}'
+            % ("true" if is_satisfactory else "false", score)
+        ),
+        usage=LLMUsage.empty_usage(),
+    )
+
+
+def _final_text(strategy, parameters: dict) -> str:
+    from dify_plugin.entities.agent import AgentInvokeMessage
+
+    messages = list(strategy._invoke(parameters))
+    texts = [
+        m.message.text
+        for m in messages
+        if m.type == AgentInvokeMessage.MessageType.TEXT
+    ]
+    assert texts, "expected exactly one final text message"
+    return texts[-1]
+
+
+def _invoke_params(model, max_refinements: int) -> dict:
+    return {
+        "query": "hello",
+        "instruction": "answer briefly",
+        "model": model.model_dump(mode="json"),
+        "max_refinements": max_refinements,
+    }
+
+
+class TestSelfRefineScoreContract(unittest.TestCase):
+    """Issue #3874: the documented score>=80 stopping rule and best-output
+    return, proven against the real _invoke loop (issue text, not mocks)."""
+
+    def setUp(self):
+        self.strategy = SelfRefineStrategy(runtime=Mock(), session=Mock())
+
+    def test_below_threshold_satisfactory_continues_and_high_score_stops(self):
+        model = AgentModelConfig(provider="openai", model="gpt-4o", mode="chat")
+        self.strategy.session.model.llm.invoke = Mock(
+            side_effect=[
+                _exec_result("first"),
+                _eval_result(True, 70),
+                _exec_result("second"),
+                _eval_result(False, 90),
+            ]
+        )
+
+        text = _final_text(self.strategy, _invoke_params(model, 2))
+
+        # Score 70 must NOT stop even with is_satisfactory=true; score 90 stops.
+        self.assertEqual(text, "second")
+        self.assertEqual(self.strategy.session.model.llm.invoke.call_count, 4)
+
+    def test_exhausted_budget_returns_best_scoring_output(self):
+        model = AgentModelConfig(provider="openai", model="gpt-4o", mode="chat")
+        self.strategy.session.model.llm.invoke = Mock(
+            side_effect=[
+                _exec_result("first-75"),
+                _eval_result(False, 75),
+                _exec_result("second-60"),
+                _eval_result(False, 60),
+            ]
+        )
+
+        text = _final_text(self.strategy, _invoke_params(model, 1))
+
+        # Both attempts evaluated (including the final one); best (75) wins.
+        self.assertEqual(text, "first-75")
+        self.assertEqual(self.strategy.session.model.llm.invoke.call_count, 4)
+
+    def test_zero_refinements_performs_no_evaluation(self):
+        model = AgentModelConfig(provider="openai", model="gpt-4o", mode="chat")
+        self.strategy.session.model.llm.invoke = Mock(
+            return_value=_exec_result("only")
+        )
+
+        text = _final_text(self.strategy, _invoke_params(model, 0))
+
+        # Exactly the initial execution, no added evaluator LLM call.
+        self.assertEqual(text, "only")
+        self.assertEqual(self.strategy.session.model.llm.invoke.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3874.

## Runtime contract implemented

The Self-Refine README documents a score-based quality contract that the runtime did not implement: stop refining once an evaluated output reaches score 80 or above, and when the refinement budget is exhausted below the threshold, return the best-scoring output instead of the most recent one. This change implements exactly that contract in `SelfRefineStrategy._invoke()`:

- stopping is now driven by `evaluation.score >= 80` (`SCORE_STOP_THRESHOLD`), not by the `is_satisfactory` boolean alone — so `(is_satisfactory=true, score=70)` correctly continues refining;
- every successful attempt is evaluated, including the final allowed attempt (previously skipped);
- the highest-scoring successful output is tracked, and on budget exhaustion below threshold it is returned instead of the latest output;
- `max_refinements=0` is byte-for-byte the old cost path: exactly the initial execution with NO added evaluator LLM call.

Execution-failure budget handling is intentionally unchanged, as are ToolEntity prompt serialization, the README's separate no-significant-improvements rule, and everything outside the self-refine strategy.

## Regressions added

- `(true, 70)` continues and a following `(false, 90)` stops and returns the second output (4 LLM calls: 2 exec + 2 eval);
- `(false, 75)` then `(false, 60)` with `max_refinements=1` returns the earlier 75 output (final attempt evaluated);
- `max_refinements=0` performs exactly one LLM call and returns the initial output.

One existing end-to-end test's first-attempt eval score was raised 10 → 95 so its "clean first-attempt pass" scenario still clears the documented threshold; no test was deleted.

## Validation performed

- `python -m pytest tests/` in `agent-strategies/self_refine_agent`: 12 passed (9 existing + 3 new).
- New tests were watched failing before the fix (early-stop returning `first`; budget exhaustion returning `second-60`).
- `git diff --check` clean; manifest patch version bumped 0.0.3 → 0.0.4.
- Full monorepo suite not run; no such claim is made.

## Release Notes

Fix the Self-Refine agent strategy to honor its documented score contract: stop refining at evaluation score 80+, evaluate every attempt including the last, and return the best-scoring output when the budget runs out. `max_refinements=0` behavior and cost are unchanged.

From ChatGPT