### PR TITLE
fix(lemonade): only forward speech2text language/prompt when configured

### DIFF
--- a/models/lemonade/manifest.yaml
+++ b/models/lemonade/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.17
+version: 0.0.18
 type: plugin
 author: "langgenius"
 name: "lemonade"

--- a/models/lemonade/models/speech2text/speech2text.py
+++ b/models/lemonade/models/speech2text/speech2text.py
@@ -35,9 +35,18 @@ class LemonadeSpeech2TextModel(OAICompatSpeech2TextModel):
 
         endpoint_url = urljoin(_lemonade_base_url(credentials), "audio/transcriptions")
 
-        language = credentials.get("language") or "en"
-        prompt = credentials.get("initial_prompt") or "convert the audio to text"
-        payload = {"model": model, "language": language, "prompt": prompt}
+        payload = {"model": model}
+        # `language` and `prompt` are optional in the OpenAI transcription API and both
+        # change the output, so only forward them when the user actually configured one.
+        # Sending a hardcoded default made every request claim a language the server may
+        # not support, and injected an unrelated English instruction as the decoder prompt.
+        language = credentials.get("language")
+        if language:
+            payload["language"] = language
+        prompt = credentials.get("initial_prompt")
+        if prompt:
+            payload["prompt"] = prompt
+
         files = [("file", file)]
 
         response = requests.post(

--- a/models/lemonade/provider/lemonade.yaml
+++ b/models/lemonade/provider/lemonade.yaml
@@ -108,29 +108,11 @@ model_credential_schema:
       label:
         en_US: Language
         zh_Hans: 语言
-      type: select
+      type: text-input
       required: false
-      default: en
       placeholder:
-        zh_Hans: 模型支持的语言，例如 en,zh
-        en_US: The language supported by the model, e.g. en,zh
-      options:
-        - value: en
-          label:
-            en_US: en-US
-            zh_Hans: 英文
-        - value: zh
-          label:
-            en_US: zh-Hans
-            zh_Hans: 中文
-        - value: ja
-          label:
-            en_US: ja-JP
-            zh_Hans: 日语
-        - value: ko
-          label:
-            en_US: ko-KR
-            zh_Hans: 韩语
+        zh_Hans: ISO-639-1 语言代码，例如 zh、en、ru；留空则由模型自动检测
+        en_US: ISO-639-1 language code, e.g. zh, en, ru. Leave empty to let the model auto-detect.
     - variable: initial_prompt
       show_on:
         - variable: __model_type

--- a/models/lemonade/tests/test_speech2text_language.py
+++ b/models/lemonade/tests/test_speech2text_language.py
@@ -1,0 +1,81 @@
+"""Regression tests for the speech2text `language` and `initial_prompt` handling.
+
+The plugin used to force both fields into every transcription request:
+`language` fell back to a hardcoded value and the credential schema only
+offered `zh`, `en`, `ja` and `ko`, while `prompt` fell back to the literal
+string "convert the audio to text". Both are optional in the OpenAI
+transcription API, so a Lemonade server that serves any other language
+could not be used at all, and the injected decoder prompt biased the
+transcript.
+
+These tests drive the model directly so we can capture the form payload the
+implementation actually sends, without needing a real Lemonade server.
+"""
+
+import io
+from unittest.mock import MagicMock, patch
+
+from models.speech2text.speech2text import LemonadeSpeech2TextModel
+
+
+def _captured_payload(mock_post):
+    """Extract the form data passed to requests.post from the mock call."""
+    assert mock_post.call_count == 1
+    _args, kwargs = mock_post.call_args
+    return kwargs.get("data") or {}
+
+
+def _credentials(**overrides):
+    creds = {
+        "endpoint_url": "http://127.0.0.1:13305",
+    }
+    creds.update(overrides)
+    return creds
+
+
+def _invoke(credentials):
+    model = LemonadeSpeech2TextModel(model_schemas=[])
+    with patch("models.speech2text.speech2text.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=200, json=lambda: {"text": "ok"})
+        model._invoke(
+            model="whisper-small",
+            credentials=credentials,
+            file=io.BytesIO(b"RIFF"),
+        )
+    return mock_post
+
+
+def test_language_is_omitted_when_not_configured():
+    payload = _captured_payload(_invoke(_credentials()))
+    assert "language" not in payload, (
+        f"An unconfigured language must let the server auto-detect; payload={payload!r}"
+    )
+
+
+def test_prompt_is_omitted_when_not_configured():
+    payload = _captured_payload(_invoke(_credentials()))
+    assert "prompt" not in payload, (
+        f"An unconfigured initial prompt must not bias the transcript; payload={payload!r}"
+    )
+
+
+def test_language_outside_the_former_option_list_is_forwarded():
+    payload = _captured_payload(_invoke(_credentials(language="ru")))
+    assert payload.get("language") == "ru", (
+        f"Any ISO-639-1 code must reach the server, not just zh/en/ja/ko; payload={payload!r}"
+    )
+
+
+def test_configured_prompt_is_forwarded():
+    payload = _captured_payload(_invoke(_credentials(initial_prompt="Kubernetes, kubectl")))
+    assert payload.get("prompt") == "Kubernetes, kubectl", (
+        f"A configured initial prompt must reach the server; payload={payload!r}"
+    )
+
+
+def test_request_has_a_timeout():
+    mock_post = _invoke(_credentials())
+    _args, kwargs = mock_post.call_args
+    assert kwargs.get("timeout") is not None, (
+        "A stalled transcription server must not hang the worker thread forever"
+    )


### PR DESCRIPTION
## What
Fixes #3876.

The lemonade speech2text model forced `language` (select limited to en/zh/ja/ko, default en) and the literal prompt "convert the audio to text" into every transcription request. Audio in any other language could not be served, Whisper auto-detection never ran, and the canned prompt biased the decoder on every call.

Mirrors the fix merged for openai_api_compatible in #3750:
- models/speech2text/speech2text.py: forward `language` and `prompt` only when the user configured them
- provider/lemonade.yaml: language field select -> free text input ("Leave empty to let the model auto-detect"), same as the reference schema
- tests/test_speech2text_language.py: regression tests mirroring #3750's test file
- manifest: 0.0.17 -> 0.0.18

## Test
pytest models/lemonade/tests: 10 passed (5 new). Captured payload with unconfigured credentials, before and after:
- before: {'model': 'whisper-small', 'language': 'en', 'prompt': 'convert the audio to text'}
- after: {'model': 'whisper-small'}